### PR TITLE
[Script 315] Traduction initiale et optimisation complète

### DIFF
--- a/scripts/script_315.json
+++ b/scripts/script_315.json
@@ -6,8 +6,8 @@
     "data_size": 250,
     "nom_orig": "Eikichi",
     "texte_orig": "No[SP]one[SP]at[SP]my[SP]school[SP]smokes![SP]I[SP]have[SP]a[SP]strict\nrule[SP]against[SP]it.[1205][001E][SP]The[SP]same[SP]goes[SP]for[SP]Ken,[SP]Shogo,\nand[SP]Takeshi,[SP]too...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Zéro fumeur chez moi ! C'est\nma règle.[1205][001E] Pareil pour Ken,\nShogo et Takeshi..."
   },
   {
     "id": 1,
@@ -16,8 +16,8 @@
     "data_size": 236,
     "nom_orig": "Eikichi",
     "texte_orig": "Hm?[SP]Don't[SP]bother[SP]me[SP]right[SP]now.[SP]I'm[SP]coming[SP]up\nwith[SP]a[SP]song[SP]worthy[SP]of[SP]serving[SP]as[SP]Gas[SP]Chamber's\ndebut[SP]single.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Hm ? Ne me dérange pas maintenant.\nJ'invente une chanson digne d'être le\npremier single de Gas Chamber."
   },
   {
     "id": 2,
@@ -26,8 +26,8 @@
     "data_size": 272,
     "nom_orig": "Eikichi",
     "texte_orig": "English[SP]is[SP]like,[SP]totally[SP]whoa.[SP]Bilingual?[SP]Psh.\nI've[SP]been[SP]SO[SP]bilingual[SP]since[SP]the[SP]day[SP]I[SP]was[SP]born.\nIt's[SP]so[SP]nothing.[SP]Seriously.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "L'anglais, c'est grave wouah. Bilingue ? Pff.\nJe suis TELLEMENT bilingue depuis ma\nnaissance. C'est rien du tout. Sérieux."
   },
   {
     "id": 3,
@@ -36,8 +36,8 @@
     "data_size": 268,
     "nom_orig": "Eikichi",
     "texte_orig": "Yeah![SP]Mission[SP]accomplished![1205][U+000F][SP]Elly-san[SP]was[SP]right\non[SP]the[SP]money.[SP]Guess[SP]there's[SP]something[SP]to[SP]this\nastrology[SP]stuff[SP]after[SP]all.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Ouais ! Mission accomplie ![1205][U+000F] Elly a vu\njuste. Faut croire qu'il y a du vrai\ndans ces trucs d'astrologie."
   },
   {
     "id": 4,
@@ -46,8 +46,8 @@
     "data_size": 264,
     "nom_orig": "Eikichi",
     "texte_orig": "Tch,[SP]I[SP]hate[SP]this...[1205][U+000F][SP]That[SP]lion[SP]bastard[SP]just\nmoved[SP]up[SP]to[SP]the[SP]top[SP]of[SP]my[SP]list![SP]I'll[SP]tear\nhim[SP]to[SP]pieces[SP]with[SP]my[SP]own[SP]hands!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Tch, je déteste ça...[1205][U+000F] Ce lion de\nmalheur est en haut de ma liste !\nJe le mettrai en pièces à mains nues !"
   },
   {
     "id": 5,
@@ -56,8 +56,8 @@
     "data_size": 270,
     "nom_orig": "Eikichi",
     "texte_orig": "No...[SP]Playing[SP]Masked[SP]Circle...[1205][U+000F][SP]It[SP]was[SP]just[SP]a\ndream...[SP]H-Hey,[SP]c'mon,[SP]it[SP]was[SP]just[SP]a[SP]dream!\nTell[SP]me[SP]it[SP]was[SP]only[SP]a[SP]dream,[SP][U+1113]!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Non... Le Cercle masqué...[1205][U+000F] C'était\nqu'un rêve... Hé, dis-moi que c'était\njuste un rêve, [U+1113] !"
   },
   {
     "id": 6,
@@ -66,8 +66,8 @@
     "data_size": 190,
     "nom_orig": "Eikichi",
     "texte_orig": "Hey,[SP][U+1114]...[1205][U+000F][SP]We[SP]did[SP]play[SP]Masked[SP]Circle,\nbut[SP]I[SP]don't[SP]think[SP]we[SP]ever[SP]played[SP]drugstore.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Eikichi",
+    "texte_fr": "Hé, [U+1114]...[1205][U+000F] On a joué au Cercle,\nmais pas à la pharmacie, je crois."
   },
   {
     "id": 7,
@@ -76,8 +76,8 @@
     "data_size": 270,
     "nom_orig": "Lisa",
     "texte_orig": "You[SP]always[SP]have[SP]that[SP]lighter[SP]with[SP]you,[SP][U+1113].\nI[SP]can[SP]understand[SP]Cuss[SP]High[SP]guys[SP]carrying[SP]one,\nbut[SP]you[SP]don't[SP]smoke.[SP]What's[SP]the[SP]deal?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Lisa",
+    "texte_fr": "Tu as toujours ce briquet, [U+1113].\nLes gars de Kakasu en ont un, d'accord,\nmais tu ne fumes pas. Pourquoi ?"
   },
   {
     "id": 8,
@@ -86,8 +86,8 @@
     "data_size": 272,
     "nom_orig": "Ginko",
     "texte_orig": "You[SP]always[SP]have[SP]that[SP]lighter[SP]with[SP]you,[SP][U+1113].\nI[SP]can[SP]understand[SP]Cuss[SP]High[SP]guys[SP]carrying[SP]one,\nbut[SP]you[SP]don't[SP]smoke.[SP]What's[SP]the[SP]deal?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Tu as toujours ce briquet, [U+1113].\nLes gars de Kakasu en ont un, d'accord,\nmais tu ne fumes pas. Pourquoi ?"
   },
   {
     "id": 9,
@@ -96,8 +96,8 @@
     "data_size": 266,
     "nom_orig": "Ginko",
     "texte_orig": "Eikichi[SP]should[SP]just[SP]swipe[SP]the[SP]song[SP]here.\nHe'll[SP]have[SP]at[SP]least[SP]one[SP]fan.[SP]Like[SP]a[SP]certain\nsomeone[SP]with[SP]hearts[SP]over[SP]her[SP]boobs...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Eikichi devrait piquer la chanson\nd'ici. Il aurait au moins une fan avec\ndes cœurs sur la poitrine..."
   },
   {
     "id": 10,
@@ -106,8 +106,8 @@
     "data_size": 150,
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![SP]I[SP]was[SP]in[SP]a[SP]fix[SP]because[SP]I[SP]didn't[SP]want\nto[SP]end[SP]up[SP]like[SP]you!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Kehhei ! J'ai fui pour ne\npas finir comme vous !"
   },
   {
     "id": 11,
@@ -116,8 +116,8 @@
     "data_size": 284,
     "nom_orig": "Ginko",
     "texte_orig": "Maybe[SP]finding[SP]the[SP]next[SP]target[SP]will[SP]be[SP]a[SP]breeze\ntoo.[SP]Let's[SP]get[SP]this[SP]over[SP]with[SP]fast,[SP]so[SP]we[SP]can\nget[SP]a[SP]step[SP]ahead[SP]of[SP]that[SP]King[SP]Leo[SP]guy!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Trouver la cible sera p't'être aussi\nun jeu d'enfant. Finissons-en vite,\npour prendre une longueur d'avance\nsur ce Roi Lion !"
   },
   {
     "id": 12,
@@ -126,8 +126,8 @@
     "data_size": 222,
     "nom_orig": "Ginko",
     "texte_orig": "Weren't[SP]there[SP]still[SP]people[SP]inside[SP]Smile\nHirasaka?[1205][U+000F][SP]We[SP]couldn't[SP]do[SP]anything...[1205][U+000F]\nSorry-ia...[SP]*sniff*",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Y'avait des gens au Smile\nHirasaka ?[1205][U+000F] On n'a rien\npu faire...[1205][U+000F] Pardon... *sniff*"
   },
   {
     "id": 13,
@@ -136,8 +136,8 @@
     "data_size": 276,
     "nom_orig": "Ginko",
     "texte_orig": "If[SP]there's[SP]only[SP]one[SP]possibility,[SP]that[SP]takes\nthe[SP]guesswork[SP]out[SP]of[SP]it![SP]Let's[SP]get[SP]to[SP]the\nAerospace[SP]Museum[SP]and[SP]smash[SP]that[SP]King[SP]Leo!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "S'il n'y a qu'une possibilité, plus besoin\nde deviner ! Allons au Musée de l'Espace\net pulvérisons ce Roi Lion !"
   },
   {
     "id": 14,
@@ -146,8 +146,8 @@
     "data_size": 130,
     "nom_orig": "Ginko",
     "texte_orig": "Yep,[SP]those[SP]kids[SP]did[SP]a[SP]great[SP]job[SP]spreading\nthe[SP]rumor...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Ces gosses ont bien\nrépandu la rumeur..."
   },
   {
     "id": 15,
@@ -156,8 +156,8 @@
     "data_size": 268,
     "nom_orig": "Ginko",
     "texte_orig": "If...[1205][U+000F][SP]If[SP]they're[SP]Joker,[SP]then[SP]we[SP]have[SP]to[SP]clear\nup[SP]what[SP]happened[SP]10[SP]years[SP]ago...[1205][U+000F][SP]That'll[SP]help\nus[SP]figure[SP]everything[SP]out...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Si c'est eux le Joker,[1205][U+000F] il faut\nclarifier ce qui s'est passé il y\na 10 ans...[1205][U+000F] Ça nous aidera..."
   },
   {
     "id": 16,
@@ -166,8 +166,8 @@
     "data_size": 206,
     "nom_orig": "Ginko",
     "texte_orig": "Hey[SP][U+1113],[SP]once[SP]this[SP]is[SP]all[SP]settled,[SP]let's\nplay[SP]Masked[SP]Circle[SP]again.[1205][U+000F][SP]It[SP]might[SP]actually\nbe[SP]fun!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Ginko",
+    "texte_fr": "Hé [U+1113], une fois que ce sera\nréglé, rejouons au Cercle masqué.[1205][U+000F]\nCe sera peut-être amusant !"
   },
   {
     "id": 17,
@@ -176,8 +176,8 @@
     "data_size": 274,
     "nom_orig": "Maya",
     "texte_orig": "Nothing[SP]wrong[SP]with[SP]carrying[SP]a[SP]lighter,[SP]but,\numm...[1205][001E][SP]Just[SP]be[SP]careful![SP]Ahahah.[SP]It[SP]would[SP]be\nawful[SP]if[SP]anything[SP]caught[SP]fire,[SP]right?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Y'a pas de mal à avoir un briquet,\nmais, euh...[1205][001E] Sois prudent ! Ahahah.\nCe serait affreux si quelque chose\nprenait feu, non ?"
   },
   {
     "id": 18,
@@ -186,8 +186,8 @@
     "data_size": 222,
     "nom_orig": "Maya",
     "texte_orig": "Huh,[SP]so[SP]Satomi[SP]Tadashi[SP]uses[SP]different[SP]remixes\nin[SP]each[SP]branch.[1205][U+000F][SP]I[SP]like[SP]the[SP]version[SP]at[SP]this\nplace[SP]too.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Satomi Tadashi remixe\nselon la boutique.[1205][U+000F] J'aime\nbien la version d'ici aussi."
   },
   {
     "id": 19,
@@ -196,8 +196,8 @@
     "data_size": 282,
     "nom_orig": "Maya",
     "texte_orig": "Everyone[SP]has[SP]problems[SP]they[SP]can't[SP]talk[SP]about\nwith[SP]others.[SP]They[SP]may[SP]seem[SP]trivial[SP]to[SP]some,\nbut[SP]they're[SP]very[SP]painful[SP]for[SP]that[SP]person...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Chacun a des soucis durs à\navouer. C'est banal pour certains,\nmais très douloureux pour la\npersonne..."
   },
   {
     "id": 20,
@@ -206,8 +206,8 @@
     "data_size": 260,
     "nom_orig": "Maya",
     "texte_orig": "Elly-san[SP]can[SP]only[SP]figure[SP]out[SP]the[SP]general\ndirection[SP]of[SP]the[SP]next[SP]target.[SP]In[SP]the[SP]end,[SP]we\nhave[SP]to[SP]rely[SP]on[SP][U+1113]-kun's[SP]intuition.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Elly ne peut trouver que la\ndirection générale de la cible.\nAu final, on doit se fier à l'intuition\nde [U+1113]."
   },
   {
     "id": 21,
@@ -216,8 +216,8 @@
     "data_size": 288,
     "nom_orig": "Maya",
     "texte_orig": "I[SP]know[SP]this[SP]is[SP]tough...[SP]But[SP]we[SP]can't[SP]allow[SP]any\nmore[SP]casualties,[SP]for[SP]the[SP]sake[SP]of[SP]the[SP]ones[SP]who\ngot[SP]dragged[SP]into[SP]this.[SP]Let's[SP]go[SP]stop[SP]him!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "C'est dur, je sais... Mais on ne peut\npas permettre d'autres victimes, pour\nceux qui ont été entraînés là-dedans.\nAllons l'arrêter !"
   },
   {
     "id": 22,
@@ -226,8 +226,8 @@
     "data_size": 198,
     "nom_orig": "Maya",
     "texte_orig": "Who[SP]knows[SP]what[SP]other[SP]traps[SP]are[SP]still[SP]ahead...\nLet's[SP]be[SP]sure[SP]to[SP]stock[SP]up[SP]while[SP]we're[SP]here.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "D'autres pièges nous\nattendent... Faisons\nle plein tant qu'on est là."
   },
   {
     "id": 23,
@@ -236,8 +236,8 @@
     "data_size": 368,
     "nom_orig": "Maya",
     "texte_orig": "Eikichi-kun[SP]is[SP]frightened.\n[E1][E2][E4][NULL][NULL]\"Maya\nFrightened[SP]of[SP]his[SP]memory[SP]from[SP]ten[SP]years[SP]ago...[1205][U+000F]\nOr[SP]rather,[SP]frightened[SP]to[SP]admit[SP]that[SP]it[SP]really\nhappened.[SP]Isn't[SP]it[SP]the[SP]same[SP]for[SP]you,[SP]too?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "Eikichi est effrayé.\n[E1][E2][E4][NULL][NULL]\"Maya\nEffrayé par son souvenir d'il y a 10 ans...[1205][U+000F]\nOu plutôt, effrayé d'admettre que\nc'est vraiment arrivé. N'est-ce\npas pareil pour toi, aussi ?"
   },
   {
     "id": 24,
@@ -246,8 +246,8 @@
     "data_size": 282,
     "nom_orig": "Maya",
     "texte_orig": "Did[SP]you[SP]hear[SP]Lisa's[SP]idea?[SP]Let's[SP]play[SP]Masked\nCircle[SP]again.[SP]This[SP]time,[SP]we'll[SP]do[SP]a[SP]drugstore![1205][U+000F]\nHehe...[SP]I[SP]should[SP]ask[SP]Yukki[SP]to[SP]join[SP]us.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Maya",
+    "texte_fr": "L'idée de Lisa ? Rejouer au\nCercle masqué, version\npharmacie ![1205][U+000F] Héhé... Je\nvais inviter Yukki."
   },
   {
     "id": 25,
@@ -256,8 +256,8 @@
     "data_size": 164,
     "nom_orig": "Yukino",
     "texte_orig": "Thinking[SP]ahead,[SP]part[SP]3![SP]Make[SP]the[SP]most[SP]of\nsupplemental[SP]items[SP]in[SP]battle.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Leçon 3 ! Bien utiliser\nles objets en combat."
   },
   {
     "id": 26,
@@ -266,8 +266,8 @@
     "data_size": 272,
     "nom_orig": "Yukino",
     "texte_orig": "Some[SP]demons[SP]can[SP]seal[SP]your[SP]skills.[SP]You'll\ndefinitely[SP]need[SP]items[SP]when[SP]you're[SP]in[SP]a[SP]jam\nlike[SP]that.[SP]You[SP]always[SP]gotta[SP]be[SP]prepared.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Certains démons scellent vos\ncompétences. Il vous faudra des\nobjets dans ce genre de pétrin.\nFaut toujours être prêt."
   },
   {
     "id": 27,
@@ -276,8 +276,8 @@
     "data_size": 250,
     "nom_orig": "Yukino",
     "texte_orig": "There[SP]was[SP]a[SP]guy[SP]I[SP]knew[SP]who[SP]got[SP]hooked[SP]on[SP]this\nplace's[SP]theme[SP]song[SP]just[SP]like[SP]Maya-san.[SP]I[SP]wonder\nhow[SP]he's[SP]doing[SP]now.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Un ami était accro à cette\nchanson, comme Maya.\nJe me demande comment il va."
   },
   {
     "id": 28,
@@ -286,8 +286,8 @@
     "data_size": 298,
     "nom_orig": "Yukino",
     "texte_orig": "Let's[SP]see...[SP]Take[SP]three[SP]times[SP]a[SP]day[SP]to[SP]burn[SP]fat,\nand[SP]the[SP]vitamins[SP]moisturize[SP]your[SP]skin...[1205][U+000F][SP]Hmm...\nAny[SP]breast[SP]enhancement[SP]supplements...?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Voyons... Brûle-graisse 3x\npar jour, vitamines pour la peau...[1205][U+000F]\nHmm... Des trucs pour gonfler\nles seins... ?"
   },
   {
     "id": 29,
@@ -296,8 +296,8 @@
     "data_size": 298,
     "nom_orig": "Yukino",
     "texte_orig": "I've[SP]known[SP]her[SP]for[SP]a[SP]long[SP]time[SP]and[SP]I'm[SP]still\nimpressed[SP]she[SP]can[SP]predict[SP]the[SP]next[SP]target[SP]just\nfrom[SP]those[SP]cards.[SP]I[SP]hope[SP]we[SP]can[SP]keep[SP]this[SP]up.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Elle m'impressionne à prédire\nla cible avec ses cartes.\nPourvu qu'on continue ainsi."
   },
   {
     "id": 30,
@@ -306,8 +306,8 @@
     "data_size": 304,
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]know[SP]how[SP]you[SP]guys[SP]feel.[SP]I'm[SP]angry[SP]at[SP]myself\ntoo,[SP]but[SP]it's[SP]at[SP]times[SP]like[SP]these[SP]that[SP]we[SP]need\nto[SP]keep[SP]calm.[SP]Consider[SP]it[SP]advice[SP]from[SP]a[SP]senpai.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Je vous comprends. Je m'en veux,\nmais on doit rester calmes.\nC'est le conseil d'une senpai."
   },
   {
     "id": 31,
@@ -316,8 +316,8 @@
     "data_size": 172,
     "nom_orig": "Yukino",
     "texte_orig": "What's[SP]with[SP]the[SP]grim[SP]faces[SP]on[SP]those[SP]two?\nWhere'd[SP]all[SP]their[SP]usual[SP]cheer[SP]go?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Pourquoi ces têtes tristes ?\nOù est leur gaieté habituelle ?"
   },
   {
     "id": 32,
@@ -326,8 +326,8 @@
     "data_size": 188,
     "nom_orig": "Yukino",
     "texte_orig": "Maya-san...[SP]I[SP]can[SP]hear[SP]you.[1205][U+000F][SP]Honestly,[SP]you're\ntoo[SP]old[SP]for[SP]that...[1205][U+000F][SP]Count[SP]me[SP]out.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Yukino",
+    "texte_fr": "Maya... Je t'entends.[1205][U+000F] T'es\ntrop vieille pour ça...[1205][U+000F] Sans moi."
   },
   {
     "id": 33,
@@ -336,8 +336,8 @@
     "data_size": 1074,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Heeheehee![1205][U+000A][SP]Yes?[SP]Yes?[SP]Anything[SP]else?\n[U+1208][U+0006]Buy[SP]items\nSell[SP]items\nTalk[SP]to[SP]Sister[SP]#5\n[U+1210]ĀView[SP]items\nNever[SP]mind\nLeave[SP]the[SP]store\n[U+1109][E2][E3][E4][NULL][NULL]\"Sister[SP]#5\nNow,[SP]what[SP]are[SP]you[SP]selling?\n[U+1208][U+0007][U+111F][U+1210]ĀUndisplayed[SP]selection\n[U+111F]Sell[SP]items\n[U+111F]Sell[SP]weapons\n[U+111F][U+1210]ĀSell[SP]head[SP]armor\n[U+111F]Sell[SP]armor\n[U+111F][U+1210]ĀSell[SP]leg[SP]armor\n[U+111F]Sell[SP]accessories\n[U+1109][E2][E3][E4][NULL][NULL]\"Sister[SP]#5\nSo[SP]what[SP]do[SP]you[SP]want[SP]to[SP]talk[SP]about?\n[U+1208][U+0003]Make[SP]small[SP]talk\nAsk[SP]about[SP]shopping\n[U+1210]ĀUndisplayed[SP]selection\n[U+1109][E2][E3][E4][NULL][NULL]\"Sister[SP]#5\nHeeheehee![SP]Our[SP]drugstore[SP]is[SP]making[SP]plans[SP]to\nbranch[SP]out[SP]all[SP]over[SP]the[SP]country![SP]We're[SP]starting\nwith[SP]Sumaru[SP]City!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Héhéhé ![1205][U+000A] Oui ? Oui ? Autre chose ?\n[U+1208][U+0006]Acheter\nVendre\nParler à la Sœur #5\n[U+1210]ĀVoir les objets\nRien\nQuitter\n[U+1109][E2][E3][E4][NULL][NULL]\"Sœur[SP]#5\nAlors, que vendez-vous ?\n[U+1208][U+0007][U+111F][U+1210]ĀSélection masquée\n[U+111F]Objets\n[U+111F]Armes\n[U+111F][U+1210]ĀCasques\n[U+111F]Armures\n[U+111F][U+1210]ĀJambières\n[U+111F]Accessoires\n[U+1109][E2][E3][E4][NULL][NULL]\"Sœur[SP]#5\nDe quoi voulez-vous parler ?\n[U+1208][U+0003]Bavarder\nParler de la boutique\n[U+1210]ĀSélection masquée\n[U+1109][E2][E3][E4][NULL][NULL]\"Sœur[SP]#5\nHéhéhé ! Notre pharmacie compte\ns'étendre dans tout le pays ! On\ncommence par la ville de Sumaru !"
   },
   {
     "id": 34,
@@ -346,8 +346,8 @@
     "data_size": 212,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Leave[SP]it[SP]to[SP]us[SP]Seven[SP]Satomi[SP]Sisters[SP]to\nbrainwash--[1205][001E]I[SP]mean,[SP]take[SP]over[SP]this[SP]city!\nHeeheehee!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Les sœurs Satomi vont laver\nle cerveau--[1205][001E] euh, diriger\nla ville ! Héhéhé !"
   },
   {
     "id": 35,
@@ -356,8 +356,8 @@
     "data_size": 304,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Our[SP]medicine[SP]was[SP]a[SP]hot[SP]seller[SP]until[SP]recently.[1205][U+000F]\nYou[SP]know[SP]how[SP]Cuss[SP]High[SP]is[SP]close[SP]by?[1205][U+000F][SP]Those[SP]kids\nare[SP]so[SP]hot-blooded,[SP]sales[SP]were[SP]sky-high.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Ça se vendait bien avant.[1205][U+000F]\nLe Lycée Kakasu est près.[1205][U+000F]\nLeurs ados au sang chaud\nfaisaient exploser les ventes."
   },
   {
     "id": 36,
@@ -366,8 +366,8 @@
     "data_size": 256,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "But[SP]it's[SP]really[SP]dropped[SP]off.[1205][U+000F][SP]The[SP]Cuss[SP]High[SP]kids\nhave[SP]suddenly[SP]calmed[SP]down.[SP]It's[SP]ruining[SP]our\nbusiness...[SP]*sniff*",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Mais ça a chuté.[1205][U+000F] Les jeunes de Kakasu\nse sont soudain calmés. Ça ruine\nnotre affaire... *sniff*"
   },
   {
     "id": 37,
@@ -376,8 +376,8 @@
     "data_size": 284,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "That[SP]reminds[SP]me,[SP]how[SP]did[SP]the[SP]masquerade[SP]go?\nKasuga[SP]Festival[SP]was[SP]the[SP]talk[SP]of[SP]the[SP]city,\nbut[SP]it[SP]ended[SP]without[SP]a[SP]bang,[SP]so[SP]to[SP]speak.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Ça me rappelle, comment s'est\npassée la mascarade ? Tout le\nmonde parlait du festival Kasuga,\nmais ça s'est fini sans étincelle."
   },
   {
     "id": 38,
@@ -386,8 +386,8 @@
     "data_size": 278,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "My[SP]sister[SP]called[SP]and[SP]told[SP]me[SP]to[SP]watch[SP]out[SP]for\nthe[SP]terrorists.[SP]But[SP]they're[SP]not[SP]like[SP]a[SP]typhoon\nyou[SP]can[SP]get[SP]to[SP]high[SP]ground[SP]for.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Ma sœur m'a dit de fuir\nles terroristes. Mais c'est\npas un typhon où on\npeut s'abriter en hauteur."
   },
   {
     "id": 39,
@@ -396,8 +396,8 @@
     "data_size": 314,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "I[SP]heard[SP]the[SP]terrorists[SP]targeted[SP]Smile[SP]Hirasaka.[1205][U+000F]\nThank[SP]goodness[SP]it[SP]was[SP]prevented,[SP]but[SP]maybe[SP]the\nrumors[SP]of[SP]random[SP]acts[SP]of[SP]violence[SP]are[SP]true...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Les terroristes visaient le\nSmile Hirasaka.[1205][U+000F] On l'a évité,\nmais les rumeurs de\nviolences aléatoires sont vraies..."
   },
   {
     "id": 40,
@@ -405,9 +405,9 @@
     "slot_size": 282,
     "data_size": 278,
     "nom_orig": "Sister[SP]#5",
-    "texte_orig": "*sniff*[SP]Smile[SP]Hirasaka[SP]went[SP]up[SP]in[SP]flames!\nThese[SP]terrorists[SP]hit[SP]closer[SP]to[SP]home[SP]than[SP]I\nthought[SP]they[SP]would.[SP]But[SP]we[SP]won't[SP]close!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "texte_orig": "*sniff*[SP]Smile[SP]Hirasaka[SP]went[SP]up[SP]in[SP]flames!\nThese[SP]terrorists[SP]hit[SP]closer[SP]to[SP]home[SP]than[SP]I\nthought[SP]they[SP]would.[SP]But[SP]we[SP]won[SP]close!",
+    "nom_fr": "Sœur #5",
+    "texte_fr": "*sniff* Le Smile Hirasaka\na brûlé ! Les terroristes\nsont tout près, mais on\nne fermera pas !"
   },
   {
     "id": 41,
@@ -416,8 +416,8 @@
     "data_size": 292,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "This[SP]strangely[SP]dressed[SP]girl[SP]just[SP]came[SP]by.[1205][U+000F]\nShe[SP]said[SP]something[SP]about[SP]those[SP]five[SP]actually\nbeing[SP]heroes...[1205][U+000F][SP]Well,[SP]I[SP]don't[SP]care[SP]much.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Une fille bizarrement vêtue est passée.[1205][U+000F]\nElle a dit que ces cinq-là\nétaient en fait des héros...[1205][U+000F]\nBref, je m'en fiche un peu."
   },
   {
     "id": 42,
@@ -426,8 +426,8 @@
     "data_size": 288,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "The[SP]girl[SP]in[SP]those[SP]odd[SP]clothes[SP]who[SP]was[SP]here[SP]a\nwhile[SP]ago[SP]was[SP]just[SP]on[SP]TV.[SP]She[SP]said[SP]those[SP]five\nare[SP]heroes[SP]fighting[SP]the[SP]Masked[SP]Circle.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "La fille bizarre de tout à\nl'heure est passée à la télé.\nCes cinq-là seraient des héros\ncombattant le Cercle masqué."
   },
   {
     "id": 43,
@@ -436,8 +436,8 @@
     "data_size": 292,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Those[SP]soldiers[SP]were[SP]headed[SP]for[SP]Mt.[SP]Katatsumuri.\nI'm[SP]glad[SP]we[SP]don't[SP]have[SP]a[SP]branch[SP]there.[SP]I[SP]know\nthat[SP]sounds[SP]bad,[SP]but[SP]it's[SP]how[SP]I[SP]feel!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Les soldats allaient au\nmont Katatsumuri. Heureusement\nqu'on n'y a pas de magasin.\nC'est mal dit, mais je le pense !"
   },
   {
     "id": 44,
@@ -446,8 +446,8 @@
     "data_size": 166,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Satomi[SP]Tadashi[SP]is[SP]open[SP]all[SP]year[SP]'round![1205][U+000A]\nCome[SP]back[SP]soon![SP]Heeheehee!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Satomi Tadashi est ouvert toute l'année ![1205][U+000A]\nRevenez vite ! Héhéhé !"
   },
   {
     "id": 45,
@@ -456,8 +456,8 @@
     "data_size": 216,
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Tum[SP]te[SP]duuuum...[1205][001E][SP]*gasp*[SP]The[SP]song![SP]I[SP]can't[SP]get\nit[SP]out[SP]of[SP]my[SP]head![SP]Hmm[SP]hmmmm[SP]hm[SP]hmmmmm...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Employé",
+    "texte_fr": "Tou dou doum...[1205][001E] *gasp* La\nchanson ! Impossible de l'oublier !\nHmm hmmmm hm hmmmmm..."
   },
   {
     "id": 46,
@@ -466,8 +466,8 @@
     "data_size": 258,
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Noooo![SP]The[SP]song[SP]won't[SP]leave[SP]my[SP]brain![1205][U+000F][SP]I[SP]should\nget[SP]out[SP]of[SP]this[SP]store...[1205][U+000F][SP]but[SP]I[SP]can't![SP]And[SP]I\ndon't[SP]know[SP]why!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Employé",
+    "texte_fr": "Non ! La chanson me hante ![1205][U+000F]\nJe dois fuir ce magasin...[1205][U+000F]\nMais je n'y arrive pas !\nEt j'ignore pourquoi !"
   },
   {
     "id": 47,
@@ -476,8 +476,8 @@
     "data_size": 300,
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Noooo![SP]I[SP]was[SP]so[SP]excited[SP]about[SP]that[SP]idol[SP]trio,\nbut[SP]I[SP]can't[SP]listen[SP]to[SP]anything[SP]besides[SP]this\nsong![1205][U+000F][SP]Someone[SP]stop[SP]it--wait,[SP]no,[SP]don't!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Employé",
+    "texte_fr": "Noooon ! J'aimais ce trio d'idoles,\nmais je n'écoute plus que cette\nchanson ![1205][U+000F] Que quelqu'un\nl'arrête--non, attendez !"
   },
   {
     "id": 48,
@@ -486,8 +486,8 @@
     "data_size": 276,
     "nom_orig": "Office[SP]worker",
     "texte_orig": "No[SP]more![1205][U+000F][SP]I've[SP]hit[SP]my[SP]limit![1205][U+000F][SP]How[SP]much[SP]longer\ndo[SP]I[SP]have[SP]to[SP]keep[SP]listening[SP]to[SP]this[SP]song!?\nI've[SP]had[SP]enough![SP]Stooooooop!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Employé",
+    "texte_fr": "Assez ![1205][U+000F] Je suis à bout ![1205][U+000F]\nCombien de temps vais-je\nencore subir cette chanson !?\nJ'en ai marre ! Stop !"
   },
   {
     "id": 49,
@@ -496,8 +496,8 @@
     "data_size": 270,
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Wait[SP]a[SP]second![SP]What[SP]if[SP]the[SP]terrorists[SP]target\nthis[SP]place[SP]next!?[SP]What'll[SP]happen[SP]to[SP]me[SP]if[SP]I\ncan't[SP]move[SP]from[SP]this[SP]spot!?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Employé",
+    "texte_fr": "Attendez ! Et si les terroristes visaient\ncet endroit !? Qu'est-ce qui va m'arriver\nsi je ne peux pas bouger d'ici !?"
   },
   {
     "id": 50,
@@ -506,8 +506,8 @@
     "data_size": 208,
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Oh[SP]my[SP]God![SP]Merciful[SP]heavens![SP]Smile[SP]Hirasaka\nwas[SP]bombed![SP]This[SP]place[SP]isn't[SP]safe[SP]either!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Employé",
+    "texte_fr": "Mon Dieu ! Miséricorde ! Le\nSmile Hirasaka a explosé !\nCe n'est pas sûr ici non plus !"
   },
   {
     "id": 51,
@@ -516,8 +516,8 @@
     "data_size": 258,
     "nom_orig": "Office[SP]worker",
     "texte_orig": "This[SP]is[SP]no[SP]time[SP]to[SP]be[SP]listening[SP]to[SP]music!\nI[SP]wanna[SP]run![SP]I[SP]really[SP]do![SP]But[SP]I[SP]can't...!\nAnd[SP]I[SP]don't[SP]even[SP]know[SP]why!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Employé",
+    "texte_fr": "Pas le moment d'écouter de la\nmusique ! Je veux fuir !\nMais je ne peux pas... !\nEt je ne sais même pas pourquoi !"
   },
   {
     "id": 52,
@@ -526,8 +526,8 @@
     "data_size": 260,
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Huh?[SP]Have[SP]any[SP]kids[SP]been[SP]here?[1205][U+000F][SP]Yeah,[SP]I[SP]saw\na[SP]couple[SP]of[SP]'em...[1205][U+000F][SP]But[SP]I[SP]was[SP]paying[SP]more\nattention[SP]to[SP]the[SP]song...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Employé",
+    "texte_fr": "Hein ? Des jeunes sont venus ?[1205][U+000F]\nOuais, j'en ai vu quelques-uns...[1205][U+000F]\nMais je faisais plus attention\nà la chanson..."
   },
   {
     "id": 53,
@@ -536,8 +536,8 @@
     "data_size": 240,
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Sorry,[SP]but[SP]did[SP]the[SP]news[SP]mention[SP]something[SP]big?\nI[SP]keep[SP]hearing[SP]people[SP]allude[SP]to[SP]it...[SP]What's\ngoing[SP]on?",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Employé",
+    "texte_fr": "Pardon, y'a un truc grave aux\ninfos ? Les gens y font\nallusion... Que se passe-t-il ?"
   },
   {
     "id": 54,
@@ -546,8 +546,8 @@
     "data_size": 266,
     "nom_orig": "Office[SP]worker",
     "texte_orig": "I[SP]don't[SP]care[SP]what[SP]happens[SP]anymore![SP]I'm[SP]just\ngoing[SP]to[SP]stay[SP]here[SP]and[SP]listen[SP]to[SP]the[SP]song.\nI'll[SP]be[SP]here[SP]even[SP]if[SP]I[SP]die!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Employé",
+    "texte_fr": "Je me fiche de ce qui arrivera !\nJe vais rester ici et écouter\nla chanson. Je resterai\nmême si je dois mourir !"
   },
   {
     "id": 55,
@@ -556,8 +556,8 @@
     "data_size": 302,
     "nom_orig": "Composer",
     "texte_orig": "I[SP]make[SP]my[SP]living[SP]as[SP]a[SP]composer,[SP]but[SP]an[SP]artist's\nlife[SP]is[SP]extremely[SP]tiring.[SP]The[SP]more[SP]I[SP]tap[SP]into\nmy[SP]creative[SP]side,[SP]the[SP]more[SP]exhausted[SP]I[SP]get.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Compositeur",
+    "texte_fr": "Je suis compositeur, mais la vie d'artiste\nest très fatigante. Plus je puise dans\nma créativité, plus je m'épuise."
   },
   {
     "id": 56,
@@ -566,8 +566,8 @@
     "data_size": 308,
     "nom_orig": "Composer",
     "texte_orig": "Sometimes[SP]this[SP]causes[SP]me[SP]to[SP]see[SP]things[SP]that\nordinary[SP]people[SP]can't.[SP]Such[SP]as[SP]the[SP]blue[SP]door[SP]to\nthe[SP]Velvet[SP]Room...[1205][001E][SP]Hmm,[SP]that[SP]gives[SP]me[SP]an[SP]idea!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Compositeur",
+    "texte_fr": "Ça me fait voir des choses invisibles\naux autres. Comme la porte bleue de la\nChambre de Velours...[1205][001E] Hmm,\nça me donne une idée !"
   },
   {
     "id": 57,
@@ -576,8 +576,8 @@
     "data_size": 296,
     "nom_orig": "Composer",
     "texte_orig": "The[SP]Kasuga[SP]Festival[SP]will[SP]include[SP]a[SP]masquerade.\nI[SP]think[SP]it's[SP]wonderful[SP]for[SP]the[SP]young[SP]students\nto[SP]come[SP]into[SP]contact[SP]with[SP]other[SP]cultures.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Compositeur",
+    "texte_fr": "Le festival Kasuga inclura une mascarade.\nJe trouve merveilleux que les jeunes\nélèves entrent en contact avec\nd'autres cultures."
   },
   {
     "id": 58,
@@ -586,8 +586,8 @@
     "data_size": 200,
     "nom_orig": "Composer",
     "texte_orig": "Do[SP]you[SP]know[SP]of[SP]the[SP]music[SP]producer[SP]Ginji[SP]Sasaki?\nHe's[SP]been[SP]the[SP]talk[SP]of[SP]the[SP]town[SP]lately.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Compositeur",
+    "texte_fr": "Connaissez-vous le producteur\nGinji Sasaki ? Il fait beaucoup\nparler de lui."
   },
   {
     "id": 59,
@@ -596,8 +596,8 @@
     "data_size": 294,
     "nom_orig": "Composer",
     "texte_orig": "Everyone[SP]respects[SP]him[SP]as[SP]a[SP]hit[SP]maker[SP]in[SP]the\nmusic[SP]industry[SP]these[SP]days.[SP]Personally,[SP]though,\nI[SP]don't[SP]find[SP]his[SP]songs[SP]that[SP]spectacular...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Compositeur",
+    "texte_fr": "Tous le respectent comme le\nfaiseur de tubes du moment.\nPourtant, je ne trouve pas ses\nchansons spectaculaires..."
   },
   {
     "id": 60,
@@ -606,8 +606,8 @@
     "data_size": 298,
     "nom_orig": "Composer",
     "texte_orig": "In[SP]truth,[SP]it[SP]was[SP]a[SP]dream[SP]of[SP]mine[SP]to[SP]perform[SP]at\nthat[SP]concert[SP]hall[SP]one[SP]day...[SP]What[SP]a[SP]pity[SP]to[SP]see\nthat[SP]dream[SP]die[SP]in[SP]such[SP]a[SP]horrible[SP]way...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Compositeur",
+    "texte_fr": "En vérité, c'était un de mes rêves\nde jouer dans cette salle un jour...\nQuel dommage de voir ce rêve\nmourir si horriblement..."
   },
   {
     "id": 61,
@@ -616,8 +616,8 @@
     "data_size": 272,
     "nom_orig": "Composer",
     "texte_orig": "First[SP]the[SP]concert[SP]hall,[SP]now[SP]Smile[SP]Hirasaka...\nIt's[SP]hard[SP]to[SP]keep[SP]my[SP]mind[SP]on[SP]my[SP]compositions\nwith[SP]the[SP]city[SP]in[SP]such[SP]bedlam...",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Compositeur",
+    "texte_fr": "La salle de concert, puis le Smile\nHirasaka... Dur de me concentrer\nsur mes compos avec la ville\ndans ce chaos..."
   },
   {
     "id": 62,
@@ -626,8 +626,8 @@
     "data_size": 310,
     "nom_orig": "Composer",
     "texte_orig": "I[SP]went[SP]to[SP]see[SP]the[SP]composite[SP]sketches,[SP]and[SP]I[SP]was\nsurprised[SP]to[SP]find[SP]they[SP]were[SP]much[SP]younger[SP]than[SP]I\nexpected.[SP]They[SP]were[SP]around[SP]your[SP]age,[SP]in[SP]fact.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Compositeur",
+    "texte_fr": "J'ai vu les portraits-robots, et\nj'ai été surpris de voir qu'ils étaient\nbien plus jeunes que prévu.\nIls avaient votre âge, en fait."
   },
   {
     "id": 63,
@@ -636,8 +636,8 @@
     "data_size": 236,
     "nom_orig": "Composer",
     "texte_orig": "Hmmm...[SP]Evildoers...[SP]or[SP]agents[SP]of[SP]justice...?[1205][U+000F]\nThis[SP]may[SP]be[SP]quite[SP]a[SP]promising[SP]theme...[SP]Aha!\nI've[SP]got[SP]it!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Compositeur",
+    "texte_fr": "Hmmm... Malfaiteurs... ou agents\nde la justice... ?[1205][U+000F] C'est un thème\nprometteur... Aha ! Je l'ai !"
   },
   {
     "id": 64,
@@ -646,8 +646,8 @@
     "data_size": 218,
     "nom_orig": "Composer",
     "texte_orig": "I[SP]wonder[SP]if[SP]crises[SP]stimulate[SP]man's[SP]brain...[1205][U+000F]\nNew[SP]songs[SP]are[SP]leaping[SP]from[SP]me,[SP]one[SP]after\nanother.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Compositeur",
+    "texte_fr": "La crise stimule le cerveau ?[1205][U+000F]\nDe nouvelles chansons me\nviennent l'une après l'autre."
   },
   {
     "id": 65,
@@ -656,8 +656,8 @@
     "data_size": 228,
     "nom_orig": "Composer",
     "texte_orig": "Ah,[SP]I[SP]cannot[SP]die[SP]until[SP]I[SP]finish[SP]these[SP]songs!\nI[SP]must[SP]not![SP]I[SP]feel[SP]as[SP]though[SP]a[SP]fire[SP]in[SP]me\nhas[SP]been[SP]lit!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Compositeur",
+    "texte_fr": "Ah, je ne dois pas mourir avant\nd'avoir fini ! J'ai l'impression\nqu'un feu m'anime !"
   },
   {
     "id": 66,
@@ -666,8 +666,8 @@
     "data_size": 256,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Welcome[SP]to[SP]Satomi[SP]Tadashi.[1205][U+000F][SP]I'm[SP]sorry,[SP]but[SP]we're\nnot[SP]quite[SP]open[SP]for[SP]business[SP]yet.[1205][U+000F][SP]Please[SP]come\nback[SP]in[SP]a[SP]while.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Bienvenue chez Satomi Tadashi.[1205][U+000F]\nDésolée, on n'est pas encore tout à\nfait ouverts.[1205][U+000F] Revenez plus tard."
   },
   {
     "id": 67,
@@ -676,8 +676,8 @@
     "data_size": 1244,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Ah,[SP]yes,[SP]welcome![1205][U+000A][SP]We[SP]work[SP]hard[SP]to[SP]spread[SP]our\nchain[SP]throughout[SP]the[SP]country![1205][U+000F][SP]What[SP]is[SP]it\nyou're[SP]here[SP]for[SP]today?\n[U+1208][U+0006]Buy[SP]items\nSell[SP]items\nTalk[SP]to[SP]Sister[SP]#5\n[U+1210]ĀView[SP]items\nNever[SP]mind\nLeave[SP]the[SP]store\n[U+1109][E2][E3][E4][NULL][NULL]\"Sister[SP]#5\nSo,[SP]what[SP]would[SP]you[SP]like[SP]to[SP]sell?\n[U+1208][U+0007][U+111F][U+1210]ĀUndisplayed[SP]selection\n[U+111F]Sell[SP]items\n[U+111F]Sell[SP]weapons\n[U+111F][U+1210]ĀSell[SP]head[SP]armor\n[U+111F]Sell[SP]armor\n[U+111F][U+1210]ĀSell[SP]leg[SP]armor\n[U+111F]Sell[SP]accessories\n[U+1109][E2][E3][E4][NULL][NULL]\"Sister[SP]#5\nSo[SP]what[SP]do[SP]you[SP]want[SP]to[SP]talk[SP]about?\n[U+1208][U+0003]Make[SP]small[SP]talk\nAsk[SP]about[SP]shopping\n[U+1210]ĀUndisplayed[SP]selection\n[U+1109][E2][E3][E4][NULL][NULL]\"Hanako's[SP]mother\nHonestly,[SP]this[SP]girl...[SP]She[SP]went[SP]to[SP]Kasugayama\nHigh[SP]alone[SP]just[SP]to[SP]see[SP]if[SP]their[SP]emblem[SP]really\ndid[SP]repel[SP]evil!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Ah, bienvenue ![1205][U+000A] Nous œuvrons pour\nrépandre notre chaîne dans tout\nle pays ![1205][U+000F] Que puis-je pour vous ?\n[U+1208][U+0006]Acheter\nVendre\nParler à la Sœur #5\n[U+1210]ĀVoir les objets\nRien\nQuitter\n[U+1109][E2][E3][E4][NULL][NULL]\"Sœur[SP]#5\nQue voulez-vous vendre ?\n[U+1208][U+0007][U+111F][U+1210]ĀSélection masquée\n[U+111F]Objets\n[U+111F]Armes\n[U+111F][U+1210]ĀCasques\n[U+111F]Armures\n[U+111F][U+1210]ĀJambières\n[U+111F]Accessoires\n[U+1109][E2][E3][E4][NULL][NULL]\"Sœur[SP]#5\nDe quoi voulez-vous parler ?\n[U+1208][U+0003]Bavarder\nParler de la boutique\n[U+1210]ĀSélection masquée\n[U+1109][E2][E3][E4][NULL][NULL]\"Mère[SP]d'Hanako\nFranchement, cette fille... Elle est\nallée seule au Lycée Kasugayama juste\npour voir si leur emblème repoussait\nvraiment le mal !"
   },
   {
     "id": 68,
@@ -686,8 +686,8 @@
     "data_size": 330,
     "nom_orig": "Hanako's[SP]mother",
     "texte_orig": "I[SP]know[SP]she's[SP]an[SP]inquisitive[SP]child,[SP]but[SP]for[SP]a[SP]girl\nto[SP]sneak[SP]into[SP]an[SP]all-male[SP]high[SP]school[SP]like[SP]that...[1205][U+000F]\nWell,[SP]at[SP]least[SP]I[SP]admire[SP]her[SP]fearlessness.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Mère d'Hanako",
+    "texte_fr": "Elle est curieuse, mais qu'une fille\ns'infiltre dans un lycée pour garçons\nainsi...[1205][U+000F] Eh bien, j'admire au\nmoins son intrépidité."
   },
   {
     "id": 69,
@@ -696,8 +696,8 @@
     "data_size": 152,
     "nom_orig": "Hanako",
     "texte_orig": "I[SP]went[SP]to[SP]go[SP]see[SP]if[SP]Cuss[SP]High's[SP]emblem[SP]really\ndid[SP]keep[SP]out[SP]evil.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Hanako",
+    "texte_fr": "Je voulais voir si l'emblème de\nKakasu repoussait le mal."
   },
   {
     "id": 70,
@@ -706,8 +706,8 @@
     "data_size": 194,
     "nom_orig": "Hanako",
     "texte_orig": "When[SP]I[SP]was[SP]in[SP]there,[SP]this[SP]man[SP]who[SP]looked[SP]like\na[SP]girl[SP]came[SP]up[SP]to[SP]me[SP]and[SP]asked[SP]my[SP]name.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Hanako",
+    "texte_fr": "Sur place, un homme qui\nressemblait à une fille est\nvenu me demander mon nom."
   },
   {
     "id": 71,
@@ -716,8 +716,8 @@
     "data_size": 238,
     "nom_orig": "Hanako",
     "texte_orig": "I[SP]didn't[SP]want[SP]to[SP]cause[SP]trouble[SP]like[SP]I[SP]did[SP]at\nSevens[SP]by[SP]saying[SP]Hanako,[SP]so[SP]I[SP]lied[SP]and[SP]said\nmy[SP]name[SP]was[SP]Akemi.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Hanako",
+    "texte_fr": "Pour éviter les ennuis\ncomme à Seven en disant Hanako,\nj'ai menti et dit m'appeler Akemi."
   },
   {
     "id": 72,
@@ -726,8 +726,8 @@
     "data_size": 148,
     "nom_orig": "Hanako",
     "texte_orig": "Then[SP]the[SP]man[SP]ran[SP]off[SP]screaming,[SP][1432][NULL][NULL][0014]It's[SP]Bukimi![1432][NULL][NULL][0014]\nHow[SP]rude!",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Hanako",
+    "texte_fr": "Puis il a fui en hurlant :\n[1432][NULL][NULL][0014]C'est Bukimi ![1432][NULL][NULL][0014]\nQuel culot !"
   },
   {
     "id": 73,
@@ -736,8 +736,8 @@
     "data_size": 120,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Oh,[SP]but[SP]you[SP]don't[SP]have[SP]anything[SP]you[SP]can[SP]sell.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Oh, vous n'avez rien à vendre."
   },
   {
     "id": 74,
@@ -746,7 +746,7 @@
     "data_size": 1358,
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "The[SP]total[SP]comes[SP]to[SP][U+120E][NULL][SP]yen.\nIs[SP]that[SP]all[SP]right?\n[U+1208][0002]Yes\nNo\n[U+1109][E2][E3][E4][NULL][NULL]\"Sister[SP]#5\nHeeheehee.[SP]Okay,[SP]I'll[SP]tell[SP]you[SP]a[SP]little[SP]about\nshopping.\n[E1][E2][E4][NULL][NULL]\"Sister[SP]#5\nFirst,[SP]buying[SP]things.[SP]If[SP]you[SP]select[SP][1432][NULL][NULL][0014]Buy[SP]items,[1432][NULL][NULL][0014]\nyou[SP]can[SP]choose[SP]from[SP]our[SP]sundries.\n[E1][E2][E4][NULL][NULL]\"Sister[SP]#5\nOh,[SP]and[SP]there's[SP]a[SP]limit[SP]to[SP]how[SP]many[SP]of[SP]the\nsame[SP]item[SP]you[SP]can[SP]carry.\n[E1][E2][E4][NULL][NULL]\"Sister[SP]#5\nNext,[SP]selling.[SP]Select[SP][1432][NULL][NULL][0014]Sell[SP]items[1432][NULL][NULL][0014][SP]first,[SP]and\nthen[SP]choose[SP]which[SP]type[SP]of[SP]item[SP]to[SP]sell.[SP]Then\npick[SP]a[SP]particular[SP]item[SP]to[SP]sell[SP]us.\n[E1][E2][E4][NULL][NULL]\"Sister[SP]#5\nOur[SP]resale[SP]prices[SP]are[SP]around[SP]half[SP]the[SP]original\nprice.[SP]You[SP]can't[SP]sell[SP]anything[SP]you[SP]have[SP]equipped,\nand[SP]some[SP]special[SP]items[SP]are[SP]off-limits[SP]too.\n[E1][E2][E4][NULL][NULL]\"Sister[SP]#5\nThat's[SP]about[SP]it.[SP]Heeheehee.",
-    "nom_fr": "",
-    "texte_fr": ""
+    "nom_fr": "Sœur #5",
+    "texte_fr": "Total : [U+120E][NULL] yens.\nD'accord ?\n[U+1208][0002]Oui\nNon\n[U+1109][E2][E3][E4][NULL][NULL]\"Sœur[SP]#5\nHéhé. Parlons des achats.\n[E1][E2][E4][NULL][NULL]\"Sœur[SP]#5\nAchat: via [1432][NULL][NULL][0014]Acheter[1432][NULL][NULL][0014], choisissez\nparmi nos divers articles.\n[E1][E2][E4][NULL][NULL]\"Sœur[SP]#5\nOh, il y a une limite\nd'objets identiques portés.\n[E1][E2][E4][NULL][NULL]\"Sœur[SP]#5\nVente: via [1432][NULL][NULL][0014]Vendre[1432][NULL][NULL][0014], choisissez\nle type d'objet, puis l'objet.\n[E1][E2][E4][NULL][NULL]\"Sœur[SP]#5\nOn rachète à moitié prix.\nRien d'équipé ou d'interdit.\n[E1][E2][E4][NULL][NULL]\"Sœur[SP]#5\nC'est tout. Héhé."
   }
 ]


### PR DESCRIPTION
- Traduction complète des 75 entrées du script.
- Remplacement systématique des balises [SP] par des espaces standards.
- Conservation rigoureuse de tous les codes de formatage complexes.
- Correction ciblée des ID 46, 48, 58, 64 et 69 pour appliquer une réduction extrême du nombre de caractères, respectant ainsi les contraintes de mémoire de la PSP.