### PR TITLE
[Script 004] Traduction de l'invocation du Joker (IDs 0-27)

### DIFF
--- a/scripts/script_004.json
+++ b/scripts/script_004.json
@@ -6,8 +6,8 @@
     "data_size": 114,
     "nom_orig": "Kozy",
     "texte_orig": "Eikichi-ku--[1205][001E]I[SP]mean,[SP]Boss-san!\nAre[SP]you[SP]okay!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Kozy",
+    "texte_fr": "Eikichi-ku--[1205][001E] Enfin je veux dire, Boss-san !\nVous allez bien !?"
   },
   {
     "id": 1,
@@ -16,8 +16,8 @@
     "data_size": 94,
     "nom_orig": "Eikichi",
     "texte_orig": "That...[1205][001E][SP]wasn't[SP]a[SP]dream,[SP]was[SP]it?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "C'était...[1205][001E] pas un rêve, hein ?"
   },
   {
     "id": 2,
@@ -26,8 +26,8 @@
     "data_size": 154,
     "nom_orig": "Lisa",
     "texte_orig": "I[SP]knew[SP]it...![1205][001E][SP]I[SP]saw[SP]it,[SP]too.[SP]It[SP]called\nthose[SP]things[SP]Personas...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "J'en étais sûre... ![1205][001E] Je l'ai vu aussi. Ça\nappelait ces trucs des Personas... ?"
   },
   {
     "id": 3,
@@ -36,8 +36,8 @@
     "data_size": 268,
     "nom_orig": "Eikichi",
     "texte_orig": "Even[SP]the[SP]part[SP]about[SP]rumors[SP]coming[SP]true,\nand[SP]the[SP]stuff[SP]about[SP]the[SP]future...?[1205][001E][SP]That's\ntoo[SP]much[SP]for[SP]it[SP]to[SP]be[SP]a[SP]coincidence.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Même la partie sur les rumeurs qui\ndeviennent réalité, et les trucs sur l'avenir... ?[1205][001E]\nÇa fait trop pour que ce soit une coïncidence."
   },
   {
     "id": 4,
@@ -46,8 +46,8 @@
     "data_size": 114,
     "nom_orig": "Lisa",
     "texte_orig": "Hey,[SP]I[SP]know...[1205][001E][SP]You[SP]wanna[SP]try[SP]the\nJoker[SP]Game?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Eh, je sais...[1205][001E] Tu veux essayer le\nJeu du Joker ?"
   },
   {
     "id": 5,
@@ -56,8 +56,8 @@
     "data_size": 202,
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]thing[SP]where[SP]you[SP]call[SP]your[SP]own[SP]cell\nand[SP]it[SP]shows[SP]up?[1205][001E][SP]Why[SP]would[SP]I[SP]want[SP]to\ntry[SP]that?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Le truc où tu appelles ton propre\nportable et où il se pointe ?[1205][001E] Pourquoi je\nvoudrais essayer ça ?"
   },
   {
     "id": 6,
@@ -66,8 +66,8 @@
     "data_size": 240,
     "nom_orig": "Lisa",
     "texte_orig": "To[SP]test[SP]if[SP]that[SP]was[SP]just[SP]a[SP]dream[SP]or\nsomething[SP]more.[1205][001E][SP]If[SP]the[SP]rumor[SP]really\ncomes[SP]true,[SP]then[SP]it[SP]was[SP]all[SP]real...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Pour voir si c'était juste un rêve ou\nquelque chose de plus.[1205][001E] Si la rumeur se\nréalise, alors c'était bien vrai..."
   },
   {
     "id": 7,
@@ -76,8 +76,8 @@
     "data_size": 142,
     "nom_orig": "Eikichi",
     "texte_orig": "I'll[SP]pass.[1205][001E][SP]There's[SP]no[SP]way[SP]all[SP]that\ncould[SP]be[SP]possible...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Je passe mon tour.[1205][001E] C'est impossible que\ntout ça soit vrai..."
   },
   {
     "id": 8,
@@ -86,8 +86,8 @@
     "data_size": 158,
     "nom_orig": "Lisa",
     "texte_orig": "That's[SP]why[SP]I'll[SP]prove[SP]it.[1205][001E][SP]Hey...[1205][001E][SP]Are[SP]you\nscared[SP]or[SP]something...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "C'est pour ça que je vais le prouver.[1205][001E]\nHé...[1205][001E] T'as peur ou quoi... ?"
   },
   {
     "id": 9,
@@ -96,8 +96,8 @@
     "data_size": 270,
     "nom_orig": "Eikichi",
     "texte_orig": "If[SP]you[SP]say[SP]so...[1205][001E][SP]It[SP]does[SP]feel[SP]like[SP]we\nshould[SP]be[SP]doing[SP]something[SP]after[SP]a[SP]dream\nlike[SP]that.[SP]Let's[SP]see[SP]if[SP]this[SP]is[SP]for[SP]real.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Si tu le dis...[1205][001E] C'est vrai qu'on devrait\nfaire quelque chose après un rêve\npareil. Voyons si c'est pour de vrai."
   },
   {
     "id": 10,
@@ -106,8 +106,8 @@
     "data_size": 124,
     "nom_orig": "Ken",
     "texte_orig": "*sigh*[1205][001E][SP]Why[SP]are[SP]we[SP]the[SP]ones[SP]who[SP]have\nto[SP]do[SP]this...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ken",
+    "texte_fr": "*soupir*[1205][001E] Pourquoi c'est nous qui\ndevons faire ça... ?"
   },
   {
     "id": 11,
@@ -116,8 +116,8 @@
     "data_size": 140,
     "nom_orig": "Lisa",
     "texte_orig": "Well[SP]then,[SP]here[SP]goes...[1205][001E][SP]Joker,[SP]Joker,\nplease[SP]come[SP]here...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Bon, on y va...[1205][001E] Joker, Joker, s'il te plaît,\nviens ici..."
   },
   {
     "id": 12,
@@ -126,8 +126,8 @@
     "data_size": 40,
     "nom_orig": "Lisa",
     "texte_orig": "No[SP]way...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Pas possible..."
   },
   {
     "id": 13,
@@ -136,8 +136,8 @@
     "data_size": 74,
     "nom_orig": "Ken,[SP]Shogo[SP]&[SP]Takeshi",
     "texte_orig": "It[SP]just...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ken, Shogo & Takeshi",
+    "texte_fr": "Ça a juste..."
   },
   {
     "id": 14,
@@ -146,8 +146,8 @@
     "data_size": 52,
     "nom_orig": "Lisa",
     "texte_orig": "Um...[SP]Hello...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Euh... Allô... ?"
   },
   {
     "id": 15,
@@ -156,8 +156,8 @@
     "data_size": 46,
     "nom_orig": "???",
     "texte_orig": "Behind[SP]you...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "???",
+    "texte_fr": "Derrière vous..."
   },
   {
     "id": 16,
@@ -166,8 +166,8 @@
     "data_size": 188,
     "nom_orig": "Joker",
     "texte_orig": "I[SP]am[SP]Joker...[1205][001E][SP]The[SP]final[SP]trump[SP]card[SP]drawn\nby[SP]those[SP]anguished[SP]over[SP]their[SP]dreams...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Je suis le Joker...[1205][001E] L'atout final tiré\npar ceux que leurs rêves tourmentent..."
   },
   {
     "id": 17,
@@ -176,8 +176,8 @@
     "data_size": 310,
     "nom_orig": "Joker",
     "texte_orig": "Tell[SP]me[SP]your[SP]ideal...\n[E1][E2][E4][NULL][NULL][0010]Joker\n[SP]A[SP]masked[SP]figure[SP]rumored[SP]to[SP]grant[SP]one's\n[SP]dreams.[SP]Why[SP]he[SP]does[SP]this,[SP]and[SP]who[SP]he[SP]is,\n[SP]is[SP]a[SP]complete[SP]mystery.[E4][NULL][NULL][U+0001]",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Dites-moi votre idéal...\nJoker\nUne figure masquée censée exaucer\nles rêves. Ses motivations et son identité\nsont un mystère total."
   },
   {
     "id": 18,
@@ -186,8 +186,8 @@
     "data_size": 256,
     "nom_orig": "Kozy",
     "texte_orig": "No![SP]You[SP]have[SP]to[SP]hurry[SP]and[SP]tell[SP]it[SP]your\nideals![SP]The[SP]rumor[SP]says[SP]that[SP]those[SP]who\ndon't[SP]get[SP]turned[SP]into[SP][E4][NULL][NULL][U+0006]shadowmen[E4][NULL][NULL][0002]!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Kozy",
+    "texte_fr": "Non ! Vous devez vite lui révéler vos\nidéaux ! La rumeur dit que ceux qui\nrefusent se changent en [E4][NULL][NULL][U+0006]hommes-ombres[E4][NULL][NULL][0002] !"
   },
   {
     "id": 19,
@@ -196,8 +196,8 @@
     "data_size": 98,
     "nom_orig": "Joker",
     "texte_orig": "Your[SP]trump[SP]cards[SP]have[SP]been[SP]spoiled...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Vos atouts ont été gâchés..."
   },
   {
     "id": 20,
@@ -206,8 +206,8 @@
     "data_size": 250,
     "nom_orig": "Joker",
     "texte_orig": "The[SP]bet[SP]on[SP]the[SP]table[SP]was[SP]your[SP]inner,\ndreaming[SP]heart...[1205][001E][SP]In[SP]accordance[SP]with[SP]the\nritual,[SP]I[SP]will[SP]now[SP]claim[SP]the[SP]pot.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "La mise sur la table était votre cœur\nrêveur profond...[1205][001E] Conformément au\nrituel, je vais à présent réclamer le gain."
   },
   {
     "id": 21,
@@ -216,8 +216,8 @@
     "data_size": 46,
     "nom_orig": "Ken",
     "texte_orig": "A-Aaaaaah...!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ken",
+    "texte_fr": "A-Aaaaaah... !"
   },
   {
     "id": 22,
@@ -226,8 +226,8 @@
     "data_size": 72,
     "nom_orig": "Eikichi",
     "texte_orig": "K-Ken![SP]Shogo![SP]Takeshi!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "K-Ken ! Shogo ! Takeshi !"
   },
   {
     "id": 23,
@@ -236,8 +236,8 @@
     "data_size": 96,
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]bastard...[1205][001E][SP]What[SP]did[SP]you[SP]do!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Espèce d'enfoiré...[1205][001E] Qu'est-ce que t'as fait !?"
   },
   {
     "id": 24,
@@ -246,8 +246,8 @@
     "data_size": 272,
     "nom_orig": "Joker",
     "texte_orig": "Ideals[SP]only[SP]cause[SP]pain[SP]to[SP]the[SP]powerless.\nI[SP]have[SP]freed[SP]them[SP]from[SP]that[SP]anguish...[1205][001E]\nBetter[SP]not[SP]to[SP]yearn[SP]for[SP]impossible[SP]dreams.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Les idéaux ne font souffrir que les faibles.\nJe les ai libérés de cette angoisse...[1205][001E]\nMieux vaut ne pas aspirer à des rêves impossibles."
   },
   {
     "id": 25,
@@ -256,8 +256,8 @@
     "data_size": 260,
     "nom_orig": "Joker",
     "texte_orig": "They[SP]are[SP]lifeless[SP]shells[SP]of[SP]dreams...[1205][001E]\nThey[SP]can[SP]be[SP]seen,[SP]but[SP]are[SP]not.[SP]They[SP]will\nbe[SP]forgotten[SP]and[SP]become[SP]true[SP]shadows.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Ce sont des coquilles vides de rêves...[1205][001E]\nOn peut les voir, mais ils ne sont plus. Ils\nseront oubliés et deviendront de vraies ombres."
   },
   {
     "id": 26,
@@ -266,8 +266,8 @@
     "data_size": 132,
     "nom_orig": "Joker",
     "texte_orig": "But[SP]enough[SP]chitchat.[SP]I[SP]have[SP]other[SP]business\nwith[SP]you...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Mais trêve de bavardages. J'ai d'autres\naffaires avec vous..."
   },
   {
     "id": 27,
@@ -276,7 +276,7 @@
     "data_size": 98,
     "nom_orig": "Lisa",
     "texte_orig": "I[SP]can't[SP]move...![1205][001E][SP]Is[SP]it[SP]the[SP]fear...!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Je peux pas bouger... ![1205][001E] C'est la peur...!?"
   }
 ]


### PR DESCRIPTION
- Traduction complète du fichier script_004.json (IDs 0 à 27).
- Remplacement des balises [SP] par des espaces classiques.
- Conservation stricte des codes de contrôle ([1205][001E]) et des balises de couleur pour "shadowmen" traduit par "hommes-ombres".
- Adaptation du dialogue pour différencier le ton familier des lycéens ("Espèce d'enfoiré", "Jeu du Joker") du registre froid et cynique du Joker ("L'atout final tiré", "réclamer le gain").
- Attention portée à la concision (slot_size).
- Note: Les balises de fin [E1][E2]... ont été retirées comme demandé dans l'ID 17.