### PR TITLE
[Script 009] Rencontre avec Maya et Yukino — formation du groupe (IDs…

### DIFF
--- a/scripts/script_009.json
+++ b/scripts/script_009.json
@@ -6,8 +6,8 @@
     "data_size": 74,
     "nom_orig": "Maya",
     "texte_orig": "Whew...[1205][001E][SP]Is[SP]everyone[SP]okay?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Ouf..[1205][001E] Tout le monde va bien ?"
   },
   {
     "id": 1,
@@ -16,8 +16,8 @@
     "data_size": 102,
     "nom_orig": "Maya",
     "texte_orig": "Whoa![SP]What's[SP]wrong?[SP]Were[SP]you[SP]that[SP]scared?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Waouh ! Qu'est-ce qui se passe ? Vous avez eu si peur ?"
   },
   {
     "id": 2,
@@ -26,8 +26,8 @@
     "data_size": 174,
     "nom_orig": "Ginko",
     "texte_orig": "Huh...?[1205][0014][SP]Why[SP]am[SP]I[SP]crying?[SP]It's[SP]so[SP]strange,\nbut...[SP]*sniff*[1205][0014][SP]I[SP]can't[SP]stop...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Hein...?[1205][0014] Pourquoi je pleure ? C'est trop bizarre,\nmais... *sniff*[1205][0014] J'arrive pas à m'arrêter..."
   },
   {
     "id": 3,
@@ -36,8 +36,8 @@
     "data_size": 232,
     "nom_orig": "Eikichi",
     "texte_orig": "It's...[1205][001E][SP]like[SP]a[SP]nice[SP]memory...[SP]Warmer[SP]than\nwhat[SP]I[SP]felt[SP]with[SP][U+1113][SP]and[SP]Ginko...[1205][001E]\nLike[SP]a[SP]hug[SP]from[SP]my[SP]mom...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "C'est...[1205][001E] comme un bon souvenir... Plus chaud que\nce que je ressens avec [U+1113] et Ginko...[1205][001E]\nComme un câlin de ma mère..."
   },
   {
     "id": 4,
@@ -46,8 +46,8 @@
     "data_size": 152,
     "nom_orig": "Maya",
     "texte_orig": "How[SP]weird...[1205][0014][SP]I[SP]felt[SP]it,[SP]too.[SP]What[SP]was\nthat[SP]wave[SP]of[SP]nostalgia...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "C'est bizarre...[1205][0014] Moi aussi j'ai ressenti ça. C'était\nquoi cette vague de nostalgie...?"
   },
   {
     "id": 5,
@@ -56,8 +56,8 @@
     "data_size": 228,
     "nom_orig": "Yukino",
     "texte_orig": "Could[SP]you[SP]elaborate?[SP]I[SP]know[SP]more[SP]than\nyou'd[SP]think[SP]about[SP]demons.[SP]Maybe[SP]I[SP]could\nhelp[SP]you[SP]kids[SP]out[SP]a[SP]bit.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Développez. Je m'y connais en démons, plus que\nvous croyez. Je peux peut-être\nvous filer un coup de main."
   },
   {
     "id": 6,
@@ -66,8 +66,8 @@
     "data_size": 218,
     "nom_orig": "Maya",
     "texte_orig": "You[SP]mean[SP]you[SP]three[SP]have[SP]the[SP]same[SP]powers\nI[SP]do?[SP]Persona,[SP]huh...[SP]So[SP]it's[SP]not[SP]just\nmy[SP]guardian[SP]angel...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Vous trois, vous avez les mêmes pouvoirs\nque moi ? Persona, hein... Donc c'est pas juste\nmon ange gardien..."
   },
   {
     "id": 7,
@@ -76,8 +76,8 @@
     "data_size": 136,
     "nom_orig": "Maya",
     "texte_orig": "And[SP]wow,[SP]I[SP]can't[SP]believe[SP]you're[SP]a\nPersona-user[SP]too,[SP]Yukki!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Et dire que toi aussi t'es une\nutilisatrice de Persona, Yukki !"
   },
   {
     "id": 8,
@@ -86,8 +86,8 @@
     "data_size": 254,
     "nom_orig": "Yukino",
     "texte_orig": "I've[SP]been[SP]a[SP]Persona-user[SP]since[SP]I[SP]played\nthe[SP][1432][NULL][NULL][0014]Persona[SP]Game[1432][NULL][NULL][0014][SP]back[SP]in[SP]high[SP]school...[1205][0014]\nThat[SP]was[SP]three[SP]years[SP]ago.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "J'utilise le Persona depuis que j'ai fait\nle [1432][NULL][NULL][0014]Jeu du Persona[1432][NULL][NULL][0014] au lycée...[1205][0014]\nY'a trois ans de ça."
   },
   {
     "id": 9,
@@ -96,8 +96,8 @@
     "data_size": 84,
     "nom_orig": "Yukino",
     "texte_orig": "Have[SP]you[SP]guys[SP]never[SP]played[SP]it?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Vous y avez jamais joué ?"
   },
   {
     "id": 10,
@@ -106,8 +106,8 @@
     "data_size": 86,
     "nom_orig": "Eikichi[SP]&[SP]Ginko",
     "texte_orig": "[1432][NULL][NULL][0014]Persona[SP]Game[1432][NULL][NULL][0014]!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi & Ginko",
+    "texte_fr": "[1432][NULL][NULL][0014]Jeu du Persona[1432][NULL][NULL][0014] !?"
   },
   {
     "id": 11,
@@ -116,8 +116,8 @@
     "data_size": 138,
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]played[SP]a[SP]kid's[SP]game[SP]like[SP]that[SP]in\na[SP]dream[SP]once,[SP]but...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "J'ai joué à un truc de gosses comme ça\ndans un rêve, une fois, mais..."
   },
   {
     "id": 12,
@@ -126,8 +126,8 @@
     "data_size": 46,
     "nom_orig": "Ginko",
     "texte_orig": "A[SP]dream...!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Un rêve... !?"
   },
   {
     "id": 13,
@@ -136,8 +136,8 @@
     "data_size": 100,
     "nom_orig": "Yukino",
     "texte_orig": "Lisa,[SP]right?[SP]Know[SP]anything[SP]about[SP]this?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Ginko, c'est ça ? T'en sais quelque chose ?"
   },
   {
     "id": 14,
@@ -146,8 +146,8 @@
     "data_size": 130,
     "nom_orig": "Ginko",
     "texte_orig": "No,[SP]nothing...[SP]I've[SP]never[SP]played[SP]any\ngame[SP]like[SP]that...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Non, rien... J'ai jamais joué à un\ntruc pareil..."
   },
   {
     "id": 15,
@@ -156,8 +156,8 @@
     "data_size": 206,
     "nom_orig": "Maya",
     "texte_orig": "Well,[SP]we[SP]can[SP]save[SP]your[SP]origin[SP]stories\nfor[SP]later.[SP]Let's[SP]focus[SP]on[SP]where[SP]we\nshould[SP]go[SP]from[SP]here!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Bon, vos histoires perso, c'est pour plus\ntard. Concentrons-nous sur ce qu'on\nfait maintenant !"
   },
   {
     "id": 16,
@@ -166,8 +166,8 @@
     "data_size": 128,
     "nom_orig": "Ginko",
     "texte_orig": "Haime!?[SP]Seriously!?[SP]You're[SP]gonna[SP]come\nalong[SP]with[SP]us?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Quoi !? Sérieusement !? Tu vas venir\navec nous ?"
   },
   {
     "id": 17,
@@ -176,8 +176,8 @@
     "data_size": 224,
     "nom_orig": "Maya",
     "texte_orig": "You[SP]three[SP]are[SP]chasing[SP]Joker[SP]himself,\nright?[SP]If[SP]we[SP]could[SP]catch[SP]him,[SP]that[SP]would\nbe[SP]one[SP]hell[SP]of[SP]a[SP]scoop!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Vous trois, vous courez après Joker en personne,\nc'est ça ? Si on l'attrape, ça ferait\nun sacré scoop !"
   },
   {
     "id": 18,
@@ -186,8 +186,8 @@
     "data_size": 170,
     "nom_orig": "Maya",
     "texte_orig": "Plus,[SP]if[SP]we[SP]go[SP]with[SP]you,[SP]maybe[SP]I[SP]can[SP]find\nout[SP]how[SP]I[SP]became[SP]a[SP]Persona-user.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Et en plus, si je viens avec vous, je saurai\npeut-être comment je suis devenue utilisatrice de Persona."
   },
   {
     "id": 19,
@@ -196,8 +196,8 @@
     "data_size": 222,
     "nom_orig": "Yukino",
     "texte_orig": "I'll[SP]tag[SP]along.[SP]Now[SP]that[SP]I[SP]know[SP]this[SP]guy's\nin[SP]cahoots[SP]with[SP]demons,[SP]I[SP]can't[SP]sit[SP]back\nand[SP]do[SP]nothing.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Je viens aussi. Maintenant que je sais que ce type\nest de mèche avec des démons, je peux pas\nrester les bras croisés."
   },
   {
     "id": 20,
@@ -206,8 +206,8 @@
     "data_size": 262,
     "nom_orig": "Ginko",
     "texte_orig": "Hold[SP]on[SP]a[SP]sec![SP]Our[SP]only[SP]lead[SP]is[SP]Principal\nHanya,[SP]and[SP]he's[SP]not[SP]here.[SP]There's[SP]nothing\nfor[SP]us[SP]to[SP]do[SP]even[SP]if[SP]you[SP]come[SP]along!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Attendez une seconde ! Notre seule piste c'est le\ndirecteur Hanya, et il est pas là. Y'a rien\nà faire même si vous venez !"
   },
   {
     "id": 21,
@@ -216,8 +216,8 @@
     "data_size": 122,
     "nom_orig": "Maya",
     "texte_orig": "Then[SP]let's[SP]start[SP]by[SP]putting[SP]an[SP]end[SP]to\nthis[SP]madness!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Alors on commence par mettre fin à\ncette folie !"
   },
   {
     "id": 22,
@@ -226,8 +226,8 @@
     "data_size": 208,
     "nom_orig": "Maya",
     "texte_orig": "If[SP]the[SP]principal[SP]is[SP]behind[SP]the[SP]chaos[SP]like\nyou[SP]think[SP]he[SP]is,[SP]won't[SP]that[SP]draw[SP]him[SP]out\nof[SP]hiding?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Si le directeur est derrière tout ce bazar comme\nvous le pensez, ça le fera pas sortir\nde sa planque ?"
   },
   {
     "id": 23,
@@ -236,8 +236,8 @@
     "data_size": 168,
     "nom_orig": "Yukino",
     "texte_orig": "But[SP]Maya-san,[SP]how[SP]are[SP]we[SP]supposed[SP]to\ndeal[SP]with[SP]this?[SP]Do[SP]you[SP]have[SP]a[SP]plan?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Mais Maya-san, on est censées faire\nquoi exactement ? T'as un plan ?"
   },
   {
     "id": 24,
@@ -246,8 +246,8 @@
     "data_size": 244,
     "nom_orig": "Maya",
     "texte_orig": "I[SP]know![SP]Let's[SP]destroy[SP]all[SP]the[SP]emblems[SP]in\nthe[SP]school.[SP]Getting[SP]rid[SP]of[SP]the[SP]cause[SP]of\nthe[SP]problem[SP]should[SP]help,[SP]right?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "J'ai une idée ! On détruit tous les emblèmes du\nlycée. Éliminer la source du problème,\nça devrait aider, non ?"
   },
   {
     "id": 25,
@@ -256,8 +256,8 @@
     "data_size": 248,
     "nom_orig": "Yukino",
     "texte_orig": "If[SP]rumors[SP]ARE[SP]coming[SP]true,[SP]the[SP]curse'll\nbe[SP]lifted[SP]once[SP]the[SP]emblems[SP]are[SP]gone.\nBut[SP]could[SP]that[SP]really[SP]be[SP]happening?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Si les rumeurs deviennent vraiment réalité, la malédiction\nse lèvera quand les emblèmes seront détruits.\nMais c'est vraiment possible ?"
   },
   {
     "id": 26,
@@ -266,8 +266,8 @@
     "data_size": 214,
     "nom_orig": "Maya",
     "texte_orig": "Think[SP]positive,[SP]guys![SP]Even[SP]if[SP]it[SP]doesn't\nwork[SP]out[SP]in[SP]the[SP]end,[SP]we[SP]have[SP]to[SP]at[SP]least\ngive[SP]it[SP]a[SP]shot!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Pensez positif ! Même si ça marche pas,\non doit au moins essayer !\nCiaaao !"
   },
   {
     "id": 27,
@@ -276,8 +276,8 @@
     "data_size": 154,
     "nom_orig": "Maya",
     "texte_orig": "If[SP]I[SP]remember[SP]right,[SP]Sevens'[SP]emblem[SP]is\nbased[SP]on[SP]the[SP]Pleiades,[SP]yeah?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Si je me souviens bien, l'emblème des Sevens\nest basé sur les Pléiades, c'est ça ?"
   },
   {
     "id": 28,
@@ -286,8 +286,8 @@
     "data_size": 210,
     "nom_orig": "Maya",
     "texte_orig": "That[SP]design[SP]must[SP]show[SP]up[SP]somewhere[SP]else\nbesides[SP]the[SP]emblems[SP]on[SP]the[SP]uniforms.\nLet's[SP]look[SP]for[SP]it!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Ce motif doit apparaître ailleurs que sur\nles emblèmes des uniformes.\nOn le cherche !"
   },
   {
     "id": 29,
@@ -296,8 +296,8 @@
     "data_size": 196,
     "nom_orig": "Ginko",
     "texte_orig": "Like...[1205][001E][SP]the[SP]clocks[SP]in[SP]the[SP]classrooms?\nTheir[SP]faces[SP]have[SP]the[SP]same[SP]design[SP]as\nour[SP]emblem.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Genre...[1205][001E] les horloges des salles de classe ?\nLeurs cadrans ont le même motif que\nnotre emblème."
   },
   {
     "id": 30,
@@ -306,8 +306,8 @@
     "data_size": 110,
     "nom_orig": "Eikichi",
     "texte_orig": "Okay,[SP]friends[SP]and[SP]enemies[SP]of\nmodern[SP]music!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Bien, amis et ennemis de la\nmusique moderne !"
   },
   {
     "id": 31,
@@ -316,8 +316,8 @@
     "data_size": 226,
     "nom_orig": "Eikichi",
     "texte_orig": "Our[SP]fleeting[SP]youth[SP]isn't[SP]going[SP]to[SP]wait\nwhile[SP]we[SP]stand[SP]around.[SP]Let's[SP]hurry[SP]up\nand[SP]find[SP]those[SP]emblems!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Notre jeunesse éphémère n'attendra pas\nqu'on reste là à rien faire. On se magne\net on trouve ces emblèmes !"
   },
   {
     "id": 32,
@@ -326,8 +326,8 @@
     "data_size": 284,
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]memories[SP]evoked[SP]by[SP]the[SP]lady[SP]Maya-san...[1205][001E]\nThey[SP]were[SP]warm,[SP]sad,[SP]and[SP]painful,[SP]all[SP]at\nonce...[1205][001E][SP]Like[SP]the[SP]wringing[SP]of[SP]my[SP]heart...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Les souvenirs que la belle Maya-san a éveillés...[1205][001E]\nChauds, tristes et douloureux à la fois...[1205][001E] Comme si\nmon cœur se tordait..."
   },
   {
     "id": 33,
@@ -336,8 +336,8 @@
     "data_size": 234,
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]felt[SP]it[SP]too,[SP]right,[SP][U+1113]?[SP]And[SP]yet,\nthis[SP]is[SP]our[SP]first[SP]meeting...[1205][001E][SP]Is[SP]this[SP]a\nlove[SP]that's[SP]destined[SP]to[SP]be?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "T'as ressenti ça aussi, [U+1113] ? Et pourtant,\nc'est notre première rencontre...[1205][001E] Serait-ce un\namour écrit dans les étoiles ?"
   },
   {
     "id": 34,
@@ -346,8 +346,8 @@
     "data_size": 116,
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]get[SP]this[SP]weird,[SP]nostalgic[SP]feeling\nfrom[SP]her...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Elle me donne un sentiment bizarre,\nnostalgique..."
   },
   {
     "id": 35,
@@ -356,8 +356,8 @@
     "data_size": 130,
     "nom_orig": "Ginko",
     "texte_orig": "Nah,[SP]that's[SP]impossible![1205][001E][SP]We've[SP]never\neven[SP]met[SP]before.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Non, c'est impossible ![1205][001E] On s'est même\njamais vues avant."
   },
   {
     "id": 36,
@@ -366,8 +366,8 @@
     "data_size": 252,
     "nom_orig": "Maya",
     "texte_orig": "We[SP]were[SP]actually[SP]looking[SP]for[SP]you[SP]earlier.[1205][001E]\nI[SP]mean,[SP]there's[SP]no[SP]way[SP]we'd[SP]leave[SP]without\ninterviewing[SP]the[SP]famous[SP][U+1113]-kun!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "En fait on te cherchait tout à l'heure.[1205][001E]\nHors de question qu'on reparte sans interviewer\nle célèbre [U+1113]-kun !"
   },
   {
     "id": 37,
@@ -376,8 +376,8 @@
     "data_size": 184,
     "nom_orig": "Maya",
     "texte_orig": "*staaa[1205][U+000F]a[1205][U+000F]a[1205][U+000F]a[1205][U+000F]a[1205][U+000F]re*[1205][001E]\nBut[SP]that[SP]aside,[SP][U+1113]-kun...[1205][001E]\nHave[SP]we[SP]met[SP]somewhere[SP]before?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "*regaaaaaarde*[1205][001E]\nMais bon, à part ça, [U+1113]-kun...[1205][001E]\nOn s'est déjà vus quelque part ?"
   },
   {
     "id": 38,
@@ -386,8 +386,8 @@
     "data_size": 264,
     "nom_orig": "Maya",
     "texte_orig": "Nah,[SP]just[SP]kidding![1205][001E][SP]Like[SP]that'd[SP]even[SP]be\npossible![1205][001E][SP]You're[SP]just[SP]such[SP]a[SP]fine-lookin'\nguy[SP]that[SP]I[SP]had[SP]to[SP]get[SP]a[SP]good[SP]ogle[SP]in!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Ha, je rigole ![1205][001E] Comme si c'était\npossible ![1205][001E] T'es juste tellement beau gosse\nque je pouvais pas m'empêcher de mater !"
   },
   {
     "id": 39,
@@ -396,8 +396,8 @@
     "data_size": 244,
     "nom_orig": "Yukino",
     "texte_orig": "This[SP]is[SP]a[SP]surprise.[1205][001E][SP]I[SP]never[SP]knew[SP]there\nwere[SP]other[SP]Persona-users[SP]besides[SP]us...[1205][001E]\nBy[SP]which[SP]I[SP]mean[SP]my[SP]old[SP]pals.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "C'est une surprise.[1205][001E] J'savais pas qu'il existait\nd'autres utilisateurs de Persona que nous...[1205][001E]\nEnfin, mes anciens potes."
   },
   {
     "id": 40,
@@ -406,8 +406,8 @@
     "data_size": 230,
     "nom_orig": "Yukino",
     "texte_orig": "You've[SP]heard[SP]of[SP]it,[SP]right?[1205][001E][SP]The[SP]SEBEC\nScandal[SP]three[SP]years[SP]ago.[SP]Mikage-cho[SP]got\ncompletely[SP]walled[SP]off...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Vous en avez entendu parler, non ?[1205][001E] Le scandale\nSEBEC il y a trois ans. Mikage-cho avait été\ncomplètement bouclé..."
   },
   {
     "id": 41,
@@ -416,8 +416,8 @@
     "data_size": 226,
     "nom_orig": "Yukino",
     "texte_orig": "It's[SP]a[SP]long[SP]story,[SP]but...[1205][001E][SP]That's[SP]when[SP]I\nawoke[SP]to[SP]my[SP]Persona.[1205][001E][SP]There[SP]was[SP]me[SP]and\neight[SP]other[SP]guys...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "C'est une longue histoire, mais...[1205][001E] C'est là que j'ai\néveillé mon Persona.[1205][001E] Il y avait moi\net huit autres gars..."
   },
   {
     "id": 42,
@@ -426,8 +426,8 @@
     "data_size": 194,
     "nom_orig": "Yukino",
     "texte_orig": "My[SP]pals[SP]and[SP]me[SP]threw[SP]down[SP]with[SP]demons\nand[SP]other[SP]Persona-users[SP]and[SP]took[SP]back\nour[SP]town.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Mes potes et moi on s'est battus contre des démons\net d'autres utilisateurs de Persona pour reprendre\nnotre ville."
   },
   {
     "id": 43,
@@ -436,8 +436,8 @@
     "data_size": 270,
     "nom_orig": "Yukino",
     "texte_orig": "The[SP]news[SP]called[SP]it[SP]an[SP]accident,[SP]but[SP]that\nwasn't[SP]it[SP]at[SP]all.[1205][001E][SP]SEBEC's[SP]Kandori...[1205][001E]\nHaha,[SP]never[SP]mind.[SP]Water[SP]under[SP]the[SP]bridge.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Les infos ont appelé ça un accident, mais c'était\npas ça du tout.[1205][001E] Kandori de SEBEC...[1205][001E]\nPfft, laissez tomber. C'est du passé."
   },
   {
     "id": 44,
@@ -446,8 +446,8 @@
     "data_size": 82,
     "nom_orig": "Eikichi",
     "texte_orig": "Oh[SP]yeah![1205][0014][SP]Wait[SP]a[SP]second,[SP][U+1113]!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Ah oui ![1205][0014] Attends une seconde, [U+1113] !"
   },
   {
     "id": 45,
@@ -456,8 +456,8 @@
     "data_size": 230,
     "nom_orig": "Eikichi",
     "texte_orig": "Could[SP]I[SP]bother[SP]you[SP]two[SP]fine[SP]misses[SP]for\na[SP]second?[SP]I've[SP]got[SP]a[SP]special[SP]present[SP]for\nyou[SP]as[SP]our[SP]new[SP]allies!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Puis-je me permettre de déranger ces deux\ncharmantes demoiselles ? J'ai un cadeau spécial\npour vous, nos nouvelles alliées !"
   },
   {
     "id": 46,
@@ -466,8 +466,8 @@
     "data_size": 172,
     "nom_orig": "Maya",
     "texte_orig": "This[SP]is[SP]so[SP]cute![SP]Can[SP]I[SP]really[SP]have[SP]one?\nLook,[SP]Yukki,[SP]they're[SP]a[SP]matching[SP]set!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "C'est trop mignon ! Je peux vraiment en avoir un ?\nRegarde, Yukki, ils sont assortis !"
   },
   {
     "id": 47,
@@ -476,8 +476,8 @@
     "data_size": 96,
     "nom_orig": "Yukino",
     "texte_orig": "You...[SP]want[SP]me[SP]to[SP]use[SP]a[SP]pink[SP]gun...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Tu... tu veux que j'utilise un flingue rose... ?"
   },
   {
     "id": 48,
@@ -486,8 +486,8 @@
     "data_size": 134,
     "nom_orig": "Yukino",
     "texte_orig": "Sorry...[1205][001E][SP]But[SP]I'm[SP]already[SP]carrying[SP]my\nfavorite[SP]weapon!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Désolée...[1205][001E] Mais j'ai déjà mon\narme préférée !"
   },
   {
     "id": 49,
@@ -496,7 +496,7 @@
     "data_size": 136,
     "nom_orig": "Maya",
     "texte_orig": "Oooh![SP]Soooo[SP]cooool,[SP]Yukki![SP]Hey,[SP]check\nout[SP]my[SP]sweet[SP]skills!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Ouuaaah ! Trop trop cooool, Yukki ! Hé, regarde\nce que je sais faire !"
   }
 ]


### PR DESCRIPTION
… 0–49)

Traduction complète du fichier (IDs 0 à 49).
Adaptation des onomatopées et expressions selon les préférences validées :

Maya : Ouf.. (2 pts), Waouh !, Ouuaaah ! Trop trop cooool, *regaaaaaarde*, Ciaaao !.
Ginko : Hein...?, *sniff* conservé, Quoi !? (pour Haime!?).
Eikichi : aucune nouvelle ono — registre arrogant/lyrique maintenu.
Yukino : ton sec et factuel, tutoiement envers les jeunes, Maya-san conservé.


Localisation du Persona Game en Jeu du Persona (cohérence avec balises [1432]). Lisa → Ginko systématique, Yukki conservé comme surnom affectif de Maya. Ajout de Ciaaao ! en fin de réplique id:26 pour combler le slot et ancrer le caractère de Maya. Conservation rigoureuse des codes de contrôle ([U+1113], [1205][001E], [1205][0014], [1432][NULL][NULL][0014]) et remplacement de tous les [SP] par des espaces normaux.