### PR TITLE
[Script 013] Après le combat — fuite de Hanya et nouvelle stratégie (…

### DIFF
--- a/scripts/script_013.json
+++ b/scripts/script_013.json
@@ -6,8 +6,8 @@
     "data_size": 138,
     "nom_orig": "Ginko",
     "texte_orig": "Hah![SP]We[SP]won![SP]Now[SP]tell[SP]us[SP]everything[SP]you\nknow[SP]about[SP]Joker!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Hah ! On a gagné ! Maintenant dis-nous\ntout ce que tu sais sur Joker !"
   },
   {
     "id": 1,
@@ -16,8 +16,8 @@
     "data_size": 54,
     "nom_orig": "Eikichi",
     "texte_orig": "Wh-What[SP]the!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Qu-Quoi !?"
   },
   {
     "id": 2,
@@ -26,8 +26,8 @@
     "data_size": 96,
     "nom_orig": "Yukino",
     "texte_orig": "Careful,[SP]everyone![SP]It's[SP]collapsing!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Attention tout le monde ! Ça s'effondre !"
   },
   {
     "id": 3,
@@ -36,8 +36,8 @@
     "data_size": 72,
     "nom_orig": "Maya",
     "texte_orig": "Owww...[SP]Is[SP]everyone[SP]okay?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Aïe... Tout le monde va bien ?"
   },
   {
     "id": 4,
@@ -46,8 +46,8 @@
     "data_size": 74,
     "nom_orig": "Eikichi",
     "texte_orig": "Hey![SP]Wait,[SP]you[SP]bastard!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Hé ! Attends, enfoiré !"
   },
   {
     "id": 5,
@@ -56,8 +56,8 @@
     "data_size": 240,
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Guidance[SP]sessions[SP]are[SP]over[SP]for[SP]today!\nSo[SP]long[SP]as[SP]you[SP]defy[SP]Master[SP]Joker,[SP]you\nwill[SP]never[SP]find[SP]peace!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Directeur Hanya",
+    "texte_fr": "Les séances d'orientation sont terminées\npour aujourd'hui ! Tant que vous défierez\nle Maître Joker, vous n'aurez jamais la paix !"
   },
   {
     "id": 6,
@@ -66,8 +66,8 @@
     "data_size": 72,
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Waaaaaaaaaaah!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Directeur Hanya",
+    "texte_fr": "AAAAAAAAAAAH !"
   },
   {
     "id": 7,
@@ -76,8 +76,8 @@
     "data_size": 170,
     "nom_orig": "Eikichi",
     "texte_orig": "Isn't[SP]this[SP]the[SP]fourth[SP]floor!?[SP]Eh...[1205][001E]\nI[SP]doubt[SP]even[SP]that[SP]would[SP]kill[SP]him.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "C'est pas le quatrième étage !? Bah...[1205][001E]\nÇa suffirait même pas à le tuer."
   },
   {
     "id": 8,
@@ -86,8 +86,8 @@
     "data_size": 186,
     "nom_orig": "Maya",
     "texte_orig": "Joker...[SP]He's[SP]so[SP]alone.[1205][001E][SP]He's[SP]struggling\nwith[SP]a[SP]sin[SP]in[SP]the[SP]depths[SP]of[SP]his[SP]heart...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Joker... Il est tellement seul.[1205][001E]\nIl se bat contre un péché au fond\nde son cœur..."
   },
   {
     "id": 9,
@@ -96,8 +96,8 @@
     "data_size": 170,
     "nom_orig": "Maya",
     "texte_orig": "He[SP]reminds[SP]me[SP]somehow[SP]of[SP][U+1113]-kun...[1205][001E]\nI[SP]feel[SP]like[SP]I[SP]know[SP]him[SP]from[SP]somewhere.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Il me rappelle [U+1113]-kun d'une façon...[1205][001E]\nJ'ai l'impression de le connaître\nde quelque part."
   },
   {
     "id": 10,
@@ -106,8 +106,8 @@
     "data_size": 252,
     "nom_orig": "Maya",
     "texte_orig": "[1432][NULL][NULL][0014]I[SP]shudder[SP]when[SP]I[SP]behold[SP]his[SP]face.\nThe[SP]moon[SP]reveals[SP]to[SP]me[SP]my[SP]own[SP]likeness.\nYou[SP]Doppelganger,[SP]you[SP]pale[SP]companion!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "[1432][NULL][NULL][0014]Je frémis en contemplant son visage.\nLa lune me révèle ma propre ressemblance.\nToi le Doppelganger, mon pâle compagnon !"
   },
   {
     "id": 11,
@@ -116,8 +116,8 @@
     "data_size": 232,
     "nom_orig": "Maya",
     "texte_orig": "[1432][NULL][NULL][0014]Why[SP]do[SP]you[SP]mimic[SP]my[SP]lovesickness,\nThat[SP]tormented[SP]me[SP]at[SP]this[SP]place\nFor[SP]so[SP]many[SP]nights[SP]in[SP]the[SP]past?[1432][NULL][NULL][0014]",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "[1432][NULL][NULL][0014]Pourquoi imites-tu mon mal d'amour,\nQui me torturait en ce lieu\nTant de nuits passées ?[1432][NULL][NULL][0014]"
   },
   {
     "id": 12,
@@ -126,8 +126,8 @@
     "data_size": 182,
     "nom_orig": "Maya",
     "texte_orig": "That's[SP]from[SP]a[SP]poem[SP]called[SP][1432][NULL][NULL][0014]Der[SP]Doppelganger.[1432][NULL][NULL][0014]\nHave[SP]you[SP]heard[SP]of[SP]it,[SP][U+1113]-kun?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "C'est d'un poème appelé [1432][NULL][NULL][0014]Der Doppelganger.[1432][NULL][NULL][0014]\nT'en as entendu parler, [U+1113]-kun ?"
   },
   {
     "id": 13,
@@ -136,8 +136,8 @@
     "data_size": 186,
     "nom_orig": "Yukino",
     "texte_orig": "Uh,[SP]Maya-san...[1205][001E][SP]You're[SP]not[SP]suggesting\nthat[SP]Joker[SP]is[SP][U+1113]'s[SP]doppelganger,\nare[SP]you?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Euh, Maya-san...[1205][001E] Vous insinuez pas que\nJoker est le doppelganger de [U+1113],\nquand même ?"
   },
   {
     "id": 14,
@@ -146,8 +146,8 @@
     "data_size": 170,
     "nom_orig": "Maya",
     "texte_orig": "Oh,[SP]no![SP]I[SP]just[SP]thought[SP]there[SP]were\nsome[SP]similarities.[SP]Ah,[SP]ignore[SP]me,\n[U+1113]-kun.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Oh non ! Je trouvais juste qu'il y avait\ndes ressemblances. Ah, laisse tomber,\n[U+1113]-kun."
   },
   {
     "id": 15,
@@ -156,8 +156,8 @@
     "data_size": 192,
     "nom_orig": "Ginko",
     "texte_orig": "Wai![SP]What[SP]should[SP]we[SP]do[SP]now?[SP]Hanya[SP]got\naway[SP]and[SP]took[SP]our[SP]only[SP]lead[SP]to[SP]Joker\nwith[SP]him.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Hé ! On fait quoi maintenant ? Hanya\ns'est tiré et a emporté notre seule\npiste vers Joker avec lui."
   },
   {
     "id": 16,
@@ -166,8 +166,8 @@
     "data_size": 196,
     "nom_orig": "Maya",
     "texte_orig": "Think[SP]positive,[SP]guys![SP]You[SP]have[SP]to,[SP]at\ntimes[SP]like[SP]this.[SP]We're[SP]not[SP]out[SP]of[SP]leads\njust[SP]yet.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Pensez positif ! C'est obligatoire dans\nces moments-là. On n'a pas encore\népuisé toutes les pistes."
   },
   {
     "id": 17,
@@ -176,8 +176,8 @@
     "data_size": 152,
     "nom_orig": "Maya",
     "texte_orig": "Let's[SP]chase[SP]the[SP]rumors![SP]They'll[SP]surely\nlead[SP]us[SP]straight[SP]to[SP]Joker.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "On suit les rumeurs ! Elles nous\nmèneront sûrement droit à Joker."
   },
   {
     "id": 18,
@@ -186,8 +186,8 @@
     "data_size": 254,
     "nom_orig": "Yukino",
     "texte_orig": "Hey,[SP]that's[SP]a[SP]great[SP]idea![SP]Hamya[SP]did[SP]say\nthat[SP]the[SP][1432][NULL][NULL][0014]emblem[SP]curse[1432][NULL][NULL][0014][SP]was[SP]started[SP]by\nsome[SP]students[SP]from[SP]Cuss[SP]High.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Hé, bonne idée ! Ce foutu Hanya a dit que\nla [1432][NULL][NULL][0014]malédiction de l'emblème[1432][NULL][NULL][0014] avait été\nlancée par des élèves du Lycée Kasu."
   },
   {
     "id": 19,
@@ -196,8 +196,8 @@
     "data_size": 242,
     "nom_orig": "Eikichi",
     "texte_orig": "Whoa[SP]there![SP]There's[SP]no[SP]one[SP]at[SP]Kasugayama\nHigh[SP]whom[SP]the[SP]great[SP]Michel[SP]knows[SP]of[SP]that\nwould[SP]start[SP]such[SP]a[SP]rumor.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Doucement ! Personne au lycée Kasugayama\nque le grand Michel connaît n'aurait\nlancé une telle rumeur."
   },
   {
     "id": 20,
@@ -206,8 +206,8 @@
     "data_size": 212,
     "nom_orig": "Eikichi",
     "texte_orig": "We'd[SP]be[SP]wasting[SP]our[SP]time[SP]checking[SP]it[SP]out.\nIf[SP]we're[SP]gonna[SP]search,[SP]let's[SP]start\nsomewhere[SP]else.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "On perdrait notre temps à vérifier.\nSi on cherche, autant commencer\nailleurs."
   },
   {
     "id": 21,
@@ -216,8 +216,8 @@
     "data_size": 250,
     "nom_orig": "Ginko",
     "texte_orig": "Well,[SP]the[SP]editor[SP]of[SP]our[SP]school[SP]paper[SP]is\nlooking[SP]for[SP]info[SP]on[SP]Joker[SP]and[SP]rumors.\nMaybe[SP]she's[SP]found[SP]something[SP]by[SP]now.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "La rédac du journal du lycée cherche\ndes infos sur Joker et les rumeurs.\nElle a peut-être trouvé quelque chose."
   },
   {
     "id": 22,
@@ -226,8 +226,8 @@
     "data_size": 158,
     "nom_orig": "Ginko",
     "texte_orig": "We[SP]can[SP]probably[SP]find[SP]Kozy[SP]at[SP]Peace[SP]Diner\nin[SP]Yumezaki.[SP]How[SP]about[SP]it?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "On trouvera sûrement Kozy au Peace Diner\nà Yumezaki. Ça vous dit ?"
   },
   {
     "id": 23,
@@ -236,8 +236,8 @@
     "data_size": 242,
     "nom_orig": "Female[SP]student",
     "texte_orig": "Omigosh![SP]I[SP]heard[SP]the[SP]principal[SP]went[SP]to\nthe[SP]clock[SP]tower[SP]to[SP]lift[SP]the[SP]emblem\ncurse...[SP]Did[SP]you[SP]see[SP]him!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lycéenne",
+    "texte_fr": "Mon dieu ! J'ai entendu que le directeur\nétait allé à la tour lever la malédiction\nde l'emblème... Vous l'avez vu !?"
   },
   {
     "id": 24,
@@ -246,8 +246,8 @@
     "data_size": 224,
     "nom_orig": "Female[SP]student",
     "texte_orig": "W-Wait...[1205][001E][SP]Was[SP]he[SP]here[SP]when[SP]the[SP]clock\ntower[SP]was[SP]collapsing?[SP]No...[1205][001E][SP]He's[SP]not\ndead,[SP]is[SP]he!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lycéenne",
+    "texte_fr": "A-Attendez...[1205][001E] Il était là quand la tour\ns'effondrait ? Non...[1205][001E] Il est pas\nmort, quand même !?"
   },
   {
     "id": 25,
@@ -256,8 +256,8 @@
     "data_size": 398,
     "nom_orig": "Female[SP]student",
     "texte_orig": "He's[SP]not[SP]dead,[SP]is[SP]he!?\n[U+1208][0002][1432][NULL][NULL][0014]He's[SP]dead.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]No,[SP]he[SP]made[SP]it.[1432][NULL][NULL][0014]\n[U+1109][E2][E3][E4][NULL][NULL]\"Female[SP]student\nNo...![SP]He[SP]died[SP]trying[SP]to[SP]protect[SP]us...?[1205][001E]\nThank[SP]you,[SP]dear[SP]principal...[1205][001E]\nAnd[SP]farewell...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lycéenne",
+    "texte_fr": "Il est pas mort, quand même !?\n[U+1208][0002][1432][NULL][NULL][0014]Il est mort.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, il s'en est sorti.[1432][NULL][NULL][0014]\n[U+1109][E2][E3][E4][NULL][NULL]\"Lycéenne\nNon... ! Il est mort en nous protégeant... ?[1205][001E]\nMerci, cher directeur...[1205][001E]\nAdieu..."
   },
   {
     "id": 26,
@@ -266,7 +266,7 @@
     "data_size": 242,
     "nom_orig": "Female[SP]student",
     "texte_orig": "I[SP]knew[SP]it![SP]Our[SP]dear[SP]principal[SP]is\ninvincible![SP]I[SP]bet[SP]he'll[SP]show[SP]up[SP]again\nin[SP]our[SP]hour[SP]of[SP]greatest[SP]need!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lycéenne",
+    "texte_fr": "Je le savais ! Notre cher directeur est\ninvincible ! Je parie qu'il reviendra\nà notre heure de plus grand besoin !"
   }
 ]


### PR DESCRIPTION
…IDs 0–26)

Traduction et localisation complète du fichier (IDs 0 à 26). Adaptation des onomatopées selon les préférences validées :

Ginko : Hah! conservé, Wai! → Hé !
Maya : Owww... → Aïe...
Hanya : Waaaaaaaaaaah! → AAAAAAAAAAAH !
Lycéenne : Omigosh! → Mon dieu !


Terminologie établie : Maître Joker (id:5), Lycée Kasu (id:18), malédiction de l'emblème avec balises [1432] (ids 18 et 23), ce foutu Hanya (id:18). Female student → Lycéenne, Principal Hanya → Directeur Hanya. Conservation rigoureuse de tous les codes de contrôle ([U+1113], [U+1208], [U+1109], [1205][001E], [E2][E3][E4], [NULL][NULL]).