### PR TITLE
[Script 10] Chasse aux emblèmes et retrouvailles de Yukino avec Mme Saeko (IDs 0–45)

### DIFF
--- a/scripts/script_010.json
+++ b/scripts/script_010.json
@@ -6,8 +6,8 @@
     "data_size": 38,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Hey!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "Hé !"
   },
   {
     "id": 1,
@@ -16,8 +16,8 @@
     "data_size": 218,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Enough[SP]is[SP]enough![SP]Stop[SP]letting[SP]random\nrumors[SP]push[SP]you[SP]around![1205][001E][SP]Honestly...\nWhat[SP]a[SP]headache...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "Ça suffit ! Arrêtez de vous laisser mener\npar des rumeurs ![1205][001E] Franchement...\nQuelle migraine..."
   },
   {
     "id": 2,
@@ -26,8 +26,8 @@
     "data_size": 78,
     "nom_orig": "Yukino",
     "texte_orig": "Ms.[SP]Saeko!?[SP]What[SP]are[SP]you...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Mme Saeko !? Mais qu'est-ce que..."
   },
   {
     "id": 3,
@@ -36,8 +36,8 @@
     "data_size": 110,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Y-Yukino...?[1205][001E][SP]It[SP]really[SP]is[SP]you,[SP]Yukino!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "Yu-Yukino...?[1205][001E] C'est bien toi, Yukino !"
   },
   {
     "id": 4,
@@ -46,8 +46,8 @@
     "data_size": 266,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "I[SP]transferred[SP]here[SP]last[SP]year.[SP]But[SP]never\nmind[SP]me--what[SP]are[SP]YOU[SP]doing[SP]here?[SP]Don't\ntell[SP]me[SP]you're[SP]redoing[SP]high[SP]school...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "J'ai été mutée ici l'année dernière. Mais\nparlons de TOI -- qu'est-ce que tu fais là ?\nDis-moi pas que tu redoubles..."
   },
   {
     "id": 5,
@@ -56,8 +56,8 @@
     "data_size": 240,
     "nom_orig": "Yukino",
     "texte_orig": "Oh,[SP]no,[SP]I'm[SP]on[SP]assignment![SP]I[SP]have[SP]a[SP]part-\ntime[SP]job[SP]as[SP]an[SP]assistant[SP]photographer,[SP]so[SP]I\ncame[SP]to[SP]cover[SP]a[SP]story.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Ah non, je suis en reportage ! Je bosse\nen extra comme assistante photographe, alors\nje suis venue couvrir un article."
   },
   {
     "id": 6,
@@ -66,8 +66,8 @@
     "data_size": 118,
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah![SP]Ms.[SP]Saeko[SP]and[SP]Yukino-san[SP]know\neach[SP]other?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Aiya ! Mme Saeko et Yukino-san se\nconnaissent ?"
   },
   {
     "id": 7,
@@ -76,8 +76,8 @@
     "data_size": 118,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "She[SP]was[SP]a[SP]student[SP]of[SP]mine[SP]at[SP]my\nlast[SP]school.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "Elle était dans mes classes dans\nmon ancien lycée."
   },
   {
     "id": 8,
@@ -86,8 +86,8 @@
     "data_size": 234,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Your[SP]timing[SP]in[SP]coming[SP]here[SP]wasn't[SP]very\ngood,[SP]I'm[SP]afraid.[SP]As[SP]you[SP]can[SP]see,[SP]we're\nin[SP]a[SP]bit[SP]of[SP]a[SP]crisis...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "Tu es arrivée au mauvais moment,\nj'en ai peur. Comme tu vois, on est\nen pleine crise..."
   },
   {
     "id": 9,
@@ -96,8 +96,8 @@
     "data_size": 138,
     "nom_orig": "Yukino",
     "texte_orig": "Yeah,[SP]about[SP]that,[SP]there's[SP]something[SP]I[SP]need\nto[SP]tell[SP]you...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Justement, à ce sujet, j'ai quelque chose\nà vous dire..."
   },
   {
     "id": 10,
@@ -106,8 +106,8 @@
     "data_size": 250,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "A[SP]rumor[SP]caused[SP]all[SP]this!?[SP]Then[SP]the[SP]curse\nwill[SP]lift[SP]when[SP]the[SP]emblems[SP]are[SP]gone...[1205][001E]\nIn[SP]that[SP]case,[SP]I'll[SP]help[SP]too!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "Une rumeur a causé tout ça !? Alors la malédiction\nse lèvera quand les emblèmes seront détruits...[1205][001E]\nDans ce cas, je vous aide aussi !"
   },
   {
     "id": 11,
@@ -116,8 +116,8 @@
     "data_size": 212,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "[U+1113]![SP]I[SP]take[SP]full[SP]responsibility[SP]here.\nYou[SP]have[SP]my[SP]blessing[SP]to[SP]go[SP]and[SP]destroy\nall[SP]the[SP]emblems!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "[U+1113] ! J'assume l'entière responsabilité.\nVous avez ma bénédiction pour aller\ndétruire tous les emblèmes !"
   },
   {
     "id": 12,
@@ -126,8 +126,8 @@
     "data_size": 120,
     "nom_orig": "Eikichi",
     "texte_orig": "Okay,[SP]my[SP]lovelies![SP]That[SP]should[SP]be\nthe[SP]last[SP]one!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Et voilà, mes beautés ! Ça devrait\nêtre le dernier !"
   },
   {
     "id": 13,
@@ -136,8 +136,8 @@
     "data_size": 106,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "That[SP]means[SP]everyone[SP]should[SP]get[SP]better!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "Ça veut dire que tout le monde va aller mieux !"
   },
   {
     "id": 14,
@@ -146,8 +146,8 @@
     "data_size": 206,
     "nom_orig": "Maya",
     "texte_orig": "Huh,[SP]that's[SP]weird.[SP]I[SP]really[SP]thought[SP]that'd\nget[SP]rid[SP]of[SP]the[SP]curse...[SP]Did[SP]we[SP]overlook\nsomething?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Hein, c'est bizarre. J'étais sûre que ça\nallait lever la malédiction... On a\noublié quelque chose ?"
   },
   {
     "id": 15,
@@ -156,8 +156,8 @@
     "data_size": 242,
     "nom_orig": "Ginko",
     "texte_orig": "Oh[SP]man,[SP]I[SP]think[SP]we're[SP]forgetting[SP]the\nbiggest[SP]one...[1205][001E][SP]The[SP]enormous[SP]clock[SP]in\nthe[SP]clock[SP]tower![SP]It's[SP]still[SP]there!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Oh non, je crois qu'on a oublié\nle plus grand...[1205][001E] L'énorme horloge de\nla tour ! Elle est toujours là !"
   },
   {
     "id": 16,
@@ -166,8 +166,8 @@
     "data_size": 698,
     "nom_orig": "Principal[SP]Hanya's[SP]voice",
     "texte_orig": "Ahem![SP]Attention[SP]all[SP]students![SP]You[SP]will\nimmediately[SP]cease[SP]all[SP]destructive\nactivity[SP]within[SP]school[SP]grounds![E1][E2][E4][NULL][NULL]\"Principal[SP]Hanya's[SP]voice\nAs[SP]principal,[SP]everyone[SP]must[SP]obey[SP]my\norders.[SP]Do[SP]you[SP]hear[SP]me?[1205][001E][SP]You[SP]will[SP]treat\nMY[SP]Seven[SP]Sisters[SP]High[SP]with[SP]respect![E1][E2]\n[E3][E4][NULL][NULL]\"Ms.[SP]Saeko\nI[SP]suppose[SP]we[SP]have[SP]no[SP]choice,[SP]if[SP]the\nprincipal[SP]says[SP]so...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Voix du directeur Hanya",
+    "texte_fr": "Hum ! Attention tous les élèves ! Vous allez\nimmédiatement cesser toute activité\ndestructrice dans l'enceinte du lycée ![E1][E2][E4][NULL][NULL]\"Voix du directeur Hanya\nEn tant que directeur, tout le monde doit\nobéir à mes ordres. Vous m'entendez ?[1205][001E] Vous\nrespectez MON lycée des Sept Sœurs ![E1][E2]\n[E3][E4][NULL][NULL]\"Mme Saeko\nSi le directeur l'ordonne, on n'a pas\nle choix..."
   },
   {
     "id": 17,
@@ -176,8 +176,8 @@
     "data_size": 170,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Come[SP]on,[SP]everyone.[SP]The[SP]emblem[SP]hunt\nis[SP]over![1205][001E][SP]Let's[SP]start[SP]cleaning[SP]up.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "Allez, tout le monde. La chasse aux emblèmes\nest terminée ![1205][001E] On commence le nettoyage."
   },
   {
     "id": 18,
@@ -186,8 +186,8 @@
     "data_size": 172,
     "nom_orig": "Yukino",
     "texte_orig": "Damn[SP]Hamya...[1205][001E][SP]But[SP]if[SP]everyone's[SP]like\nthis,[SP]there's[SP]not[SP]much[SP]we[SP]can[SP]do.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Ce foutu Hanya...[1205][001E] Mais si tout le monde est\ndans cet état, on peut pas grand-chose."
   },
   {
     "id": 19,
@@ -196,8 +196,8 @@
     "data_size": 116,
     "nom_orig": "Yukino",
     "texte_orig": "Anyway,[SP]don't[SP]we[SP]have[SP]a[SP]big[SP]clock[SP]to\ngo[SP]break?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Bref, on n'a pas une grosse horloge\nà aller casser ?"
   },
   {
     "id": 20,
@@ -206,8 +206,8 @@
     "data_size": 194,
     "nom_orig": "Ginko",
     "texte_orig": "Wait[SP]a[SP]sec,[SP]Chinyan.[SP]Isn't[SP]the[SP]clock\ntower[SP]always[SP]locked?[SP]I[SP]say[SP]we[SP]find\nthe[SP]key[SP]first.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Attends une seconde, Chinyan. La tour de\nl'horloge est pas toujours fermée à clé ?\nJe dis qu'on trouve la clé d'abord."
   },
   {
     "id": 21,
@@ -216,8 +216,8 @@
     "data_size": 198,
     "nom_orig": "Ginko",
     "texte_orig": "It's[SP]probably[SP]in[SP]the[SP]teacher's[SP]lounge\nsomewhere.[SP]Let's[SP]try[SP]asking[SP]the[SP]teachers\nabout[SP]it.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Elle est sûrement quelque part dans la salle\ndes profs. On essaie de leur demander\noù elle est."
   },
   {
     "id": 22,
@@ -226,8 +226,8 @@
     "data_size": 244,
     "nom_orig": "Eikichi",
     "texte_orig": "We're[SP]finally[SP]on[SP]the[SP]last[SP]emblem...[1205][001E]\nWe[SP]need[SP]to[SP]hurry[SP]and[SP]find[SP]Mr.[SP]Hanya.\nC'mon,[SP][U+1113]![SP]Time[SP]for[SP]the[SP]big[SP]finish!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "On est enfin au dernier emblème...[1205][001E]\nFaut qu'on retrouve M. Hanya vite fait.\nAllez, [U+1113] ! Le grand final !"
   },
   {
     "id": 23,
@@ -236,8 +236,8 @@
     "data_size": 246,
     "nom_orig": "Eikichi",
     "texte_orig": "What's[SP]with[SP]everyone[SP]all[SP]of[SP]a[SP]sudden?\nNow's[SP]no[SP]time[SP]to[SP]clean[SP]up...[SP]Mr.[SP]Hanya's\nsway[SP]over[SP]them[SP]is[SP]pretty[SP]scary.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "C'est quoi ce délire avec tout le monde ?\nC'est pas le moment de nettoyer... L'emprise\nde M. Hanya sur eux, c'est flippant."
   },
   {
     "id": 24,
@@ -246,8 +246,8 @@
     "data_size": 264,
     "nom_orig": "Ginko",
     "texte_orig": "Is[SP]this[SP]really[SP]going[SP]to[SP]work,[SP]Chinyan?\nYou[SP]think[SP]Maya-san's[SP]right[SP]and[SP]the[SP]curse\nwill[SP]be[SP]lifted[SP]once[SP]the[SP]emblems[SP]are[SP]gone?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Ça va vraiment marcher, Chinyan ?\nTu crois que Maya-san a raison et que la\nmalédiction se lèvera quand les emblèmes seront détruits ?"
   },
   {
     "id": 25,
@@ -256,8 +256,8 @@
     "data_size": 240,
     "nom_orig": "Ginko",
     "texte_orig": "I-I[SP]know[SP]what[SP]I[SP]said[SP]before,[SP]but[SP]shouldn't\nwe[SP]help[SP]with[SP]the[SP]cleanup?[SP]We[SP]need[SP]to[SP]obey\nour[SP]beloved[SP]Principal...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Je-je sais ce que j'ai dit avant, mais on\ndevrait pas aider au nettoyage ? On doit obéir\nà notre bien-aimé directeur..."
   },
   {
     "id": 26,
@@ -266,8 +266,8 @@
     "data_size": 166,
     "nom_orig": "Ginko",
     "texte_orig": "No![SP]No,[SP]no,[SP]NO![SP]Aaagh,[SP]my[SP]head's[SP]a\ncomplete[SP]mess![SP]Kaumena![SP]Someone[SP]help!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Non ! Non, non, NON ! Argh, j'ai la tête\ncomplètement à l'envers ! Pitié ! Au secours !"
   },
   {
     "id": 27,
@@ -276,8 +276,8 @@
     "data_size": 186,
     "nom_orig": "Maya",
     "texte_orig": "These[SP]emblems[SP]here[SP]are[SP]the[SP]last[SP]of[SP]them.\nI[SP]hope[SP]the[SP]curse[SP]gets[SP]lifted[SP]after[SP]this...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Ces emblèmes-là, c'est les derniers.\nJ'espère que la malédiction se lèvera après ça..."
   },
   {
     "id": 28,
@@ -286,8 +286,8 @@
     "data_size": 236,
     "nom_orig": "Maya",
     "texte_orig": "Looks[SP]like[SP]the[SP]principal's[SP]making[SP]his\nmove,[SP]right[SP]on[SP]cue![1205][001E][SP]Let's[SP]hurry[SP]and[SP]find\nthe[SP]key[SP]to[SP]the[SP]clock[SP]tower!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "On dirait que le directeur passe à l'action,\njuste au bon moment ![1205][001E] On se dépêche de trouver\nla clé de la tour de l'horloge !"
   },
   {
     "id": 29,
@@ -296,8 +296,8 @@
     "data_size": 238,
     "nom_orig": "Yukino",
     "texte_orig": "Ms.[SP]Saeko's[SP]as[SP]cool[SP]as[SP]ever.[SP]I[SP]never\nthought[SP]I'd[SP]see[SP]her[SP]again[SP]here...[1205][001E]\nGood[SP]thing[SP]I[SP]took[SP]this[SP]assignment!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Mme Saeko, toujours aussi classe. J'aurais\njamais cru la revoir ici...[1205][001E]\nBien que j'aie accepté ce reportage !"
   },
   {
     "id": 30,
@@ -306,8 +306,8 @@
     "data_size": 220,
     "nom_orig": "Yukino",
     "texte_orig": "That[SP]goddamn[SP]Hamya...[SP]How[SP]dare[SP]he\nbrainwash[SP]my[SP]Ms.[SP]Saeko![SP][1205][001E][SP]Now[SP]how[SP]should\nI[SP]settle[SP]the[SP]score...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Ce foutu Hanya... Comment il ose\nlavé le cerveau de ma Mme Saeko ![1205][001E] Je vais\nlui régler son compte, mais comment..."
   },
   {
     "id": 31,
@@ -316,8 +316,8 @@
     "data_size": 264,
     "nom_orig": "Yukino",
     "texte_orig": "Ms.[SP]Saeko[SP]would[SP]never[SP]blindly[SP]obey[SP]like\nthis.[1205][001E][SP]She's[SP]the[SP]kind[SP]of[SP]lady[SP]who'd[SP]punch\na[SP]minister[SP]if[SP]she[SP]thought[SP]she[SP]had[SP]to.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Mme Saeko obéirait jamais aveuglément\ncomme ça.[1205][001E] C'est le genre de femme à coller\nune beigne à un ministre si elle le juge nécessaire."
   },
   {
     "id": 32,
@@ -326,8 +326,8 @@
     "data_size": 226,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Rumors[SP]becoming[SP]reality,[SP]huh...?[SP]That\nsounds[SP]ludicrous,[SP]but[SP]if[SP]you[SP]and[SP]Yukino\nsay[SP]so,[SP]I[SP]trust[SP]you.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "Des rumeurs qui deviennent réalité, hein...? Ça\nsemble absurde, mais si toi et Yukino\nle dites, je vous fais confiance."
   },
   {
     "id": 33,
@@ -336,8 +336,8 @@
     "data_size": 256,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Still,[SP]this[SP]chaos[SP]inside[SP]the[SP]school\nreminds[SP]me[SP]of[SP]St.[SP]Hermelin[SP]High[SP]three\nyears[SP]ago...[1205][001E][SP]Oh,[SP]sorry![SP]It's[SP]nothing.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "Quand même, ce chaos dans le lycée\nme rappelle le lycée St. Hermelin il y a\ntrois ans...[1205][001E] Oh, pardon ! C'est rien."
   },
   {
     "id": 34,
@@ -346,8 +346,8 @@
     "data_size": 254,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "The[SP]clock[SP]tower?[SP]Why[SP]would[SP]you[SP]go[SP]there?\nIf[SP]you[SP]have[SP]time,[SP]you[SP]should[SP]be[SP]cleaning![1205][001E]\nWe[SP]must[SP]obey[SP]our[SP]principal.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "La tour de l'horloge ? Pourquoi vous iriez là-bas ?\nSi vous avez du temps, nettoyez ![1205][001E]\nOn doit obéir à notre directeur."
   },
   {
     "id": 35,
@@ -356,8 +356,8 @@
     "data_size": 270,
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "It[SP]really[SP]makes[SP]me[SP]mad[SP]for[SP]some[SP]reason,\nbut[SP]that[SP]bald[SP]buf--[1205][001E]I[SP]mean,[SP]errr...[1205][001E][SP]Y-You\nlike[SP]Principal[SP]Hanya[SP]too,[SP]right,[SP][U+1113]?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mme Saeko",
+    "texte_fr": "Ça m'énerve pour une raison que j'ignore,\nmais ce vieux chau--[1205][001E] je veux dire, euh...[1205][001E] T-Toi\naussi t'aimes le directeur Hanya, hein, [U+1113] ?"
   },
   {
     "id": 36,
@@ -366,8 +366,8 @@
     "data_size": 508,
     "nom_orig": "Mr.[SP]Aishi",
     "texte_orig": "So[SP]the[SP]curse[SP]will[SP]be[SP]lifted[SP]if[SP]we[SP]destroy\nall[SP]the[SP]emblems?[SP]I[SP]see![SP]And[SP]Ms.[SP]Saeko[SP]has\nagreed[SP]to[SP]this?[SP]Ahh,[SP]I[SP]see![SP]Wahahah![E1][E2]\n[E3][E4][NULL][NULL]\"Mr.[SP]Aishi\nHrm?[SP]The[SP]key[SP]to[SP]the[SP]clock[SP]tower?[SP]I[SP]see!\nSo[SP]you're[SP]going[SP]to[SP]handle[SP]cleanup[SP]there!\nAhh,[SP]I[SP]see![SP]Wahahah!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "M. Aishi",
+    "texte_fr": "Donc la malédiction se lèvera si on détruit\ntous les emblèmes ? Je vois ! Et Mme Saeko a\naccepté ça ? Ahh, je vois ! Wahahah ![E1][E2]\n[E3][E4][NULL][NULL]\"M. Aishi\nHm ? La clé de la tour de l'horloge ? Je vois !\nDonc vous allez vous occuper du nettoyage là-bas !\nAhh, je vois ! Wahahah !"
   },
   {
     "id": 37,
@@ -376,8 +376,8 @@
     "data_size": 278,
     "nom_orig": "Mr.[SP]Aishi",
     "texte_orig": "The[SP]principal[SP]took[SP]the[SP]key[SP]that[SP]was[SP]here\nin[SP]the[SP]lounge.[SP]The[SP]janitor[SP]should[SP]have[SP]the\nother[SP]one![SP]Hahaha![SP]I[SP]see![SP]How[SP]marvelous!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "M. Aishi",
+    "texte_fr": "Le directeur a pris la clé qui était ici\ndans la salle des profs. Le concierge devrait\navoir l'autre ! Hahaha ! Je vois ! Formidable !"
   },
   {
     "id": 38,
@@ -386,8 +386,8 @@
     "data_size": 556,
     "nom_orig": "Mr.[SP]Oriri",
     "texte_orig": "Oh[SP]really?[SP]The[SP]curse[SP]will[SP]be[SP]lifted[SP]if[SP]we\ndestroy[SP]the[SP]emblems?[SP]The[SP]students[SP]will[SP]be\ncured?[SP]Then[SP]go[SP]ahead[SP]and[SP]destroy[SP]them![E1][E2]\n[E3][E4][NULL][NULL]\"Mr.[SP]Oriri\nOh[SP]really?[SP]You[SP]need[SP]the[SP]key[SP]to[SP]the[SP]clock\ntower?[SP]Hmm...[SP]Someone[SP]seems[SP]to[SP]have[SP]taken\nit,[SP]so[SP]I[SP]can't[SP]lend[SP]it[SP]to[SP]you[SP]right[SP]now.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "M. Oriri",
+    "texte_fr": "Ah bon ? La malédiction se lèvera si on\ndétruit les emblèmes ? Les élèves seront\nguéris ? Alors allez-y, détruisez-les ![E1][E2]\n[E3][E4][NULL][NULL]\"M. Oriri\nAh bon ? Vous avez besoin de la clé de la\ntour de l'horloge ? Hm... Quelqu'un semble\nl'avoir prise, je peux pas vous la prêter là."
   },
   {
     "id": 39,
@@ -396,8 +396,8 @@
     "data_size": 258,
     "nom_orig": "Mr.[SP]Oriri",
     "texte_orig": "Oh,[SP]and[SP]since[SP]Lisa's[SP]with[SP]you...[SP]Her\ngrades[SP]in[SP]English[SP]are[SP]horrible![SP]Tell[SP]her\nshe[SP]needs[SP]to[SP]take[SP]it[SP]more[SP]seriously!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "M. Oriri",
+    "texte_fr": "Ah, et puisque Ginko est avec vous... Ses\nnotes en anglais sont catastrophiques ! Dites-lui\nqu'elle doit prendre ça plus au sérieux !"
   },
   {
     "id": 40,
@@ -406,8 +406,8 @@
     "data_size": 290,
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "It's[SP]tough[SP]finding[SP]EVERY[SP]emblem...[SP]Not\neven[SP]I[SP]can[SP]predict[SP]where[SP]they'll[SP]all[SP]be!\nBut[SP]I'm[SP]sure[SP]the[SP]curse[SP]will[SP]be[SP]lifted.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Élève bandagé",
+    "texte_fr": "C'est dur de trouver TOUS les emblèmes...\nMême moi je peux pas prédire où ils sont tous !\nMais je suis sûr que la malédiction va se lever."
   },
   {
     "id": 41,
@@ -416,8 +416,8 @@
     "data_size": 272,
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "Th-This[SP]is[SP]tough...[SP]I[SP]shouldn't[SP]have[SP]been\nso[SP]sloppy...[1205][001E][SP]Not[SP]even[SP]I[SP]could[SP]have\npredicted[SP]this[SP]turn[SP]of[SP]events!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Élève bandagé",
+    "texte_fr": "C-C'est dur... J'aurais pas dû être\naussi négligent...[1205][001E] Même moi j'aurais pas pu\nprédire ce retournement de situation !"
   },
   {
     "id": 42,
@@ -426,8 +426,8 @@
     "data_size": 270,
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "See?[SP]It's[SP]just[SP]like[SP]we[SP]said.[SP]We[SP]should've\ndestroyed[SP]those[SP]emblems[SP]a[SP]long[SP]time[SP]ago!\nAlright,[SP][U+1113],[SP]go[SP]crush[SP]'em!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Élève bandagé",
+    "texte_fr": "Vous voyez ? C'est exactement ce qu'on disait.\nOn aurait dû détruire ces emblèmes depuis longtemps !\nAllez, [U+1113], vas les écraser !"
   },
   {
     "id": 43,
@@ -436,8 +436,8 @@
     "data_size": 234,
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "Tch...[SP]If[SP]the[SP]principal[SP]commands[SP]it,\nwe've[SP]got[SP]no[SP]choice.[SP]You'd[SP]better[SP]help\nclean[SP]up,[SP]too.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Élève bandagé",
+    "texte_fr": "Tch... Si le directeur l'ordonne,\non a pas le choix. Toi aussi tu ferais\nmieux d'aider au nettoyage."
   },
   {
     "id": 44,
@@ -446,8 +446,8 @@
     "data_size": 258,
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "What!?[SP]I'm[SP]a[SP]little[SP]busy[SP]here![SP]I[SP]need[SP]to\ndestroy[SP]those[SP]emblems[SP]quick[SP]and[SP]get[SP]my\nface[SP]back[SP]to[SP]normal!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Élève bandagée",
+    "texte_fr": "Quoi !? Je suis un peu occupée là ! Faut\nque je détruise ces emblèmes vite fait pour\nretrouver mon visage normal !"
   },
   {
     "id": 45,
@@ -456,7 +456,7 @@
     "data_size": 208,
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "Ugh,[SP]what[SP]IS[SP]it!?[SP]Out[SP]of[SP]my[SP]way![SP]I'm[SP]in[SP]a\nfoul[SP]mood[SP]here![SP]I[SP]gotta[SP]clean[SP]up!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Élève bandagée",
+    "texte_fr": "Ugh, c'est QUOI !? Poussez-vous ! Je suis\nde mauvais poil là ! Faut que je nettoie !"
   }
 ]


### PR DESCRIPTION


Traduction complète du fichier script_010.json (IDs 0 à 45). Adaptation des onomatopées et expressions selon les préférences validées :

Ginko : Aiyah! → Aiya ! (marque établie), Aaagh → Argh, Kaumena! → Pitié ! Au secours ! (francisation naturelle).
Hanya : Ahem! → Hum !.
M. Aishi : Wahahah! conservé (rire excentrique distinctif du personnage).
Élève bandagée : Ugh conservé tel quel (interjection universelle).


Francisation du surnom Hamya : Damn Hamya et goddamn Hamya → Ce foutu Hanya (option A, niveau uniforme). Lisa → Ginko systématique (id:39, réplique de M. Oriri). Noms des PNJs traduits : Bandaged male/female student → Élève bandagé/bandagée, Ms. Saeko → Mme Saeko, Mr. Aishi/Oriri → M. Aishi/Oriri. Conservation rigoureuse des codes de contrôle ([U+1113], [1205][001E], [E1][E2][E3][E4], [NULL][NULL]) et remplacement de tous les [SP] par des espaces normaux.