### PR TITLE
[Script 003] Traduction de l'introduction de Philemon (IDs 0-7)

### DIFF
--- a/scripts/script_003.json
+++ b/scripts/script_003.json
@@ -6,8 +6,8 @@
     "data_size": 248,
     "nom_orig": "Philemon",
     "texte_orig": "Welcome[SP]to[SP]the[SP]gulf[SP]between[SP]consciousness\nand[SP]unconsciousness...[1205][001E][SP]My[SP]name[SP]is[SP]Philemon.[1205][001E]\nHave[SP]you[SP]forgotten?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Philemon",
+    "texte_fr": "Bienvenue dans l'abîme entre conscience\net inconscience...[1205][001E] Mon nom est Philemon.[1205][001E]\nAvez-vous oublié ?"
   },
   {
     "id": 1,
@@ -16,8 +16,8 @@
     "data_size": 52,
     "nom_orig": "Lisa",
     "texte_orig": "Phile...mon...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Phile...mon... ?"
   },
   {
     "id": 2,
@@ -26,8 +26,8 @@
     "data_size": 294,
     "nom_orig": "Philemon",
     "texte_orig": "The[SP]power[SP]you[SP]hold[SP]is[SP]called[SP][E4][NULL][NULL][U+0006]Persona[E4][NULL][NULL][0002].[1205][001E][SP]It\nis[SP]the[SP]power[SP]to[SP]summon[SP]the[SP]selves[SP]within\nyou,[SP]the[SP]gods[SP]and[SP]the[SP]demons[SP]you[SP]harbor.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Philemon",
+    "texte_fr": "Le pouvoir que vous détenez se nomme [E4][NULL][NULL][U+0006]Persona[E4][NULL][NULL][0002].[1205][001E] C'est\nle pouvoir d'invoquer les entités enfouies en\nvous, les dieux et les démons que vous abritez."
   },
   {
     "id": 3,
@@ -36,8 +36,8 @@
     "data_size": 270,
     "nom_orig": "Philemon",
     "texte_orig": "The[SP]self[SP]suffused[SP]with[SP]divine[SP]love...[1205][001E]\nThe[SP]self[SP]capable[SP]of[SP]demonic[SP]cruelty...[1205][001E]\nPeople[SP]live[SP]by[SP]wearing[SP]different[SP]masks.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Philemon",
+    "texte_fr": "Le moi baigné d'amour divin...[1205][001E]\nLe moi capable de cruauté démoniaque...[1205][001E]\nLes gens vivent en portant différents masques."
   },
   {
     "id": 4,
@@ -46,8 +46,8 @@
     "data_size": 244,
     "nom_orig": "Philemon",
     "texte_orig": "Your[SP]current[SP]self[SP]is[SP]only[SP]one[SP]of[SP]these\ninnumerable[SP]masks.[SP]Your[SP]Persona[SP]is[SP]also\namong[SP]your[SP]countless[SP]selves.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Philemon",
+    "texte_fr": "Votre moi actuel n'est qu'un de ces\ninnombrables masques. Votre Persona figure\naussi parmi vos multiples facettes."
   },
   {
     "id": 5,
@@ -56,8 +56,8 @@
     "data_size": 98,
     "nom_orig": "Eikichi",
     "texte_orig": "That's...[SP]me...?[1205][001E]\nWhat[SP]are[SP]you...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "C'est... moi... ?[1205][001E]\nT'es quoi, toi... ?"
   },
   {
     "id": 6,
@@ -66,8 +66,8 @@
     "data_size": 184,
     "nom_orig": "Philemon",
     "texte_orig": "From[SP]here[SP]on,[SP]you[SP]will[SP]face[SP]a[SP]fearsome\nentity[SP]which[SP]threatens[SP]your[SP]existence.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Philemon",
+    "texte_fr": "Dès à présent, vous ferez face à une entité\nredoutable qui menace votre existence."
   },
   {
     "id": 7,
@@ -76,7 +76,7 @@
     "data_size": 294,
     "nom_orig": "Philemon",
     "texte_orig": "From[SP]time[SP]out[SP]of[SP]mind,[SP]beyond[SP]oblivion...\nThe[SP]land[SP]of[SP]Sumaru[SP]is[SP]now[SP]a[SP]netherworld[SP]where\nrumors[SP]are[SP]reality.[1205][001E][SP]The[SP]battle[SP]is[SP]begun...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Philemon",
+    "texte_fr": "Depuis la nuit des temps, par-delà l'oubli...\nSumaru est devenu un monde ténébreux où les\nrumeurs sont réalité.[1205][001E] La bataille commence..."
   }
 ]


### PR DESCRIPTION
- Traduction complète du fichier script_003.json (IDs 0 à 7).
- Remplacement des balises [SP] par des espaces classiques.
- Conservation stricte des codes de contrôle ([1205][001E]) et de formatage liés au mot "Persona" ([E4][NULL][NULL][U+0006]...).
- Adaptation du champ lexical pour correspondre au ton mystique de Philemon ("abîme" entre conscience et inconscience, "monde ténébreux", "multiples facettes").
- Vérification de la concision pour respecter les limites de slot_size.