### PR TITLE
Add French translations for dialogue entries

### DIFF
--- a/scripts/script_002.json
+++ b/scripts/script_002.json
@@ -6,8 +6,8 @@
     "data_size": 86,
     "nom_orig": "???",
     "texte_orig": "Whew...[1205][001E][SP]Thank[SP]you[SP]for[SP]the[SP]food.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "???",
+    "texte_fr": "Ouf...[1205][001E] Merci pour le repas."
   },
   {
     "id": 1,
@@ -16,8 +16,8 @@
     "data_size": 58,
     "nom_orig": "???",
     "texte_orig": "...[1205][U+000A]...[1205][U+000A]...[1205][U+000A]Gah!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "???",
+    "texte_fr": "...[1205][U+000A]...[1205][U+000A]...[1205][U+000A]Gah !"
   },
   {
     "id": 2,
@@ -26,8 +26,8 @@
     "data_size": 464,
     "nom_orig": "???",
     "texte_orig": "H-Hey![SP]Is[SP]this[SP]chica[SP]really[SP]one[SP]of[SP]my\nfans!?[1205][001E][SP]That[SP]ain't[SP]right!\n[E1][E2][E4][NULL][NULL][0010]Eikichi[SP][1432][NULL][NULL][0014]Michel[1432][NULL][NULL][0014][SP]Mishina\n[SP]A[SP]2nd-year[SP]at[SP]Kasugayama[SP]High[SP]who[SP]has[SP]it\n[SP]in[SP]for[SP][U+1113].[SP]A[SP]narcissistic[SP]gang[SP]boss[SP]as\n[SP]well[SP]as[SP]lead[SP]vocalist[SP]in[SP]his[SP]band.[E4][NULL][NULL][0002]",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "???",
+    "texte_fr": "Hé ! Cette meuf est vraiment une de\nmes fans !?[1205][001E] C'est n'importe quoi !\nEikichi [1432][NULL][NULL][0014]Michel[1432][NULL][NULL][0014] Mishina\n2e année à Kasugayama qui en a\naprès [U+1113]. Un chef de gang narcissique\nainsi que le chanteur de son groupe."
   },
   {
     "id": 3,
@@ -36,8 +36,8 @@
     "data_size": 68,
     "nom_orig": "Ken",
     "texte_orig": "C-Calm[SP]down,[SP]Michel-san!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ken",
+    "texte_fr": "C-Calmez-vous, Michel-san !"
   },
   {
     "id": 4,
@@ -46,8 +46,8 @@
     "data_size": 148,
     "nom_orig": "Shogo",
     "texte_orig": "Y-Yeah.[SP]If[SP]we[SP]wait[SP]just[SP]a[SP]little[SP]longer,\nI'm[SP]sure[SP][U+1113][SP]will[SP]show!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Shogo",
+    "texte_fr": "O-Ouais. Si on attend encore un peu,\nje suis sûr que [U+1113] va se pointer !"
   },
   {
     "id": 5,
@@ -56,8 +56,8 @@
     "data_size": 58,
     "nom_orig": "Shogo",
     "texte_orig": "Er...[SP]Oh[SP]crud...!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Shogo",
+    "texte_fr": "Euh... Oh mince... !"
   },
   {
     "id": 6,
@@ -66,8 +66,8 @@
     "data_size": 144,
     "nom_orig": "Eikichi",
     "texte_orig": "Hey...[1205][001E][SP]What's[SP]this[SP]about[SP][U+1113]?\nWhat[SP]are[SP]you[SP]three[SP]scheming?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Hé...[1205][001E] C'est quoi cette histoire avec [U+1113] ?\nQu'est-ce que vous manigancez tous les trois ?"
   },
   {
     "id": 7,
@@ -76,8 +76,8 @@
     "data_size": 98,
     "nom_orig": "Lisa",
     "texte_orig": "Huh...[1205][001E][SP]So[SP]that's[SP]what[SP]this[SP]is[SP]about?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Hein...[1205][001E] Alors c'était ça le but ?"
   },
   {
     "id": 8,
@@ -86,8 +86,8 @@
     "data_size": 34,
     "nom_orig": "Eikichi",
     "texte_orig": "[U+1113]!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "[U+1113] !?"
   },
   {
     "id": 9,
@@ -96,8 +96,8 @@
     "data_size": 74,
     "nom_orig": "Lisa",
     "texte_orig": "Michel[SP]Eikichi,[SP]I[SP]take[SP]it?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Michel Eikichi, je présume ?"
   },
   {
     "id": 10,
@@ -106,8 +106,8 @@
     "data_size": 98,
     "nom_orig": "Eikichi",
     "texte_orig": "Yeah[SP]yeah[SP]yeah![SP]Do[SP]I[SP]got[SP]you,[SP]babe?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Ouais ouais ouais ! Tu craques pour moi, bébé ?"
   },
   {
     "id": 11,
@@ -116,8 +116,8 @@
     "data_size": 250,
     "nom_orig": "Eikichi",
     "texte_orig": "Allow[SP]me[SP]to[SP]introduce[SP]myself[SP]as[SP]the\ngenius[SP]artist[SP]Michel,[SP]spreading[SP]love[SP]to\nladies[SP]around[SP]the[SP]world![SP]Hooooooo!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Laisse-moi me présenter : le génial\nartiste Michel, qui répand l'amour auprès\ndes femmes du monde entier ! Hooooooo !"
   },
   {
     "id": 12,
@@ -126,8 +126,8 @@
     "data_size": 74,
     "nom_orig": "Lisa",
     "texte_orig": "What...[1205][001E][SP]are[SP]you[SP]smoking?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Mais qu'est-ce que...[1205][001E] tu as fumé ?"
   },
   {
     "id": 13,
@@ -136,8 +136,8 @@
     "data_size": 86,
     "nom_orig": "Eikichi",
     "texte_orig": "What[SP]was[SP]that,[SP]you[SP]little--!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Qu'est-ce que t'as dit, petite-- !?"
   },
   {
     "id": 14,
@@ -146,8 +146,8 @@
     "data_size": 174,
     "nom_orig": "Shogo",
     "texte_orig": "Um...[SP]Please[SP]forgive[SP]us![1205][001E][SP]We[SP]used[SP]Kozy-san\nas[SP]a[SP]hostage[SP]to[SP]lure[SP]out[SP][U+1113]-san!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Shogo",
+    "texte_fr": "Euh... Pardonnez-nous ![1205][001E] On a utilisé Kozy-san\ncomme otage pour attirer [U+1113]-san !"
   },
   {
     "id": 15,
@@ -156,8 +156,8 @@
     "data_size": 262,
     "nom_orig": "Takeshi",
     "texte_orig": "You[SP]know[SP]how[SP]you[SP]were[SP]pumped[SP]to[SP]start[SP]a\nband,[SP]Michel-san?[SP]We[SP]were[SP]looking[SP]for\nmembers.[1205][001E][SP]You[SP]were[SP]the[SP]only[SP]one,[SP]so...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Takeshi",
+    "texte_fr": "Vous vouliez tellement monter un\ngroupe, Michel-san. On vous cherchait\ndes membres.[1205][001E] Vous étiez seul, alors..."
   },
   {
     "id": 16,
@@ -166,8 +166,8 @@
     "data_size": 238,
     "nom_orig": "Ken",
     "texte_orig": "We[SP]thought[SP][U+1113]-san[SP]would[SP]be[SP]a[SP]good\nfit.[1205][001E][SP]And[SP]he's[SP]reliable,[SP]so[SP]we[SP]thought\nyou'd[SP]be[SP]happy[SP]to[SP]have[SP]him[SP]aboard...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ken",
+    "texte_fr": "On s'est dit que [U+1113]-san ferait\nl'affaire.[1205][001E] Et il est fiable, alors on a\npensé que ça vous ferait plaisir..."
   },
   {
     "id": 17,
@@ -176,8 +176,8 @@
     "data_size": 196,
     "nom_orig": "Eikichi",
     "texte_orig": "Y-You[SP]guys...[1205][001E][SP]You[SP]knew[SP]what[SP]would\nhappen[SP]if[SP]you[SP]violated[SP]Bro[SP]Code[SP]and\nyou[SP]still...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "L-Les gars...[1205][001E] Vous saviez ce qui arrive\nsi on brise le Code des Potes, et\npourtant vous avez..."
   },
   {
     "id": 18,
@@ -186,8 +186,8 @@
     "data_size": 268,
     "nom_orig": "Shogo,[SP]Ken[SP]&[SP]Takeshi",
     "texte_orig": "Yes,[SP]sir![SP][1432][NULL][NULL][0014]Cowardice[SP]is[SP]unbefitting[SP]of[SP]a\nreal[SP]man![1432][NULL][NULL][0014][SP]We'll[SP]take[SP]whatever[SP]punishment\nyou[SP]have[SP]in[SP]store!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Shogo, Ken & Takeshi",
+    "texte_fr": "Oui, chef ! [1432][NULL][NULL][0014]La lâcheté est indigne\nd'un vrai homme ![1432][NULL][NULL][0014] On acceptera n'importe\nquelle punition de votre part !"
   },
   {
     "id": 19,
@@ -196,8 +196,8 @@
     "data_size": 266,
     "nom_orig": "Kozy",
     "texte_orig": "Um...[SP]So[SP]that[SP]stuff[SP]about[SP]telling[SP]me[SP]the\nmystery[SP]of[SP]the[SP]emblem[SP]curse...[1205][001E][SP]Was[SP]that\nall[SP]a[SP]lie?[SP]If[SP]so,[SP]then[SP]I'm[SP]going[SP]to[SP]go.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Kozy",
+    "texte_fr": "Euh... Donc l'histoire sur le mystère\nde la malédiction de l'emblème...[1205][001E] C'était\nun mensonge ? Si c'est le cas, je m'en vais."
   },
   {
     "id": 20,
@@ -206,8 +206,8 @@
     "data_size": 142,
     "nom_orig": "Lisa",
     "texte_orig": "*sigh*[1205][001E][SP]We[SP]should[SP]go[SP]too,[SP][U+1113].[SP]This[SP]is\nso[SP]stupid[SP]I[SP]might[SP]cry.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "*soupir*[1205][001E] On devrait y aller aussi, [U+1113].\nC'est tellement stupide que j'ai envie de pleurer."
   },
   {
     "id": 21,
@@ -216,8 +216,8 @@
     "data_size": 50,
     "nom_orig": "Eikichi",
     "texte_orig": "Hold[SP]it,[SP][U+1113]!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Pas si vite, [U+1113] !"
   },
   {
     "id": 22,
@@ -226,8 +226,8 @@
     "data_size": 208,
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]hate[SP]to[SP]stoop[SP]this[SP]low...[1205][001E][SP]But[SP]for[SP]the\nsake[SP]of[SP]my[SP]bros,[SP]I[SP]can't[SP]let[SP]you[SP]go\nthat[SP]easily.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Je déteste m'abaisser à ça...[1205][001E] Mais pour\nle bien de mes potes, je peux pas\nte laisser partir si facilement."
   },
   {
     "id": 23,
@@ -236,8 +236,8 @@
     "data_size": 152,
     "nom_orig": "Eikichi",
     "texte_orig": "For[SP]my[SP]honor[SP]as[SP]the[SP]Death[SP]Boss,\nI'm[SP]dragging[SP]you[SP]into[SP]my[SP]band!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Pour mon honneur en tant que Boss de la Mort,\nje vais t'embarquer dans mon groupe !"
   },
   {
     "id": 24,
@@ -246,8 +246,8 @@
     "data_size": 106,
     "nom_orig": "Lisa",
     "texte_orig": "[1432][NULL][NULL][0014]Death[SP]Boss[1432][NULL][NULL][0014]!?[SP]More[SP]like[SP]Undie[SP]Boss!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "[1432][NULL][NULL][0014]Boss de la Mort[1432][NULL][NULL][0014] !? Plutôt Boss des Calbutes !"
   },
   {
     "id": 25,
@@ -256,8 +256,8 @@
     "data_size": 162,
     "nom_orig": "Lisa",
     "texte_orig": "I've[SP]heard[SP]the[SP]rumors![SP]You[SP]became\nBoss[SP]by[SP]pantsing[SP]people,[SP]didn't[SP]you?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "J'ai entendu les rumeurs ! Tu es devenu\nBoss en baissant les pantalons des gens, non ?"
   },
   {
     "id": 26,
@@ -266,8 +266,8 @@
     "data_size": 64,
     "nom_orig": "Ken",
     "texte_orig": "U-Uh-oh...[SP]Michel-san!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ken",
+    "texte_fr": "O-Oh oh... Michel-san !"
   },
   {
     "id": 27,
@@ -276,8 +276,8 @@
     "data_size": 44,
     "nom_orig": "Eikichi",
     "texte_orig": "Undie...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Calbute..."
   },
   {
     "id": 28,
@@ -286,7 +286,7 @@
     "data_size": 70,
     "nom_orig": "Lisa",
     "texte_orig": "Wh-What's[SP]happening...!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Qu-Qu'est-ce qui se passe... !?"
   }
 ]


### PR DESCRIPTION
Updated French translations for various dialogue entries in script_002.json.
- Traduction complète du fichier script_002.json (IDs 0 à 28).
- Remplacement des balises [SP] par des espaces classiques.
- Conservation stricte des codes de contrôle ([1205][001E], variables de nom [U+1113], menus de choix).
- Adaptation et localisation du texte (argot lycéen, "Undie Boss" traduit par "Boss des Calbutes", "Bro Code" par "Code des Potes").
- Vérification de la concision pour limiter le dépassement du slot_size.