### PR TITLE
 Confrontation dans la tour de l'horloge — apparition du fantôme et d…

### DIFF
--- a/scripts/script_012.json
+++ b/scripts/script_012.json
@@ -6,8 +6,8 @@
     "data_size": 170,
     "nom_orig": "Eikichi",
     "texte_orig": "*cough*[SP]It's[SP]so[SP]dusty[SP]here...[1205][001E][SP]My[SP]perfect\nhair[SP]is[SP]going[SP]to[SP]get[SP]mussed.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "*tousse* C'est tellement poussiéreux...[1205][001E]\nMes cheveux parfaits vont être\ntout décoiffés."
   },
   {
     "id": 1,
@@ -16,8 +16,8 @@
     "data_size": 232,
     "nom_orig": "Eikichi",
     "texte_orig": "Looks[SP]like[SP]Mr.[SP]Hanya's[SP]not[SP]here,[SP]either.\nLet's[SP]hurry[SP]and[SP]break[SP]the[SP]big[SP]clock[SP]so\nwe[SP]can[SP]get[SP]outta[SP]here.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "M. Hanya est pas là non plus.\nOn casse vite cette grande horloge\net on se casse d'ici."
   },
   {
     "id": 2,
@@ -26,8 +26,8 @@
     "data_size": 124,
     "nom_orig": "Ginko",
     "texte_orig": "But[SP]that[SP]feeling[SP]a[SP]moment[SP]ago...[1205][001E]\nWhat[SP]was[SP]it...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Mais cette sensation tout à l'heure...[1205][001E]\nC'était quoi... ?"
   },
   {
     "id": 3,
@@ -36,8 +36,8 @@
     "data_size": 98,
     "nom_orig": "Ginko",
     "texte_orig": "U-U-Undie[SP]Boss![SP]B-Behind![SP]Behind[SP]you!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "B-B-Boss des Calbutes !\nD-Derrière ! Derrière toi !"
   },
   {
     "id": 4,
@@ -46,8 +46,8 @@
     "data_size": 68,
     "nom_orig": "Teacher's[SP]ghost",
     "texte_orig": "...not[SP]be...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Fantôme du prof",
+    "texte_fr": "...ne pas être..."
   },
   {
     "id": 5,
@@ -56,8 +56,8 @@
     "data_size": 42,
     "nom_orig": "Eikichi",
     "texte_orig": "...Huh?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "...Hein ?"
   },
   {
     "id": 6,
@@ -66,8 +66,8 @@
     "data_size": 318,
     "nom_orig": "Teacher's[SP]ghost",
     "texte_orig": "I[SP]said...[1205][001E][SP]that[SP]time...[1205][001E][SP]must[SP]not[SP]be[SP]set\nfree...[1205][001E][SP]I[SP]said[SP]it...[1205][001E][SP]so[SP]often...\n[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nHe[SP]disappeared![1205][001E][SP]But...[SP]I[SP]feel[SP]like[SP]I've...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Fantôme du prof",
+    "texte_fr": "J'ai dit...[1205][001E] que le temps...[1205][001E] ne doit pas\nêtre libéré...[1205][001E] Je l'ai dit...[1205][001E] si souvent...\n[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nIl a disparu ![1205][001E] Mais... j'ai l'impression..."
   },
   {
     "id": 7,
@@ -76,8 +76,8 @@
     "data_size": 82,
     "nom_orig": "Eikichi[SP]&[SP]Ginko",
     "texte_orig": "...seen[SP]him[SP]before!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi & Ginko",
+    "texte_fr": "...de l'avoir déjà vu !"
   },
   {
     "id": 8,
@@ -86,8 +86,8 @@
     "data_size": 38,
     "nom_orig": "???",
     "texte_orig": "Hahahaha!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "???",
+    "texte_fr": "Hahahaha !"
   },
   {
     "id": 9,
@@ -96,8 +96,8 @@
     "data_size": 86,
     "nom_orig": "Yukino",
     "texte_orig": "Ugh...[SP]Hamya!?[SP]Look,[SP]up[SP]there!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Ce foutu Hanya !? Regardez, là-haut !"
   },
   {
     "id": 10,
@@ -106,8 +106,8 @@
     "data_size": 62,
     "nom_orig": "[U+1113],[SP]Eikichi[SP]&[SP]Ginko",
     "texte_orig": "Joker!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "[U+1113], Eikichi & Ginko",
+    "texte_fr": "Joker !"
   },
   {
     "id": 11,
@@ -116,8 +116,8 @@
     "data_size": 76,
     "nom_orig": "Maya[SP]&[SP]Yukino",
     "texte_orig": "Is[SP]that...[SP]Joker!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya & Yukino",
+    "texte_fr": "C'est... le Joker !?"
   },
   {
     "id": 12,
@@ -126,8 +126,8 @@
     "data_size": 122,
     "nom_orig": "Ginko",
     "texte_orig": "Principal[SP]Hanya![SP]So[SP]you[SP]were[SP]mixed[SP]up\nwith[SP]Joker!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Directeur Hanya ! Donc vous étiez\nmêlé à Joker !"
   },
   {
     "id": 13,
@@ -136,8 +136,8 @@
     "data_size": 230,
     "nom_orig": "Ginko",
     "texte_orig": "The[SP]emblem[SP]curse[SP]and[SP]everyone[SP]acting[SP]weird\nis[SP]all[SP]because[SP]you[SP]teamed[SP]up[SP]with[SP]Joker,\nisn't[SP]it!?[SP]Fess[SP]up!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "La malédiction et le comportement bizarre\nde tout le monde, c'est parce que vous\nêtes allié à Joker, non !? Crachez !"
   },
   {
     "id": 14,
@@ -146,8 +146,8 @@
     "data_size": 278,
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Foolish[SP]girl![SP]How[SP]dare[SP]you?[SP]The[SP][1432][NULL][NULL][0014]emblem\ncurse[1432][NULL][NULL][0014][SP]is[SP]a[SP]divine[SP]punishment[SP]brought[SP]on\nby[SP]the[SP]students'[SP]poor[SP]conduct!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Directeur Hanya",
+    "texte_fr": "Sotte gamine ! Comment osez-vous ?\nLa [1432][NULL][NULL][0014]malédiction de l'emblème[1432][NULL][NULL][0014] est un\nchâtiment divin dû à la mauvaise conduite\ndes élèves !"
   },
   {
     "id": 15,
@@ -156,8 +156,8 @@
     "data_size": 230,
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "You[SP]fools[SP]forget[SP]that[SP]you're[SP]students[SP]and\nwaste[SP]your[SP]lives[SP]worrying[SP]about[SP]dating\nand[SP]fashion!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Directeur Hanya",
+    "texte_fr": "Vous oubliez que vous êtes des élèves\net gâchez votre vie à vous soucier\ndes sorties et de la mode !"
   },
   {
     "id": 16,
@@ -166,8 +166,8 @@
     "data_size": 256,
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "You[SP]brought[SP]this[SP]curse[SP]on[SP]yourselves!\nThough[SP]I[SP]didn't[SP]think[SP]the[SP]rumor[SP]Cuss[SP]High\nstarted[SP]would[SP]come[SP]true...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Directeur Hanya",
+    "texte_fr": "Vous avez provoqué cette malédiction !\nMême si je pensais pas que la rumeur\ndu Lycée Kasu deviendrait réalité..."
   },
   {
     "id": 17,
@@ -176,8 +176,8 @@
     "data_size": 238,
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "But[SP]if[SP]they'd[SP]make[SP]a[SP]wish[SP]to[SP]Master[SP]Joker,\nthe[SP]students'[SP]faces[SP]would[SP]return[SP]to[SP]normal\nin[SP]no[SP]time.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Directeur Hanya",
+    "texte_fr": "Mais s'ils font un vœu au Maître Joker,\nles visages des élèves redeviendraient\nnormaux en un rien de temps."
   },
   {
     "id": 18,
@@ -186,8 +186,8 @@
     "data_size": 238,
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Not[SP]only[SP]that,[SP]but[SP]following[SP]Master[SP]Joker\nis[SP]the[SP]essence[SP]of[SP]having[SP]a[SP]chance[SP]at[SP]a\nfulfilling[SP]life!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Directeur Hanya",
+    "texte_fr": "Et pas seulement ça ! Suivre le\nMaître Joker, c'est la clé d'une\nvie épanouie !"
   },
   {
     "id": 19,
@@ -196,8 +196,8 @@
     "data_size": 76,
     "nom_orig": "Yukino",
     "texte_orig": "So[SP]what[SP]did[SP]he[SP]give[SP]you!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Et lui, il vous a donné quoi !?"
   },
   {
     "id": 20,
@@ -206,8 +206,8 @@
     "data_size": 288,
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Hahaha![SP]Me,[SP]you[SP]ask?[SP]My[SP]wish[SP]was[SP]to[SP]become\na[SP]principal[SP]beloved[SP]by[SP]his[SP]students...[1205][001E]\nAs[SP]well[SP]as[SP]this[SP]fine[SP]mane[SP]you[SP]now[SP]see!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Directeur Hanya",
+    "texte_fr": "Hahaha ! Moi ? Mon vœu était de devenir\nun directeur aimé de ses élèves...[1205][001E]\nAinsi que cette magnifique chevelure !"
   },
   {
     "id": 21,
@@ -216,8 +216,8 @@
     "data_size": 112,
     "nom_orig": "Eikichi",
     "texte_orig": "Joker![SP]Weren't[SP]you[SP]out[SP]for[SP]revenge\non[SP]us!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Joker ! Tu voulais pas te venger\nde nous !?"
   },
   {
     "id": 22,
@@ -226,8 +226,8 @@
     "data_size": 134,
     "nom_orig": "Eikichi",
     "texte_orig": "What's[SP]the[SP]point[SP]in[SP]granting[SP]a[SP]stupid\ngeezer's[SP]wish!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Ça sert à quoi d'exaucer le vœu\nd'un vieux con !?"
   },
   {
     "id": 23,
@@ -236,8 +236,8 @@
     "data_size": 204,
     "nom_orig": "Joker",
     "texte_orig": "The[SP]seven[SP]Pleaides[SP]set[SP]the[SP]frozen[SP]time[SP]free...\n[E1][E2]\n[E3][E4][NULL][NULL]\"Joker\nRevenge[SP]isn't[SP]my[SP]only[SP]motive.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Les sept Pléiades ont libéré le temps figé...\n[E1][E2]\n[E3][E4][NULL][NULL]\"Joker\nLa vengeance n'est pas mon seul mobile."
   },
   {
     "id": 24,
@@ -246,8 +246,8 @@
     "data_size": 204,
     "nom_orig": "Joker",
     "texte_orig": "This[SP]is[SP]between[SP]myself,[SP]the[SP]Giver,[SP]and\nyou,[SP]the[SP]Thief...[1205][001E][SP]A[SP]battle[SP]with\n[U+1113][SP][U+1112][SP]for[SP]my[SP]dream!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "C'est entre moi, le Donneur, et\ntoi, le Voleur...[1205][001E] Un combat contre\n[U+1113] [U+1112] pour mon rêve !"
   },
   {
     "id": 25,
@@ -256,8 +256,8 @@
     "data_size": 190,
     "nom_orig": "Joker",
     "texte_orig": "I'll[SP]never[SP]let[SP]you[SP]destroy[SP]my[SP]dream\nagain...[1205][001E][SP]I[SP]won't[SP]make[SP]the[SP]same\nmistake[SP]twice!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Je te laisserai jamais détruire mon rêve\nencore...[1205][001E] Je ne ferai pas deux fois\nla même erreur !"
   },
   {
     "id": 26,
@@ -266,8 +266,8 @@
     "data_size": 60,
     "nom_orig": "Maya",
     "texte_orig": "Is[SP]he...[SP]crying...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Il... pleure... ?"
   },
   {
     "id": 27,
@@ -276,8 +276,8 @@
     "data_size": 182,
     "nom_orig": "Joker",
     "texte_orig": "Time[SP]is[SP]free[SP]again...[1205][001E][SP]Heed[SP]the[SP]sound[SP]of[SP]the\nbells[SP]that[SP]toll[SP]for[SP]your[SP]dreams!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Joker",
+    "texte_fr": "Le temps est libre à nouveau...[1205][001E]\nÉcoutez le son des cloches qui\nsonnent le glas de vos rêves !"
   },
   {
     "id": 28,
@@ -286,8 +286,8 @@
     "data_size": 96,
     "nom_orig": "Eikichi",
     "texte_orig": "Dammit![SP]You're[SP]not[SP]going[SP]anywhere!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Merde ! Tu vas nulle part !"
   },
   {
     "id": 29,
@@ -296,8 +296,8 @@
     "data_size": 96,
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Okay,[SP]hold[SP]it[SP]right[SP]there!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Directeur Hanya",
+    "texte_fr": "Halte-là !"
   },
   {
     "id": 30,
@@ -306,7 +306,7 @@
     "data_size": 76,
     "nom_orig": "Eikichi",
     "texte_orig": "Gah![SP]Get[SP]out[SP]of[SP]our[SP]way!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Hé ! Poussez-vous de là !"
   }
 ]


### PR DESCRIPTION
…e Joker (IDs 0–30)

Traduction et localisation complète du fichier (IDs 0 à 30). Adaptation des onomatopées et expressions selon les préférences validées :

Eikichi : *cough* → *tousse*, Dammit! → Merde !, Gah! → Hé ! Hahahaha! conservé pour Joker/Hanya.
Ugh... Hamya!? → Ce foutu Hanya !? (francisation établie).


Noms traduits : Teacher's ghost → Fantôme du prof, Principal Hanya → Directeur Hanya. Terminologie établie : Lycée Kasu (id:16), Boss des Calbutes (id:3), Maître Joker (ids 17-18), malédiction de l'emblème avec balises [1432]. Conservation rigoureuse des codes de contrôle ([U+1113], [U+1112], [1205][001E], [E1][E2][E3][E4], [NULL][NULL]).