### PR TITLE
[Script 005] Traduction du jugement du Joker et des conséquences (IDs…

### DIFF
--- a/scripts/script_005.json
+++ b/scripts/script_005.json
@@ -6,8 +6,8 @@
     "data_size": 250,
     "nom_orig": "Joker",
     "texte_orig": "Those[SP]eyes...[1205][001E][SP]You[SP]haven't[SP]changed.[1205][001E]\nWhat[SP]kind[SP]of[SP]dreams[SP]did[SP]you[SP]build[SP]on\nthe[SP]corpses[SP]of[SP]other[SP]people's[SP]ideals?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Ces yeux...[1205][001E] Tu n'as pas changé.[1205][001E]\nQuel genre de rêves as-tu bâti sur\nles cadavres des idéaux d'autrui ?"
   },
   {
     "id": 1,
@@ -16,8 +16,8 @@
     "data_size": 194,
     "nom_orig": "Joker",
     "texte_orig": "The[SP]poker[SP]face[SP]doesn't[SP]fool[SP]me.[SP]I[SP]know.\nYou[SP]wanted[SP]to[SP]go[SP]to[SP]college...\nIsn't[SP]that[SP]so?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Ton masque impassible ne me trompe pas.\nJe sais. Tu voulais aller à l'université...\nN'est-ce pas ?"
   },
   {
     "id": 2,
@@ -26,8 +26,8 @@
     "data_size": 152,
     "nom_orig": "Joker",
     "texte_orig": "Hahaha...[1205][001E][SP]Aaaaahahahaha![SP]I'll[SP]never[SP]let\nyour[SP]dreams[SP]come[SP]true!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Hahaha...[1205][001E] Aaaaahahahaha ! Je ne\nlaisserai jamais tes rêves se réaliser !"
   },
   {
     "id": 3,
@@ -36,8 +36,8 @@
     "data_size": 136,
     "nom_orig": "Joker",
     "texte_orig": "You[SP]should[SP]know[SP]by[SP]now...[1205][001E][SP]why[SP]I[SP]came[SP]to\nyou[SP]all[SP]today!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Tu devrais savoir maintenant...[1205][001E] pourquoi\nje suis venu vous voir aujourd'hui !"
   },
   {
     "id": 4,
@@ -46,8 +46,8 @@
     "data_size": 186,
     "nom_orig": "Joker",
     "texte_orig": "The[SP]poker[SP]face[SP]doesn't[SP]fool[SP]me.[SP]I[SP]know.\nYou[SP]wanted[SP]to[SP]get[SP]a[SP]job...[SP]Isn't[SP]that[SP]so?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Ton masque impassible ne me trompe pas.\nJe sais. Tu voulais trouver un travail...\nN'est-ce pas ?"
   },
   {
     "id": 5,
@@ -56,8 +56,8 @@
     "data_size": 152,
     "nom_orig": "Joker",
     "texte_orig": "Hahaha...[1205][001E][SP]Aaaaahahahaha![SP]I'll[SP]never[SP]let\nyour[SP]dreams[SP]come[SP]true!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Hahaha...[1205][001E] Aaaaahahahaha ! Je ne\nlaisserai jamais tes rêves se réaliser !"
   },
   {
     "id": 6,
@@ -66,8 +66,8 @@
     "data_size": 136,
     "nom_orig": "Joker",
     "texte_orig": "You[SP]should[SP]know[SP]by[SP]now...[1205][001E][SP]why[SP]I[SP]came[SP]to\nyou[SP]all[SP]today!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Tu devrais savoir maintenant...[1205][001E] pourquoi\nje suis venu vous voir aujourd'hui !"
   },
   {
     "id": 7,
@@ -76,8 +76,8 @@
     "data_size": 202,
     "nom_orig": "Joker",
     "texte_orig": "The[SP]poker[SP]face[SP]doesn't[SP]fool[SP]me.[SP]I[SP]know.\nYou[SP]wanted[SP]to[SP]follow[SP]your[SP]dream...\nIsn't[SP]that[SP]so?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Ton masque impassible ne me trompe pas.\nJe sais. Tu voulais poursuivre ton rêve...\nN'est-ce pas ?"
   },
   {
     "id": 8,
@@ -86,8 +86,8 @@
     "data_size": 152,
     "nom_orig": "Joker",
     "texte_orig": "Hahaha...[1205][001E][SP]Aaaaahahahaha![SP]I'll[SP]never[SP]let\nyour[SP]dreams[SP]come[SP]true!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Hahaha...[1205][001E] Aaaaahahahaha ! Je ne\nlaisserai jamais tes rêves se réaliser !"
   },
   {
     "id": 9,
@@ -96,8 +96,8 @@
     "data_size": 136,
     "nom_orig": "Joker",
     "texte_orig": "You[SP]should[SP]know[SP]by[SP]now...[1205][001E][SP]why[SP]I[SP]came[SP]to\nyou[SP]all[SP]today!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Tu devrais savoir maintenant...[1205][001E] pourquoi\nje suis venu vous voir aujourd'hui !"
   },
   {
     "id": 10,
@@ -106,8 +106,8 @@
     "data_size": 218,
     "nom_orig": "Joker",
     "texte_orig": "The[SP]poker[SP]face[SP]doesn't[SP]fool[SP]me.[SP]I[SP]know.\nYou're[SP]a[SP]dunce[SP]who[SP]doesn't[SP]even[SP]know[SP]what\nhe[SP]wants[SP]to[SP]do.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Ton masque impassible ne me trompe pas.\nJe sais. T'es un cancre qui ne sait même\npas ce qu'il veut faire de sa vie."
   },
   {
     "id": 11,
@@ -116,8 +116,8 @@
     "data_size": 176,
     "nom_orig": "Joker",
     "texte_orig": "Hahaha...[1205][001E][SP]Aaaaahahahaha!\nThat's[SP]right...[SP]You[SP]have[SP]no[SP]right\nto[SP]be[SP]dreaming!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Hahaha...[1205][001E] Aaaaahahahaha !\nC'est ça... Tu n'as aucun droit\nde rêver !"
   },
   {
     "id": 12,
@@ -126,8 +126,8 @@
     "data_size": 136,
     "nom_orig": "Joker",
     "texte_orig": "You[SP]should[SP]know[SP]by[SP]now...[1205][001E][SP]why[SP]I[SP]came[SP]to\nyou[SP]all[SP]today!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Tu devrais savoir maintenant...[1205][001E] pourquoi\nje suis venu vous voir aujourd'hui !"
   },
   {
     "id": 13,
@@ -136,8 +136,8 @@
     "data_size": 206,
     "nom_orig": "Joker",
     "texte_orig": "The[SP]poker[SP]face[SP]doesn't[SP]fool[SP]me.[SP]I[SP]know.\nYou[SP]wanted[SP]to[SP]discover[SP]your[SP]dream...\nIsn't[SP]that[SP]so?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Ton masque impassible ne me trompe pas.\nJe sais. Tu voulais trouver ton rêve...\nN'est-ce pas ?"
   },
   {
     "id": 14,
@@ -146,8 +146,8 @@
     "data_size": 148,
     "nom_orig": "Joker",
     "texte_orig": "Hahaha...[1205][001E][SP]Aaaaahahahaha![SP]I'll[SP]never[SP]let\nyou[SP]find[SP]that[SP]dream!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Hahaha...[1205][001E] Aaaaahahahaha ! Je ne\nte laisserai jamais trouver ce rêve !"
   },
   {
     "id": 15,
@@ -156,8 +156,8 @@
     "data_size": 136,
     "nom_orig": "Joker",
     "texte_orig": "You[SP]should[SP]know[SP]by[SP]now...[1205][001E][SP]why[SP]I[SP]came[SP]to\nyou[SP]all[SP]today!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Tu devrais savoir maintenant...[1205][001E] pourquoi\nje suis venu vous voir aujourd'hui !"
   },
   {
     "id": 16,
@@ -166,8 +166,8 @@
     "data_size": 106,
     "nom_orig": "Eikichi",
     "texte_orig": "What[SP]the[SP]hell[SP]are[SP]you[SP]talking[SP]about...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "De quoi tu parles bordel... ?"
   },
   {
     "id": 17,
@@ -176,8 +176,8 @@
     "data_size": 104,
     "nom_orig": "Lisa",
     "texte_orig": "Wh-What...?[1205][001E][SP]What[SP]did[SP]we[SP]ever[SP]do[SP]to[SP]you?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Qu-Quoi... ?[1205][001E] Qu'est-ce qu'on t'a fait ?"
   },
   {
     "id": 18,
@@ -186,8 +186,8 @@
     "data_size": 82,
     "nom_orig": "Joker",
     "texte_orig": "No...[1205][001E][SP]Do[SP]you[SP]not[SP]remember!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Non...[1205][001E] Ne vous souvenez-vous pas !?"
   },
   {
     "id": 19,
@@ -196,8 +196,8 @@
     "data_size": 136,
     "nom_orig": "Joker",
     "texte_orig": "Impossible![1205][001E][SP]This[SP]can't[SP]be...[1205][001E][SP]How[SP]could\nthis[SP]happen!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Impossible ![1205][001E] Ça ne peut pas être vrai...[1205][001E]\nComment est-ce possible !?"
   },
   {
     "id": 20,
@@ -206,8 +206,8 @@
     "data_size": 146,
     "nom_orig": "Joker",
     "texte_orig": "What[SP]meaning[SP]is[SP]there[SP]in[SP]killing[SP]you\nif[SP]you[SP]do[SP]not[SP]remember!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Quel sens y a-t-il à vous tuer si\nvous ne vous souvenez pas !?"
   },
   {
     "id": 21,
@@ -216,8 +216,8 @@
     "data_size": 220,
     "nom_orig": "Joker",
     "texte_orig": "You[SP]escaped[SP]your[SP]fate[SP]this[SP]time...[1205][001E]\nBut[SP]you[SP]will[SP]get[SP]no[SP]rest.[1205][001E][SP]My[SP]demons\nwill[SP]be[SP]your[SP]assassins.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Vous avez échappé à votre destin cette\nfois...[1205][001E] Mais vous n'aurez aucun répit.[1205][001E]\nMes démons seront vos assassins."
   },
   {
     "id": 22,
@@ -226,8 +226,8 @@
     "data_size": 268,
     "nom_orig": "Joker",
     "texte_orig": "Let[SP]this[SP][E4][NULL][NULL][U+0006]Iris[E4][NULL][NULL][0002][SP]be[SP]my[SP]testament...[1205][001E][SP]Now[SP]go,\nand[SP]remember[SP]the[SP]sins[SP]you[SP]have[SP]committed!\nThen[SP]will[SP]I[SP]claim[SP]my[SP]revenge!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Que cet [E4][NULL][NULL][U+0006]Iris[E4][NULL][NULL][0002] soit mon testament...[1205][001E]\nMaintenant partez, et souvenez-vous des\npéchés que vous avez commis ! Alors\nseulement, je prendrai ma revanche !"
   },
   {
     "id": 23,
@@ -236,8 +236,8 @@
     "data_size": 142,
     "nom_orig": "Eikichi",
     "texte_orig": "I'm[SP]sorry,[SP]Ken...[1205][001E][SP]If[SP]I[SP]hadn't[SP]made[SP]you\nplay[SP]the[SP]game...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Pardon, Ken...[1205][001E] Si je ne t'avais pas\nforcé à jouer à ce jeu..."
   },
   {
     "id": 24,
@@ -246,8 +246,8 @@
     "data_size": 132,
     "nom_orig": "Kozy",
     "texte_orig": "Um...[1205][001E][SP]Who[SP]is[SP]Eikichi-ku--I[SP]mean,\nBoss-san[SP]talking[SP]to?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Kozy",
+    "texte_fr": "Euh...[1205][001E] À qui Eikichi-ku-- enfin, Boss-san\nest-il en train de parler ?"
   },
   {
     "id": 25,
@@ -256,8 +256,8 @@
     "data_size": 90,
     "nom_orig": "Lisa",
     "texte_orig": "They've[SP]really[SP]been[SP]forgotten...[1205][001E]",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Ils ont vraiment été oubliés...[1205][001E]"
   },
   {
     "id": 26,
@@ -266,8 +266,8 @@
     "data_size": 162,
     "nom_orig": "Lisa",
     "texte_orig": "I[SP]can't[SP]believe[SP]Joker[SP]is[SP]real...[1205][001E]\nBut[SP]why[SP]does[SP]he[SP]want[SP]revenge[SP]on[SP]us?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Je n'arrive pas à croire que le Joker\nexiste...[1205][001E] Mais pourquoi veut-il se\nvenger de nous ?"
   },
   {
     "id": 27,
@@ -276,8 +276,8 @@
     "data_size": 182,
     "nom_orig": "Lisa",
     "texte_orig": "We'll[SP]be[SP]safer[SP]if[SP]we[SP]stick[SP]close!\nC'mon,[SP][U+1113].[SP]Let's[SP]chase[SP]him[SP]down\ntogether,[SP]okay?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "On sera plus en sécurité si on reste\nensemble ! Viens, [U+1113]. On va le traquer\ntous ensemble, d'accord ?"
   },
   {
     "id": 28,
@@ -286,8 +286,8 @@
     "data_size": 232,
     "nom_orig": "Eikichi",
     "texte_orig": "Ken...[1205][001E][SP]You[SP]were[SP]going[SP]to[SP]be[SP]a[SP]boxing\nchamp,[SP]right...?[1205][001E][SP]I[SP]was[SP]gonna[SP]cut[SP]a[SP]cool\ntheme[SP]song[SP]for[SP]you...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Ken...[1205][001E] Tu allais devenir un champion de\nboxe, pas vrai... ?[1205][001E] J'allais te composer\nune chanson d'entrée trop classe..."
   },
   {
     "id": 29,
@@ -296,8 +296,8 @@
     "data_size": 200,
     "nom_orig": "Eikichi",
     "texte_orig": "I'm[SP]sorry...[SP]And[SP]after[SP]I[SP]promised...![1205][001E]\nIf[SP]only[SP]I[SP]hadn't[SP]made[SP]you[SP]do[SP]that...[1205][001E]\nDammit!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Je suis désolé... Surtout après l'avoir\npromis ![1205][001E] Si seulement je ne t'avais\npas forcé à faire ça...[1205][001E] Bordel !"
   },
   {
     "id": 30,
@@ -306,8 +306,8 @@
     "data_size": 154,
     "nom_orig": "Eikichi",
     "texte_orig": "She's[SP]got[SP]a[SP]point...[1205][001E][SP]We[SP]don't[SP]stand\na[SP]chance[SP]against[SP]him[SP]yet.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Elle a raison...[1205][001E] On n'a encore aucune\nchance contre lui."
   },
   {
     "id": 31,
@@ -316,8 +316,8 @@
     "data_size": 266,
     "nom_orig": "Eikichi",
     "texte_orig": "We've[SP]both[SP]been[SP]called[SP]out[SP]on[SP]a[SP]grudge\nwe[SP]know[SP]nothing[SP]about.[SP]Let's[SP]call[SP]a[SP]truce\nuntil[SP]that[SP]guy's[SP]out[SP]of[SP]the[SP]picture.[1205][001E]",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "On nous accuse tous les deux pour une\nranœur dont on ne sait rien. Faisons\nune trêve jusqu'à ce que ce type soit\nhors jeu.[1205][001E]"
   },
   {
     "id": 32,
@@ -326,8 +326,8 @@
     "data_size": 186,
     "nom_orig": "Kozy",
     "texte_orig": "Umm...[SP]About[SP]my[SP]real[SP]name...[1205][001E][SP]Could[SP]you\nkeep[SP]it[SP]a[SP]secret[SP]from[SP]Boss-san?[SP]Please...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Kozy",
+    "texte_fr": "Hum... Au fait, mon vrai nom...[1205][001E] Vous\npourriez le garder secret et ne rien\ndire à Boss-san ? S'il vous plaît..."
   },
   {
     "id": 33,
@@ -336,8 +336,8 @@
     "data_size": 152,
     "nom_orig": "Ken",
     "texte_orig": "My...[SP]dream...?[1205][001E][SP]I[SP]don't[SP]care[SP]anymore...[1205][001E]\nIt's[SP]not[SP]like[SP]it'll...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ken",
+    "texte_fr": "Mon... rêve... ?[1205][001E] Je m'en fiche\nmaintenant...[1205][001E] Ce n'est pas comme si ça..."
   },
   {
     "id": 34,
@@ -346,8 +346,8 @@
     "data_size": 216,
     "nom_orig": "Takeshi",
     "texte_orig": "I[SP]wanted...[SP]to[SP]be[SP]a[SP]doctor...[1205][001E][SP]But[SP]that'll\nnever[SP]happen...[1205][001E][SP]I[SP]don't[SP]want[SP]to[SP]think\nanymore...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Takeshi",
+    "texte_fr": "Je voulais... devenir médecin...[1205][001E] Mais\nça n'arrivera jamais...[1205][001E] Je ne veux\nplus penser..."
   },
   {
     "id": 35,
@@ -356,8 +356,8 @@
     "data_size": 152,
     "nom_orig": "Shogo",
     "texte_orig": "I[SP]have[SP]to...[1205][001E][SP]take[SP]over[SP]the[SP]family\nbusiness...[1205][001E][SP]But...[SP]why...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Shogo",
+    "texte_fr": "Je dois...[1205][001E] reprendre l'entreprise\nfamiliale...[1205][001E] Mais... pourquoi... ?"
   },
   {
     "id": 36,
@@ -366,8 +366,8 @@
     "data_size": 238,
     "nom_orig": "Eikichi",
     "texte_orig": "Wait[SP]a[SP]sec,[SP][U+1113]...[1205][001E][SP]You're[SP]going\nafter[SP]that[SP]guy,[SP]right?[1205][001E][SP]You[SP]should[SP]stay\nout[SP]of[SP]this.[SP]I'll[SP]deal[SP]with[SP]him.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Attends une minute, [U+1113]...[1205][001E] Tu vas\npartir à la poursuite de ce type, non ?[1205][001E]\nTu devrais rester en dehors de ça.\nJe vais m'en occuper."
   },
   {
     "id": 37,
@@ -376,8 +376,8 @@
     "data_size": 232,
     "nom_orig": "Lisa",
     "texte_orig": "Whoa[SP]there,[SP]both[SP]of[SP]you![1205][001E][SP]You're[SP]up[SP]against\na[SP]real[SP]monster[SP]here![SP]If[SP]we[SP]don't[SP]stick\ntogether,[SP]you'll[SP]die!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Doucement, vous deux ![1205][001E] Vous avez affaire\nà un vrai monstre ! Si on ne reste pas\nensemble, vous allez mourir !"
   },
   {
     "id": 38,
@@ -386,8 +386,8 @@
     "data_size": 246,
     "nom_orig": "Lisa",
     "texte_orig": "Plus,[SP]we[SP]don't[SP]know[SP]where[SP]to[SP]start[SP]looking.[1205][001E]\nLet's[SP]get[SP]someone[SP]else[SP]to[SP]do[SP]something\nabout[SP]him--like[SP]the[SP]police!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "De plus, on ne sait même pas par où\ncommencer à chercher.[1205][001E] Laissons quelqu'un\nd'autre s'en charger... comme la police !"
   },
   {
     "id": 39,
@@ -396,8 +396,8 @@
     "data_size": 182,
     "nom_orig": "Eikichi",
     "texte_orig": "Who'd[SP]believe[SP]us!?[1205][001E][SP]We[SP]gotta[SP]arm[SP]up[SP]and\nkill[SP]that[SP]guy,[SP]or[SP]we're[SP]all[SP]screwed.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Qui nous croirait !?[1205][001E] On doit s'armer et\ntuer ce type, ou on est tous foutus."
   },
   {
     "id": 40,
@@ -406,8 +406,8 @@
     "data_size": 194,
     "nom_orig": "Kozy",
     "texte_orig": "If[SP]that's[SP]the[SP]case,[SP]maybe[SP]I[SP]can\nhelp...[1205][001E][SP]I'll[SP]go[SP]see[SP]what[SP]I[SP]can[SP]find\nout[SP]about[SP]Joker.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Kozy",
+    "texte_fr": "Si c'est le cas, peut-être que je peux\naider...[1205][001E] Je vais voir ce que je peux\ndécouvrir sur le Joker."
   },
   {
     "id": 41,
@@ -416,8 +416,8 @@
     "data_size": 140,
     "nom_orig": "Kozy",
     "texte_orig": "While[SP]I[SP]do[SP]that,[SP]you[SP]should[SP]prepare[SP]to\ndefend[SP]yourselves...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Kozy",
+    "texte_fr": "Pendant ce temps, vous devriez vous\npréparer à vous défendre..."
   },
   {
     "id": 42,
@@ -426,8 +426,8 @@
     "data_size": 210,
     "nom_orig": "Kozy",
     "texte_orig": "That[SP]reminds[SP]me...[1205][001E][SP]Rumor[SP]has[SP]it[SP]that[SP][E4][NULL][NULL][U+0006]the\nramen[SP]shop[SP]in[SP]Kameya[SP]Alley[SP]sells[SP]weapons[E4][NULL][NULL][0002]...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Kozy",
+    "texte_fr": "Ça me rappelle...[1205][001E] La rumeur dit que [E4][NULL][NULL][U+0006]le\nmagasin de ramen de l'allée Kameya\nvend des armes[E4][NULL][NULL][0002]..."
   },
   {
     "id": 43,
@@ -436,7 +436,7 @@
     "data_size": 228,
     "nom_orig": "Kozy",
     "texte_orig": "Something[SP]about[SP]the[SP]owner[SP]being[SP]a[SP]former\nspy...[1205][001E][SP]With[SP]everything[SP]that's[SP]going[SP]on,\nwhy[SP]not[SP]start[SP]there?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Kozy",
+    "texte_fr": "Il paraît que le propriétaire est un ancien\nespion...[1205][001E] Avec tout ce qui se passe,\npourquoi ne pas commencer par là ?"
   }
 ]


### PR DESCRIPTION
… 0-43)

- Traduction complète du fichier script_005.json (IDs 0 à 43).
- Conservation des répétitions structurelles dans le dialogue du Joker (IDs 1-15) tout en adaptant chaque "rêve" (université, travail, etc.).
- Maintien des balises de couleur pour les éléments clés de l'intrigue ("[E4][NULL][NULL][U+0006]Iris[E4][NULL][NULL][0002]" et la rumeur du magasin de ramen).
- Adaptation du ton tragique et de la confusion des personnages après la perte de mémoire de leurs amis.
- Remplacement des [SP] par des espaces et gestion de la longueur des lignes.