### PR TITLE
[Script 016] Traduction et optimisation (Mystères du salon secret)

### DIFF
--- a/scripts/script_016.json
+++ b/scripts/script_016.json
@@ -27,7 +27,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm...[SP]I'm[SP]worried[SP]about[SP]Eikichi-kun,[SP]too.\nHopefully[SP]we[SP]can[SP]find[SP]a[SP]way[SP]into[SP]this\nsecret[SP]lounge...",
     "nom_fr": "Maya",
-    "texte_fr": "Hmm... Je m'inquiète pour Michel aussi.\nJ'espère qu'on trouvera un moyen d'entrer\ndans ce salon secret..."
+    "texte_fr": "Hmm... Je m'inquiète aussi pour Eikichi.\nJ'espère qu'on pourra entrer dans\nce salon secret..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Bet[SP]you're[SP]pretty[SP]handy[SP]with[SP]your[SP]fists\ntoo,[SP]huh?\n[U+1208][0002][1432][NULL][NULL][0014]Yeah.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Not[SP]really.[1432][NULL][NULL][0014]\n[U+1109][E2][E3][E4][NULL][NULL]\"Yukino\nHaha,[SP]I[SP]thought[SP]so.[SP]How[SP]'bout[SP]it?[SP]Wanna[SP]try\nteaming[SP]up[SP]in[SP]negotiations[SP]next[SP]time?",
     "nom_fr": "Yukino",
-    "texte_fr": "Je parie que tu sais aussi te servir\nde tes poings, hein?\n[U+1208][0002][1432][NULL][NULL][0014]Ouais.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Pas vraiment.[1432][NULL][NULL][0014]\n[U+1109][E2][E3][E4][NULL][NULL]\"Yukino\nHaha, je m'en doutais. Ça te dirait\nde faire équipe pour négocier la prochaine fois?"
+    "texte_fr": "Tu sais aussi te servir de tes poings, hein?\n[U+1208][0002][1432][NULL][NULL][0014]Ouais.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Pas vraiment.[1432][NULL][NULL][0014]\n[U+1109][E2][E3][E4][NULL][NULL]\"Yukino\nHaha, je m'en doutais. On fait équipe pour\nnégocier la prochaine fois ?"
   },
   {
     "id": 6,
@@ -77,7 +77,7 @@
     "nom_orig": "Masked[SP]young[SP]man",
     "texte_orig": "I[SP]take[SP]it[SP]this[SP]is[SP]your[SP]first[SP]gathering?\nThe[SP]rumor[SP]is,[SP]that's[SP]true[SP]for[SP]everyone[SP]who\nwas[SP]summoned[SP]today.",
     "nom_fr": "Jeune homme masqué",
-    "texte_fr": "Je suppose que c'est votre premier rassemblement?\nLa rumeur dit que c'est le cas pour tous\nceux convoqués aujourd'hui."
+    "texte_fr": "C'est votre premier rassemblement ?\nOn dit que c'est pareil pour tous\nceux convoqués aujourd'hui."
   },
   {
     "id": 8,
@@ -87,7 +87,7 @@
     "nom_orig": "Masked[SP]young[SP]man",
     "texte_orig": "You[SP]got[SP]a[SP]card[SP]from[SP]the[SP]Lady,[SP]right?[SP]If[SP]you\ndon't[SP]have[SP]a[SP]mask,[SP]you[SP]won't[SP]be[SP]able[SP]to[SP]get\ninto[SP]the[SP]secret[SP]lounge.",
     "nom_fr": "Jeune homme masqué",
-    "texte_fr": "Vous avez reçu une carte de la Dame, non?\nSi vous n'avez pas de masque, vous n'entrerez\npas dans le salon secret."
+    "texte_fr": "T'as eu une carte de la Dame ?\nSans masque, tu ne pourras pas\nentrer dans le salon secret."
   },
   {
     "id": 9,


### PR DESCRIPTION
Traduction des dialogues sur les masques et les cartes de la "Lady".

Respect strict des noms originaux : Eikichi remplace Michel.

Passage aux espaces standards (suppression des [SP] sur les IDs corrigés).

Optimisation de la data_size pour les IDs 2, 5, 7 et 8.