### PR TITLE
[Script 007] Traduction de la panique à l'horloge (IDs 0-15)

### DIFF
--- a/scripts/script_007.json
+++ b/scripts/script_007.json
@@ -6,8 +6,8 @@
     "data_size": 144,
     "nom_orig": "Eikichi",
     "texte_orig": "What's[SP]the[SP]matter?[SP]Why[SP]all[SP]this[SP]fuss[SP]over\na[SP]clock[SP]starting?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "C'est quoi le problème ? Pourquoi tout\nce foin pour une horloge qui redémarre ?"
   },
   {
     "id": 1,
@@ -16,8 +16,8 @@
     "data_size": 256,
     "nom_orig": "Lisa",
     "texte_orig": "There's[SP]tons[SP]of[SP]scary[SP]rumors[SP]about[SP]this\ntower![SP]Like,[SP]ghosts[SP]appearing[SP]and[SP]other\nbad[SP]stuff[SP]when[SP]the[SP]clock[SP]starts[SP]again.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Il y a des tonnes de rumeurs flippantes\nsur cette tour ! Genre des fantômes\nqui apparaissent et d'autres trucs\nmauvais quand l'horloge redémarre."
   },
   {
     "id": 2,
@@ -26,8 +26,8 @@
     "data_size": 166,
     "nom_orig": "Janitor",
     "texte_orig": "Oh[SP]no...[SP]What[SP]a[SP]terrible[SP]omen...\nNamu[SP]Amida[SP]Butsu,[SP]Namu[SP]Amida[SP]Butsu...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Concierge",
+    "texte_fr": "Oh non... Quel terrible présage...\nNamu Amida Butsu, Namu Amida Butsu..."
   },
   {
     "id": 3,
@@ -36,8 +36,8 @@
     "data_size": 232,
     "nom_orig": "Eikichi",
     "texte_orig": "Take[SP]it[SP]easy,[SP]gramps![SP]There's[SP]no[SP]need[SP]to\nbe[SP]scared.[SP]Long[SP]as[SP]I'm[SP]around,[SP]you[SP]got\nnothing[SP]to[SP]worry[SP]about!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Du calme, pépé ! Y'a pas de quoi\navoir peur. Tant que je suis dans le\ncoin, t'as pas à t'en faire !"
   },
   {
     "id": 4,
@@ -46,8 +46,8 @@
     "data_size": 262,
     "nom_orig": "Janitor",
     "texte_orig": "No![SP]Something[SP]awful[SP]will[SP]happen![SP]Before\nhe[SP]died,[SP]that[SP]teacher[SP]said,[SP][1432][NULL][NULL][0014]The[SP]world\nwill[SP]end[SP]if[SP]time[SP]is[SP]not[SP]stopped.[1432][NULL][NULL][0014]",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Concierge",
+    "texte_fr": "Non ! Quelque chose d'affreux va arriver !\nAvant de mourir, ce prof a dit : [1432][NULL][NULL][0014]Le monde\nsera détruit si le temps n'est pas arrêté.[1432][NULL][NULL][0014]"
   },
   {
     "id": 5,
@@ -56,8 +56,8 @@
     "data_size": 156,
     "nom_orig": "Lisa",
     "texte_orig": "Are[SP]you[SP]talking[SP]about...[1205][0014][SP]that[SP]teacher[SP]who\ndied[SP]in[SP]the[SP]clock[SP]tower?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Vous parlez de...[1205][0014] ce prof qui\nest mort dans la tour de l'horloge ?"
   },
   {
     "id": 6,
@@ -66,8 +66,8 @@
     "data_size": 234,
     "nom_orig": "Janitor",
     "texte_orig": "Yes,[SP]that's[SP]right...[SP]That[SP]teacher[SP]nobly\nsacrificed[SP]his[SP]life[SP]to[SP]save[SP]the[SP]children\nand[SP]ensure[SP]world[SP]peace!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Concierge",
+    "texte_fr": "Oui, c'est ça... Ce professeur a\nnoblement sacrifié sa vie pour sauver\nles enfants et assurer la paix mondiale !"
   },
   {
     "id": 7,
@@ -76,8 +76,8 @@
     "data_size": 370,
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "No...[SP]This[SP]can't[SP]be![SP][1432][NULL][NULL][0014]The[SP]seven[SP]Pleiades[SP]set\nthe[SP]frozen[SP]time[SP]free[1432][NULL][NULL][0014]...[1205][001E][SP]Has[SP]it[SP]begun!?[E1][E2]\n[E3][E4][NULL][NULL]\"Ms.[SP]Ideal\n*gasp*[1205][0014][SP]The[SP]Narurato[SP]Stone![SP]What[SP]about\nthe[SP]Narurato[SP]Stone!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Ideal",
+    "texte_fr": "Non... C'est impossible ! [1432][NULL][NULL][0014]Les sept Pléiades\nont libéré le temps figé[1432][NULL][NULL][0014]...[1205][001E] Est-ce que\nça a commencé !?[E1][E2]\n[E3][E4][NULL][NULL]\"Mme Ideal\n*halète*[1205][0014] La Pierre Narurato ! Qu'en\nest-il de la Pierre Narurato !?"
   },
   {
     "id": 8,
@@ -86,8 +86,8 @@
     "data_size": 156,
     "nom_orig": "Male[SP]student",
     "texte_orig": "What's[SP]gotten[SP]into[SP]Ms.[SP]Ideal?[SP]Can[SP]this\nday[SP]get[SP]any[SP]crazier!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lycéen",
+    "texte_fr": "Qu'est-ce qui prend à Mme Ideal ?\nCette journée peut-elle être encore\nplus dingue !?"
   },
   {
     "id": 9,
@@ -96,8 +96,8 @@
     "data_size": 134,
     "nom_orig": "Male[SP]student",
     "texte_orig": "The[SP]big[SP]clock's[SP]started[SP]again,[SP]so...\nI'd[SP]say[SP]yes!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lycéen",
+    "texte_fr": "La grande horloge a redémarré,\nalors... je dirais que oui !"
   },
   {
     "id": 10,
@@ -106,8 +106,8 @@
     "data_size": 184,
     "nom_orig": "Female[SP]student",
     "texte_orig": "Can[SP]we[SP]really[SP]prevent[SP]the[SP]curse[SP]by\ntaking[SP]the[SP]emblems[SP]off[SP]our[SP]uniforms!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lycéenne",
+    "texte_fr": "Peut-on vraiment empêcher la malédiction\nen retirant les emblèmes de\nnos uniformes !?"
   },
   {
     "id": 11,
@@ -116,8 +116,8 @@
     "data_size": 54,
     "nom_orig": "Female[SP]student",
     "texte_orig": "Eeeek!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lycéenne",
+    "texte_fr": "Iiiiik !"
   },
   {
     "id": 12,
@@ -126,8 +126,8 @@
     "data_size": 82,
     "nom_orig": "Male[SP]student",
     "texte_orig": "Oh[SP]god![SP]Y-Your[SP]face...!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lycéen",
+    "texte_fr": "Oh mon dieu ! T-Ton visage... !"
   },
   {
     "id": 13,
@@ -136,8 +136,8 @@
     "data_size": 106,
     "nom_orig": "Female[SP]student",
     "texte_orig": "The[SP]curse![SP]It's[SP]the[SP]emblem[SP]curse!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lycéenne",
+    "texte_fr": "La malédiction ! C'est la malédiction\nde l'emblème !"
   },
   {
     "id": 14,
@@ -146,8 +146,8 @@
     "data_size": 110,
     "nom_orig": "Eikichi",
     "texte_orig": "Dude,[SP]what!?[SP]Did[SP]that[SP]girl's[SP]face[SP]just...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Mec, quoi !? Est-ce que le visage\nde cette fille vient de... ?"
   },
   {
     "id": 15,
@@ -156,7 +156,7 @@
     "data_size": 214,
     "nom_orig": "Lisa",
     "texte_orig": "Kehhei!?[SP]What's[SP]going[SP]on!?[SP]Does[SP]this[SP]mean\nit[SP]isn't[SP]enough[SP]to[SP]take[SP]the[SP]emblems[SP]off\nour[SP]uniforms!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Kehhei !? Qu'est-ce qui se passe !?\nEst-ce que ça veut dire que ça ne\nsuffit pas d'enlever les emblèmes de\nnos uniformes !?"
   }
 ]


### PR DESCRIPTION
- Traduction complète du fichier script_007.json (IDs 0 à 15).
- Remplacement des [SP] par des espaces classiques.
- Conservation stricte des balises de couleur et de mise en forme (menus de choix pour les citations, balises de fin [E1][E2][E3][E4]).
- Adaptation du registre de langage : argot pour Eikichi et onomatopées adaptées pour Lisa ("Aiya" et "Hein !?").
- Traduction des noms génériques (Janitor -> Concierge, Male/Female student -> Lycéen(ne)).