### PR TITLE
Fix: Traduction Boss des calbutes et Jeu du Joker

### DIFF
--- a/Dictionnaire.md
+++ b/Dictionnaire.md
@@ -40,6 +40,7 @@
 | **Idealians** | Idéaliens | |
 | **Fuhrer** | Führer | |
 | **Grand Cross** | Croix Cosmique / Croix | |
+| **Joker Game** | Jeu du Joker | |
 | **Last Batallion** | Bataillon | Raccourci assumé en raison des contraintes mémoires du moteur. |
 | **In Lak'ech** | In Lak'ech | Terminologie d'origine inca conservée telle quelle. |
 
@@ -66,6 +67,7 @@
 |:---|:---|:---|
 | **Philemon** | Philémon | Application obligatoire de l'accentuation. |
 | **Demon Painter** | Demon Painter | Pseudonyme conservé intact en anglais par décision créative. |
+| **Undie Boss** | Boss des calbutes | |
 | **Nameless** | Nameless | Pseudonyme conservé intact en anglais par décision créative. |
 | **Maia** / **Mayan** | Maia / Maya | |
 | **Longinus** | Longinus | |

--- a/p2is_tool/src/encoders/bin_encoder.py
+++ b/p2is_tool/src/encoders/bin_encoder.py
@@ -272,9 +272,9 @@ def encode_bin_from_json(
 
         n_fr = n_fr_input or d.get("nom_orig", "").strip()
 
-        avail = d["data_size"] - 8
-        # NL avant terminateur : règle binaire universelle (event + MMAP + autres)
         term = d.get("_term", [E1, E2, E3, E4])
+        avail = d["data_size"] - (len(term) * 2)
+        # NL avant terminateur : règle binaire universelle (event + MMAP + autres)
         nl_suffix = (
             struct.pack("<H", NL)
             if _needs_nl_suffix(term, d.get("texte_orig", ""))
@@ -398,7 +398,8 @@ def encode_bnp_from_json(
             d.get("nom_orig", ""), d.get("texte_orig", ""), n_fr, t_fr
         )
         enc = text_to_bytes('"' + n_fr + "\n" + t_fr)
-        avail = d["data_size"] - 8
+        term = d.get("_term", [E1, E2, E3, E4])
+        avail = d["data_size"] - (len(term) * 2)
         is_menu = "[1208]" in d.get("texte_orig", "") or "[U+1208]" in d.get(
             "texte_orig", ""
         )
@@ -422,8 +423,6 @@ def encode_bnp_from_json(
                 enc = text_to_bytes('"' + n_fr + "\n" + t_fr)
 
         pad_len = avail - len(enc) - len(nl_sfx)
-        sp_pad = b""
-        term = d.get("_term", [E1, E2, E3, E4])
         end_c = b"".join(struct.pack("<H", t) for t in term)
         null_gap_orig = data[
             d["offset"] + d["data_size"] : d["offset"] + d["slot_size"]
@@ -482,7 +481,8 @@ def encode_bnp_from_json(
                 d.get("nom_orig", ""), d.get("texte_orig", ""), n_fr, t_fr
             )
             enc = text_to_bytes('"' + n_fr + "\n" + t_fr)
-            avail = d["data_size"] - 8
+            term = d.get("_term", [E1, E2, E3, E4])
+            avail = d["data_size"] - (len(term) * 2)
             nl_sfx = (
                 struct.pack("<H", NL)
                 if _needs_nl_suffix(
@@ -495,13 +495,13 @@ def encode_bnp_from_json(
                     log_fn(f"  [id {d['id']}] trop long, ignoré", "warn")
                 skip += 1
                 continue
-            sp_pad = struct.pack("<H", SP) * ((avail - len(enc) - len(nl_sfx)) // 2)
+            pad_len = avail - len(enc) - len(nl_sfx)
             term = d.get("_term", [E1, E2, E3, E4])
             end_c = b"".join(struct.pack("<H", t) for t in term)
             null_gap_orig = dec[
                 d["offset"] + d["data_size"] : d["offset"] + d["slot_size"]
             ]
-            full = enc + sp_pad + nl_sfx + end_c + null_gap_orig
+            full = enc + nl_sfx + end_c + null_gap_orig + b"\x00" * pad_len
             if len(full) != d["slot_size"]:
                 skip += 1
                 continue

--- a/p2is_tool/src/encoders/bin_encoder.py
+++ b/p2is_tool/src/encoders/bin_encoder.py
@@ -309,19 +309,30 @@ def encode_bin_from_json(
             depassement = len(enc) + len(nl_suffix) - avail
             if log_fn:
                 log_fn(
-                    f"  [!] [DEPASSEMENT] [id {d['id']}] Texte FR trop long de {depassement} octets ({len(enc)} > {avail}). Texte ignore et version originale restauree.",
+                    f"  [!] [DEPASSEMENT] [id {d['id']}] Texte FR trop long de {depassement} octets ({len(enc)} > {avail}). Troncature automatique.",
                     "warn",
                 )
-            skip += 1
-            continue
-        sp_pad = struct.pack("<H", SP) * ((avail - len(enc) - len(nl_suffix)) // 2)
+            import re
+            tokens = re.split(r'(\[[a-zA-Z0-9+\-_]+\]|\s)', t_fr)
+            tokens = [t for t in tokens if t]
+            
+            while tokens and len(text_to_bytes('"' + n_fr + "\n" + ''.join(tokens))) > avail - len(nl_suffix):
+                tokens.pop()
+                
+            t_fr = ''.join(tokens)
+            enc = text_to_bytes('"' + n_fr + "\n" + t_fr)
+            
+        pad_len = avail - len(enc) - len(nl_suffix)
+        if pad_len < 0:
+            pad_len = 0
 
         end_c = b"".join(struct.pack("<H", t) for t in term)
         null_gap_orig = data[
             d["offset"] + d["data_size"] : d["offset"] + d["slot_size"]
         ]
 
-        full = enc + sp_pad + nl_suffix + end_c + null_gap_orig
+        e3_pad = struct.pack("<H", E3) * (pad_len // 2)
+        full = enc + nl_suffix + end_c + e3_pad + null_gap_orig
 
         if len(full) != d["slot_size"]:
             skip += 1
@@ -405,29 +416,32 @@ def encode_bnp_from_json(
         )
         nl_sfx = struct.pack("<H", NL) if is_menu else b""
 
-        # TRONCATURE AUTOMATIQUE si le texte FR est trop long
+        # TRONCATURE AUTOMATIQUE SÉCURISÉE si le texte FR est trop long
         if len(enc) > avail - len(nl_sfx):
             depassement = len(enc) - (avail - len(nl_sfx))
             if log_fn:
                 log_fn(
-                    f"  [!] [DEPASSEMENT] [id {d['id']}] Texte FR tronque de {depassement//2} caracteres.",
+                    f"  [!] [DEPASSEMENT] [id {d['id']}] Texte FR trop long de {depassement//2} caracteres.",
                     "warn",
                 )
-            # On coupe le texte FR en retirant les caractères en trop à la fin
-            t_fr = t_fr[: -(depassement // 2)]
+            
+            import re
+            tokens = re.split(r'(\[[a-zA-Z0-9+\-_]+\]|\s)', t_fr)
+            tokens = [t for t in tokens if t]
+            
+            while tokens and len(text_to_bytes('"' + n_fr + "\n" + ''.join(tokens))) > avail - len(nl_sfx):
+                tokens.pop()
+                
+            t_fr = ''.join(tokens)
             enc = text_to_bytes('"' + n_fr + "\n" + t_fr)
-
-            # Recalcul de sécurité au cas où (si des balises complexes ont été coupées)
-            while len(enc) > avail - len(nl_sfx) and len(t_fr) > 0:
-                t_fr = t_fr[:-1]
-                enc = text_to_bytes('"' + n_fr + "\n" + t_fr)
 
         pad_len = avail - len(enc) - len(nl_sfx)
         end_c = b"".join(struct.pack("<H", t) for t in term)
         null_gap_orig = data[
             d["offset"] + d["data_size"] : d["offset"] + d["slot_size"]
         ]
-        full = enc + nl_sfx + end_c + null_gap_orig + b"\x00" * pad_len
+        e3_pad = struct.pack("<H", E3) * (pad_len // 2)
+        full = enc + nl_sfx + end_c + e3_pad + null_gap_orig
         if len(full) != d["slot_size"]:
             skip += 1
             continue
@@ -492,16 +506,28 @@ def encode_bnp_from_json(
             )
             if len(enc) + len(nl_sfx) > avail:
                 if log_fn:
-                    log_fn(f"  [id {d['id']}] trop long, ignoré", "warn")
-                skip += 1
-                continue
+                    log_fn(f"  [id {d['id']}] trop long, troncature automatique", "warn")
+                
+                import re
+                tokens = re.split(r'(\[[a-zA-Z0-9+\-_]+\]|\s)', t_fr)
+                tokens = [t for t in tokens if t]
+                
+                while tokens and len(text_to_bytes('"' + n_fr + "\n" + ''.join(tokens))) > avail - len(nl_sfx):
+                    tokens.pop()
+                    
+                t_fr = ''.join(tokens)
+                enc = text_to_bytes('"' + n_fr + "\n" + t_fr)
+                
             pad_len = avail - len(enc) - len(nl_sfx)
+            if pad_len < 0:
+                pad_len = 0
             term = d.get("_term", [E1, E2, E3, E4])
             end_c = b"".join(struct.pack("<H", t) for t in term)
             null_gap_orig = dec[
                 d["offset"] + d["data_size"] : d["offset"] + d["slot_size"]
             ]
-            full = enc + nl_sfx + end_c + null_gap_orig + b"\x00" * pad_len
+            e3_pad = struct.pack("<H", E3) * (pad_len // 2)
+            full = enc + nl_sfx + end_c + e3_pad + null_gap_orig
             if len(full) != d["slot_size"]:
                 skip += 1
                 continue

--- a/traduction/MMAP01.json
+++ b/traduction/MMAP01.json
@@ -13,7 +13,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Oh,[SP]wait[SP]a[SP]sec,[SP][1113].[SP]We[SP]should[SP]go[SP]to[SP]the\ndetective[SP]agency[SP]to[SP]ask[SP]them[SP]about[SP]the[SP]secret\ndish[SP]and[SP]stuff.",
     "nom_fr": "Lisa",
-    "texte_fr": "Attends, [1113]. Allons à l'agence\nde détectives pour demander des\ninfos sur le plat secret."
+    "texte_fr": "Attends, [1113]. Allons à l'agence\nde détectives pour demander\ndes infos sur le plat secret."
   },
   {
     "id": 1,
@@ -29,7 +29,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Not[SP]yet,[SP][1113]![SP]We[SP]gotta[SP]go[SP]get[SP]weapons\nfirst.[SP]Let's[SP]go[SP]to[SP]that[SP]ramen[SP]shop[SP]like[SP]the\nrumor[SP]says.",
     "nom_fr": "Lisa",
-    "texte_fr": "Pas encore, [1113]! Il nous faut des\narmes. Allons au ramen shop de la rumeur."
+    "texte_fr": "Pas encore, [1113] ! Il nous faut\ndes armes. Allons au ramen shop\nde la rumeur."
   },
   {
     "id": 2,
@@ -45,7 +45,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Geez,[SP]where[SP]are[SP]you[SP]going,[SP][1113]?[SP]We[SP]need\nto[SP]go[SP]to[SP]Shiraishi[SP]Ramen[SP]to[SP]check[SP]and[SP]see[SP]if\nthe[SP]experiment[SP]worked!",
     "nom_fr": "Lisa",
-    "texte_fr": "Urgh, où vas-tu [1113]? On doit\naller à Shiraishi Ramen voir si\nnotre expérience a porté ses fruits!"
+    "texte_fr": "Urgh, où vas-tu [1113] ?\nOn doit aller à Shiraishi Ramen voir si\nnotre expérience a porté ses fruits !"
   },
   {
     "id": 3,
@@ -91,7 +91,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Hah...[SP]The[SP]Kasuga[SP]Festival,[SP]eh?[SP]I[SP]think[SP]this[SP]is\nthe[SP]first[SP]time[SP]Cuss[SP]High[SP]has[SP]ever[SP]had[SP]an[SP]actual\nschool[SP]festival.[SP]They're[SP]moving[SP]up[SP]in[SP]the[SP]world.",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Le festival de Kasuga? Je crois bien\nque c'est une première pour le lycée\nKakasu. Ils gagnent en crédibilité."
+    "texte_fr": "Le festival de Kasuga ? Je crois bien que c'est\nune première pour le lycée Kakasu. Ils gagnent en\ncrédibilité."
   },
   {
     "id": 6,
@@ -107,7 +107,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "I'm[SP]from[SP]here,[SP]so[SP]seeing[SP]that[SP]makes[SP]me[SP]happy.[1205][U+000F]\nTakes[SP]me[SP]back[SP]to[SP]my[SP]high[SP]school[SP]days,[SP]it[SP]does.",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Je viens d'ici, donc voir ça me\nrend heureux.[1205][U+000F] Ah, les années lycée."
+    "texte_fr": "Je viens d'ici, donc voir ça me rend heureux.[1205][U+000F]\nAh, les années lycée."
   },
   {
     "id": 7,
@@ -123,7 +123,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Huh?[SP]That's[SP]weird...[1205][U+000F][SP]I[SP]haven't[SP]seen[SP]Cuss[SP]High\nstudents[SP]around[SP]lately.[SP]Did[SP]their[SP]enrollment\nnumbers[SP]drop?[1205][U+000F][SP]Nah,[SP]that[SP]can't[SP]be[SP]it...",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Bizarre...[1205][U+000F] Pas d'élèves du lycée Kakasu\nrécemment. Moins d'inscrits?[1205][U+000F] Nan,\nimpossible..."
+    "texte_fr": "Bizarre...[1205][U+000F] Pas d'élèves du lycée\nKakasu récemment. Moins d'inscrits ?[1205][U+000F]\nNan, impossible..."
   },
   {
     "id": 8,
@@ -139,7 +139,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "You[SP]can[SP]buy[SP]CDs[SP]at[SP]Giga[SP]Macho[SP]in[SP]Yumezaki.[1205][U+000F]\nI[SP]go[SP]there[SP]all[SP]the[SP]time.",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Achète tes CD à Giga Macho à\nYumezaki.[1205][U+000F] J'y vais tout le temps."
+    "texte_fr": "Achète tes CD à Giga Macho\nà Yumezaki.[1205][U+000F] J'y vais tout le temps."
   },
   {
     "id": 9,
@@ -154,7 +154,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "This[SP]terrorism[SP]wave's[SP]the[SP]talk[SP]of[SP]the[SP]city.\nHonestly,[SP]I'm[SP]scared[SP]too.[1205][U+000F][SP]Even[SP]the[SP]police\nstation[SP]and[SP]fire[SP]department[SP]got[SP]hit.",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Cette vague terroriste fait parler.\nJ'ai peur aussi.[1205][U+000F] Même la police et\nles pompiers sont touchés."
+    "texte_fr": "Cette vague terroriste fait parler.\nJ'ai peur aussi.[1205][U+000F] Même la police\net les pompiers sont touchés."
   },
   {
     "id": 10,
@@ -169,7 +169,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Who's[SP]left[SP]to[SP]protect[SP]this[SP]city[SP]or[SP]put[SP]out\nany[SP]fires[SP]that[SP]get[SP]started?",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Qui reste-t-il pour protéger\ncette ville et éteindre les feux?"
+    "texte_fr": "Qui reste-t-il pour protéger cette ville et\néteindre les feux ?"
   },
   {
     "id": 11,
@@ -185,7 +185,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "We're[SP]just[SP]stuck[SP]waiting[SP]for[SP]the[SP]terrorists\nto[SP]strike[SP]again!",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "On est coincés à attendre\nla prochaine attaque!"
+    "texte_fr": "On est coincés à attendre\nla prochaine attaque !"
   },
   {
     "id": 12,
@@ -200,7 +200,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Now[SP]that[SP]was[SP]strange...[1205][U+000F][SP]This[SP]girl[SP]in[SP]crazy\nclothes[SP]just[SP]ran[SP]out[SP]of[SP]Smile[SP]Hirasaka.",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Étrange...[1205][U+000F] Cette fille en tenue\nfolle a fui de Smile Hirasaka."
+    "texte_fr": "Étrange...[1205][U+000F] Cette fille en\ntenue folle a fui de Smile Hirasaka."
   },
   {
     "id": 13,
@@ -216,7 +216,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "I[SP]think[SP]I[SP]heard[SP]her[SP]say[SP]something[SP]like,[SP][1432][NULL][NULL][0014]You'll\npay[SP]for[SP]this![1432][NULL][NULL][0014][SP]as[SP]she[SP]went...",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Je crois que je l'ai entendu dire\nun truc comme [1432][NULL][NULL][0014]Tu vas le regretter![1432][NULL][NULL][0014]"
+    "texte_fr": "Je crois que je l'ai entendu dire un truc comme\n[1432][NULL][NULL][0014]Tu vas le regretter ![1432][NULL][NULL][0014]"
   },
   {
     "id": 14,
@@ -231,7 +231,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Now[SP]that[SP]was[SP]strange...[1205][U+000F][SP]This[SP]girl[SP]with[SP]crazy\nclothes[SP]and[SP]a[SP]burning[SP]ass[SP]ran[SP]out[SP]of[SP]Smile\nHirasaka[SP]when[SP]it[SP]was[SP]on[SP]fire[SP]just[SP]now.",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "C'est étrange...[1205][U+000F] Cette fille habillée\nbizarrement vient de sortir de Smile\nHirasaka qui flambait en courant."
+    "texte_fr": "C'est étrange...[1205][U+000F] Cette fille habillée\nbizarrement vient de sortir de Smile Hirasaka qui flambait\nen courant."
   },
   {
     "id": 15,
@@ -247,7 +247,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "I[SP]think[SP]I[SP]heard[SP]her[SP]say[SP]something[SP]like,\n[1432][NULL][NULL][0014]This[SP]wasn't[SP]how[SP]it[SP]was[SP]supposed[SP]to[SP]go![1432][NULL][NULL][0014]\nas[SP]she[SP]went...",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Je crois que je l'ai entendu dire un truc\ncomme [1432][NULL][NULL][0014]C'était pas censé se passer comme ça![1432][NULL][NULL][0014]"
+    "texte_fr": "Je crois que je l'ai entendu dire un truc comme\n[1432][NULL][NULL][0014]C'était pas censé se passer comme ça ![1432][NULL][NULL][0014]"
   },
   {
     "id": 16,
@@ -262,7 +262,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Huh?[SP]It's[SP]that[SP]girl[SP]again...[1205][U+000F][SP]I[SP]mean[SP]the[SP]one[SP]in\nthe[SP]weird[SP]getup[SP]who[SP]ran[SP]out[SP]of[SP]Smile[SP]Hirasaka\nbefore.[1205][U+000F]",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "C'est encore cette fille?[1205][U+000F] Celle que j'ai\nvu sortir de Smile Hirasaka en courant.[1205][U+000F]"
+    "texte_fr": "C'est encore cette fille ?[1205][U+000F] Celle que j'ai vu sortir\nde Smile Hirasaka en courant.[1205][U+000F]"
   },
   {
     "id": 17,
@@ -277,7 +277,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "And[SP]it[SP]seemed[SP]like[SP]there[SP]were[SP]a[SP]bunch[SP]of[SP]kids\nwith[SP]her[SP]this[SP]time...",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Et cette fois, elle était\naccompagnée d'une bande de gamins..."
+    "texte_fr": "Et cette fois, elle était accompagnée\nd'une bande de gamins..."
   },
   {
     "id": 18,
@@ -293,7 +293,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "They[SP]said[SP]something[SP]about[SP]how[SP]the[SP]five[SP]people\non[SP]the[SP]news[SP]are[SP]actually[SP]heroes[SP]fighting\nagainst[SP]the[SP]Masked[SP]Circle...[1205][U+000F][SP]Is[SP]that[SP]true?",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Ils disent que les cinq personnes dans le\njournal sont en fait des héros qui\ncombattent le cercle masqué.[1205][U+000F] C'est vrai, ça?"
+    "texte_fr": "Ils disent que les cinq personnes dans le journal\nsont en fait des héros qui combattent le cercle masqué.[1205][U+000F]\nC'est vrai, ça ?"
   },
   {
     "id": 19,
@@ -308,7 +308,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "That[SP]girl[SP]gets[SP]around.[SP]I[SP]just[SP]saw[SP]her[SP]on\nthe[SP]news.[1205][U+000F]",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Cette fille bouge beaucoup. Vue aux infos.[1205][U+000F]"
+    "texte_fr": "Cette fille bouge beaucoup.\nVue aux infos.[1205][U+000F]"
   },
   {
     "id": 20,
@@ -323,7 +323,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "She[SP]said[SP]the[SP]five[SP]suspects[SP]are[SP]heroes\nthere[SP]too...",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Elle dit que ces 5 suspects sont des héros..."
+    "texte_fr": "Elle dit que ces 5 suspects\nsont des héros..."
   },
   {
     "id": 21,
@@ -339,7 +339,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "I-I'm[SP]starting[SP]to[SP]feel[SP]like[SP]I[SP]might[SP]believe\nher...[1205][U+000F][SP]Huh?[SP]Hey,[SP]don't[SP]get[SP]the[SP]wrong[SP]idea!",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Elle a peut-être raison...[1205][U+000F] Hah?\nEh, ne te fais pas d'idées!"
+    "texte_fr": "Elle a peut-être raison...[1205][U+000F] Hah ?\nEh, ne te fais pas d'idées !"
   },
   {
     "id": 22,
@@ -355,7 +355,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Wh-Where[SP]are[SP]those[SP]soldiers[SP]going?[1205][U+000F][SP]There's\nnothing[SP]over[SP]there[SP]but[SP]Mt.[SP]Katatsumuri.[1205][U+000F][SP]What\nare[SP]they[SP]doing[SP]there[SP]with[SP]all[SP]those[SP]guns?",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Où vont ces soldats?[1205][U+000F] Il n'y a rien là-bas\nà part le Mt Katatsumuri.[1205][U+000F] Qu'est-ce\nqu'ils font avec tous ces flingues?"
+    "texte_fr": "Où vont ces soldats ?[1205][U+000F] Il n'y a rien là-bas\nà part le Mt Katatsumuri.[1205][U+000F] Qu'est-ce qu'ils\nfont avec tous ces flingues ?"
   },
   {
     "id": 23,
@@ -370,7 +370,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Dude,[SP]what's[SP]going[SP]on!?[1205][U+0008]",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Que se passe-t-il!?[1205][U+0008]"
+    "texte_fr": "Que se passe-t-il !?[1205][U+0008]"
   },
   {
     "id": 24,
@@ -385,7 +385,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "First[SP]that[SP]weird[SP]temple[SP]shows[SP]up,[SP]then[SP]the\nLast[SP]Battalion[SP]and[SP]Masked[SP]Circle[SP]goons[SP]show\nup[SP]and[SP]swarm[SP]into[SP]it!",
     "nom_fr": "Jeune homme",
-    "texte_fr": "D'abord ce temple bizarre, puis le Bataillon\net le Cercle masqué l'envahissent!"
+    "texte_fr": "D'abord ce temple bizarre, puis\nle Bataillon et le Cercle masqué\nl'envahissent !"
   },
   {
     "id": 25,
@@ -401,7 +401,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "They[SP]all[SP]went[SP]inside...[1205][U+000A][SP]I[SP]can[SP]hear[SP]gunshots[SP]and\nstuff[SP]from[SP]in[SP]there.[1205][U+000F][SP]Are[SP]they[SP]still[SP]fighting?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ils y sont entrés...[1205][U+000A] J'entends des tirs\nà l'intérieur.[1205][U+000F] Ils se battent encore?"
+    "texte_fr": "Ils y sont entrés...[1205][U+000A] J'entends des tirs\nà l'intérieur.[1205][U+000F] Ils se battent encore ?"
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Looks[SP]like[SP]the[SP]war[SP]between[SP]the[SP]Masked[SP]Circle\nand[SP]the[SP]Last[SP]Battalion's[SP]being[SP]fought[SP]in[SP]that\ntemple...[1205][U+000F][SP]Will[SP]they[SP]fight[SP]to[SP]the[SP]death?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "La guerre entre le Cercle masqué\net le Bataillon a lieu dans ce\ntemple...[1205][U+000F] S'entretueront-ils?"
+    "texte_fr": "La guerre entre le Cercle masqué\net le Bataillon a lieu dans ce\ntemple...[1205][U+000F] S'entretueront-ils ?"
   },
   {
     "id": 27,
@@ -432,7 +432,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "I[SP]was[SP]like,[SP]Cuss[SP]High?[SP]Totally[SP]not[SP]my[SP]thing.\nBut[SP]then[SP]lately[SP]they've[SP]been[SP]getting[SP]these\nhot[SP]guys?",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le lycée Kakasu? Pas mon truc. Mais ces\ntemps-ci, ils ont eu plein de beaux garçons,\nnon?"
+    "texte_fr": "Le lycée Kakasu ? Pas mon truc.\nMais ces temps-ci, ils ont eu plein\nde beaux garçons, non ?"
   },
   {
     "id": 28,
@@ -448,7 +448,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "So[SP]now[SP]I[SP]go[SP]watch[SP]their[SP]shows[SP]at[SP]the[SP]Prison.\nYou're[SP]kinda[SP]cute[SP]too,[SP]but[SP]you're[SP]just[SP]a\nSevens[SP]student.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Donc je vais voir leurs shows à la Prison.\nT'es mignon, mais t'es juste un élève de\nSeven."
+    "texte_fr": "Donc je vais voir leurs shows à la Prison.\nT'es mignon, mais t'es juste\nun élève de Seven."
   },
   {
     "id": 29,
@@ -463,7 +463,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "So[SP]like,[SP]the[SP]new[SP]Leader[SP]of[SP]Cuss[SP]High[SP]was\ndecided?[1205][U+000F][SP]He's[SP]waaaay[SP]better.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le nouveau chef de Kakasu a été\nchoisi?[1205][U+000F] Il est carrément mieux."
+    "texte_fr": "Le nouveau chef de Kakasu a\nété choisi ?[1205][U+000F] Il est carrément mieux."
   },
   {
     "id": 30,
@@ -478,7 +478,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "I[SP]mean,[SP]Undie[SP]Boss?[SP]Puh-lease.[SP]Like[SP]the[SP]name\nwasn't[SP]bad[SP]enough,[SP]he[SP]kept[SP]making[SP]these[SP]rules.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Boss Calbute? Pitié. En plus de son nom,\nil n'arrêtait pas d'imposer des règles."
+    "texte_fr": "Boss Calbute ? Pitié. En plus de son\nnom, il n'arrêtait pas d'imposer des règles."
   },
   {
     "id": 31,
@@ -494,7 +494,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Honestly,[SP]he[SP]was[SP]a[SP]total[SP]drag.[1205][U+000F][SP]Plus[SP]the[SP]new\nLeader[SP]seems,[SP]like,[SP]way[SP]stronger?[SP]It's[SP]like,\nyeah![SP]Go[SP]crush[SP]that[SP]old[SP]Boss!",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Franchement, il était chiant.[1205][U+000F] Et\nle nouveau chef a l'air bien plus\nfort! Ouais! Écrase ce vieux Boss!"
+    "texte_fr": "Franchement, il était chiant.[1205][U+000F] Et le\nnouveau chef a l'air bien plus fort !\nOuais ! Écrase ce vieux Boss !"
   },
   {
     "id": 32,
@@ -509,7 +509,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "The[SP]new[SP]student[SP]council[SP]president's[SP]so[SP]cool\nthat[SP]he[SP]set[SP]up[SP]a[SP]masquerade[SP]at[SP]our[SP]school\nfestival.[1205][U+000F][SP]I[SP]got[SP]a[SP]ticket,[SP]like,[SP]day[SP]one.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le président du BDE est si cool. Il\na organisé un bal masqué pour notre\nfestival.[1205][U+000F] J'ai eu un billet direct."
+    "texte_fr": "Le président du BDE est si cool. Il a\norganisé un bal masqué pour notre\nfestival.[1205][U+000F] J'ai eu un billet direct."
   },
   {
     "id": 33,
@@ -525,7 +525,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Now[SP]I[SP]just[SP]gotta[SP]get[SP]with[SP]a[SP]cool[SP]Cuss[SP]High\nguy.[1205][U+000F][SP]Or[SP]maybe[SP]you[SP]wanna[SP]come[SP]with[SP]me?[SP]You're\nkinda[SP]cute[SP]yourself,[SP]so[SP]I[SP]wouldn't[SP]mind.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Il me faut juste un mec cool de\nKakasu.[1205][U+000F] Ou tu veux venir avec moi?\nT'es plutôt mignon, ça m'irait."
+    "texte_fr": "Il me faut juste un mec cool de Kakasu.[1205][U+000F]\nOu tu veux venir avec moi ? T'es plutôt\nmignon, ça m'irait."
   },
   {
     "id": 34,
@@ -540,7 +540,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Masquerade?[1205][U+000F][SP]Oh,[SP]that[SP]old[SP]thing?[1205][U+000F][SP]I[SP]like,[SP]ditched\non[SP]it[SP]'cause[SP]I[SP]had[SP]other[SP]stuff[SP]to[SP]do?[SP]Anyway,\nthe[SP]new[SP]hotness[SP]is[SP]Muses!",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le bal masqué?[1205][U+000F] Oh, ce vieux truc?[1205][U+000F] J'ai\nzappé, j'avais d'autres trucs à faire.\nBref, la nouveauté c'est les Muses!"
+    "texte_fr": "Le bal masqué ?[1205][U+000F] Oh, ce vieux truc ?[1205][U+000F]\nJ'ai zappé, j'avais d'autres trucs à faire.\nBref, la nouveauté c'est les Muses !"
   },
   {
     "id": 35,
@@ -556,7 +556,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "You[SP]know,[SP]that[SP]new[SP]idol[SP]trio[SP]that[SP]Ginji\nSasaki's[SP]producing?[1205][U+000F][SP]I[SP]wonder[SP]what[SP]they're\nlike...[SP]I[SP]can't[SP]wait[SP]for[SP]their[SP]debut!",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Tu sais, le trio d'idoles produit par\nGinji Sasaki?[1205][U+000F] Je me demande comment\nelles sont... Vivement leurs débuts!"
+    "texte_fr": "Tu sais, le trio d'idoles produit\npar Ginji Sasaki ?[1205][U+000F] Je me demande comment\nelles sont... Vivement leurs débuts !"
   },
   {
     "id": 36,
@@ -572,7 +572,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "The[SP]girls[SP]that[SP]got[SP]picked[SP]for[SP]Muses[SP]are[SP]soooo\nlucky.[1205][U+000F][SP]I[SP]mean,[SP]Ginji[SP]Sasaki[SP]producing[SP]you?\nThere's[SP]like,[SP]no[SP]way[SP]they[SP]won't[SP]be[SP]huge.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Les filles choisies pour Muses ont trop\nde chance.[1205][U+000F] Être produite par Ginji\nSasaki? C'est sûr qu'elles vont percer."
+    "texte_fr": "Les filles choisies pour Muses ont trop\nde chance.[1205][U+000F] Être produite par Ginji\nSasaki ? C'est sûr qu'elles vont percer."
   },
   {
     "id": 37,
@@ -603,7 +603,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "I[SP]went[SP]to[SP]go[SP]buy[SP]concert[SP]tickets,[SP]and[SP]they[SP]were\nlike,[SP][1432][NULL][NULL][0014]Durrr,[SP]we're[SP]sold[SP]out.[1432][NULL][NULL][0014][1205][U+000F][SP]That[SP]receptionist\nwas[SP]such[SP]a[SP]bitch!",
     "nom_fr": "Jeune fille",
-    "texte_fr": "J'allais acheter un billet et on\nme dit: [1432][NULL][NULL][0014]Euh, c'est complet.[1432][NULL][NULL][0014][1205][U+000F] Cette\nréceptionniste était si chiante!"
+    "texte_fr": "J'allais acheter un billet et on me dit :\n[1432][NULL][NULL][0014]Euh, c'est complet.[1432][NULL][NULL][0014][1205][U+000F]\nCette réceptionniste était si chiante !"
   },
   {
     "id": 39,
@@ -619,7 +619,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "The[SP]Masked[SP]Circle's[SP]behind[SP]this[SP]terrorist[SP]stuff,\nright?[1205][U+000F][SP]Some[SP]of[SP]their[SP]members[SP]were[SP]making[SP]trouble\nin[SP]the[SP]city,[SP]too.[SP]They're[SP]some[SP]real[SP]bad[SP]guys.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le Cercle masqué est derrière ces attaques,\nnon?[1205][U+000F] Certains membres ont fait du grabuge\nen ville. Ce sont de vrais méchants."
+    "texte_fr": "Le Cercle masqué est derrière ces attaques,\nnon ?[1205][U+000F] Certains membres ont fait du\ngrabuge en ville. Ce sont de vrais méchants."
   },
   {
     "id": 40,
@@ -634,7 +634,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "What[SP]the[SP]hell!?[SP]Why[SP]did[SP]the[SP]terrorists[SP]go\nafter[SP]Smile[SP]Hirasaka?[SP]Why[SP]target[SP]a[SP]station\nbuilding[SP]like[SP]that!?",
     "nom_fr": "Jeune fille",
-    "texte_fr": "C'est quoi ce bordel!? Pourquoi\nles terroristes ont attaqué Smile\nHirasaka? Pourquoi viser ça!?"
+    "texte_fr": "C'est quoi ce bordel !? Pourquoi les\nterroristes ont attaqué Smile Hirasaka ?\nPourquoi viser ça !?"
   },
   {
     "id": 41,
@@ -650,7 +650,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Is[SP]this,[SP]like,[SP]one[SP]of[SP]those[SP][1432][NULL][NULL][0014]random[SP]acts[SP]of\nviolence[1432][NULL][NULL][0014][SP]they[SP]talk[SP]about?[1205][U+000F][SP]'Cause[SP]like,[SP]this\nisn't[SP]funny!",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Est-ce un [1432][NULL][NULL][0014]acte de violence gratuite[1432][NULL][NULL][0014] dont\non parle?[1205][U+000F] Parce que là, c'est pas drôle!"
+    "texte_fr": "Est-ce un [1432][NULL][NULL][0014]acte de violence\ngratuite[1432][NULL][NULL][0014] dont on parle ?[1205][U+000F]\nParce que là, c'est pas drôle !"
   },
   {
     "id": 42,
@@ -665,7 +665,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "I-Is[SP]this[SP]some[SP]kind[SP]of[SP]joke?[SP]Why'd[SP]those\nterrorists[SP]blow[SP]up[SP]Smile[SP]Hirasaka!?[1205][U+000F][SP]Bombing\na[SP]place[SP]like[SP]that[SP]doesn't[SP]get[SP]them[SP]anything!",
     "nom_fr": "Jeune fille",
-    "texte_fr": "C'est une blague? Pourquoi ces terroristes\nont fait sauter Smile Hirasaka!?[1205][U+000F] Cibler un\ntel endroit ne leur apporte rien!"
+    "texte_fr": "C'est une blague ? Pourquoi ces terroristes\nont fait sauter Smile Hirasaka !?[1205][U+000F] Cibler\nun tel endroit ne leur apporte rien !"
   },
   {
     "id": 43,
@@ -681,7 +681,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Geez,[SP]what's[SP]the[SP]Masked[SP]Circle[SP]thinking!?[1205][U+000F]\nWhy[SP]would[SP]they[SP]do[SP]this!?",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Urgh, à quoi pense le Cercle\nmasqué!?[1205][U+000F] Pourquoi faire ça!?"
+    "texte_fr": "Urgh, à quoi pense le Cercle masqué !?[1205][U+000F]\nPourquoi faire ça !?"
   },
   {
     "id": 44,
@@ -696,7 +696,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Huh?[SP]You[SP]haven't[SP]seen[SP]the[SP]composite[SP]sketches[SP]yet?[1205][U+000F]\nWell,[SP]one[SP]of[SP]them[SP]had[SP]hair[SP]like[SP]yours,[SP]and[SP]his\nface[SP]looked[SP]kinda[SP]like[SP]you[SP]too...",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Hein? T'as pas vu les\nportraits-robots?[1205][U+000F] Y en a un qui a tes\ncheveux, et son visage te ressemble..."
+    "texte_fr": "Hein ? T'as pas vu les portraits-robots ?[1205][U+000F]\nY en a un qui a tes cheveux, et son\nvisage te ressemble..."
   },
   {
     "id": 45,
@@ -712,7 +712,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "His[SP]nose...[1205][U+000A][SP]was[SP]like[SP]yours...[1205][U+000F][SP]And[SP]his[SP]mouth...[1205][U+000A]\nYeah,[SP]that[SP]matches[SP]too...[1205][U+000F][SP]See?[SP]Doesn't[SP]he[SP]seem\ntotally[SP]evil?",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Son nez...[1205][U+000A] Comme le tien...[1205][U+000F] Et sa\nbouche...[1205][U+000A] Ouais, ça colle...[1205][U+000F] Tu\nvois? Il a l'air si maléfique."
+    "texte_fr": "Son nez...[1205][U+000A] Comme le tien...[1205][U+000F] Et sa bouche...[1205][U+000A]\nOuais, ça colle...[1205][U+000F] Tu vois ?\nIl a l'air si maléfique."
   },
   {
     "id": 46,
@@ -728,7 +728,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "I[SP]like,[SP]wondered[SP]after[SP]I[SP]read[SP]the[SP]In[SP]Lak'ech...\nCould[SP]the[SP]Last[SP]Battalion[SP]have[SP]been[SP]blowing[SP]stuff\nup[SP]to[SP]find[SP]Sumaru[SP]City's[SP]secret[SP]treasure?",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Je me suis demandé en lisant l'In\nLak'ech... Le Bataillon a-t-il fait sauter\ndes trucs pour trouver le trésor de Sumaru?"
+    "texte_fr": "Je me suis demandé en lisant l'In Lak'ech...\nLe Bataillon a-t-il fait sauter des trucs\npour trouver le trésor de Sumaru ?"
   },
   {
     "id": 47,
@@ -743,7 +743,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Those[SP]soldiers[SP]a[SP]moment[SP]ago[SP]saw[SP]me![SP]But[SP]then,\nlike,[SP]some[SP]Masked[SP]Circle[SP]guys[SP]totally[SP]saved\nmy[SP]bacon.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Ces soldats m'ont vue! Mais ensuite,\ndes gars du Cercle masqué m'ont sauvée."
+    "texte_fr": "Ces soldats m'ont vue ! Mais ensuite,\ndes gars du Cercle masqué m'ont sauvée."
   },
   {
     "id": 48,
@@ -758,7 +758,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "They[SP]were[SP]all,[SP][1432][NULL][NULL][0014]Joker[SP]ordered[SP]us[SP]to[SP]protect[SP]the\npeople[SP]of[SP]this[SP]city![1432][NULL][NULL][0014][1205][U+000F][SP]I[SP]wonder[SP]if[SP]I[SP]had[SP]the\nwrong[SP]idea[SP]about[SP]him.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Ils disaient: [1432][NULL][NULL][0014]Le Joker a ordonné\nde protéger les civils![1432][NULL][NULL][0014][1205][U+000F] Je me\nsuis peut-être trompée sur lui."
+    "texte_fr": "Ils disaient : [1432][NULL][NULL][0014]Le Joker a ordonné de\nprotéger les civils ![1432][NULL][NULL][0014][1205][U+000F] Je me\nsuis peut-être trompée sur lui."
   },
   {
     "id": 49,
@@ -789,7 +789,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "I[SP]almost[SP]got[SP]attacked[SP]again[SP]by[SP]some[SP]more[SP]Last\nBattalion[SP]thugs...[1205][U+000F][SP]And[SP]this[SP]time[SP]a[SP]couple[SP]of\nwomen[SP]saved[SP]me!",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le Bataillon a failli m'attaquer de nouveau...[1205][U+000F]\nEt cette fois, des femmes m'ont sauvée!"
+    "texte_fr": "Le Bataillon a failli m'attaquer de\nnouveau...[1205][U+000F] Et cette fois,\ndes femmes m'ont sauvée !"
   },
   {
     "id": 51,
@@ -805,7 +805,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "They[SP]were[SP]so[SP]cool...[1205][U+000A][SP]I[SP]gotta[SP]get[SP]my[SP]act\ntogether[SP]too.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Elles étaient si cool...[1205][U+000A] Je dois me reprendre."
+    "texte_fr": "Elles étaient si cool...[1205][U+000A] Je dois me\nreprendre."
   },
   {
     "id": 52,
@@ -821,7 +821,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Some[SP]Last[SP]Battalion[SP]guys[SP]with[SP]long[SP]spears[SP]went\ninto[SP]that[SP]temple[SP]a[SP]minute[SP]ago.[1205][U+000F][SP]They[SP]were\ncarrying[SP]something[SP]shiny,[SP]too...",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Des gars du Bataillon avec de longues\nlances sont entrés là-dedans.[1205][U+000F] Ils\nportaient un objet brillant..."
+    "texte_fr": "Des gars du Bataillon avec de longues\nlances sont entrés là-dedans.[1205][U+000F]\nIls portaient un objet brillant..."
   },
   {
     "id": 53,
@@ -837,7 +837,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "I-I[SP]just[SP]saw[SP]them[SP]pulling[SP]a[SP]woman[SP]out[SP]of[SP]the\ndetective[SP]agency![1205][U+000F][SP]Were[SP]they[SP]kidnapping[SP]her...?",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Je les ai vus sortir une femme de l'agence\nde détectives![1205][U+000F] Ils la kidnappaient...?"
+    "texte_fr": "Je les ai vus sortir une femme de l'agence\nde détectives ![1205][U+000F] Ils la kidnappaient... ?"
   },
   {
     "id": 54,
@@ -852,7 +852,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]don't[SP]know[SP]much[SP]about[SP]it,[SP]but[SP]there's[SP]some\nJoker[SP]Game[SP]that's[SP]popular[SP]with[SP]the[SP]kids[SP]today,\nright?[SP]It[SP]grants[SP]any[SP]wish?",
     "nom_fr": "Homme",
-    "texte_fr": "Y a un Joker Game populaire chez les\njeunes, non? Ça exauce les vœux?"
+    "texte_fr": "Y a un Jeu du Joker populaire chez les\njeunes, non ? Ça exauce les vœux ?"
   },
   {
     "id": 55,
@@ -868,7 +868,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Well,[SP]I[SP]doubt[SP]that,[SP]but[SP]there's[SP]nothing[SP]wrong\nwith[SP]dreaming.[SP]You[SP]can[SP]focus[SP]on[SP]your[SP]troubles\nlater,[SP]once[SP]you're[SP]older.",
     "nom_fr": "Homme",
-    "texte_fr": "J'en doute, mais on peut rêver. Tu te\nsoucieras de tes soucis plus tard."
+    "texte_fr": "J'en doute, mais on peut rêver.\nTu te soucieras de tes soucis plus tard."
   },
   {
     "id": 56,
@@ -883,7 +883,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]the[SP]lady[SP]at[SP]Shiraishi[SP]Ramen\nwas[SP]really[SP]a[SP]Russian[SP]spy.",
     "nom_fr": "Homme",
-    "texte_fr": "Il paraît que la dame de Shiraishi\nRamen est une espionne russe."
+    "texte_fr": "Il paraît que la dame de Shiraishi Ramen\nest une espionne russe."
   },
   {
     "id": 57,
@@ -899,7 +899,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "You[SP]can[SP]tell[SP]because[SP]she'll[SP]sell[SP]you[SP]real\nweapons[SP]if[SP]you[SP]order[SP]banana[SP]char[SP]siu[SP]ramen![1205][U+000F]\nFunny[SP]old[SP]world,[SP]huh?",
     "nom_fr": "Homme",
-    "texte_fr": "Si tu commandes des ramens au\nporc et à la banane, elle te vend\ndes armes![1205][U+000F] Drôle de monde, hein?"
+    "texte_fr": "Si tu commandes des ramens au porc et à la\nbanane, elle te vend des armes ![1205][U+000F]\nDrôle de monde, hein ?"
   },
   {
     "id": 58,
@@ -914,7 +914,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]the[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High\nwasn't[SP]stronger[SP]than[SP]Eikichi[SP]at[SP]all.[1205][U+000F][SP]But[SP]then,\nwho[SP]is[SP]stronger[SP]than[SP]that[SP]kid?",
     "nom_fr": "Homme",
-    "texte_fr": "Le nouveau chef de Kakasu n'est\npas plus fort qu'Eikichi.[1205][U+000F] Mais\nqui est plus fort que ce gamin?"
+    "texte_fr": "Le nouveau chef de Kakasu n'est pas plus\nfort qu'Eikichi.[1205][U+000F] Mais qui est plus fort\nque ce gamin ?"
   },
   {
     "id": 59,
@@ -945,7 +945,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "You[SP]can[SP]buy[SP]real[SP]shooters[SP]and[SP]blades[SP]at[SP]this\nguy[SP]Tony's[SP]shop[SP]in[SP]Yumezaki?[1205][U+000F][SP]Damn...[SP]sounds\ndangerous,[SP]if[SP]you[SP]ask[SP]me.",
     "nom_fr": "Homme",
-    "texte_fr": "On peut acheter des armes à feu et des lames\nchez Tony à Yumezaki?[1205][U+000F] Mince... ça craint."
+    "texte_fr": "On peut acheter des armes à feu et des lames\nchez Tony à Yumezaki ?[1205][U+000F] Mince... ça craint."
   },
   {
     "id": 61,
@@ -992,7 +992,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Aren't[SP]they[SP]doing[SP]some[SP]live[SP]event[SP]right[SP]now[SP]at\nthat[SP]Giga[SP]Macho[SP]place?[1205][U+000F][SP]What,[SP]you're[SP]not\ngonna[SP]go[SP]check[SP]it[SP]out?",
     "nom_fr": "Homme",
-    "texte_fr": "Il n'y a pas un événement live en ce moment\nà Giga Macho?[1205][U+000F] Quoi, tu vas pas y aller?"
+    "texte_fr": "Il n'y a pas un événement live en ce moment à\nGiga Macho ?[1205][U+000F] Quoi, tu vas pas y aller ?"
   },
   {
     "id": 64,
@@ -1008,7 +1008,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "You[SP]one[SP]of[SP]them[SP]guys[SP]that[SP]missed[SP]out[SP]on[SP]the\nconcert?[SP]I[SP]heard[SP]there[SP]weren't[SP]enough[SP]tickets.[1205][U+000F]\nMan[SP]like[SP]you[SP]didn't[SP]need[SP]to[SP]be[SP]there[SP]anyway.",
     "nom_fr": "Homme",
-    "texte_fr": "T'es un de ceux qui ont raté le concert? J'ai\nentendu qu'il manquait de billets.[1205][U+000F] Un gars\ncomme toi n'avait rien à y faire de toute\nfaçon."
+    "texte_fr": "T'es un de ceux qui ont raté le concert ? J'ai\nentendu qu'il manquait de billets.[1205][U+000F] Un gars\ncomme toi n'avait rien à y faire de toute façon."
   },
   {
     "id": 65,
@@ -1024,7 +1024,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "There[SP]seems[SP]to[SP]have[SP]been[SP]a[SP]group[SP]of[SP]five[SP]in\nthe[SP]concert[SP]hall[SP]when[SP]it[SP]burned[SP]down.[SP]Rumor[SP]is\nit[SP]was[SP]them[SP]who[SP]set[SP]the[SP]fire.",
     "nom_fr": "Homme",
-    "texte_fr": "Il y avait un groupe de cinq dans\nla salle quand elle a brûlé. On\ndit qu'ils ont allumé le feu."
+    "texte_fr": "Il y avait un groupe de cinq dans la salle quand\nelle a brûlé. On dit qu'ils ont allumé le feu."
   },
   {
     "id": 66,
@@ -1039,7 +1039,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]it[SP]wasn't[SP]just[SP]the[SP]concert[SP]hall.\nThose[SP]five[SP]guys[SP]were[SP]inside[SP]Smile[SP]Hirasaka\ntoo,[SP]just[SP]before[SP]things[SP]went[SP]down[SP]there.",
     "nom_fr": "Homme",
-    "texte_fr": "Pas que la salle de concert. Ces\ncinq-là étaient aussi à Smile\nHirasaka avant que ça dégénère."
+    "texte_fr": "Pas que la salle de concert. Ces cinq-là étaient\naussi à Smile Hirasaka avant que ça dégénère."
   },
   {
     "id": 67,
@@ -1055,7 +1055,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Sounds[SP]connected[SP]to[SP]me.[SP]These[SP]five[SP]guys[SP]are\nsome[SP]shady[SP]characters,[SP]ya[SP]ask[SP]me.[SP]Don't[SP]you\nthink[SP]so,[SP]kid?",
     "nom_fr": "Homme",
-    "texte_fr": "Ça me semble lié. Ce sont des individus\nlouches, à mon avis. Tu ne crois pas, petit?"
+    "texte_fr": "Ça me semble lié. Ce sont des individus louches,\nà mon avis. Tu ne crois pas, petit ?"
   },
   {
     "id": 68,
@@ -1071,7 +1071,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Jesus![SP]Smile[SP]Hirasaka[SP]just[SP]went[SP]down[SP]in[SP]flames\nright[SP]in[SP]front[SP]of[SP]me![SP]Where's[SP]the[SP]damn[SP]fire\ndepartment!?[SP]What's[SP]going[SP]on[SP]here!?",
     "nom_fr": "Homme",
-    "texte_fr": "Bon sang! Smile Hirasaka a pris feu sous mes\nyeux! Où sont les pompiers!? Il se passe\nquoi!?"
+    "texte_fr": "Bon sang ! Smile Hirasaka a pris feu sous mes\nyeux ! Où sont les pompiers !? Il se passe quoi !?"
   },
   {
     "id": 69,
@@ -1087,7 +1087,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Huh?[1205][U+000F][SP]D-Did[SP]you[SP]just[SP]get[SP]here?[SP]Coulda[SP]sworn[SP]I\njust[SP]saw[SP]you[SP]go[SP]that[SP]way...[1205][U+000F][SP]H-Hahaha,[SP]I[SP]must\nbe[SP]seein'[SP]things...",
     "nom_fr": "Homme",
-    "texte_fr": "Hein?[1205][U+000F] T-Tu viens d'arriver? J'aurais\njuré t'avoir vu passer par là...[1205][U+000F]\nH-Hahaha, je dois halluciner..."
+    "texte_fr": "Hein ?[1205][U+000F] T-Tu viens d'arriver ? J'aurais juré\nt'avoir vu passer par là...[1205][U+000F] H-Hahaha, je\ndois halluciner..."
   },
   {
     "id": 70,
@@ -1102,7 +1102,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "What[SP]the!?[SP]D-Didn't[SP]you[SP]guys[SP]just[SP]pass[SP]by[SP]here?",
     "nom_fr": "Homme",
-    "texte_fr": "Quel délire!? V-Vous ne\nvenez pas de passer là?"
+    "texte_fr": "Quel délire !? V-Vous ne venez pas\nde passer là ?"
   },
   {
     "id": 71,
@@ -1117,7 +1117,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Then[SP]who[SP]was[SP]that...?[1205][U+000F][SP]I-I'm[SP]seein'[SP]double...",
     "nom_fr": "Homme",
-    "texte_fr": "Alors qui c'était...?[1205][U+000F] J-Je vois double..."
+    "texte_fr": "Alors qui c'était... ?[1205][U+000F] J-Je vois double..."
   },
   {
     "id": 72,
@@ -1133,7 +1133,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "H-Hahaha...[1205][U+000F][SP]Guess[SP]I[SP]did[SP]have[SP]a[SP]few[SP]too[SP]many\nlast[SP]night...[SP]I[SP]really[SP]oughtta[SP]cut[SP]back[SP]on\nthe[SP]booze...",
     "nom_fr": "Homme",
-    "texte_fr": "H-Hahaha...[1205][U+000F] J'ai dû trop boire\nhier soir... Il faut vraiment que\nje lève le pied sur l'alcool..."
+    "texte_fr": "H-Hahaha...[1205][U+000F] J'ai dû trop boire hier soir...\nIl faut vraiment que je lève le pied sur l'alcool..."
   },
   {
     "id": 73,
@@ -1148,7 +1148,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Whoa,[SP]what[SP]the[SP]hell[SP]was[SP]that!?[SP]A[SP]whole[SP]army\nof[SP]guys[SP]with[SP]spears[SP]just[SP]went[SP]flyin'[SP]by!",
     "nom_fr": "Homme",
-    "texte_fr": "Waouh, c'était quoi!? Une armée de types\navec des lances vient de passer en trombe!"
+    "texte_fr": "Waouh, c'était quoi !? Une armée de types avec\ndes lances vient de passer en trombe !"
   },
   {
     "id": 74,
@@ -1164,7 +1164,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]didn't[SP]know[SP]the[SP]Last[SP]Battalion[SP]had[SP]guys\nlike[SP]that!",
     "nom_fr": "Homme",
-    "texte_fr": "Je savais pas que le Bataillon\navait des gars comme ça!"
+    "texte_fr": "Je savais pas que le Bataillon avait des gars comme ça !"
   },
   {
     "id": 75,
@@ -1179,7 +1179,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Well,[SP]I'll[SP]be[SP]damned![1205][U+000F][SP]That[SP]Xibalba[SP]thing[SP]was\nthis[SP]big!?[1205][U+000A][SP]Not[SP]too[SP]many[SP]people[SP]can[SP]say[SP]they\nlive[SP]in[SP]a[SP]city[SP]in[SP]the[SP]sky.",
     "nom_fr": "Homme",
-    "texte_fr": "Nom d'un chien![1205][U+000F] Ce Xibalba était aussi\ngrand!?[1205][U+000A] Peu de gens peuvent dire qu'ils\nvivent dans une ville dans le ciel."
+    "texte_fr": "Nom d'un chien ![1205][U+000F] Ce Xibalba était aussi grand !?[1205][U+000A]\nPeu de gens peuvent dire qu'ils vivent\ndans une ville dans le ciel."
   },
   {
     "id": 76,
@@ -1195,7 +1195,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "But[SP]I[SP]don't[SP]hold[SP]with[SP]this[SP]business[SP]about[SP]the\nworld[SP]ending.[1205][U+000A][SP]Can't[SP]you[SP]do[SP]anything[SP]about[SP]it,\nkid!?",
     "nom_fr": "Homme",
-    "texte_fr": "Mais je ne crois pas à cette histoire de\nfin du monde.[1205][U+000A] Tu peux rien y faire, petit!?"
+    "texte_fr": "Mais je ne crois pas à cette histoire de fin\ndu monde.[1205][U+000A] Tu peux rien y faire, petit !?"
   },
   {
     "id": 77,
@@ -1210,7 +1210,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Everyone[SP]I[SP]know's[SP]talkin'[SP]about[SP]how[SP]the[SP]world's\ngonna[SP]end![1205][U+000A]",
     "nom_fr": "Homme",
-    "texte_fr": "Tout le monde dit que c'est la fin du monde![1205][U+000A]"
+    "texte_fr": "Tout le monde dit que c'est la fin du monde ![1205][U+000A]"
   },
   {
     "id": 78,
@@ -1225,7 +1225,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Floods[SP]this,[SP]meteors[SP]that...[SP]All[SP]as[SP]soon[SP]as\nthis[SP]Grand[SP]Whatever[SP]happens...",
     "nom_fr": "Homme",
-    "texte_fr": "Inondations, météores... Dès que cette\nGrande Je-Sais-Pas-Quoi arrivera..."
+    "texte_fr": "Inondations, météores... Dès que cette Grande\nJe-Sais-Pas-Quoi arrivera..."
   },
   {
     "id": 79,
@@ -1241,7 +1241,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "What[SP]I[SP]don't[SP]get[SP]is,[SP]it's[SP]gonna[SP]kill[SP]everyone\ndown[SP]there,[SP]right?[SP]What's[SP]the[SP]fun[SP]in[SP]predicting\nhow[SP]they're[SP]gonna[SP]die?",
     "nom_fr": "Homme",
-    "texte_fr": "Ce que je pige pas, c'est que ça va\ntous les tuer en bas, non? Quel intérêt\nde prédire comment ils vont mourir?"
+    "texte_fr": "Ce que je pige pas, c'est que ça va tous les tuer\nen bas, non ? Quel intérêt de prédire comment\nils vont mourir ?"
   },
   {
     "id": 80,
@@ -1257,7 +1257,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]when[SP]the[SP]Grand[SP]Cross[SP]is[SP]done,\nthe[SP]gravity[SP]of[SP]the[SP]stars[SP]is[SP]gonna[SP]pulverize[SP]the\nEarth.[1205][U+000F][SP]Is[SP]that[SP]how[SP]the[SP]world's[SP]gonna[SP]end?",
     "nom_fr": "Homme",
-    "texte_fr": "Quand la Croix Cosmique sera finie,\nla gravité des étoiles va pulvériser\nla Terre.[1205][U+000F] C'est ça la fin du monde?"
+    "texte_fr": "Quand la Croix Cosmique sera finie, la gravité des\nétoiles va pulvériser la Terre.[1205][U+000F]\nC'est ça la fin du monde ?"
   },
   {
     "id": 81,
@@ -1272,7 +1272,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]I[SP]heard[SP]the[SP]world[SP]will[SP]stop[SP]spinning[SP]if\nthe[SP]Grand[SP]Cross[SP]happens.[1205][U+000A][SP]Somethin'[SP]about[SP]the\nbalance[SP]of[SP]gravity[SP]and[SP]stuff...[SP]Over[SP]my[SP]head.",
     "nom_fr": "Homme",
-    "texte_fr": "J'ai entendu dire que la Terre\narrêtera de tourner avec la Croix.[1205][U+000A] Un\ntruc sur la gravité... Ça me dépasse."
+    "texte_fr": "J'ai entendu dire que la Terre arrêtera de tourner\navec la Croix.[1205][U+000A] Un truc sur la gravité...\nÇa me dépasse."
   },
   {
     "id": 82,
@@ -1288,7 +1288,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "How[SP]bad[SP]would[SP]that[SP]really[SP]be[SP]if[SP]it[SP]happened,\nthough?[SP]I[SP]dunno...",
     "nom_fr": "Homme",
-    "texte_fr": "À quel point ce serait grave si\nça arrivait? J'en sais rien..."
+    "texte_fr": "À quel point ce serait grave si ça arrivait ?\nJ'en sais rien..."
   },
   {
     "id": 83,
@@ -1304,7 +1304,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Well,[SP]don't[SP]that[SP]beat[SP]all...[SP]I[SP]heard[SP]the\nflowers[SP]in[SP]Aoba[SP]Park[SP]can[SP]talk.[SP]Guess[SP]it[SP]takes\nall[SP]kinds[SP]to[SP]make[SP]a[SP]world.",
     "nom_fr": "Homme",
-    "texte_fr": "Eh ben, ça par exemple... Il paraît\nque les fleurs du parc Aoba parlent.\nFaut de tout pour faire un monde."
+    "texte_fr": "Eh ben, ça par exemple... Il paraît que les fleurs\ndu parc Aoba parlent. Faut de tout pour faire\nun monde."
   },
   {
     "id": 84,
@@ -1319,7 +1319,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]kid.[SP]Ya[SP]know[SP]that[SP]club[SP]Zodiac?[SP]People[SP]say\nthe[SP]second[SP]floor's[SP]a[SP]huge[SP]dungeon,[SP]packed[SP]with\ngreat[SP]stuff.",
     "nom_fr": "Homme",
-    "texte_fr": "Hé, petit. Tu connais le Zodiac? On\ndit que le 2e étage est un immense\ndonjon rempli de super trucs."
+    "texte_fr": "Hé, petit. Tu connais le Zodiac ? On dit que\nle 2e étage est un immense donjon rempli\nde super trucs."
   },
   {
     "id": 85,
@@ -1335,7 +1335,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Why[SP]not[SP]go[SP]snoop[SP]around[SP]it?[SP]Show[SP]off[SP]some\nskills[SP]and[SP]I[SP]bet[SP]your[SP]girl'll[SP]be[SP]all[SP]over[SP]ya.\nHahahaha!",
     "nom_fr": "Homme",
-    "texte_fr": "Pourquoi tu vas pas fouiner? Montre\ntes talents et je parie que ta copine\nva te sauter dessus. Hahahaha!"
+    "texte_fr": "Pourquoi tu vas pas fouiner ? Montre tes talents\net je parie que ta copine va te sauter dessus.\nHahahaha !"
   },
   {
     "id": 86,
@@ -1351,7 +1351,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]there's[SP]a[SP]ghost[SP]girl[SP]called\nHanako[SP]at[SP]Sevens.[1205][U+000F][SP]First[SP]a[SP]curse,[SP]and[SP]now[SP]a\nghost?[SP]That[SP]school,[SP]I[SP]tell[SP]ya.",
     "nom_fr": "Homme",
-    "texte_fr": "J'ai ouï-dire qu'un fantôme nommé Hanako\nest à Seven.[1205][U+000F] D'abord une malédiction,\npuis un fantôme? Cette école, sérieux."
+    "texte_fr": "J'ai ouï-dire qu'un fantôme nommé Hanako\nest à Seven.[1205][U+000F] D'abord une malédiction, puis un\nfantôme ? Cette école, sérieux."
   },
   {
     "id": 87,
@@ -1366,7 +1366,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "What,[SP]there's[SP]another[SP]ghost[SP]at[SP]Cuss[SP]High?\nBukimi[SP]this[SP]time?",
     "nom_fr": "Homme",
-    "texte_fr": "Quoi, y a un autre fantôme au\nlycée Kakasu? Bukimi cette fois?"
+    "texte_fr": "Quoi, y a un autre fantôme au lycée Kakasu ?\nBukimi cette fois ?"
   },
   {
     "id": 88,
@@ -1382,7 +1382,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Guess[SP]I[SP]can't[SP]blame[SP]a[SP]girl[SP]called[SP]Bukimi[SP]for\nwantin'[SP]vengeance[SP]on[SP]the[SP]world.",
     "nom_fr": "Homme",
-    "texte_fr": "Je peux pas blâmer une fille appelée\nBukimi de vouloir se venger."
+    "texte_fr": "Je peux pas blâmer une fille appelée Bukimi de\nvouloir se venger."
   },
   {
     "id": 89,
@@ -1397,7 +1397,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]hear[SP]a[SP]dead[SP]idol's[SP]ghost[SP]is[SP]hauntin'[SP]Aoba\nPark.[SP]Guess[SP]dead[SP]or[SP]alive,[SP]girls[SP]like[SP]flowers.",
     "nom_fr": "Homme",
-    "texte_fr": "Le fantôme d'une idole morte hante\nle parc Aoba. Mortes ou vives, les\nfilles aiment les fleurs."
+    "texte_fr": "Le fantôme d'une idole morte hante le parc Aoba.\nMortes ou vives, les filles aiment les fleurs."
   },
   {
     "id": 90,
@@ -1429,7 +1429,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Huh...[SP]A[SP]Cursed[SP]Taxi?[SP]They[SP]got[SP]one[SP]at[SP]that\nabandoned[SP]factory?[SP]What[SP]kinda[SP]passengers[SP]it\nthinks[SP]it's[SP]gonna[SP]pick[SP]up[SP]there?",
     "nom_fr": "Homme",
-    "texte_fr": "Un Taxi Maudit? Y en a un à l'usine\nabandonnée? Quels genres de\npassagers il espère prendre là-bas?"
+    "texte_fr": "Un Taxi Maudit ? Y en a un à l'usine abandonnée ?\nQuels genres de passagers il espère\nprendre là-bas ?"
   },
   {
     "id": 92,
@@ -1444,7 +1444,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "What?[SP]It[SP]was[SP]a[SP]Cursed[SP]Escort[SP]at[SP]the[SP]abandoned\nfactory,[SP]not[SP]a[SP]Cursed[SP]Taxi?",
     "nom_fr": "Homme",
-    "texte_fr": "Quoi? C'est une Escorte Maudite à\nl'usine abandonnée, pas un Taxi Maudit?"
+    "texte_fr": "Quoi ? C'est une Escorte Maudite à l'usine\nabandonnée, pas un Taxi Maudit ?"
   },
   {
     "id": 93,
@@ -1475,7 +1475,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]guess[SP]kids[SP]your[SP]age[SP]wouldn't[SP]know[SP]about\nKuchisake-onna,[SP]huh?",
     "nom_fr": "Homme",
-    "texte_fr": "Les gosses de ton âge connaissent\npas Kuchisake-onna, hein?"
+    "texte_fr": "Les gosses de ton âge connaissent pas\nKuchisake-onna, hein ?"
   },
   {
     "id": 95,
@@ -1490,7 +1490,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "She[SP]comes[SP]up[SP]to[SP]ya[SP]with[SP]her[SP]mouth[SP]covered\nand[SP]asks[SP]if[SP]ya[SP]think[SP]she's[SP]pretty...",
     "nom_fr": "Homme",
-    "texte_fr": "Elle vient te voir la bouche couverte\net te demande si tu la trouves jolie..."
+    "texte_fr": "Elle vient te voir la bouche couverte et te\ndemande si tu la trouves jolie..."
   },
   {
     "id": 96,
@@ -1505,7 +1505,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Rumor[SP]has[SP]it[SP]Kuchisake-onna's[SP]started\nshowin'[SP]up[SP]at[SP]Mt.[SP]Iwato.",
     "nom_fr": "Homme",
-    "texte_fr": "La rumeur dit que Kuchisake-onna\nest apparue au Mt Iwato."
+    "texte_fr": "La rumeur dit que Kuchisake-onna est\napparue au Mt Iwato."
   },
   {
     "id": 97,
@@ -1521,7 +1521,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]gotta[SP]admit,[SP]stories[SP]like[SP]that[SP]used[SP]to[SP]give\nme[SP]the[SP]willies[SP]when[SP]I[SP]was[SP]a[SP]kid.",
     "nom_fr": "Homme",
-    "texte_fr": "Faut avouer que ce genre d'histoires me\ndonnait la chair de poule quand j'étais gosse."
+    "texte_fr": "Faut avouer que ce genre d'histoires me donnait\nla chair de poule quand j'étais gosse."
   },
   {
     "id": 98,
@@ -1537,7 +1537,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Jumping[SP]Geezer,[SP]eh?[SP]Sounds[SP]like[SP]one[SP]stylish\nguy.[SP]I[SP]hope[SP]I'm[SP]that[SP]full[SP]of[SP]energy[SP]when[SP]I[SP]get\nto[SP]be[SP]his[SP]age.[SP]He's[SP]at[SP]Mt.[SP]Katatsumuri,[SP]right?",
     "nom_fr": "Homme",
-    "texte_fr": "Le Vieux Sauteur, hein? Quel gars stylé.\nJ'espère avoir autant d'énergie à son\nâge. Il est au Mt Katatsumuri, non?"
+    "texte_fr": "Le Vieux Sauteur, hein ? Quel gars stylé.\nJ'espère avoir autant d'énergie à son âge.\nIl est au Mt Katatsumuri, non ?"
   },
   {
     "id": 99,
@@ -1552,7 +1552,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I-I[SP]just[SP]heard[SP]a[SP]hell[SP]of[SP]a[SP]thing...[SP]Do[SP]you\nknow[SP]about[SP]this?",
     "nom_fr": "Homme",
-    "texte_fr": "J-Je viens d'entendre un truc\nde fou... T'es au courant?"
+    "texte_fr": "J-Je viens d'entendre un truc de fou...\nT'es au courant ?"
   },
   {
     "id": 100,
@@ -1568,7 +1568,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Th-That[SP]Kudan...[SP]It's[SP]at[SP]the[SP]abandoned[SP]factory,\nand...[SP]Gaaah,[SP]I[SP]can't[SP]even[SP]say[SP]it...!",
     "nom_fr": "Homme",
-    "texte_fr": "C-Ce Kudan... Il est à l'usine abandonnée,\net... Gaaah, je peux même pas le dire...!"
+    "texte_fr": "C-Ce Kudan... Il est à l'usine abandonnée,\net... Gaaah, je peux même pas le dire... !"
   },
   {
     "id": 101,
@@ -1583,7 +1583,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]kid.[SP]Hear[SP]there's[SP]a[SP]hidden[SP]CD[SP]at[SP]that\nGiga[SP]Macho[SP]place.",
     "nom_fr": "Homme",
-    "texte_fr": "Hé petit. Paraît qu'y a\nun CD caché à Giga Macho."
+    "texte_fr": "Hé petit. Paraît qu'y a un CD caché à Giga Macho."
   },
   {
     "id": 102,
@@ -1599,7 +1599,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hidden[SP]from[SP]who,[SP]is[SP]what[SP]I[SP]wanna[SP]know.\nYou[SP]know[SP]anything[SP]about[SP]this?",
     "nom_fr": "Homme",
-    "texte_fr": "Caché de qui, c'est ce que je veux\nsavoir. T'en sais quelque chose?"
+    "texte_fr": "Caché de qui, c'est ce que je veux savoir.\nT'en sais quelque chose ?"
   },
   {
     "id": 103,
@@ -1614,7 +1614,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]there's[SP]this[SP]Dresser[SP]Hag\nmonster[SP]at[SP]the[SP]abandoned[SP]factory...[SP]Really,\nnow?[SP][1432][NULL][NULL][0014]Dresser[SP]Hag[1432][NULL][NULL][0014]?",
     "nom_fr": "Homme",
-    "texte_fr": "Il paraît qu'il y a un monstre Mégère à\nCommode à l'usine... Vraiment? [1432][NULL][NULL][0014]Mégère à\nCommode[1432][NULL][NULL][0014]?"
+    "texte_fr": "Il paraît qu'il y a un monstre Mégère à Commode\nà l'usine... Vraiment ?\n[1432][NULL][NULL][0014]Mégère à Commode[1432][NULL][NULL][0014] ?"
   },
   {
     "id": 104,
@@ -1630,7 +1630,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "It's[SP]not[SP]like[SP]it's[SP]a[SP]dresser[SP]with[SP]arms[SP]and\nlegs,[SP]is[SP]it?[SP]Sheesh.[SP]All[SP]these[SP]monsters[SP]got\nthe[SP]worst[SP]names,[SP]I[SP]tell[SP]ya.",
     "nom_fr": "Homme",
-    "texte_fr": "C'est pas une commode avec des bras et des\njambes, si? Pfff. Ces monstres ont de ces\nnoms..."
+    "texte_fr": "C'est pas une commode avec des bras et\ndes jambes, si ? Pfff. Ces monstres ont de ces noms..."
   },
   {
     "id": 105,
@@ -1645,7 +1645,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Does[SP]Time[SP]Castle[SP]in[SP]Rengedai[SP]really[SP]sell[SP]real\nweapons?[SP]I[SP]hear[SP]the[SP]quality[SP]and[SP]price[SP]of[SP]their\nstuff[SP]is[SP]about[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Time Castle à Rengedai vendrait\nde vraies armes? Il paraît que la\nqualité et les prix sont moyens."
+    "texte_fr": "Time Castle à Rengedai vendrait de vraies armes ?\nIl paraît que la qualité et les prix sont moyens."
   },
   {
     "id": 106,
@@ -1676,7 +1676,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Does[SP]Time[SP]Castle[SP]in[SP]Rengedai[SP]really[SP]sell[SP]real\nweapons?[SP]I[SP]hear[SP]the[SP]quality[SP]of[SP]their[SP]stuff[SP]is\ngood,[SP]but[SP]it's[SP]expensive.",
     "nom_fr": "Homme",
-    "texte_fr": "Time Castle à Rengedai vendrait de\nvraies armes? Il paraît que la\nqualité est bonne, mais c'est cher."
+    "texte_fr": "Time Castle à Rengedai vendrait de vraies armes ?\nIl paraît que la qualité est bonne, mais c'est cher."
   },
   {
     "id": 108,
@@ -1707,7 +1707,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Does[SP]Time[SP]Castle[SP]in[SP]Rengedai[SP]really[SP]sell[SP]real\nweapons?[SP]I[SP]hear[SP]their[SP]stuff[SP]is[SP]cheap,[SP]but[SP]it's\nlow[SP]quality.",
     "nom_fr": "Homme",
-    "texte_fr": "Time Castle à Rengedai vendrait de\nvraies armes? Il paraît que c'est\npas cher, mais de piètre qualité."
+    "texte_fr": "Time Castle à Rengedai vendrait de vraies armes ?\nIl paraît que c'est pas cher, mais de piètre qualité."
   },
   {
     "id": 110,
@@ -1738,7 +1738,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]that[SP]poser[SP]Tony[SP]has[SP]been[SP]selling\nreal[SP]weapons[SP]on[SP]the[SP]sly.",
     "nom_fr": "Homme",
-    "texte_fr": "On dirait que ce poseur de Tony\nvend de vraies armes en douce."
+    "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce."
   },
   {
     "id": 112,
@@ -1754,7 +1754,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]hear[SP]his[SP]selection's[SP]good,[SP]but[SP]his[SP]resale\nprice[SP]ain't[SP]so[SP]hot.",
     "nom_fr": "Homme",
-    "texte_fr": "Son choix est bon, mais son\nprix de rachat est naze."
+    "texte_fr": "Son choix est bon, mais son prix de rachat est naze."
   },
   {
     "id": 113,
@@ -1769,7 +1769,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]that[SP]poser[SP]Tony[SP]has[SP]been[SP]selling\nreal[SP]weapons[SP]on[SP]the[SP]sly.",
     "nom_fr": "Homme",
-    "texte_fr": "On dirait que ce poseur de Tony\nvend de vraies armes en douce."
+    "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce."
   },
   {
     "id": 114,
@@ -1785,7 +1785,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]hear[SP]his[SP]stuff's[SP]cheap,[SP]but[SP]not[SP]what[SP]you'd\ncall[SP]quality.",
     "nom_fr": "Homme",
-    "texte_fr": "C'est pas cher, mais on\npeut pas parler de qualité."
+    "texte_fr": "C'est pas cher, mais on peut pas parler de qualité."
   },
   {
     "id": 115,
@@ -1800,7 +1800,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]that[SP]poser[SP]Tony[SP]has[SP]been[SP]selling\nreal[SP]weapons[SP]on[SP]the[SP]sly.",
     "nom_fr": "Homme",
-    "texte_fr": "On dirait que ce poseur de Tony\nvend de vraies armes en douce."
+    "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce."
   },
   {
     "id": 116,
@@ -1816,7 +1816,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]hear[SP]the[SP]quality[SP]and[SP]price[SP]of[SP]his[SP]stuff\nis[SP]pretty[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "La qualité et le prix de ses\ntrucs sont dans la moyenne."
+    "texte_fr": "La qualité et le prix de ses trucs sont dans la moyenne."
   },
   {
     "id": 117,
@@ -1831,7 +1831,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]that[SP]poser[SP]Tony[SP]has[SP]been[SP]selling\nreal[SP]weapons[SP]on[SP]the[SP]sly.",
     "nom_fr": "Homme",
-    "texte_fr": "On dirait que ce poseur de Tony\nvend de vraies armes en douce."
+    "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce."
   },
   {
     "id": 118,
@@ -1863,7 +1863,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]selection[SP]sucks,\nbut[SP]their[SP]resale[SP]prices[SP]are[SP]high.",
     "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies\narmes.[1205][U+000F] Leur choix craint, mais\nleurs prix de rachat sont élevés."
+    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nLeur choix craint, mais leurs prix de rachat sont élevés."
   },
   {
     "id": 120,
@@ -1895,7 +1895,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][U+000F][SP]The[SP]quality's[SP]good,\nbut[SP]the[SP]prices[SP]are[SP]high.",
     "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F] La\nqualité est là, mais les prix sont élevés."
+    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nLa qualité est là, mais les prix sont élevés."
   },
   {
     "id": 122,
@@ -1911,7 +1911,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]selection's\ngood,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]the[SP]pits.",
     "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies\narmes.[1205][U+000F] Le choix est bon, mais les\nprix de rachat sont à chier."
+    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nLe choix est bon, mais les prix de rachat sont à chier."
   },
   {
     "id": 123,
@@ -1927,7 +1927,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]quality[SP]and\nprice[SP]are[SP]basically[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nLeur qualité et leurs prix sont dans la\nmoyenne."
+    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nLeur qualité et leurs prix sont dans la moyenne."
   },
   {
     "id": 124,
@@ -1943,7 +1943,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality[SP]and[SP]price\nis[SP]just[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend\ndes armes...[1205][U+000F] Il paraît que la\nqualité et les prix sont moyens."
+    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nIl paraît que la qualité et les prix sont moyens."
   },
   {
     "id": 125,
@@ -1959,7 +1959,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][U+000F][SP]I[SP]hear[SP]they're[SP]cheap,[SP]but[SP]not\nexactly[SP]quality[SP]stuff.",
     "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend\ndes armes...[1205][U+000F] C'est pas cher, mais\nc'est pas de la top qualité."
+    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nC'est pas cher, mais c'est pas de la top qualité."
   },
   {
     "id": 126,
@@ -1975,7 +1975,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][U+000F][SP]I[SP]hear[SP]his[SP]selection's[SP]good,\nbut[SP]his[SP]resale[SP]value[SP]sucks.",
     "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend\ndes armes...[1205][U+000F] Il a du choix, mais\nles prix de rachat sont nuls."
+    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nIl a du choix, mais les prix de rachat sont nuls."
   },
   {
     "id": 127,
@@ -1991,7 +1991,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][U+000F][SP]I[SP]hear[SP]his[SP]selection[SP]sucks,\nbut[SP]his[SP]resale[SP]prices[SP]are[SP]great.",
     "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend\ndes armes...[1205][U+000F] Le choix craint, mais\nles prix de rachat sont super."
+    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nLe choix craint, mais les prix de rachat sont super."
   },
   {
     "id": 128,
@@ -2007,7 +2007,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality's[SP]good,\nbut[SP]the[SP]prices[SP]are[SP]high.",
     "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend\ndes armes...[1205][U+000F] La qualité est\nbonne, mais les prix sont élevés."
+    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nLa qualité est bonne, mais les prix sont élevés."
   },
   {
     "id": 129,
@@ -2023,7 +2023,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "It[SP]takes[SP]balls[SP]to[SP]sell[SP]armor[SP]at[SP]a[SP]fancy\nboutique[SP]like[SP]Rosa[SP]Candida[SP]at[SP]Rengedai.[1205][U+000F]\nTheir[SP]quality[SP]and[SP]price[SP]is[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Faut oser vendre des armures dans\nune boutique chic comme Rosa\nCandida.[1205][U+000F] Qualité et prix moyens."
+    "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[1205][U+000F] Qualité et prix moyens."
   },
   {
     "id": 130,
@@ -2039,7 +2039,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "It[SP]takes[SP]balls[SP]to[SP]sell[SP]armor[SP]at[SP]a[SP]fancy\nboutique[SP]like[SP]Rosa[SP]Candida[SP]at[SP]Rengedai.[1205][U+000F]\nIt's[SP]cheap,[SP]but[SP]low[SP]quality.",
     "nom_fr": "Homme",
-    "texte_fr": "Faut oser vendre des armures dans une\nboutique chic comme Rosa Candida.[1205][U+000F] Pas\ncher, mais qualité nulle."
+    "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[1205][U+000F] Pas cher, mais qualité nulle."
   },
   {
     "id": 131,
@@ -2055,7 +2055,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "It[SP]takes[SP]balls[SP]to[SP]sell[SP]armor[SP]at[SP]a[SP]fancy\nboutique[SP]like[SP]Rosa[SP]Candida[SP]at[SP]Rengedai.[1205][U+000F]\nIt's[SP]good[SP]quality,[SP]but[SP]expensive.",
     "nom_fr": "Homme",
-    "texte_fr": "Faut oser vendre des armures dans\nune boutique chic comme Rosa\nCandida.[1205][U+000F] Bonne qualité, mais cher."
+    "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[1205][U+000F] Bonne qualité, mais cher."
   },
   {
     "id": 132,
@@ -2087,7 +2087,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[SP]real\narmor,[SP]not[SP]just[SP]clothes.[SP]It's[SP]cheap[SP]stuff,[SP]but\nyou[SP]get[SP]what[SP]you[SP]pay[SP]for.",
     "nom_fr": "Homme",
-    "texte_fr": "Anima Mundi vend de vraies armures,\npas que des fringues. C'est pas\ncher, mais on en a pour son argent."
+    "texte_fr": "Anima Mundi vend de vraies armures, pas que\ndes fringues. C'est pas cher, mais on en a pour son argent."
   },
   {
     "id": 134,
@@ -2103,7 +2103,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[SP]real\narmor,[SP]not[SP]just[SP]clothes.[SP]Their[SP]selection's\ngreat,[SP]but[SP]the[SP]resale[SP]value[SP]isn't.",
     "nom_fr": "Homme",
-    "texte_fr": "Anima Mundi vend de vraies armures. Bon\nchoix, mais prix de rachat très bas."
+    "texte_fr": "Anima Mundi vend de vraies armures. Bon choix,\nmais prix de rachat très bas."
   },
   {
     "id": 135,
@@ -2119,7 +2119,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[SP]real\narmor,[SP]not[SP]just[SP]clothes.[SP]Their[SP]quality's[SP]good,\nbut[SP]it's[SP]expensive[SP]stuff.",
     "nom_fr": "Homme",
-    "texte_fr": "Anima Mundi vend de vraies armures.\nBonne qualité, mais ça coûte cher."
+    "texte_fr": "Anima Mundi vend de vraies armures. Bonne qualité,\nmais ça coûte cher."
   },
   {
     "id": 136,
@@ -2135,7 +2135,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]selection's[SP]the\npits,[SP]but[SP]they[SP]have[SP]great[SP]resale[SP]prices.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des\narmures?[1205][U+000F] Le choix craint, mais les\nprix de rachat sont excellents."
+    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nLe choix craint, mais les prix de rachat sont excellents."
   },
   {
     "id": 137,
@@ -2151,7 +2151,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality[SP]and\nprices[SP]are[SP]just[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures?[1205][U+000F] La\nqualité et les prix sont très moyens."
+    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nLa qualité et les prix sont très moyens."
   },
   {
     "id": 138,
@@ -2167,7 +2167,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]stuff[SP]is[SP]top-\nnotch,[SP]but[SP]it's[SP]expensive.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures?[1205][U+000F] C'est\ndu matos top niveau, mais c'est cher."
+    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nC'est du matos top niveau, mais c'est cher."
   },
   {
     "id": 139,
@@ -2183,7 +2183,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]prices[SP]are\nlow,[SP]but[SP]so's[SP]the[SP]quality.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures?[1205][U+000F]\nC'est pas cher, mais la qualité suit."
+    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nC'est pas cher, mais la qualité suit."
   },
   {
     "id": 140,
@@ -2199,7 +2199,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]selection's[SP]good,\nbut[SP]their[SP]resale[SP]value[SP]is[SP]awful.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures?[1205][U+000F] Bon\nchoix, mais le prix de rachat est affreux."
+    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nBon choix, mais le prix de rachat est affreux."
   },
   {
     "id": 141,
@@ -2215,7 +2215,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]selection\nis[SP]great,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]low.",
     "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures?[1205][U+000F] Le\nchoix est super, mais le prix de rachat est\nbas."
+    "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nLe choix est super, mais le prix de rachat est bas."
   },
   {
     "id": 142,
@@ -2231,7 +2231,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]stuff\nis[SP]cheap,[SP]but[SP]really[SP]low[SP]quality.",
     "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures?[1205][U+000F]\nC'est pas cher, mais de mauvaise qualité."
+    "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nC'est pas cher, mais de mauvaise qualité."
   },
   {
     "id": 143,
@@ -2247,7 +2247,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality's\ngreat,[SP]if[SP]you[SP]can[SP]afford[SP]it.",
     "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures?[1205][U+000F] La\nqualité est top, si tu peux te le permettre."
+    "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nLa qualité est top, si tu peux te le permettre."
   },
   {
     "id": 144,
@@ -2263,7 +2263,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality\nand[SP]prices[SP]are[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures?[1205][U+000F]\nLa qualité et les prix sont moyens."
+    "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nLa qualité et les prix sont moyens."
   },
   {
     "id": 145,
@@ -2279,7 +2279,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]selection\nis[SP]terrible,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]great.",
     "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des\narmures?[1205][U+000F] Le choix est nul, mais\nle prix de rachat est excellent."
+    "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nLe choix est nul, mais le prix de rachat est excellent."
   },
   {
     "id": 146,
@@ -2295,7 +2295,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "You[SP]can[SP]win[SP]weapons[SP]in[SP]a[SP]magazine[SP]sweepstakes?\nWhat[SP]is[SP]this[SP]world[SP]coming[SP]to?[SP]I[SP]hear[SP]you[SP]don't\nwin[SP]often,[SP]but[SP]the[SP]prizes[SP]are[SP]nice.",
     "nom_fr": "Homme",
-    "texte_fr": "Gagner des armes à un concours de magazine? On\ngagne pas souvent, mais les prix sont sympas."
+    "texte_fr": "Gagner des armes à un concours de magazine ?\nOn gagne pas souvent, mais les prix sont sympas."
   },
   {
     "id": 147,
@@ -2311,7 +2311,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "You[SP]can[SP]win[SP]weapons[SP]in[SP]a[SP]magazine[SP]sweepstakes?\nWhat[SP]is[SP]this[SP]world[SP]coming[SP]to?[SP]I[SP]hear[SP]it's[SP]rare\nanyone[SP]wins,[SP]but[SP]the[SP]prizes[SP]are[SP]first-rate.",
     "nom_fr": "Homme",
-    "texte_fr": "Gagner des armes à un concours de magazine?\nC'est rare de gagner, mais les prix sont top."
+    "texte_fr": "Gagner des armes à un concours de magazine ?\nC'est rare de gagner, mais les prix sont top."
   },
   {
     "id": 148,
@@ -2327,7 +2327,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "You[SP]can[SP]win[SP]weapons[SP]in[SP]a[SP]magazine[SP]sweepstakes?\nWhat[SP]is[SP]this[SP]world[SP]coming[SP]to?[SP]I[SP]hear[SP]it's[SP]easy\nto[SP]win,[SP]but[SP]the[SP]prizes[SP]are[SP]barely[SP]worth[SP]it.",
     "nom_fr": "Homme",
-    "texte_fr": "Gagner des armes à un concours de magazine?\nC'est facile de gagner, mais c'est pas dingue."
+    "texte_fr": "Gagner des armes à un concours de magazine ?\nC'est facile de gagner, mais c'est pas dingue."
   },
   {
     "id": 149,
@@ -2343,7 +2343,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "So[SP]Mu[SP]is[SP]actually[SP]a[SP]gambling[SP]parlor?[SP]I[SP]didn't\nknow[SP]that.[SP]Now[SP]I'm[SP]excited![SP]I[SP]hear[SP]you[SP]can\nwin[SP]big[SP]there[SP]at[SP]poker.",
     "nom_fr": "Homme",
-    "texte_fr": "Mu a un casino? Je savais pas. C'est\ngénial! On gagne gros au poker."
+    "texte_fr": "Mu a un casino ? Je savais pas.\nC'est génial ! On gagne gros au poker."
   },
   {
     "id": 150,
@@ -2359,7 +2359,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "So[SP]Mu[SP]is[SP]actually[SP]a[SP]gambling[SP]parlor?[SP]I[SP]didn't\nknow[SP]that.[SP]Now[SP]I'm[SP]excited![SP]I[SP]hear[SP]you[SP]can\nwin[SP]big[SP]there[SP]at[SP]slots.",
     "nom_fr": "Homme",
-    "texte_fr": "Mu a un casino? Je savais pas. C'est\ngénial! On gagne gros aux machines."
+    "texte_fr": "Mu a un casino ? Je savais pas.\nC'est génial ! On gagne gros aux machines."
   },
   {
     "id": 151,
@@ -2374,7 +2374,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "So[SP]Mu[SP]is[SP]actually[SP]a[SP]gambling[SP]parlor?[SP]I[SP]didn't\nknow[SP]that![SP]I[SP]love[SP]gambling![SP]Now[SP]I'm[SP]excited!",
     "nom_fr": "Homme",
-    "texte_fr": "Mu a un casino? Je savais pas!\nJ'adore ça! Je suis à fond!"
+    "texte_fr": "Mu a un casino ? Je savais pas !\nJ'adore ça ! Je suis à fond !"
   },
   {
     "id": 152,
@@ -2390,7 +2390,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Plus,[SP]I[SP]hear[SP]you[SP]can[SP]win[SP]big[SP]there[SP]at\nblackjack.[SP]Hah,[SP]my[SP]favorite!",
     "nom_fr": "Homme",
-    "texte_fr": "En plus, tu gagnes gros au\nblackjack. Hah, mon préféré!"
+    "texte_fr": "En plus, tu gagnes gros au\nblackjack. Hah, mon préféré !"
   },
   {
     "id": 153,
@@ -2406,7 +2406,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]hear[SP]there's[SP]a[SP]legendary[SP]weapon[SP]for[SP]sale[SP]at\nShiraishi[SP]Ramen.[SP]Is[SP]that[SP]true?[SP]Sheesh...[SP]First\na[SP]Russian[SP]spy,[SP]now[SP]a[SP]legendary[SP]weapon...",
     "nom_fr": "Homme",
-    "texte_fr": "Shiraishi Ramen vend une arme légendaire?\nSérieux? Une espionne, puis ça..."
+    "texte_fr": "Shiraishi Ramen vend une arme légendaire ?\nSérieux ? Une espionne, puis ça..."
   },
   {
     "id": 154,
@@ -2454,7 +2454,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hahaha,[SP]I[SP]hear[SP]the[SP]owner[SP]of[SP]Time[SP]Castle[SP]is[SP]too\nscared[SP]of[SP]monsters[SP]to[SP]fetch[SP]the[SP]legendary[SP]weapon\nwaiting[SP]for[SP]him[SP]at[SP]the[SP]abandoned[SP]factory.",
     "nom_fr": "Homme",
-    "texte_fr": "Hahaha, le boss de Time Castle a\ntrop peur des monstres pour aller\nchercher son arme à l'usine."
+    "texte_fr": "Hahaha, le boss de Time Castle a trop peur\ndes monstres pour aller chercher son arme à l'usine."
   },
   {
     "id": 157,
@@ -2469,7 +2469,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]is[SP]it[SP]true[SP]some[SP]demons[SP]stole[SP]the[SP]legendary\nweapon[SP]from[SP]Time[SP]Castle?",
     "nom_fr": "Homme",
-    "texte_fr": "Hé, des démons ont vraiment volé\nl'arme légendaire de Time Castle?"
+    "texte_fr": "Hé, des démons ont vraiment volé l'arme\nlégendaire de Time Castle ?"
   },
   {
     "id": 158,
@@ -2485,7 +2485,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "What[SP]a[SP]load[SP]of[SP]it.[1205][U+000F][SP]Then[SP]again,[SP]lately[SP]it[SP]seems\nlike[SP]anything[SP]goes...",
     "nom_fr": "Homme",
-    "texte_fr": "Quelle connerie.[1205][U+000F] M'enfin, on peut\ns'attendre à tout de nos jours..."
+    "texte_fr": "Quelle connerie.[1205][U+000F] M'enfin, on\npeut s'attendre à tout de nos jours..."
   },
   {
     "id": 159,
@@ -2500,7 +2500,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]heard[SP]some[SP]unlucky[SP]woman[SP]bought[SP]the[SP]legendary\nweapon[SP]at[SP]Time[SP]Castle.[SP]A[SP]lady's[SP]got[SP]no[SP]business\nownin'[SP]something[SP]that[SP]dangerous.",
     "nom_fr": "Homme",
-    "texte_fr": "Une femme malchanceuse a acheté l'arme\nlégendaire de Time Castle. Une dame avec ça,\nsérieux."
+    "texte_fr": "Une femme malchanceuse a acheté l'arme\nlégendaire de Time Castle. Une dame avec ça, sérieux."
   },
   {
     "id": 160,
@@ -2516,7 +2516,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Huh?[SP]My[SP]attitude's[SP]out[SP]of[SP]date?[SP]Heh,[SP]that's\nfine[SP]by[SP]me![SP]In[SP]my[SP]book,[SP]men[SP]are[SP]supposed[SP]to\nprotect[SP]women!",
     "nom_fr": "Homme",
-    "texte_fr": "Hein? Je suis ringard? M'en fiche! Pour\nmoi, les hommes protègent les femmes!"
+    "texte_fr": "Hein ? Je suis ringard ? M'en fiche !\nPour moi, les hommes protègent les femmes !"
   },
   {
     "id": 161,
@@ -2531,7 +2531,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]did[SP]ya[SP]hear?[SP]The[SP]owner[SP]of[SP]Time[SP]Castle[SP]gave\nthat[SP]legendary[SP]weapon[SP]to[SP]some[SP]girl[SP]with[SP]short\nhair.",
     "nom_fr": "Homme",
-    "texte_fr": "Hé, t'as entendu? Le boss de Time\nCastle a distribué son arme légendaire\nà une fille aux cheveux courts."
+    "texte_fr": "Hé, t'as entendu ? Le boss de Time Castle a\ndistribué son arme légendaire à une fille\naux cheveux courts."
   },
   {
     "id": 162,
@@ -2547,7 +2547,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hahaha,[SP]pretty[SP]generous[SP]of[SP]him,[SP]huh?[SP]Now[SP]there's\na[SP]man[SP]for[SP]you.",
     "nom_fr": "Homme",
-    "texte_fr": "Hahaha, plutôt généreux,\nnon? C'est ça un vrai homme."
+    "texte_fr": "Hahaha, plutôt généreux, non ? C'est ça\nun vrai homme."
   },
   {
     "id": 163,
@@ -2562,7 +2562,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaaah![SP]I'm[SP]not[SP]a[SP]Cuss[SP]High[SP]student[SP]anymore.\nI[SP]used[SP]to[SP]be[SP]one,[SP]but[SP]no[SP]longer.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaaah! Je ne suis plus à Kakasu.\nJ'y étais, mais plus maintenant."
+    "texte_fr": "Hyaaaaah ! Je ne suis plus à Kakasu.\nJ'y étais, mais plus maintenant."
   },
   {
     "id": 164,
@@ -2577,7 +2577,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Now,[SP]I[SP]am[SP]a[SP]washout[SP]who's[SP]fighting[SP]to[SP]study\nhard[SP]and[SP]make[SP]it[SP]into[SP]the[SP]best[SP]university[SP]in\nthe[SP]country!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Maintenant, j'étudie dur pour intégrer\nla meilleure université du pays!"
+    "texte_fr": "Maintenant, j'étudie dur pour intégrer\nla meilleure université du pays !"
   },
   {
     "id": 165,
@@ -2593,7 +2593,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "However![SP]The[SP]recent[SP]influx[SP]of[SP]women[SP]into[SP]this\ncity[SP]is[SP]troubling![SP]While[SP]I'm[SP]happy[SP]my[SP]alma[SP]mater\nis[SP]gaining[SP]popularity,[SP]they're[SP]distracting!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Cependant! L'afflux de femmes\nici est troublant! Mon école est\npopulaire, mais ça me distrait!"
+    "texte_fr": "Cependant ! L'afflux de femmes ici est troublant !\nMon école est populaire, mais ça me distrait !"
   },
   {
     "id": 166,
@@ -2608,7 +2608,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Was[SP]it[SP]only[SP]a[SP]groundless[SP]rumor?[1205][U+000F][SP]I[SP]hear\ntell[SP]of[SP]a[SP]walking[SP]statue[SP]at[SP]Sevens,[SP]my[SP]alma\nmater's[SP]rival...[1205][U+000F][SP]Hate[SP]the[SP]sin,[SP]love[SP]the[SP]sinner!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] C'était juste une rumeur?[1205][U+000F] On\nparle d'une statue vivante à Seven...\n[1205][U+000F]Aime le pécheur, hais le péché!"
+    "texte_fr": "Hyaaaah ![1205][U+000F] C'était juste une rumeur ?[1205][U+000F] On\nparle d'une statue vivante à Seven...\n[1205][U+000F]Aime le pécheur, hais le péché !"
   },
   {
     "id": 167,
@@ -2623,7 +2623,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Having[SP]such[SP]a[SP]statue[SP]on[SP]school[SP]grounds[SP]must[SP]be\na[SP]serious[SP]impediment[SP]to[SP]the[SP]education[SP]of[SP]the\nstudents[SP]there.[1205][U+000F]",
     "nom_fr": "Étudiant",
-    "texte_fr": "Avoir une telle statue à l'école doit gêner\nsérieusement l'éducation de ces élèves.[1205][U+000F]"
+    "texte_fr": "Avoir une telle statue à l'école doit\ngêner sérieusement l'éducation de ces\nélèves.[1205][U+000F]"
   },
   {
     "id": 168,
@@ -2639,7 +2639,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "As[SP]a[SP]fighting[SP]student,[SP]I[SP]will[SP]bring[SP]divine\npunishment[SP]to[SP]that[SP]vexing[SP]statue![SP]Eventually,\nthat[SP]is...",
     "nom_fr": "Étudiant",
-    "texte_fr": "En tant qu'étudiant, j'apporterai le châtiment\ndivin à cette statue! Éventuellement..."
+    "texte_fr": "En tant qu'étudiant, j'apporterai le châtiment\ndivin à cette statue ! Éventuellement..."
   },
   {
     "id": 169,
@@ -2654,7 +2654,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "H-Hyaaaah...![1205][U+000F][SP]My[SP]vision[SP]is[SP]blurry[SP]with[SP]tears...\nThe[SP]students[SP]at[SP]my[SP]alma[SP]mater[SP]are[SP]incredible!",
     "nom_fr": "Étudiant",
-    "texte_fr": "H-Hyaaaah...![1205][U+000F] J'ai les larmes aux yeux...\nLes élèves de mon école sont incroyables!"
+    "texte_fr": "H-Hyaaaah... ![1205][U+000F] J'ai les larmes aux yeux...\nLes élèves de mon école sont incroyables !"
   },
   {
     "id": 170,
@@ -2669,7 +2669,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "You[SP]are[SP]all[SP]shining[SP]examples![1205][U+000F][SP]I[SP]have[SP]long\nawaited[SP]such[SP]a[SP]sight!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Vous êtes de brillants exemples![1205][U+000F] J'ai\nlongtemps attendu une telle chose!"
+    "texte_fr": "Vous êtes de brillants exemples ![1205][U+000F]\nJ'ai longtemps attendu une telle chose !"
   },
   {
     "id": 171,
@@ -2684,7 +2684,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "A[SP]school[SP]festival[SP]is[SP]an[SP]important[SP]event[SP]that\nshows[SP]the[SP]fruits[SP]of[SP]daily[SP]education[SP]and[SP]school\ntraditions![1205][U+000F]",
     "nom_fr": "Étudiant",
-    "texte_fr": "Le festival montre les fruits de\nl'éducation et des traditions scolaires![1205][U+000F]"
+    "texte_fr": "Le festival montre les fruits de l'éducation\net des traditions scolaires ![1205][U+000F]"
   },
   {
     "id": 172,
@@ -2699,7 +2699,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "To[SP]host[SP]a[SP]foreign[SP]dance[SP]like[SP]this[SP]masquerade\ntruly[SP]speaks[SP]of[SP]your[SP]international[SP]spirit!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Faire un bal masqué comme ça\nprouve votre esprit international!"
+    "texte_fr": "Faire un bal masqué comme ça prouve\nvotre esprit international !"
   },
   {
     "id": 173,
@@ -2714,7 +2714,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "It[SP]is[SP]in[SP]the[SP]nature[SP]of[SP]youth[SP]to[SP]be[SP]reckless\nin[SP]the[SP]name[SP]of[SP]freedom![1205][U+000F]",
     "nom_fr": "Étudiant",
-    "texte_fr": "C'est dans la nature de la jeunesse\nd'être imprudent au nom de la liberté![1205][U+000F]"
+    "texte_fr": "C'est dans la nature de la jeunesse d'être\nimprudent au nom de la liberté ![1205][U+000F]"
   },
   {
     "id": 174,
@@ -2730,7 +2730,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Even[SP]drops[SP]of[SP]water[SP]wear[SP]away[SP]at[SP]stone![1205][U+000F][SP]Do[SP]your\nbest[SP]to[SP]work[SP]towards[SP]your[SP]future,[SP]and[SP]a[SP]bright\ntomorrow[SP]will[SP]await[SP]you[SP]all!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Les gouttes d'eau usent la pierre![1205][U+000F] Faites\nde votre mieux pour votre avenir, et des\nlendemains radieux vous attendent!"
+    "texte_fr": "Les gouttes d'eau usent la pierre ![1205][U+000F] Faites de\nvotre mieux pour votre avenir, et des\nlendemains radieux vous attendent !"
   },
   {
     "id": 175,
@@ -2745,7 +2745,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![SP]I[SP]can't[SP]believe[SP]I[SP]let[SP]myself[SP]be[SP]taken\nin[SP]by[SP]a[SP]groundless[SP]rumor![1205][U+000F][SP]What?[SP]You[SP]wish[SP]to\nknow[SP]more[SP]of[SP]my[SP]folly?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah! J'arrive pas à croire que\nj'ai gobé une rumeur infondée![1205][U+000F] Quoi?\nTu veux en savoir plus sur ma folie?"
+    "texte_fr": "Hyaaaah ! J'arrive pas à croire que j'ai\ngobé une rumeur infondée ![1205][U+000F] Quoi ? Tu\nveux en savoir plus sur ma folie ?"
   },
   {
     "id": 176,
@@ -2775,7 +2775,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "But[SP]in[SP]truth,[SP]there[SP]was[SP]nothing[SP]of[SP]the[SP]kind!\nThe[SP]employees[SP]there[SP]even[SP]mocked[SP]me[SP]for[SP]asking!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Mais en fait, il n'y avait rien de tel!\nLes employés se sont même moqués de moi!"
+    "texte_fr": "Mais en fait, il n'y avait rien de tel !\nLes employés se sont même moqués de moi !"
   },
   {
     "id": 178,
@@ -2791,7 +2791,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "But[SP]perhaps[SP]my[SP]information[SP]was[SP]bad...[1205][U+000F][SP]Maybe\nthat[SP]stout[SP]man[SP]knows[SP]something.[1205][U+000F][SP]I[SP]believe[SP]his\nname[SP]is[SP]Toro,[SP]and[SP]he[SP]loves[SP]fatty[SP]tuna.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Mais mes infos étaient peut-être fausses...[1205][U+000F] Ce\ngrand costaud sait peut-être quelque chose.[1205][U+000F] Il\ns'appelle Toro, et adore le thon gras."
+    "texte_fr": "Mais mes infos étaient peut-être fausses...[1205][U+000F]\nCe grand costaud sait peut-être\nquelque chose.[1205][U+000F] Il s'appelle Toro,\net adore le thon gras."
   },
   {
     "id": 179,
@@ -2806,7 +2806,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]heard[SP]that[SP]the[SP]members[SP]of[SP]Muses[SP]are\nall[SP]still[SP]in[SP]high[SP]school!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] J'ai entendu dire que les membres\nde Muses sont toutes encore au lycée!"
+    "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu dire que les membres de\nMuses sont toutes encore au lycée !"
   },
   {
     "id": 180,
@@ -2821,7 +2821,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "What[SP]about[SP]their[SP]studies!?[1205][U+000A][SP]What[SP]about[SP]their\ncollege[SP]entrance[SP]exams!?[1205][U+000A][SP]Have[SP]you[SP]even[SP]taken\nyour[SP]finals[SP]yet!?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Qu'en est-il de leurs études!?[1205][U+000A] Et leurs\nexamens d'entrée à la fac!?[1205][U+000A] Avez-vous\nseulement passé vos examens finaux!?"
+    "texte_fr": "Qu'en est-il de leurs études !?[1205][U+000A] Et leurs\nexamens d'entrée à la fac !?[1205][U+000A] Avez-vous\nseulement passé vos examens finaux !?"
   },
   {
     "id": 181,
@@ -2837,7 +2837,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "One's[SP]good[SP]looks[SP]will[SP]not[SP]keep[SP]one[SP]afloat![1205][U+000F]\nHow[SP]dare[SP]they[SP]be[SP]dazzled[SP]by[SP]show[SP]business!?\nA[SP]student's[SP]first[SP]duty[SP]is[SP]studying!",
     "nom_fr": "Étudiant",
-    "texte_fr": "La beauté seule ne suffit pas![1205][U+000F] Comment\nosent-elles se laisser éblouir par le\nshow-biz!? Le premier devoir d'un étudiant est\nd'étudier!"
+    "texte_fr": "La beauté seule ne suffit pas ![1205][U+000F]\nComment osent-elles se laisser éblouir par le show-biz !?\nLe premier devoir d'un étudiant est d'étudier !"
   },
   {
     "id": 182,
@@ -2852,7 +2852,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]like[SP]Ginji[SP]Sasaki[SP]too![1205][U+000F][SP]I[SP]don't[SP]really\nlisten[SP]to[SP]them,[SP]but[SP]I've[SP]bought[SP]everything[SP]he's\nproduced![SP]Even[SP]his[SP]compilation[SP]album!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] J'aime Ginji Sasaki moi aussi![1205][U+000F] Je\nne les écoute pas vraiment, mais j'ai acheté\ntout ce qu'il a produit! Même sa compil!"
+    "texte_fr": "Hyaaaah ![1205][U+000F] J'aime Ginji Sasaki moi aussi ![1205][U+000F]\nJe ne les écoute pas vraiment, mais j'ai acheté\ntout ce qu'il a produit ! Même sa compil !"
   },
   {
     "id": 183,
@@ -2867,7 +2867,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "But[SP]I[SP]cannot[SP]abide[SP]by[SP]his[SP]dragging[SP]innocent\nmaidens[SP]who[SP]should[SP]be[SP]studying[SP]into[SP]his[SP]tawdry\nindustry!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Mais je hais qu'il entraîne des\nfilles innocentes devant étudier\ndans cette industrie tape-à-l'œil!"
+    "texte_fr": "Mais je hais qu'il entraîne des filles\ninnocentes devant étudier dans cette\nindustrie tape-à-l'œil !"
   },
   {
     "id": 184,
@@ -2883,7 +2883,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Though[SP]I[SP]don't[SP]necessarily[SP]hate[SP]his[SP]music.[1205][U+000F]\nAm[SP]I[SP]contradicting[SP]myself?[1205][U+000F][SP]I[SP]am,[SP]aren't[SP]I...?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Bien que je ne déteste pas vraiment\nsa musique.[1205][U+000F] Est-ce que je me\ncontredis?[1205][U+000F] Oui, n'est-ce pas...?"
+    "texte_fr": "Bien que je ne déteste pas vraiment sa musique.[1205][U+000F]\nEst-ce que je me contredis ?[1205][U+000F] Oui, n'est-ce pas... ?"
   },
   {
     "id": 185,
@@ -2898,7 +2898,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]don't[SP]know[SP]if[SP]it[SP]was[SP]actually[SP]a\nterrorism[SP]wave,[SP]but[SP]my[SP]cram[SP]school[SP]was[SP]shut\ndown[SP]because[SP]of[SP]fools[SP]playing[SP]with[SP]fire!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Je ne sais pas s'il y a vraiment une\nvague de terrorisme, mais ma prépa a fermé à\ncause d'idiots qui jouent avec le feu!"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Je ne sais pas s'il y a vraiment\nune vague de terrorisme, mais ma prépa a\nfermé à cause d'idiots qui jouent avec le feu !"
   },
   {
     "id": 186,
@@ -2914,7 +2914,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Nothing[SP]will[SP]get[SP]in[SP]the[SP]way[SP]of[SP]my[SP]studies!\nThe[SP]pen[SP]is[SP]mightier[SP]than[SP]the[SP]sword![SP]I'll[SP]bring\ndown[SP]the[SP]Masked[SP]Circle![1205][U+000F][SP]Eventually...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Rien ne m'empêchera d'étudier! La plume\nest plus forte que l'épée! Je ferai\ntomber le Cercle masqué![1205][U+000F] Bientôt..."
+    "texte_fr": "Rien ne m'empêchera d'étudier !\nLa plume est plus forte que l'épée !\nJe ferai tomber le Cercle masqué ![1205][U+000F] Bientôt..."
   },
   {
     "id": 187,
@@ -2929,7 +2929,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]People[SP]talk[SP]about[SP]terrorism[SP]this[SP]and\nterrorism[SP]that,[SP]but[SP]if[SP]this[SP]is[SP]the[SP]work[SP]of\nterrorists,[SP]we[SP]should[SP]know[SP]their[SP]demands[SP]now.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] On parle de terrorisme par-ci\npar-là, mais on devrait connaître\nleurs revendications maintenant."
+    "texte_fr": "Hyaaaah ![1205][U+000F] On parle de terrorisme par-ci\npar-là, mais on devrait connaître leurs\nrevendications maintenant."
   },
   {
     "id": 188,
@@ -2945,7 +2945,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Yet[SP]none[SP]have[SP]been[SP]made.[SP]It's[SP]possible[SP]that\nthis[SP]is[SP]being[SP]perpetrated[SP]for[SP]someone's[SP]sick\namusement...[1205][U+000F][SP]My[SP]anger[SP]will[SP]never[SP]be[SP]stilled!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Pourtant, aucune n'a été faite. C'est\npeut-être l'œuvre de quelqu'un qui\ns'amuse...[1205][U+000F] Ma colère ne s'apaisera jamais!"
+    "texte_fr": "Pourtant, aucune n'a été faite. C'est peut-être\nl'œuvre de quelqu'un qui s'amuse...[1205][U+000F]\nMa colère ne s'apaisera jamais !"
   },
   {
     "id": 189,
@@ -2960,7 +2960,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]People[SP]talk[SP]about[SP]terrorism[SP]this[SP]and\nterrorism[SP]that,[SP]but[SP]if[SP]this[SP]is[SP]the[SP]work[SP]of\nterrorists,[SP]we[SP]should[SP]know[SP]their[SP]demands[SP]now.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] On parle de terrorisme par-ci\npar-là, mais on devrait connaître\nleurs revendications maintenant."
+    "texte_fr": "Hyaaaah ![1205][U+000F] On parle de terrorisme par-ci\npar-là, mais on devrait connaître leurs\nrevendications maintenant."
   },
   {
     "id": 190,
@@ -2976,7 +2976,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Yet[SP]none[SP]have[SP]been[SP]made.[SP]It's[SP]possible[SP]that\nthis[SP]is[SP]being[SP]perpetrated[SP]for[SP]someone's[SP]sick\namusement...[1205][U+000F][SP]My[SP]anger[SP]will[SP]never[SP]be[SP]stilled!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Pourtant, aucune n'a été faite. C'est\npeut-être l'œuvre de quelqu'un qui\ns'amuse...[1205][U+000F] Ma colère ne s'apaisera jamais!"
+    "texte_fr": "Pourtant, aucune n'a été faite. C'est peut-être\nl'œuvre de quelqu'un qui s'amuse...[1205][U+000F]\nMa colère ne s'apaisera jamais !"
   },
   {
     "id": 191,
@@ -2991,7 +2991,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Hmm,[SP]if[SP]my[SP]high[SP]school[SP]memories[SP]are\naccurate,[SP]that[SP]lady[SP]a[SP]moment[SP]ago[SP]was[SP]Sevens'...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Hmm, si mes souvenirs du\nlycée sont exacts, cette dame d'il\ny a un instant était de Seven..."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Hmm, si mes souvenirs du lycée\nsont exacts, cette dame d'il y a un\ninstant était de Seven..."
   },
   {
     "id": 192,
@@ -3006,7 +3006,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Did[SP]something[SP]happen[SP]for[SP]her[SP]to[SP]rush[SP]into[SP]the\ndetective[SP]agency[SP]like[SP]that?[1205][U+000F][SP]*gasp*[SP]No![SP]What[SP]an\nawful[SP]thought!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Il s'est passé un truc pour qu'elle se\nrue ainsi à l'agence de détectives?[1205][U+000F]\n*gasp* Non! Quelle pensée affreuse!"
+    "texte_fr": "Il s'est passé un truc pour qu'elle se rue\nainsi à l'agence de détectives ?[1205][U+000F]\n*gasp* Non ! Quelle pensée affreuse !"
   },
   {
     "id": 193,
@@ -3022,7 +3022,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "It's[SP]terribly[SP]vulgar[SP]to[SP]pry[SP]into[SP]the[SP]privacy[SP]of\nothers.[1205][U+000F][SP]I[SP]must[SP]admonish[SP]myself![1205][U+000F][SP]Time[SP]to[SP]copy\nall[SP]the[SP]pages[SP]of[SP]the[SP]Compendium[SP]of[SP]Laws!",
     "nom_fr": "Étudiant",
-    "texte_fr": "C'est terriblement vulgaire de s'immiscer dans\nla vie privée des autres.[1205][U+000F] Je dois me faire une\nraison![1205][U+000F] Je vais copier le code civil!"
+    "texte_fr": "C'est terriblement vulgaire de s'immiscer dans\nla vie privée des autres.[1205][U+000F] Je dois me faire une\nraison ![1205][U+000F] Je vais copier le code civil !"
   },
   {
     "id": 194,
@@ -3037,7 +3037,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Fear[SP]makes[SP]men[SP]panic[SP]and[SP]become\nconfused![SP]What[SP]is[SP]right[SP]and[SP]what[SP]is[SP]wrong...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaah![1205][U+000F] La peur fait paniquer les\nhommes et les rend confus! Ce qui\nest bien et ce qui est mal..."
+    "texte_fr": "Hyaaah![1205][U+000F] La peur fait paniquer\nles hommes et les rend confus ! Ce qui\nest bien et ce qui est mal..."
   },
   {
     "id": 195,
@@ -3068,7 +3068,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]The[SP]Last[SP]Battalion's[SP]invasion[SP]is[SP]a\nserious[SP]problem,[SP]but[SP]even[SP]more[SP]serious[SP]is[SP]the\nIn[SP]Lak'ech!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] L'invasion du Bataillon\nest un grave problème, mais l'In\nLak'ech est encore plus sérieux!"
+    "texte_fr": "Hyaaaah ![1205][U+000F] L'invasion du Bataillon est un\ngrave problème, mais l'In Lak'ech est\nencore plus sérieux !"
   },
   {
     "id": 197,
@@ -3083,7 +3083,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "If[SP]it[SP]speaks[SP]truly,[SP]the[SP]world[SP]will[SP]face[SP]utter\ndestruction[SP]soon.",
     "nom_fr": "Étudiant",
-    "texte_fr": "S'il dit vrai, le monde fera face\nà une destruction totale bientôt."
+    "texte_fr": "S'il dit vrai, le monde fera face à\nune destruction totale bientôt."
   },
   {
     "id": 198,
@@ -3099,7 +3099,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "If[SP]that[SP]happens,[SP]what[SP]will[SP]become[SP]of[SP]my[SP]dream!?[1205][U+000F]\nHow[SP]will[SP]I[SP]make[SP]it[SP]into[SP]the[SP]best[SP]university[SP]in\nthe[SP]country[SP]if[SP]the[SP]country[SP]is[SP]destroyed!?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Si ça arrive, que deviendra mon rêve!?[1205][U+000F]\nComment intégrer la meilleure université\ndu pays si le pays est détruit!?"
+    "texte_fr": "Si ça arrive, que deviendra mon rêve !?[1205][U+000F]\nComment intégrer la meilleure université\ndu pays si le pays est détruit !?"
   },
   {
     "id": 199,
@@ -3114,7 +3114,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+0008][SP]What[SP]should[SP]I[SP]do?[1205][U+000A][SP]A[SP]city[SP]soaring[SP]in\nthe[SP]sky[SP]is[SP]the[SP]epitome[SP]of[SP]absurdity![1205][U+000A][SP]Worse,\nthere[SP]are[SP]no[SP]colleges[SP]in[SP]Sumaru[SP]City!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+0008] Que dois-je faire?[1205][U+000A] Une ville dans\nle ciel, c'est le comble de l'absurdité![1205][U+000A]\nPire, il n'y a pas de facultés à Sumaru!"
+    "texte_fr": "Hyaaaah ![1205][U+0008] Que dois-je faire ?[1205][U+000A] Une ville dans\nle ciel, c'est le comble de l'absurdité ![1205][U+000A] Pire,\nil n'y a pas de facultés à Sumaru !"
   },
   {
     "id": 200,
@@ -3130,7 +3130,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hrrrgh...[1205][U+000A][SP]If[SP]the[SP]world[SP]does[SP]end,[SP]what[SP]was[SP]all\nmy[SP]hard[SP]work[SP]for...?[1205][U+000F][SP]It[SP]pains[SP]my[SP]heart[SP]to[SP]even\nthink[SP]about[SP]it!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hrrrgh...[1205][U+000A] Si le monde s'arrête, à quoi\ntout ce travail aura-t-il servi...?[1205][U+000F] Rien\nque d'y penser, ça me brise le cœur!"
+    "texte_fr": "Hrrrgh...[1205][U+000A] Si le monde s'arrête, à quoi tout ce\ntravail aura-t-il servi... ?[1205][U+000F] Rien que\nd'y penser, ça me brise le cœur !"
   },
   {
     "id": 201,
@@ -3145,7 +3145,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+0008][SP]Making[SP]it[SP]into[SP]a[SP]top[SP]college,[SP]working\nfor[SP]the[SP]best[SP]company...[1205][U+000A][SP]This[SP]has[SP]been[SP]my[SP]dream\nfor[SP]31[SP]years...[1205][U+000F][SP]Now[SP]neither[SP]will[SP]come[SP]true...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+0008] Entrer dans une grande faculté,\nbosser pour la meilleure boîte...[1205][U+000A] C'est mon\nrêve depuis 31 ans...[1205][U+000F] Aucun ne se réalisera..."
+    "texte_fr": "Hyaaaah ![1205][U+0008] Entrer dans une grande faculté, bosser\npour la meilleure boîte...[1205][U+000A] C'est mon rêve\ndepuis 31 ans...[1205][U+000F] Aucun ne se réalisera..."
   },
   {
     "id": 202,
@@ -3160,7 +3160,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "At[SP]the[SP]very[SP]least,[SP]I'll[SP]witness[SP]the[SP]end[SP]of\nMother[SP]Earth,[SP]since[SP]my[SP]life[SP]will[SP]be[SP]spared.[1205][U+000F]\nShould[SP]auld[SP]acquaintance[SP]be[SP]forgot...[1205][U+000A][SP]*sniff*[E1][E2]\n[E3][E4][NULL][NULL]\"Fighting[SP]washout[SP]student\nHyaaaah![1205][U+0008][SP]I[SP]hear[SP]tell[SP]that[SP]when[SP]the[SP]Grand[SP]Cross\nis[SP]complete,[SP]a[SP]black[SP]hole[SP]will[SP]form[SP]at[SP]its\ncenter[SP]and[SP]swallow[SP]this[SP]planet[SP]whole.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Au moins, je verrai la fin de notre Terre,\npuisque ma vie sera épargnée.[1205][U+000F] Faut-il oublier\nles vieilles connaissances...[1205][U+000A] *sniff*[E1][E2]\n[E3][E4][NULL][NULL]\"Étudiant Hyaaaah![1205][U+0008] J'entends dire que quand la\nCroix Cosmique sera terminée, un trou noir va\nse former au centre et engloutir cette\nplanète."
+    "texte_fr": "Au moins, je verrai la fin de notre\nTerre, puisque ma vie sera épargnée.[1205][U+000F]\nFaut-il oublier les vieilles connaissances...[1205][U+000A]\n*sniff*[E1][E2]\n[E3][E4][NULL][NULL]\"Étudiant\nHyaaaah ![1205][U+0008] J'entends dire que quand la Croix\nCosmique sera terminée, un trou noir va se\nformer au centre et engloutir cette planète."
   },
   {
     "id": 203,
@@ -3191,7 +3191,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+0008][SP]I[SP]doubt[SP]any[SP]severe[SP]natural[SP]disaster\nbut[SP]this[SP]one[SP]could[SP]happen![1205][U+000A][SP]It[SP]seems[SP]that[SP]the\nEarth's[SP]rotation[SP]will[SP]suddenly[SP]halt.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+0008] Je doute qu'une autre catastrophe\nnaturelle puisse se produire![1205][U+000A] Il semble\nque la Terre va soudainement s'arrêter."
+    "texte_fr": "Hyaaaah ![1205][U+0008] Je doute qu'une autre catastrophe\nnaturelle puisse se produire ![1205][U+000A] Il semble\nque la Terre va soudainement s'arrêter."
   },
   {
     "id": 205,
@@ -3222,7 +3222,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+0008][SP]What[SP]strange[SP]news![SP]It[SP]seems[SP]there[SP]are\nflowers[SP]in[SP]Aoba[SP]Park[SP]who[SP]talk.[SP]Perhaps[SP]the\nmystery[SP]of[SP]the[SP]plants[SP]will[SP]be[SP]revealed...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+0008] Quelle étrange nouvelle! Il semble\ny avoir des fleurs au parc Aoba qui parlent.\nPeut-être que le mystère sera révélé..."
+    "texte_fr": "Hyaaaah ![1205][U+0008] Quelle étrange nouvelle ! Il\nsemble y avoir des fleurs au parc Aoba qui\nparlent. Peut-être que le mystère sera révélé..."
   },
   {
     "id": 207,
@@ -3238,7 +3238,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "It[SP]must[SP]be[SP]a[SP]sign[SP]from[SP]God,[SP]pointing[SP]me[SP]to\nthe[SP]way[SP]to[SP]win[SP]the[SP]Nobel[SP]Peace[SP]Prize![1205][0014]\n...Or[SP]so[SP]I[SP]thought,[SP]but[SP]I'm[SP]no[SP]scientist.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Ce doit être un signe de Dieu, m'indiquant le\nchemin du prix Nobel de la paix![1205][0014] ... Ou c'est\nce que je croyais. Je suis pas scientifique."
+    "texte_fr": "Ce doit être un signe de Dieu, m'indiquant\nle chemin du prix Nobel de la paix ![1205][0014]\n...Ou c'est ce que je croyais. Je suis pas scientifique."
   },
   {
     "id": 208,
@@ -3253,7 +3253,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+0008][SP]Did[SP]you[SP]hear?[SP]Club[SP]Zodiac's[SP]second\nfloor[SP]is[SP]undergoing[SP]extensive[SP]remodeling![1205][U+000A]\nIt's[SP]now[SP]an[SP]item-filled[SP]labyrinth.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+0008] Tu as entendu? Le deuxième étage\ndu club Zodiac est en rénovation![1205][U+000A] C'est\nmaintenant un labyrinthe rempli d'objets."
+    "texte_fr": "Hyaaaah ![1205][U+0008] Tu as entendu ? Le deuxième\nétage du club Zodiac est en rénovation ![1205][U+000A]\nC'est maintenant un labyrinthe rempli d'objets."
   },
   {
     "id": 209,
@@ -3269,7 +3269,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hmm,[SP]this[SP]ordeal[SP]must[SP]have[SP]been[SP]made[SP]for[SP]me...[1205][U+000A]\nBut[SP]I'm[SP]too[SP]busy[SP]with[SP]my[SP]studies.[SP]I[SP]will[SP]be\ngenerous[SP]and[SP]allow[SP]you[SP]to[SP]challenge[SP]it!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hmm, cette épreuve a sûrement été\nfaite pour moi...[1205][U+000A] Mais je suis trop\npris par mes études. Je serai généreux\net te permettrai de la relever!"
+    "texte_fr": "Hmm, cette épreuve a sûrement été faite pour moi...[1205][U+000A]\nMais je suis trop pris par mes études. Je serai\ngénéreux et te permettrai de la relever !"
   },
   {
     "id": 210,
@@ -3285,7 +3285,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]even[SP]the[SP]ghost[SP]Hanako[SP]is[SP]appearing\nat[SP]Sevens!?[SP]What[SP]an[SP]ill-fated[SP]institution.\nI[SP]pity[SP]its[SP]students.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Même le fantôme Hanako\napparaît à Seven!? Quelle institution\nmaudite. J'ai pitié de ses étudiants."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Même le fantôme Hanako apparaît\nà Seven !? Quelle institution\nmaudite. J'ai pitié de ses étudiants."
   },
   {
     "id": 211,
@@ -3300,7 +3300,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]This[SP]is[SP]serious[SP]indeed![SP]It[SP]seems[SP]the\nghost[SP]of[SP]Bukimi[SP]is[SP]haunting[SP]my[SP]beloved[SP]alma\nmater,[SP]Kasugayama[SP]High!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] C'est vraiment sérieux! Il\nsemble que le fantôme de Bukimi hante\nmon école adorée, le lycée Kasugayama!"
+    "texte_fr": "Hyaaaah ![1205][U+000F] C'est vraiment sérieux ! Il\nsemble que le fantôme de Bukimi hante\nmon école adorée, le lycée Kasugayama !"
   },
   {
     "id": 212,
@@ -3316,7 +3316,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Ahh,[SP]but[SP]fear[SP]not,[SP]my[SP]fellow[SP]students...\nAs[SP]a[SP]Kasugayama[SP]graduate,[SP]I[SP]shall[SP]dispose[SP]of\nthis[SP]Bukimi![1205][U+000F][SP]Eventually...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Ahh, mais ne craignez rien, mes amis... En\ntant qu'ancien de Kasugayama, je me\ndébarrasserai de Bukimi![1205][U+000F] Éventuellement..."
+    "texte_fr": "Ahh, mais ne craignez rien, mes amis...\nEn tant qu'ancien de Kasugayama, je me\ndébarrasserai de Bukimi ![1205][U+000F] Éventuellement..."
   },
   {
     "id": 213,
@@ -3331,7 +3331,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![SP]It[SP]seems[SP]the[SP]ghost[SP]of[SP]a[SP]former[SP]idol\nis[SP]haunting[SP]Aoba[SP]Park...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah! Il semble que le fantôme d'une\nancienne idole hante le parc Aoba..."
+    "texte_fr": "Hyaaaah ! Il semble que le fantôme d'une\nancienne idole hante le parc Aoba..."
   },
   {
     "id": 214,
@@ -3347,7 +3347,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "A[SP]pity,[SP]truly[SP]it[SP]is,[SP]but[SP]such[SP]is[SP]the[SP]fate[SP]of\nmany[SP]who[SP]are[SP]tempted[SP]by[SP]showbiz.",
     "nom_fr": "Étudiant",
-    "texte_fr": "C'est dommage, vraiment, mais c'est le destin\nde beaucoup de gens tentés par le show-biz."
+    "texte_fr": "C'est dommage, vraiment, mais c'est le\ndestin de beaucoup de gens tentés\npar le show-biz."
   },
   {
     "id": 215,
@@ -3362,7 +3362,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Apparently,[SP]a[SP]monster[SP]known[SP]as[SP]a\nCursed[SP]Taxi[SP]is[SP]menacing[SP]the[SP]abandoned[SP]factory.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Apparemment, un monstre connu sous le\nnom de Taxi Maudit menace l'usine abandonnée."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Apparemment, un monstre connu sous le\nnom de Taxi Maudit menace l'usine abandonnée."
   },
   {
     "id": 216,
@@ -3378,7 +3378,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Normally,[SP]I[SP]wouldn't[SP]suffer[SP]such[SP]a[SP]monster[SP]to\nlive,[SP]but[SP]I'm[SP]rather[SP]busy[SP]today.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Normalement, je ne laisserais pas vivre un\ntel monstre, mais je suis occupé aujourd'hui."
+    "texte_fr": "Normalement, je ne laisserais pas vivre un\ntel monstre, mais je suis\noccupé aujourd'hui."
   },
   {
     "id": 217,
@@ -3393,7 +3393,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Dear[SP]me...[SP]So[SP]it[SP]was[SP]a[SP]Cursed[SP]Escort,\nand[SP]not[SP]a[SP]Cursed[SP]Taxi,[SP]that[SP]made[SP]the[SP]abandoned\nfactory[SP]its[SP]home...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Mon Dieu... C'était donc une\nEscorte Maudite, et non un Taxi Maudit,\nqui a élu domicile à l'usine abandonnée..."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Mon Dieu... C'était donc une Escorte\nMaudite, et non un Taxi Maudit, qui a élu domicile\nà l'usine abandonnée..."
   },
   {
     "id": 218,
@@ -3409,7 +3409,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Er,[SP]what[SP]is[SP]the[SP]difference[SP]between[SP]the[SP]two?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Euh, quelle est la différence entre les deux?"
+    "texte_fr": "Euh, quelle est la différence entre les deux ?"
   },
   {
     "id": 219,
@@ -3424,7 +3424,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]Kuchisake-onna[SP]is[SP]at[SP]Mt.[SP]Iwato?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Kuchisake-onna est au Mt Iwato?"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Kuchisake-onna est au Mt Iwato ?"
   },
   {
     "id": 220,
@@ -3439,7 +3439,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "I've[SP]had[SP]my[SP]share[SP]of[SP]run-ins[SP]with[SP]urban[SP]legends\nlike[SP]her[SP]in[SP]my[SP]youth.[SP]She[SP]was[SP]said[SP]to[SP]chase\nafter[SP]children[SP]who[SP]didn't[SP]head[SP]straight[SP]home.",
     "nom_fr": "Étudiant",
-    "texte_fr": "J'ai eu mon lot de problèmes avec des\nlégendes urbaines comme elle dans ma\njeunesse. Elle chassait les enfants qui\nne rentraient pas direct à la maison."
+    "texte_fr": "J'ai eu mon lot de problèmes avec des légendes\nurbaines comme elle dans ma jeunesse. Elle chassait\nles enfants qui ne rentraient pas direct à la maison."
   },
   {
     "id": 221,
@@ -3470,7 +3470,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]An[SP]oddity[SP]by[SP]the[SP]name[SP]of[SP]Jumping\nGeezer[SP]has[SP]been[SP]sighted[SP]at[SP]Mt.[SP]Katatsumuri.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Une bizarrerie nommée Vieux\nSauteur a été aperçue au Mt Katatsumuri."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Une bizarrerie nommée Vieux\nSauteur a été aperçue au Mt Katatsumuri."
   },
   {
     "id": 223,
@@ -3486,7 +3486,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Why[SP]would[SP]a[SP]man[SP]in[SP]his[SP]nineties[SP]be[SP]jumping\naround...?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Pourquoi un homme de quatre-vingt-dix\nans sauterait-il partout...?"
+    "texte_fr": "Pourquoi un homme de quatre-vingt-dix ans\nsauterait-il partout... ?"
   },
   {
     "id": 224,
@@ -3502,7 +3502,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "H-Hyaa...aaah...[1205][U+000F][SP]Oh,[SP]who[SP]am[SP]I[SP]kidding?[1205][U+000F][SP]I'm[SP]so\nfrightened,[SP]my[SP]legs[SP]won't[SP]stop[SP]shaking.[1205][U+000F]\nK-Kudan...[SP]It's[SP]at[SP]the[SP]abandoned[SP]factory...",
     "nom_fr": "Étudiant",
-    "texte_fr": "H-Hyaa... aaah...[1205][U+000F] Oh, à qui je veux\nfaire croire ça?[1205][U+000F] J'ai tellement peur\nque mes jambes ne s'arrêtent pas de\ntrembler.[1205][U+000F] Kudan... À l'usine..."
+    "texte_fr": "H-Hyaa...aaah...[1205][U+000F] Oh, à qui je veux faire\ncroire ça ?[1205][U+000F] J'ai tellement peur que mes jambes\nne s'arrêtent pas de trembler.[1205][U+000F] Kudan... À l'usine..."
   },
   {
     "id": 225,
@@ -3517,7 +3517,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]How[SP]dare[SP]a[SP]merchant[SP]hide[SP]his[SP]own\nmerchandise!?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Comment un marchand ose-t-il\ncacher sa propre marchandise!?"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Comment un marchand ose-t-il\ncacher sa propre marchandise !?"
   },
   {
     "id": 226,
@@ -3533,7 +3533,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "And[SP]a[SP]secret[SP]CD,[SP]no[SP]less!?[SP]What[SP]is[SP]the\nproprietor[SP]of[SP]Giga[SP]Macho[SP]thinking?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Et un CD secret, en plus!? À quoi\npense le propriétaire de Giga Macho?"
+    "texte_fr": "Et un CD secret, en plus !? À quoi\npense le propriétaire de Giga Macho ?"
   },
   {
     "id": 227,
@@ -3548,7 +3548,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]It[SP]seems[SP]there's[SP]a[SP]creature[SP]known[SP]as\na[SP]Dresser[SP]Hag[SP]at[SP]the[SP]abandoned[SP]factory.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Il semble qu'il y ait\nune créature connue sous le nom\nde Mégère à Commode à l'usine."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Il semble qu'il y ait une créature\nconnue sous le nom de Mégère à Commode à l'usine."
   },
   {
     "id": 228,
@@ -3564,7 +3564,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "That[SP]place[SP]has[SP]spawned[SP]so[SP]many[SP]rumors.[1205][U+000F]\nThey[SP]should[SP]do[SP]what[SP]needs[SP]doing[SP]and[SP]condemn\nthe[SP]place.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Cet endroit a engendré tellement de\nrumeurs.[1205][U+000F] Ils devraient faire ce\nqu'il faut et condamner cet endroit."
+    "texte_fr": "Cet endroit a engendré tellement de rumeurs.[1205][U+000F]\nIls devraient faire ce qu'il faut et condamner\ncet endroit."
   },
   {
     "id": 229,
@@ -3579,7 +3579,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Selling[SP]weapons[SP]at[SP]an[SP]antique[SP]shop...[1205][U+000F]\nTime[SP]Castle's[SP]owner[SP]is[SP]no[SP]ordinary[SP]man.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Vendre des armes chez\nun antiquaire...[1205][U+000F] Le propriétaire\nde Time Castle est audacieux."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Vendre des armes chez un antiquaire...[1205][U+000F]\nLe propriétaire de Time Castle est audacieux."
   },
   {
     "id": 230,
@@ -3595,7 +3595,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "The[SP]quality[SP]and[SP]price[SP]of[SP]his[SP]goods[SP]seems[SP]to\nbe[SP]average,[SP]though.",
     "nom_fr": "Étudiant",
-    "texte_fr": "La qualité et le prix de ses biens\nsemblent cependant être dans la moyenne."
+    "texte_fr": "La qualité et le prix de ses biens semblent\ncependant être dans la moyenne."
   },
   {
     "id": 231,
@@ -3610,7 +3610,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Selling[SP]weapons[SP]at[SP]an[SP]antique[SP]shop...[1205][U+000F]\nTime[SP]Castle's[SP]owner[SP]is[SP]no[SP]ordinary[SP]man.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Vendre des armes chez\nun antiquaire...[1205][U+000F] Le propriétaire\nde Time Castle est audacieux."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Vendre des armes chez un antiquaire...[1205][U+000F]\nLe propriétaire de Time Castle est audacieux."
   },
   {
     "id": 232,
@@ -3626,7 +3626,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "The[SP]quality[SP]of[SP]his[SP]goods[SP]is[SP]superb,[SP]but[SP]his\nprices[SP]are[SP]very[SP]steep.",
     "nom_fr": "Étudiant",
-    "texte_fr": "La qualité de ses biens est superbe,\nmais ses prix sont très élevés."
+    "texte_fr": "La qualité de ses biens est superbe, mais ses\nprix sont très élevés."
   },
   {
     "id": 233,
@@ -3641,7 +3641,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Selling[SP]weapons[SP]at[SP]an[SP]antique[SP]shop...[1205][U+000F]\nTime[SP]Castle's[SP]owner[SP]is[SP]no[SP]ordinary[SP]man.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Vendre des armes chez\nun antiquaire...[1205][U+000F] Le propriétaire\nde Time Castle est audacieux."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Vendre des armes chez un antiquaire...[1205][U+000F]\nLe propriétaire de Time Castle est audacieux."
   },
   {
     "id": 234,
@@ -3657,7 +3657,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "I[SP]hear[SP]tell[SP]that[SP]the[SP]price[SP]is[SP]right,[SP]but[SP]the\nquality[SP]is[SP]shoddy.",
     "nom_fr": "Étudiant",
-    "texte_fr": "On m'a dit que le prix est correct,\nmais que la qualité laisse à désirer."
+    "texte_fr": "On m'a dit que le prix est correct, mais\nque la qualité laisse à désirer."
   },
   {
     "id": 235,
@@ -3672,7 +3672,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street\nvendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in\nreal[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Ce Tony, qui travaille\ncomme vendeur ambulant à Yumezaki,\nsemble trafiquer de vraies armes."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes."
   },
   {
     "id": 236,
@@ -3703,7 +3703,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street\nvendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in\nreal[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Ce Tony, qui travaille\ncomme vendeur ambulant à Yumezaki,\nsemble trafiquer de vraies armes."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes."
   },
   {
     "id": 238,
@@ -3734,7 +3734,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street\nvendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in\nreal[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Ce Tony, qui travaille\ncomme vendeur ambulant à Yumezaki,\nsemble trafiquer de vraies armes."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes."
   },
   {
     "id": 240,
@@ -3750,7 +3750,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "It[SP]appears[SP]that[SP]the[SP]quality[SP]and[SP]price[SP]of[SP]his\ngoods[SP]are[SP]both[SP]average.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Il semble que la qualité et le prix\nde ses biens soient tous deux moyens."
+    "texte_fr": "Il semble que la qualité et le prix de\nses biens soient tous deux moyens."
   },
   {
     "id": 241,
@@ -3765,7 +3765,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street\nvendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in\nreal[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Ce Tony, qui travaille\ncomme vendeur ambulant à Yumezaki,\nsemble trafiquer de vraies armes."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes."
   },
   {
     "id": 242,
@@ -3796,7 +3796,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] J'ai entendu que de vraies\narmes sont en vente chez Clair de Lune\nà Aoba. J'ai du mal à y croire..."
+    "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire..."
   },
   {
     "id": 244,
@@ -3827,7 +3827,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] J'ai entendu que de vraies\narmes sont en vente chez Clair de Lune\nà Aoba. J'ai du mal à y croire..."
+    "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire..."
   },
   {
     "id": 246,
@@ -3843,7 +3843,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Their[SP]goods[SP]are[SP]cheap,[SP]but[SP]lacking[SP]in[SP]quality.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Leurs biens sont bon marché,\nmais manquent de qualité."
+    "texte_fr": "Leurs biens sont bon marché, mais manquent de qualité."
   },
   {
     "id": 247,
@@ -3858,7 +3858,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] J'ai entendu que de vraies\narmes sont en vente chez Clair de Lune\nà Aoba. J'ai du mal à y croire..."
+    "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire..."
   },
   {
     "id": 248,
@@ -3874,7 +3874,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "The[SP]quality[SP]of[SP]their[SP]goods[SP]is[SP]high,[SP]but[SP]it\ncomes[SP]at[SP]a[SP]price.",
     "nom_fr": "Étudiant",
-    "texte_fr": "La qualité de leurs produits est\nélevée, mais cela a un prix."
+    "texte_fr": "La qualité de leurs produits est élevée,\nmais cela a un prix."
   },
   {
     "id": 249,
@@ -3889,7 +3889,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] J'ai entendu que de vraies\narmes sont en vente chez Clair de Lune\nà Aoba. J'ai du mal à y croire..."
+    "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire..."
   },
   {
     "id": 250,
@@ -3905,7 +3905,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "They[SP]seem[SP]to[SP]have[SP]a[SP]wide[SP]selection[SP]of[SP]goods,\nbut[SP]their[SP]buyback[SP]prices[SP]are[SP]low.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Ils semblent avoir un grand choix de\nproduits, mais leurs prix de rachat sont bas."
+    "texte_fr": "Ils semblent avoir un grand choix de produits,\nmais leurs prix de rachat sont bas."
   },
   {
     "id": 251,
@@ -3920,7 +3920,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] J'ai entendu que de vraies\narmes sont en vente chez Clair de Lune\nà Aoba. J'ai du mal à y croire..."
+    "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire..."
   },
   {
     "id": 252,
@@ -3936,7 +3936,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "The[SP]quality[SP]and[SP]price[SP]of[SP]their[SP]goods[SP]is\nmerely[SP]average.",
     "nom_fr": "Étudiant",
-    "texte_fr": "La qualité et le prix de leurs\nproduits sont tout juste moyens."
+    "texte_fr": "La qualité et le prix de leurs produits\nsont tout juste moyens."
   },
   {
     "id": 253,
@@ -3951,7 +3951,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
   },
   {
     "id": 254,
@@ -3967,7 +3967,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "The[SP]quality[SP]and[SP]price[SP]of[SP]their[SP]things[SP]seems\nfairly[SP]average.",
     "nom_fr": "Étudiant",
-    "texte_fr": "La qualité et le prix de leurs\narticles semblent plutôt moyens."
+    "texte_fr": "La qualité et le prix de leurs articles\nsemblent plutôt moyens."
   },
   {
     "id": 255,
@@ -3982,7 +3982,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
   },
   {
     "id": 256,
@@ -3998,7 +3998,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Their[SP]goods[SP]are[SP]inexpensive,[SP]but[SP]unfortunately\nlacking[SP]in[SP]quality.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Leurs produits sont bon marché, mais\nmanquent malheureusement de qualité."
+    "texte_fr": "Leurs produits sont bon marché, mais manquent\nmalheureusement de qualité."
   },
   {
     "id": 257,
@@ -4013,7 +4013,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
   },
   {
     "id": 258,
@@ -4029,7 +4029,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Their[SP]selection[SP]is[SP]great,[SP]but[SP]their[SP]buyback\nprices[SP]seem[SP]to[SP]be[SP]low.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Leur choix est excellent, mais leurs\nprix de rachat semblent être bas."
+    "texte_fr": "Leur choix est excellent, mais leurs prix de\nrachat semblent être bas."
   },
   {
     "id": 259,
@@ -4044,7 +4044,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
   },
   {
     "id": 260,
@@ -4060,7 +4060,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Their[SP]selection[SP]is[SP]quite[SP]poor,[SP]but[SP]I[SP]suppose\ntheir[SP]buyback[SP]prices[SP]are[SP]good.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Leur sélection est assez pauvre, mais je\nsuppose que leurs prix de rachat sont bons."
+    "texte_fr": "Leur sélection est assez pauvre, mais je suppose\nque leurs prix de rachat sont bons."
   },
   {
     "id": 261,
@@ -4075,7 +4075,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
   },
   {
     "id": 262,
@@ -4091,7 +4091,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "The[SP]quality[SP]of[SP]their[SP]goods[SP]is[SP]excellent,\nbut[SP]it's[SP]expensive[SP]indeed.",
     "nom_fr": "Étudiant",
-    "texte_fr": "La qualité de leurs produits est\nexcellente, mais elle est très chère."
+    "texte_fr": "La qualité de leurs produits est excellente,\nmais elle est très chère."
   },
   {
     "id": 263,
@@ -4106,7 +4106,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]reminds[SP]me,[SP]I[SP]heard[SP]an[SP]interesting\nrumor[SP]that[SP]Rosa[SP]Candida[SP]sells[SP]armor.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Ça me rappelle, j'ai\nentendu la rumeur intéressante que\nRosa Candida vend des armures."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures."
   },
   {
     "id": 264,
@@ -4122,7 +4122,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "I've[SP]heard[SP]lately[SP]that[SP]the[SP]quality[SP]and[SP]price\nof[SP]their[SP]stock[SP]is[SP]average.",
     "nom_fr": "Étudiant",
-    "texte_fr": "J'ai entendu récemment que la qualité\net le prix de leur stock sont moyens."
+    "texte_fr": "J'ai entendu récemment que la qualité et le prix\nde leur stock sont moyens."
   },
   {
     "id": 265,
@@ -4137,7 +4137,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]reminds[SP]me,[SP]I[SP]heard[SP]an[SP]interesting\nrumor[SP]that[SP]Rosa[SP]Candida[SP]sells[SP]armor.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Ça me rappelle, j'ai\nentendu la rumeur intéressante que\nRosa Candida vend des armures."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures."
   },
   {
     "id": 266,
@@ -4153,7 +4153,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "I've[SP]heard[SP]lately[SP]that[SP]their[SP]goods[SP]are[SP]cheap,\nbut[SP]low[SP]in[SP]quality.",
     "nom_fr": "Étudiant",
-    "texte_fr": "J'ai entendu récemment que leurs biens\nsont bon marché, mais de piètre qualité."
+    "texte_fr": "J'ai entendu récemment que leurs biens sont\nbon marché, mais de piètre qualité."
   },
   {
     "id": 267,
@@ -4168,7 +4168,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]reminds[SP]me,[SP]I[SP]heard[SP]an[SP]interesting\nrumor[SP]that[SP]Rosa[SP]Candida[SP]sells[SP]armor.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Ça me rappelle, j'ai\nentendu la rumeur intéressante que\nRosa Candida vend des armures."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures."
   },
   {
     "id": 268,
@@ -4184,7 +4184,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "I've[SP]heard[SP]lately[SP]that[SP]the[SP]quality[SP]of[SP]their\nstock[SP]is[SP]high,[SP]but[SP]it's[SP]expensive.",
     "nom_fr": "Étudiant",
-    "texte_fr": "J'ai entendu récemment que la qualité de\nleur stock est élevée, mais que c'est cher."
+    "texte_fr": "J'ai entendu récemment que la qualité de leur\nstock est élevée, mais que c'est cher."
   },
   {
     "id": 269,
@@ -4199,7 +4199,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi\nsells[SP]armor!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Donc il est VRAI\nqu'Anima Mundi vend des armures!"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Donc il est VRAI qu'Anima Mundi\nvend des armures !"
   },
   {
     "id": 270,
@@ -4215,7 +4215,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "I[SP]hear[SP]that[SP]their[SP]quality[SP]and[SP]prices[SP]are\nentirely[SP]average,[SP]though.",
     "nom_fr": "Étudiant",
-    "texte_fr": "J'entends dire que leur qualité et leurs\nprix sont dans la moyenne, cela dit."
+    "texte_fr": "J'entends dire que leur qualité et leurs prix\nsont dans la moyenne, cela dit."
   },
   {
     "id": 271,
@@ -4230,7 +4230,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi\nsells[SP]armor!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Donc il est VRAI\nqu'Anima Mundi vend des armures!"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Donc il est VRAI qu'Anima Mundi\nvend des armures !"
   },
   {
     "id": 272,
@@ -4261,7 +4261,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi\nsells[SP]armor!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Donc il est VRAI\nqu'Anima Mundi vend des armures!"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Donc il est VRAI qu'Anima Mundi\nvend des armures !"
   },
   {
     "id": 274,
@@ -4292,7 +4292,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi\nsells[SP]armor!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Donc il est VRAI\nqu'Anima Mundi vend des armures!"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Donc il est VRAI qu'Anima Mundi\nvend des armures !"
   },
   {
     "id": 276,
@@ -4324,7 +4324,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters\nare[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]selection\nis[SP]bad,[SP]but[SP]the[SP]buyback[SP]price[SP]is[SP]good.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Rosa Candida à Aoba vend des armures.\nCes sœurs ne sont pas des marchandes\nordinaires... Leur choix est pauvre,\nmais le prix de rachat est bon."
+    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leur choix\nest pauvre, mais le prix de rachat est bon."
   },
   {
     "id": 278,
@@ -4340,7 +4340,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters\nare[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]quality[SP]and\nprices[SP]are[SP]average.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces\nsœurs ne sont pas des marchandes ordinaires...\nLeur qualité et leurs prix sont moyens."
+    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leur qualité et\nleurs prix sont moyens."
   },
   {
     "id": 279,
@@ -4356,7 +4356,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters\nare[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]merchandise\nis[SP]good,[SP]but[SP]expensive.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces\nsœurs ne sont pas des marchandes ordinaires...\nLeurs marchandises sont bonnes, mais chères."
+    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leurs marchandises\nsont bonnes, mais chères."
   },
   {
     "id": 280,
@@ -4372,7 +4372,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters\nare[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]merchandise\nis[SP]cheap,[SP]but[SP]lacking[SP]in[SP]quality.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces\nsœurs sont des marchandes hors pair... Leurs\nbiens sont bon marché, mais manquent de\nqualité."
+    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs\nsont des marchandes hors pair... Leurs biens\nsont bon marché, mais manquent de qualité."
   },
   {
     "id": 281,
@@ -4388,7 +4388,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters\nare[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]selection\nis[SP]good,[SP]but[SP]the[SP]buyback[SP]price[SP]is[SP]dismal.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Rosa Candida à Aoba vend des armures.\nCes sœurs ne sont pas des marchandes\nordinaires... Leur choix est bon, mais\nle prix de rachat est lamentable."
+    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leur choix\nest bon, mais le prix de rachat est lamentable."
   },
   {
     "id": 282,
@@ -4403,7 +4403,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah! Les tailleurs fabriquent\nmême des armures? On peut apparemment\nen acheter à London Clothier."
+    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier."
   },
   {
     "id": 283,
@@ -4434,7 +4434,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah! Les tailleurs fabriquent\nmême des armures? On peut apparemment\nen acheter à London Clothier."
+    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier."
   },
   {
     "id": 285,
@@ -4450,7 +4450,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Their[SP]prices[SP]are[SP]cheap,[SP]but[SP]their[SP]goods[SP]are\nlow[SP]in[SP]quality.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Leurs prix sont bas, mais leurs\nbiens sont de mauvaise qualité."
+    "texte_fr": "Leurs prix sont bas, mais leurs biens sont\nde mauvaise qualité."
   },
   {
     "id": 286,
@@ -4465,7 +4465,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah! Les tailleurs fabriquent\nmême des armures? On peut apparemment\nen acheter à London Clothier."
+    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier."
   },
   {
     "id": 287,
@@ -4481,7 +4481,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "The[SP]quality[SP]of[SP]their[SP]goods[SP]is[SP]first-rate,\nbut[SP]it's[SP]quite[SP]expensive.",
     "nom_fr": "Étudiant",
-    "texte_fr": "La qualité de leurs biens est de\npremier ordre, mais c'est assez cher."
+    "texte_fr": "La qualité de leurs biens est de premier ordre,\nmais c'est assez cher."
   },
   {
     "id": 288,
@@ -4496,7 +4496,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah! Les tailleurs fabriquent\nmême des armures? On peut apparemment\nen acheter à London Clothier."
+    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier."
   },
   {
     "id": 289,
@@ -4512,7 +4512,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Their[SP]quality[SP]and[SP]prices[SP]are[SP]just[SP]average.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Leur qualité et leurs prix\nsont tout à fait moyens."
+    "texte_fr": "Leur qualité et leurs prix sont tout à fait moyens."
   },
   {
     "id": 290,
@@ -4527,7 +4527,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah! Les tailleurs fabriquent\nmême des armures? On peut apparemment\nen acheter à London Clothier."
+    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier."
   },
   {
     "id": 291,
@@ -4558,7 +4558,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Is[SP]it[SP]true[SP]one[SP]may[SP]win[SP]real[SP]weapons\nin[SP]a[SP]magazine[SP]sweepstakes?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Est-il vrai qu'on peut gagner de\nvraies armes dans un concours de magazine?"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?"
   },
   {
     "id": 293,
@@ -4574,7 +4574,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "It's[SP]not[SP]easy[SP]to[SP]win,[SP]but[SP]you'll[SP]get[SP]some[SP]nice\nitems[SP]for[SP]your[SP]trouble.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Il n'est pas facile de gagner, mais on\nreçoit de beaux objets en récompense."
+    "texte_fr": "Il n'est pas facile de gagner, mais on reçoit\nde beaux objets en récompense."
   },
   {
     "id": 294,
@@ -4589,7 +4589,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Is[SP]it[SP]true[SP]one[SP]may[SP]win[SP]real[SP]weapons\nin[SP]a[SP]magazine[SP]sweepstakes?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Est-il vrai qu'on peut gagner de\nvraies armes dans un concours de magazine?"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?"
   },
   {
     "id": 295,
@@ -4620,7 +4620,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Is[SP]it[SP]true[SP]one[SP]may[SP]win[SP]real[SP]weapons\nin[SP]a[SP]magazine[SP]sweepstakes?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Est-il vrai qu'on peut gagner de\nvraies armes dans un concours de magazine?"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?"
   },
   {
     "id": 297,
@@ -4636,7 +4636,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "It's[SP]not[SP]hard[SP]to[SP]win[SP]one,[SP]but[SP]if[SP]you[SP]do,[SP]you[SP]may\nwonder[SP]why[SP]you[SP]bothered.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Il n'est pas difficile de gagner, mais on\npeut se demander pourquoi on a pris la peine."
+    "texte_fr": "Il n'est pas difficile de gagner, mais on peut\nse demander pourquoi on a pris la peine."
   },
   {
     "id": 298,
@@ -4651,7 +4651,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]am[SP]a[SP]mere[SP]student[SP]striving[SP]to[SP]make\nit[SP]into[SP]the[SP]country's[SP]best[SP]college.[SP]I[SP]have[SP]no\ntime[SP]to[SP]fritter[SP]away[SP]on[SP]gambling!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Je suis un simple étudiant voulant\nintégrer la meilleure faculté. Je n'ai pas\nde temps à perdre dans les jeux d'argent!"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent !"
   },
   {
     "id": 299,
@@ -4667,7 +4667,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "...Still,[SP]it[SP]doesn't[SP]pay[SP]to[SP]neglect[SP]the[SP]real\nworld.[SP]I[SP]hear[SP]that[SP]one[SP]can[SP]win[SP]big[SP]on[SP]the[SP]#5\npoker[SP]machine...[1205][U+000F][SP]It[SP]wouldn't[SP]hurt[SP]to[SP]try.",
     "nom_fr": "Étudiant",
-    "texte_fr": "... Cependant, il ne faut pas négliger\nle monde réel. J'entends qu'on peut\ngagner gros à la machine #5...[1205][U+000F] Ça ne\nferait pas de mal d'essayer."
+    "texte_fr": "...Cependant, il ne faut pas négliger le monde réel.\nJ'entends qu'on peut gagner gros à la\nmachine #5...[1205][U+000F] Ça ne ferait pas de mal d'essayer."
   },
   {
     "id": 300,
@@ -4682,7 +4682,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]am[SP]a[SP]mere[SP]student[SP]striving[SP]to[SP]make\nit[SP]into[SP]the[SP]country's[SP]best[SP]college.[SP]I[SP]have[SP]no\ntime[SP]to[SP]fritter[SP]away[SP]on[SP]gambling!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Je suis un simple étudiant voulant\nintégrer la meilleure faculté. Je n'ai pas\nde temps à perdre dans les jeux d'argent!"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent !"
   },
   {
     "id": 301,
@@ -4698,7 +4698,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "...Still,[SP]it[SP]doesn't[SP]pay[SP]to[SP]neglect[SP]the[SP]real\nworld.[SP]I[SP]hear[SP]that[SP]one[SP]can[SP]win[SP]big[SP]on[SP]the[SP]#1\nslots[SP]machine...[1205][U+000F][SP]It[SP]wouldn't[SP]hurt[SP]to[SP]try.",
     "nom_fr": "Étudiant",
-    "texte_fr": "... Cependant, il ne faut pas négliger\nle monde réel. J'entends qu'on peut\ngagner gros à la machine #1...[1205][U+000F] Ça ne\nferait pas de mal d'essayer."
+    "texte_fr": "...Cependant, il ne faut pas négliger le monde réel.\nJ'entends qu'on peut gagner gros à la\nmachine #1...[1205][U+000F] Ça ne ferait pas de mal d'essayer."
   },
   {
     "id": 302,
@@ -4713,7 +4713,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]am[SP]a[SP]mere[SP]student[SP]striving[SP]to[SP]make\nit[SP]into[SP]the[SP]country's[SP]best[SP]college.[SP]I[SP]have[SP]no\ntime[SP]to[SP]fritter[SP]away[SP]on[SP]gambling!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Je suis un simple étudiant voulant\nintégrer la meilleure faculté. Je n'ai pas\nde temps à perdre dans les jeux d'argent!"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent !"
   },
   {
     "id": 303,
@@ -4729,7 +4729,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "But[SP]blackjack[SP]is[SP]an[SP]exception.[SP]I[SP]don't[SP]enjoy\nit,[SP]not[SP]really,[SP]but[SP]I[SP]hear[SP]you[SP]can[SP]win[SP]big[SP]at\nit.[SP]My[SP]studies[SP]aren't[SP]free,[SP]after[SP]all!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Mais le blackjack est une exception.\nJe n'aime pas ça, pas vraiment, mais\nil paraît qu'on peut y gagner gros.\nMes études ne sont pas gratuites!"
+    "texte_fr": "Mais le blackjack est une exception. Je n'aime pas ça,\npas vraiment, mais il paraît qu'on peut y gagner\ngros. Mes études ne sont pas gratuites !"
   },
   {
     "id": 304,
@@ -4745,7 +4745,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]A[SP]legendary[SP]weapon...[SP]They[SP]have[SP]such\na[SP]thing[SP]at[SP]Shiraishi[SP]Ramen...[SP]I'd[SP]like[SP]to[SP]see\nit[SP]for[SP]myself,[SP]just[SP]once.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Une arme légendaire... Ils ont\nça chez Shiraishi Ramen... J'aimerais la\nvoir de mes propres yeux, juste une fois."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Une arme légendaire... Ils ont ça\nchez Shiraishi Ramen... J'aimerais la voir\nde mes propres yeux, juste une fois."
   },
   {
     "id": 305,
@@ -4760,7 +4760,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]Is[SP]there[SP]really[SP]a[SP]legendary[SP]weapon\nin[SP]stock[SP]at[SP]Clair[SP]de[SP]Lune?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Y a-t-il vraiment une arme\nlégendaire en stock chez Clair de Lune?"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Y a-t-il vraiment une arme légendaire\nen stock chez Clair de Lune ?"
   },
   {
     "id": 306,
@@ -4776,7 +4776,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Bah![SP]The[SP]weapons[SP]of[SP]a[SP]student[SP]are[SP]pens[SP]and\nbooks![SP]This[SP]doesn't[SP]concern[SP]me.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Bah! Les armes d'un étudiant sont les stylos\net les livres! Cela ne me concerne pas."
+    "texte_fr": "Bah ! Les armes d'un étudiant sont les stylos\net les livres ! Cela ne me concerne pas."
   },
   {
     "id": 307,
@@ -4791,7 +4791,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]owner[SP]at[SP]Time[SP]Castle...[SP]Claiming\nnot[SP]to[SP]have[SP]what[SP]he[SP]in[SP]fact[SP]does,[SP]in[SP]a[SP]bid[SP]to\ndrive[SP]up[SP]its[SP]price,[SP]is[SP]unforgivable.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Ce propriétaire de Time\nCastle... Prétendre ne pas avoir ce\nqu'il a en fait, dans le but de faire\nmonter son prix, est impardonnable."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Ce propriétaire de Time Castle... Prétendre\nne pas avoir ce qu'il a en fait, dans le but\nde faire monter son prix, est impardonnable."
   },
   {
     "id": 308,
@@ -4807,7 +4807,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "But[SP]does[SP]Time[SP]Castle[SP]really[SP]have[SP]a[SP]legendary\nweapon[SP]to[SP]begin[SP]with?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Mais Time Castle a-t-il vraiment une\narme légendaire, pour commencer?"
+    "texte_fr": "Mais Time Castle a-t-il vraiment une arme\nlégendaire, pour commencer ?"
   },
   {
     "id": 309,
@@ -4822,7 +4822,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]A[SP]merchant[SP]should[SP]meet[SP]the[SP]needs[SP]of\nhis[SP]customers[SP]even[SP]at[SP]the[SP]risk[SP]of[SP]his[SP]own[SP]life!\nYet[SP]that[SP]owner[SP]at[SP]Time[SP]Castle...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Un marchand doit répondre aux\nbesoins de ses clients au péril de sa\nvie! Pourtant ce propriétaire..."
+    "texte_fr": "Hyaaaah ![1205][U+000F] Un marchand doit répondre aux besoins\nde ses clients au péril de sa vie !\nPourtant ce propriétaire..."
   },
   {
     "id": 310,
@@ -4853,7 +4853,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "But[SP]he's[SP]too[SP]afraid[SP]of[SP]monsters[SP]to[SP]venture\nout![SP]How[SP]utterly[SP]pathetic![SP]I[SP]wish[SP]someone[SP]else\nwould[SP]go[SP]buy[SP]the[SP]weapon[SP]in[SP]his[SP]stead.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Mais il a trop peur des monstres pour sortir!\nC'est pitoyable! J'aimerais que quelqu'un\nd'autre aille acheter l'arme à sa place."
+    "texte_fr": "Mais il a trop peur des monstres pour sortir !\nC'est pitoyable ! J'aimerais que quelqu'un d'autre\naille acheter l'arme à sa place."
   },
   {
     "id": 312,
@@ -4868,7 +4868,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "The[SP]legendary[SP]weapon[SP]belonging[SP]to[SP]Time[SP]Castle\nwas[SP]stolen[SP]by[SP]a[SP]demon.[SP]But[SP]is[SP]it[SP]possible[SP]that\nthe[SP]owner[SP]is[SP]lying?",
     "nom_fr": "Étudiant",
-    "texte_fr": "L'arme légendaire de Time Castle a\nété volée par un démon. Mais est-il\npossible que le propriétaire mente?"
+    "texte_fr": "L'arme légendaire de Time Castle a été volée par un\ndémon. Mais est-il possible que le propriétaire mente ?"
   },
   {
     "id": 313,
@@ -4884,7 +4884,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Honestly,[SP]do[SP]demons[SP]actually[SP]exist?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Honnêtement, les démons existent-ils vraiment?"
+    "texte_fr": "Honnêtement, les démons existent-ils vraiment ?"
   },
   {
     "id": 314,
@@ -4899,7 +4899,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]It[SP]seems[SP]the[SP]legendary[SP]weapon[SP]at\nTime[SP]Castle[SP]has[SP]been[SP]sold![SP]I[SP]hear[SP]that[SP]an\nunusually[SP]unlucky[SP]woman[SP]bought[SP]it.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] L'arme légendaire de Time Castle\na été vendue! J'entends qu'une femme\nparticulièrement malchanceuse l'a achetée."
+    "texte_fr": "Hyaaaah ![1205][U+000F] L'arme légendaire de\nTime Castle a été vendue ! J'entends qu'une femme\nparticulièrement malchanceuse l'a achetée."
   },
   {
     "id": 315,
@@ -4915,7 +4915,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hrghhh...[SP]What[SP]cheek![SP]What[SP]if[SP]she[SP]were[SP]to[SP]use\nit[SP]to[SP]end[SP]her[SP]life!?[SP]If[SP]only[SP]he'd[SP]entrusted[SP]it\nto[SP]me,[SP]I'd[SP]have[SP]put[SP]it[SP]to[SP]good[SP]use...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hrghhh... Quel culot! Et si elle l'utilisait\npour mettre fin à ses jours!? S'il me l'avait\nconfiée, j'en aurais fait bon usage..."
+    "texte_fr": "Hrghhh... Quel culot ! Et si elle l'utilisait pour\nmettre fin à ses jours !? S'il me l'avait\nconfiée, j'en aurais fait bon usage..."
   },
   {
     "id": 316,
@@ -4930,7 +4930,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]dastardly[SP]owner[SP]of[SP]Time[SP]Castle!\nHe[SP]gave[SP]the[SP]legendary[SP]weapon[SP]to[SP]a[SP]woman[SP]with\nshort[SP]hair![SP]How[SP]dare[SP]he[SP]become[SP]so[SP]smitten!?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah![1205][U+000F] Ce lâche propriétaire de Time\nCastle! Il a donné l'arme légendaire à une\nfemme aux cheveux courts! Comment a-t-il pu!?"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Ce lâche propriétaire de Time Castle !\nIl a donné l'arme légendaire à une femme\naux cheveux courts ! Comment a-t-il pu !?"
   },
   {
     "id": 317,
@@ -4946,7 +4946,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Eh?[SP]What[SP]kind[SP]of[SP]woman[SP]was[SP]she?[SP]B-Beautiful,[SP]I\nsuppose...[1205][U+000F][SP]N-Not[SP]that[SP]I'm[SP]envious,[SP]not[SP]at[SP]all!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Eh? Quel genre de femme était-ce?\nB-Belle, je suppose...[1205][U+000F] J-Je ne\nsuis pas envieux, pas du tout!"
+    "texte_fr": "Eh ? Quel genre de femme était-ce ? B-Belle, je\nsuppose...[1205][U+000F] J-Je ne suis pas envieux, pas du tout !"
   },
   {
     "id": 318,
@@ -4962,7 +4962,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Many[SP]of[SP]my[SP]comrades[SP]are[SP]complaining,[SP]but[SP]I\nintend[SP]to[SP]follow[SP]Joker's[SP]orders![1205][U+000F][SP]This[SP]is[SP]our\ncity,[SP]after[SP]all!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Beaucoup de camarades se plaignent, mais\nj'obéirai au Joker![1205][U+000F] C'est notre ville, après\ntout!"
+    "texte_fr": "Beaucoup de camarades se plaignent,\nmais j'obéirai au Joker ![1205][U+000F] C'est\nnotre ville, après tout !"
   },
   {
     "id": 319,
@@ -4994,7 +4994,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "This[SP]is[SP]Kasugayama[SP]High,[SP]the[SP]great[SP]Michel's\nschool![SP]We're[SP]gonna[SP]have[SP]a[SP]festival[SP]soon.",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est le lycée Kasu, l'école du grand\nMichel! On aura bientôt un festival."
+    "texte_fr": "C'est le lycée Kasu, l'école du grand\nMichel ! On aura bientôt un festival."
   },
   {
     "id": 321,
@@ -5010,7 +5010,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "The[SP]guys[SP]here[SP]hate[SP]Sevens[SP]because[SP]they're[SP]not\nthe[SP]popular[SP]ones,[SP]right?[SP]How[SP]appropriate[SP]for\nUndie[SP]Boss's[SP]school.",
     "nom_fr": "Ginko",
-    "texte_fr": "Ils détestent Seven car ce ne sont\npas eux les plus populaires, hein?\nTypique de l'école du Boss Calbute."
+    "texte_fr": "Ils détestent Seven car ce ne sont pas eux\nles plus populaires, hein ? Typique de\nl'école du Boss Calbute."
   },
   {
     "id": 322,
@@ -5026,7 +5026,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Wait[SP]for[SP]me...[SP]I'll[SP]get[SP]you[SP]guys[SP]back[SP]to\nnormal[SP]if[SP]it's[SP]the[SP]last[SP]thing[SP]I[SP]do!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Attendez... Je vous rendrai\nnormaux, coûte que coûte!"
+    "texte_fr": "Attendez... Je vous rendrai normaux,\ncoûte que coûte !"
   },
   {
     "id": 323,
@@ -5042,7 +5042,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "C'mon,[SP][1113].[SP]Let's[SP]go!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Viens [1113], on y va!"
+    "texte_fr": "Viens [1113], on y va !"
   },
   {
     "id": 324,
@@ -5058,7 +5058,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]bet[SP]everyone's[SP]waiting[SP]at[SP]the[SP]detective\nagency.[SP]We[SP]should[SP]hurry[SP]back[SP]there!",
     "nom_fr": "Ginko",
-    "texte_fr": "Tous nous attendent à l'agence\nde détectives. Dépêchons-nous!"
+    "texte_fr": "Tous nous attendent à l'agence de détectives.\nDépêchons-nous !"
   },
   {
     "id": 325,
@@ -5074,7 +5074,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]like[SP]the[SP]school's[SP]dead...[SP]There's[SP]no[SP]one\naround[SP]and[SP]I[SP]don't[SP]hear[SP]any[SP]voices,[SP]either...\nIs[SP]this[SP]really[SP]my[SP]Kasugayama[SP]High?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est comme si l'école était morte... Y a\npersonne et je n'entends aucune voix, non\nplus... C'est vraiment mon lycée Kasu?"
+    "texte_fr": "C'est comme si l'école était morte... Y a personne\net je n'entends aucune voix, non plus...\nC'est vraiment mon lycée Kasu ?"
   },
   {
     "id": 326,
@@ -5090,7 +5090,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Aiyah...[SP]You[SP]want[SP]to[SP]go[SP]into[SP]Smile[SP]Hirasaka?",
     "nom_fr": "Lisa",
-    "texte_fr": "Aïe... Tu veux aller à Smile Hirasaka?"
+    "texte_fr": "Aïe... Tu veux aller à Smile Hirasaka ?"
   },
   {
     "id": 327,
@@ -5106,7 +5106,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Let's[SP]skip[SP]this[SP]hole[SP]and[SP]go[SP]somewhere\nlike[SP]Zodiac!",
     "nom_fr": "Lisa",
-    "texte_fr": "Zappons ce trou et allons plutôt à Zodiac!"
+    "texte_fr": "Zappons ce trou et allons plutôt à Zodiac !"
   },
   {
     "id": 328,
@@ -5122,7 +5122,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah...[SP]You[SP]want[SP]to[SP]go[SP]into[SP]Smile[SP]Hirasaka?",
     "nom_fr": "Ginko",
-    "texte_fr": "Aïe... Tu veux aller à Smile Hirasaka?"
+    "texte_fr": "Aïe... Tu veux aller à Smile Hirasaka ?"
   },
   {
     "id": 329,
@@ -5138,7 +5138,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Let's[SP]skip[SP]this[SP]hole[SP]and[SP]go[SP]somewhere\nlike[SP]Zodiac!",
     "nom_fr": "Ginko",
-    "texte_fr": "Zappons ce trou et allons plutôt à Zodiac!"
+    "texte_fr": "Zappons ce trou et allons plutôt à Zodiac !"
   },
   {
     "id": 330,
@@ -5154,7 +5154,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Smile[SP]Hirasaka?[SP]You[SP]really[SP]enjoy[SP]detours,\nhuh,[SP][1113]?[SP]Weren't[SP]we[SP]supposed[SP]to[SP]be\ngoing[SP]to[SP]Peace[SP]Diner?",
     "nom_fr": "Yukino",
-    "texte_fr": "Smile Hirasaka? Tu aimes les détours, hein,\n[1113]? On ne devait pas aller au Peace\nDiner?"
+    "texte_fr": "Smile Hirasaka ? Tu aimes les détours,\nhein, [1113] ? On ne devait pas\naller au Peace Diner ?"
   },
   {
     "id": 331,
@@ -5170,7 +5170,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]come[SP]here[SP]with[SP]my[SP]friend[SP]a[SP]lot.[SP]Hm?[SP]Who[SP]am\nI[SP]talking[SP]about?[SP]Haha...[SP]I'll[SP]introduce[SP]you\nsometime.",
     "nom_fr": "Maya",
-    "texte_fr": "Je viens souvent ici avec mon\namie. Hm? De qui je parle? Haha...\nJe te la présenterai bientôt."
+    "texte_fr": "Je viens souvent ici avec mon amie. Hm ? De qui\nje parle ? Haha... Je te la présenterai bientôt."
   },
   {
     "id": 332,
@@ -5186,7 +5186,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Smile[SP]Hirasaka...[1205][U+000F][SP]Is[SP]this[SP]the[SP]target?\nOr...?",
     "nom_fr": "Maya",
-    "texte_fr": "Smile Hirasaka...[1205][U+000F] Est-ce la cible? Ou...?"
+    "texte_fr": "Smile Hirasaka...[1205][U+000F] Est-ce la cible ?\nOu... ?"
   },
   {
     "id": 333,
@@ -5202,7 +5202,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We[SP]can't[SP]overthink[SP]this.[1205][U+000F][SP]Let's[SP]just[SP]hurry[SP]up\nand[SP]get[SP]inside.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Faut pas trop y penser.[1205][U+000F]\nDépêchons-nous d'entrer."
+    "texte_fr": "Faut pas trop y penser.[1205][U+000F] Dépêchons-nous\nd'entrer."
   },
   {
     "id": 334,
@@ -5218,7 +5218,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?\n[1208][0002][1432][NULL][NULL][0014]Yeah,[SP]let's[SP]check[SP]it[SP]out.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]No,[SP]this[SP]isn't[SP]the[SP]place.[1432][NULL][NULL][0014]",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun?[1205][U+000F] On devrait chercher par ici?\n[1208][0002][1432][NULL][NULL][0014]Ouais, jetons un œil.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas le bon endroit.[1432][NULL][NULL][0014]",
+    "texte_fr": "[1113]-kun ?[1205][U+000F] On devrait chercher par ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, jetons un œil.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas le bon endroit.[1432][NULL][NULL][0014]",
     "question_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?",
     "choix_orig": [
       "Yeah,[SP]let's[SP]check[SP]it[SP]out.",
@@ -5260,7 +5260,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Then[SP]we[SP]don't[SP]need[SP]to[SP]be[SP]here.[SP]Let's[SP]hurry\nto[SP]the[SP]Sakanoue[SP]Building.",
     "nom_fr": "Yukino",
-    "texte_fr": "Alors on n'a rien à faire ici.\nVite, allons au Bâtiment Sakanoue."
+    "texte_fr": "Alors on n'a rien à faire ici. Vite,\nallons au Bâtiment Sakanoue."
   },
   {
     "id": 337,
@@ -5275,7 +5275,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]place[SP]is[SP]safe[SP]and[SP]sound.\nQuestion[SP]is,[SP]where's[SP]the[SP]next[SP]target...?\nGOLD[SP]or[SP]Pachinko[SP]Silver?",
     "nom_fr": "Maya",
-    "texte_fr": "Cet endroit est sain et sauf. Mais où est la\nprochaine cible...? GOLD ou Pachinko Silver?"
+    "texte_fr": "Cet endroit est sain et sauf.\nMais où est la prochaine cible... ?\nGOLD ou Pachinko Silver ?"
   },
   {
     "id": 338,
@@ -5291,7 +5291,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]up[SP]to[SP]you,[SP][1113]-kun.[SP]But[SP]we[SP]don't\nhave[SP]much[SP]time,[SP]so[SP]let's[SP]get[SP]moving.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est à toi de voir, [1113]-kun. Mais\non a peu de temps, alors en route."
+    "texte_fr": "C'est à toi de voir, [1113]-kun. Mais on a\npeu de temps, alors en route."
   },
   {
     "id": 339,
@@ -5307,7 +5307,7 @@
     "nom_orig": "Maya",
     "texte_orig": "How[SP]could[SP]this[SP]happen...?[SP]There[SP]must've[SP]been\nso[SP]many[SP]people[SP]still[SP]inside...[SP]The[SP]flames[SP]are\nswallowing[SP]lives[SP]again...",
     "nom_fr": "Maya",
-    "texte_fr": "C'est pas vrai...? Il devait y avoir\ntant de gens à l'intérieur... Les\nflammes ôtent encore des vies..."
+    "texte_fr": "C'est pas vrai... ? Il devait y avoir tant\nde gens à l'intérieur... Les flammes\nôtent encore des vies..."
   },
   {
     "id": 340,
@@ -5323,7 +5323,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]have[SP]to[SP]prevent[SP]any[SP]more[SP]casualties!\nThe[SP]next[SP]target[SP]is[SP]either[SP]GOLD[SP]or[SP]Pachinko\nSilver...[SP]It's[SP]up[SP]to[SP]you,[SP][1113]-kun!",
     "nom_fr": "Maya",
-    "texte_fr": "On doit empêcher d'autres victimes! La\nprochaine cible est GOLD ou Pachinko\nSilver... Ça dépend de toi, [1113]-kun!"
+    "texte_fr": "On doit empêcher d'autres victimes !\nLa prochaine cible est GOLD ou Pachinko\nSilver... Ça dépend de toi, [1113]-kun !"
   },
   {
     "id": 341,
@@ -5339,7 +5339,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Are[SP]you[SP]angry[SP]I[SP]let[SP]that[SP]Ixquic[SP]girl[SP]go?\nI[SP]think[SP]it's[SP]just[SP]my[SP]nature...[SP]I'm[SP]sorry\nif[SP]you[SP]were[SP]upset.",
     "nom_fr": "Maya",
-    "texte_fr": "Fâché que j'aie laissé fuir Ixquic? C'est dans\nma nature... Désolée si ça t'a contrarié."
+    "texte_fr": "Fâché que j'aie laissé fuir Ixquic ?\nC'est dans ma nature... Désolée si ça\nt'a contrarié."
   },
   {
     "id": 342,
@@ -5355,7 +5355,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I'm[SP]sure[SP]King[SP]Leo[SP]is[SP]waiting[SP]for[SP]us[SP]at[SP]the\nAerospace[SP]Museum.[SP]I'll[SP]put[SP]an[SP]end[SP]to[SP]this...\nFor[SP]both[SP]him[SP]and[SP]myself.",
     "nom_fr": "Maya",
-    "texte_fr": "Le Roi Lion nous attend au Musée de\nl'Aérospatiale. Je vais y mettre\nfin... Pour lui comme pour moi."
+    "texte_fr": "Le Roi Lion nous attend au Musée de\nl'Aérospatiale. Je vais y mettre fin...\nPour lui comme pour moi."
   },
   {
     "id": 343,
@@ -5371,7 +5371,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "This[SP]is[SP]horrible...[SP]Is[SP]this[SP]their[SP]will[SP]too?\nIf[SP]so...[SP]What[SP]are[SP]we[SP]going[SP]to[SP]do...?",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est horrible... Est-ce leur volonté\naussi? Si oui... Que va-t-on faire...?"
+    "texte_fr": "C'est horrible... Est-ce leur volonté aussi ?\nSi oui... Que va-t-on faire... ?"
   },
   {
     "id": 344,
@@ -5387,7 +5387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]not[SP]like[SP]Jun-kun[SP]to[SP]wish[SP]for[SP]something\nlike[SP]this.[SP]Wait[SP]for[SP]me...[SP]I'm[SP]coming[SP]to[SP]get\nyou[SP]this[SP]time...[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nThe[SP]Sakanoue[SP]Building?[1205][U+000A][SP]Why[SP]would[SP]we[SP]go[SP]there?[1205][U+000A]\nC'mon,[SP]let's[SP]go[SP]somewhere[SP]else.",
     "nom_fr": "Maya",
-    "texte_fr": "Ce n'est pas le genre de Jun-kun de\nsouhaiter une telle chose. Attends-moi...\nJe viens te chercher cette fois...[NULL][NULL]\"Eikichi\nLe Bâtiment Sakanoue?[1205][U+000A] Pourquoi on irait\nlà-bas?[1205][U+000A] Allez, allons ailleurs."
+    "texte_fr": "Ce n'est pas le genre de Jun-kun de souhaiter\nune telle chose. Attends-moi... Je viens\nte chercher cette fois...[NULL][NULL]\"Eikichi\nLe Bâtiment Sakanoue ?[1205][U+000A] Pourquoi on irait là-bas ?[1205][U+000A]\nAllez, allons ailleurs."
   },
   {
     "id": 345,
@@ -5419,7 +5419,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]Sakanoue[SP]Building...[1205][U+000F][SP]Is[SP]this[SP]the[SP]next\ntarget...?",
     "nom_fr": "Maya",
-    "texte_fr": "Bâtiment Sakanoue...[1205][U+000F] Est-ce\nla prochaine cible...?"
+    "texte_fr": "Bâtiment Sakanoue...[1205][U+000F] Est-ce la prochaine\ncible... ?"
   },
   {
     "id": 347,
@@ -5435,7 +5435,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Let's[SP]worry[SP]about[SP]that[SP]later.[1205][U+000F][SP]We[SP]gotta[SP]hurry\nand[SP]take[SP]care[SP]of[SP]those[SP]bombs!",
     "nom_fr": "Eikichi",
-    "texte_fr": "On s'en souciera plus tard.[1205][U+000F] Faut se\ndépêcher de s'occuper de ces bombes!"
+    "texte_fr": "On s'en souciera plus tard.[1205][U+000F] Faut se dépêcher\nde s'occuper de ces bombes !"
   },
   {
     "id": 348,
@@ -5451,7 +5451,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?\n[1208][0002][1432][NULL][NULL][0014]Yeah,[SP]let's[SP]check[SP]it[SP]out.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]No,[SP]this[SP]isn't[SP]the[SP]place.[1432][NULL][NULL][0014]",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun?[1205][U+000F] On devrait chercher par ici?\n[1208][0002][1432][NULL][NULL][0014]Ouais, jetons un œil.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas le bon endroit.[1432][NULL][NULL][0014]",
+    "texte_fr": "[1113]-kun ?[1205][U+000F] On devrait chercher par ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, jetons un œil.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas le bon endroit.[1432][NULL][NULL][0014]",
     "question_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?",
     "choix_orig": [
       "Yeah,[SP]let's[SP]check[SP]it[SP]out.",
@@ -5493,7 +5493,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "H-Hey,[SP]wait[SP]a[SP]sec![SP]Look[SP]at[SP]that!",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, attendez! Regardez ça!"
+    "texte_fr": "Hé, attendez ! Regardez ça !"
   },
   {
     "id": 351,
@@ -5509,7 +5509,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "If[SP]we'd[SP]picked[SP]this[SP]building,[SP]Smile[SP]Hirasaka\nwould[SP]be[SP]ashes[SP]by[SP]now...[SP]Oof,[SP]just[SP]thinking\nabout[SP]it[SP]gives[SP]me[SP]the[SP]chills.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Si on avait choisi ici, Smile\nHirasaka serait en cendres... Pfiou,\ny penser me donne des frissons."
+    "texte_fr": "Si on avait choisi ici, Smile Hirasaka\nserait en cendres... Pfiou, y penser\nme donne des frissons."
   },
   {
     "id": 352,
@@ -5525,7 +5525,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]all[SP]this[SP]building's[SP]fault![SP]They[SP]shouldn't\nhave[SP]put[SP]it[SP]in[SP]such[SP]a[SP]misleading[SP]place![SP]I[SP]want\nthis[SP]thing[SP]outta[SP]my[SP]sight![SP]Let's[SP]go!",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est la faute de ce bâtiment! Ils\nn'auraient pas dû le mettre dans un endroit\nsi trompeur! Je veux plus le voir! Allons-y!"
+    "texte_fr": "C'est la faute de ce bâtiment ! Ils n'auraient\npas dû le mettre dans un endroit si trompeur !\nJe veux plus le voir ! Allons-y !"
   },
   {
     "id": 353,
@@ -5557,7 +5557,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Huh?[SP]It's[SP]locked.[SP]Guess[SP]we[SP]can't[SP]get[SP]in.[1205][U+000F]\nOh[SP]well,[SP]let's[SP]go[SP]somewhere[SP]else.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hein? C'est fermé, on ne peut pas\nentrer.[1205][U+000F] Tant pis, allons ailleurs."
+    "texte_fr": "Hein ? C'est fermé, on ne peut pas\nentrer.[1205][U+000F] Tant pis, allons ailleurs."
   },
   {
     "id": 355,
@@ -5573,7 +5573,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "There's[SP]nothing[SP]left[SP]for[SP]us[SP]to[SP]do[SP]here,[SP]right?\nLet's[SP]go[SP]get[SP]the[SP]rest[SP]of[SP]those[SP]skulls.",
     "nom_fr": "Eikichi",
-    "texte_fr": "On n'a plus rien à faire ici, non?\nAllons chercher le reste de ces crânes."
+    "texte_fr": "On n'a plus rien à faire ici, non ?\nAllons chercher le reste de ces crânes."
   },
   {
     "id": 356,
@@ -5589,7 +5589,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "If[SP]this[SP]isn't[SP]the[SP]place...[SP]then[SP]it's[SP]Smile\nHirasaka.[SP]Let's[SP]move[SP]it,[SP][1113]!",
     "nom_fr": "Yukino",
-    "texte_fr": "Si ce n'est pas ici... alors c'est\nSmile Hirasaka. Bougeons-nous, [1113]!"
+    "texte_fr": "Si ce n'est pas ici... alors c'est Smile\nHirasaka. Bougeons-nous, [1113] !"
   },
   {
     "id": 357,
@@ -5621,7 +5621,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Holy[SP]shit...[1205][U+000F][SP]We[SP]were[SP]so[SP]close!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Merde...[1205][U+000F] On y était presque!"
+    "texte_fr": "Merde...[1205][U+000F] On y était presque !"
   },
   {
     "id": 359,
@@ -5652,7 +5652,7 @@
     "nom_orig": "Elly's[SP]voice",
     "texte_orig": "Hello?[1205][U+000F][SP]It's[SP]me,[SP]Elly.[1205][U+000F][SP]I've[SP]narrowed[SP]down[SP]the\nnext[SP]target.[SP]This[SP]clue's[SP]also[SP]related[SP]to\nastrology...",
     "nom_fr": "Voix d'Elly",
-    "texte_fr": "Allô?[1205][U+000F] C'est moi, Elly.[1205][U+000F] J'ai réduit\nla prochaine cible. Cet indice est\naussi lié à l'astrologie..."
+    "texte_fr": "Allô ?[1205][U+000F] C'est moi, Elly.[1205][U+000F] J'ai réduit la\nprochaine cible. Cet indice est aussi lié à\nl'astrologie..."
   },
   {
     "id": 361,
@@ -5668,7 +5668,7 @@
     "nom_orig": "Elly's[SP]voice",
     "texte_orig": "It's[SP]most[SP]likely[SP]north-northeast[SP]from[SP]Sevens.\nThe[SP]only[SP]things[SP]there[SP]are[SP]Pachinko[SP]Silver[SP]and\nGOLD[SP]in[SP]Yumezaki.[SP]So[SP]the[SP]next[SP]target[SP]is--",
     "nom_fr": "Voix d'Elly",
-    "texte_fr": "C'est au nord-nord-est de Seven. Les seuls\ntrucs là-bas sont Pachinko Silver et GOLD\nà Yumezaki. La prochaine cible est--"
+    "texte_fr": "C'est au nord-nord-est de Seven.\nLes seuls trucs là-bas sont Pachinko Silver\net GOLD à Yumezaki. La prochaine cible est--"
   },
   {
     "id": 362,
@@ -5684,7 +5684,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Elly-san,[SP]please![SP]Can[SP]you[SP]be[SP]more[SP]specific\nabout[SP]the[SP]location?[1205][U+000F][SP]Which[SP]one[SP]is[SP]King[SP]Leo's\nnext[SP]target?",
     "nom_fr": "Maya",
-    "texte_fr": "Elly-san! Sois plus précise sur le lieu.[1205][U+000F]\nQuelle est la prochaine cible du Roi Lion?"
+    "texte_fr": "Elly-san ! Sois plus précise\nsur le lieu.[1205][U+000F] Quelle est la\nprochaine cible du Roi Lion ?"
   },
   {
     "id": 363,
@@ -5700,7 +5700,7 @@
     "nom_orig": "Elly's[SP]voice",
     "texte_orig": "Then...[1205][U+000F][SP]You...[1205][U+000F][SP]You[SP]couldn't[SP]prevent[SP]the\nfire...[1205][U+000F][SP]I-I'm[SP]sorry...[1205][U+000F][SP]There's[SP]not[SP]much[SP]more\nI[SP]can[SP]tell[SP]you...",
     "nom_fr": "Voix d'Elly",
-    "texte_fr": "Alors...[1205][U+000F] Vous...[1205][U+000F] N'avez pas pu\nstopper l'incendie...[1205][U+000F] Désolée...[1205][U+000F]\nJe ne peux vous en dire plus..."
+    "texte_fr": "Alors...[1205][U+000F] Vous...[1205][U+000F] N'avez pas pu stopper\nl'incendie...[1205][U+000F] Désolée...[1205][U+000F] Je ne peux\nvous en dire plus..."
   },
   {
     "id": 364,
@@ -5716,7 +5716,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Thanks,[SP]Eriko.[SP]That's[SP]more[SP]than[SP]enough[SP]to[SP]get\nus[SP]started.[SP]Contact[SP]us[SP]again[SP]if[SP]you[SP]figure[SP]out\nanything[SP]else.",
     "nom_fr": "Yukino",
-    "texte_fr": "Merci, Eriko. C'est plus qu'assez\npour commencer. Recontacte-nous\nsi tu découvres autre chose."
+    "texte_fr": "Merci, Eriko. C'est plus qu'assez pour commencer.\nRecontacte-nous si tu découvres\nautre chose."
   },
   {
     "id": 365,
@@ -5731,7 +5731,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Look[SP]alive,[SP]people![SP]This[SP]is[SP]not[SP]the[SP]time[SP]for\nmoping![SP]We[SP]have[SP]to[SP]get[SP]a[SP]grip[SP]if[SP]we[SP]want[SP]to\nstop[SP]any[SP]more[SP]deaths!",
     "nom_fr": "Yukino",
-    "texte_fr": "Réveillez-vous! Ce n'est pas le moment\nde broyer du noir! Reprenons-nous si\non veut éviter d'autres morts!"
+    "texte_fr": "Réveillez-vous ! Ce n'est pas le moment\nde broyer du noir ! Reprenons-nous si on veut\néviter d'autres morts !"
   },
   {
     "id": 366,
@@ -5746,7 +5746,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Hang[SP]in[SP]there![1205][U+000F][SP]Dig[SP]deep![1205][U+000F][SP]The[SP]next[SP]target[SP]is\neither[SP]GOLD[SP]or[SP]Pachinko[SP]Silver[SP]in[SP]Yumezaki!",
     "nom_fr": "Yukino",
-    "texte_fr": "Tenez bon![1205][U+000F] Courage![1205][U+000F] La prochaine cible\nest GOLD ou Pachinko Silver à Yumezaki!"
+    "texte_fr": "Tenez bon ![1205][U+000F] Courage ![1205][U+000F] La prochaine cible est\nGOLD ou Pachinko Silver à Yumezaki !"
   },
   {
     "id": 367,
@@ -5762,7 +5762,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "We[SP]HAVE[SP]to[SP]do[SP]this,[SP]or[SP]there's[SP]no[SP]stopping[SP]the\nnext[SP]bombing![SP][1113],[SP]don't[SP]steer[SP]us[SP]wrong\nthis[SP]time!",
     "nom_fr": "Yukino",
-    "texte_fr": "Il LE faut, sinon la prochaine bombe\nexplosera! [1113], ne nous égare pas!"
+    "texte_fr": "Il LE faut, sinon la prochaine\nbombe explosera ! [1113], ne\nnous égare pas !"
   },
   {
     "id": 368,
@@ -5778,7 +5778,7 @@
     "nom_orig": "Jun",
     "texte_orig": "We[SP]already[SP]have[SP]the[SP]crystal[SP]skull[SP]that[SP]was[SP]here.\nLet's[SP]hurry[SP]and[SP]gather[SP]the[SP]remaining[SP]skulls.",
     "nom_fr": "Jun",
-    "texte_fr": "On a déjà le crâne en cristal qui était\nici. Dépêchons-nous d'obtenir les autres."
+    "texte_fr": "On a déjà le crâne en cristal qui était ici.\nDépêchons-nous d'obtenir les autres."
   },
   {
     "id": 369,
@@ -5794,7 +5794,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Some[SP]of[SP]the[SP]Masked[SP]Circle[SP]are[SP]still[SP]fighting\nin[SP]there...[SP]If[SP]I[SP]still[SP]had[SP]my[SP]powers[SP]as[SP]Joker,\nI[SP]could[SP]stop[SP]it[SP]in[SP]an[SP]instant...",
     "nom_fr": "Jun",
-    "texte_fr": "Le Cercle se bat encore ici... Si\nj'avais mes pouvoirs de Joker, je\nles arrêterais de suite..."
+    "texte_fr": "Le Cercle se bat encore ici...\nSi j'avais mes pouvoirs de Joker,\nje les arrêterais de suite..."
   },
   {
     "id": 370,
@@ -5810,7 +5810,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ken...[SP]Takeshi...[SP]Shogo...[SP]Don't[SP]worry,[SP]guys.\nI'll[SP]get[SP]you[SP]back[SP]to[SP]normal.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ken... Takeshi... Shogo... Vous\nen faites pas. J'vais vous aider."
+    "texte_fr": "Ken... Takeshi... Shogo... Vous en faites pas.\nJ'vais vous aider."
   },
   {
     "id": 371,
@@ -5826,7 +5826,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "C'mon,[SP][1114].[SP]There's[SP]stuff[SP]we[SP]gotta[SP]take\ncare[SP]of.[SP]Right?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Yo, [1114]. Faut qu'on s'occupe\nd'autre chose là, nan?"
+    "texte_fr": "Yo, [1114]. Faut qu'on s'occupe d'autre chose\nlà, nan ?"
   },
   {
     "id": 372,
@@ -5842,7 +5842,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Whoa,[SP]hold[SP]your[SP]horses.[SP]We[SP]haven't[SP]gotten[SP]the\nskull[SP]at[SP]Leo[SP]Temple[SP]yet,[SP]right?[SP]Let's[SP]take\ncare[SP]of[SP]that[SP]before[SP]we[SP]jump[SP]in[SP]here.",
     "nom_fr": "Maya",
-    "texte_fr": "Wah, ralentis. On n'a pas encore\nacquis le crâne au temple lion,\nnon? Faisons ça avant de venir ici."
+    "texte_fr": "Wah, ralentis. On n'a pas encore acquis le crâne au\ntemple lion, non ? Faisons ça avant de venir ici."
   },
   {
     "id": 373,
@@ -5858,6 +5858,6 @@
     "nom_orig": "Ginko",
     "texte_orig": "Wait[SP]a[SP]sec,[SP]Chinyan![SP]We[SP]don't[SP]have[SP]the[SP]skull\nfrom[SP]Taurus[SP]Temple[SP]yet.[SP]We[SP]should[SP]stop[SP]by\nthere[SP]first.",
     "nom_fr": "Ginko",
-    "texte_fr": "Attends Chinyan! On n'a pas encore le crâne du\ntemple taureau. On devrait y passer d'abord."
+    "texte_fr": "Attends Chinyan ! On n'a pas encore le crâne\ndu temple taureau. On devrait y passer d'abord."
   }
 ]

--- a/traduction/MMAP02.json
+++ b/traduction/MMAP02.json
@@ -12,7 +12,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Yo,[SP]you[SP]here[SP]to[SP]have[SP]some[SP]fun[SP]too?[1205][U+000F][SP]'Course[SP]you\nare.[SP]Yumezaki's[SP]the[SP]district[SP]for[SP]kids![SP]Wall-to-\nwall[SP]entertainment!",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Yo, tu viens t'amuser aussi?[1205][U+000F] Bien\nsûr. Yumezaki est pour les jeunes!\nDu divertissement partout!"
+    "texte_fr": "Yo, tu viens t'amuser aussi ?[1205][U+000F] Bien sûr.\nYumezaki est pour les jeunes !\nDu divertissement partout !"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Mu,[SP]the[SP]hottest[SP]amusement[SP]center.[1205][U+000F][SP]Giga[SP]Macho,\na[SP]record[SP]store[SP]with[SP]a[SP]recording[SP]studio.[1205][U+000F][SP]Anima\nMundi,[SP]home[SP]of[SP]the[SP]latest[SP]fashions.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Mu, le meilleur centre de jeux.[1205][U+000F] Giga\nMacho, un disquaire avec studio.[1205][U+000F]\nAnima Mundi, le temple de la mode."
+    "texte_fr": "Mu, le meilleur centre de jeux.[1205][U+000F] Giga Macho,\nun disquaire avec studio.[1205][U+000F] Anima Mundi,\nle temple de la mode."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "A[SP]guy[SP]my[SP]age[SP]could[SP]easily[SP]spend[SP]an[SP]entire[SP]day\nhere[SP]and[SP]never[SP]get[SP]bored.[1205][U+000F]",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Un gars de mon âge peut passer toute\nla journée ici sans s'ennuyer.[1205][U+000F]"
+    "texte_fr": "Un gars de mon âge peut passer toute la\njournée ici sans s'ennuyer.[1205][U+000F]"
   },
   {
     "id": 3,
@@ -58,7 +58,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "And[SP]the[SP]girls[SP]here...[SP]Whew![SP]Heheheh.",
     "nom_fr": "Jeune",
-    "texte_fr": "Les filles ici... Ouf! Heheh."
+    "texte_fr": "Les filles ici... Ouf ! Heheh."
   },
   {
     "id": 4,
@@ -74,7 +74,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Looks[SP]like[SP]there's[SP]a[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High.[1205][U+000F]\nHe's[SP]stronger[SP]than[SP]the[SP]old[SP]Boss,[SP]right?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "On dirait qu'il y a un nouveau chef à\nKakasu.[1205][U+000F] Plus fort que l'ancien, non?"
+    "texte_fr": "On dirait qu'il y a un nouveau chef à Kakasu.[1205][U+000F]\nPlus fort que l'ancien, non ?"
   },
   {
     "id": 5,
@@ -90,7 +90,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Heh,[SP]they're[SP]having[SP]a[SP]masquerade[SP]as[SP]part[SP]of\ntheir[SP]school[SP]festival.[SP]Cuss[SP]High[SP]sure[SP]knows\nhow[SP]to[SP]draw[SP]a[SP]crowd.[1205][U+000F][SP]All[SP]my[SP]friends[SP]are[SP]going.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ils font un bal masqué pour leur\nfestival. Le lycée Kakasu sait comment\nattirer la foule.[1205][U+000F] Tous mes potes y vont."
+    "texte_fr": "Ils font un bal masqué pour leur festival.\nLe lycée Kakasu sait comment attirer la\nfoule.[1205][U+000F] Tous mes potes y vont."
   },
   {
     "id": 6,
@@ -106,7 +106,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Ooh,[SP]you[SP]on[SP]your[SP]way[SP]to[SP]Mu?[1205][U+000F][SP]We[SP]might[SP]catch[SP]a\nglimpse[SP]of[SP]the[SP]Muses[SP]live![SP]I[SP]better[SP]get[SP]going.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ooh, tu vas à Mu?[1205][U+000F] On pourrait voir les\nMuses en direct! Il faut que j'y aille."
+    "texte_fr": "Ooh, tu vas à Mu ?[1205][U+000F] On pourrait voir les\nMuses en direct ! Il faut que j'y aille."
   },
   {
     "id": 7,
@@ -121,7 +121,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Ugh,[SP]I[SP]was[SP]just[SP]at[SP]Giga[SP]Macho,[SP]and[SP]it[SP]was[SP]packed\nwith[SP]guys[SP]trying[SP]to[SP]scope[SP]out[SP]the[SP]Muses[SP]event.[1205][U+000F]\nBandwagon-hopping[SP]bastards...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ugh, j'étais à Giga Macho, c'était\nrempli de gars voulant voir l'événement\ndes Muses.[1205][U+000F] Bande de moutons..."
+    "texte_fr": "Ugh, j'étais à Giga Macho, c'était rempli de\ngars voulant voir l'événement des Muses.[1205][U+000F]\nBande de moutons..."
   },
   {
     "id": 8,
@@ -137,7 +137,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "It's[SP]gonna[SP]suck[SP]if[SP]more[SP]schmoes[SP]like[SP]them[SP]keep\nshowing[SP]up.[1205][U+000F][SP]I've[SP]been[SP]a[SP]fan[SP]of[SP]those[SP]girls\nsince[SP]before[SP]it[SP]was[SP]cool.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ça va puer si d'autres nazes se pointent.[1205][U+000F] Je\nsuis fan depuis bien avant que ce soit cool."
+    "texte_fr": "Ça va puer si d'autres nazes se pointent.[1205][U+000F]\nJe suis fan depuis bien avant que ce soit cool."
   },
   {
     "id": 9,
@@ -153,7 +153,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Dude,[SP]everyone[SP]went[SP]to[SP]go[SP]see[SP]the[SP]concert\nin[SP]Aoba...[1205][U+000F][SP]Am[SP]I[SP]the[SP]only[SP]one[SP]who[SP]didn't[SP]go?[1205][U+000F]\nLame...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Tous sont allés voir le concert à Aoba...[1205][U+000F]\nJe suis le seul à pas y être allé?[1205][U+000F] Nul..."
+    "texte_fr": "Tous sont allés voir le concert à Aoba...[1205][U+000F]\nJe suis le seul à pas y être allé ?[1205][U+000F] Nul..."
   },
   {
     "id": 10,
@@ -168,7 +168,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Hey,[SP]what's[SP]the[SP]Masked[SP]Circle?[1205][U+000F][SP]They're[SP]the[SP]ones\nwho[SP]set[SP]fire[SP]to[SP]the[SP]concert[SP]hall,[SP]right?[SP]That's\nwhat[SP]my[SP]friend's[SP]friend[SP]said.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Hé, c'est quoi le Cercle masqué?[1205][U+000F] Ce sont\neux qui ont incendié la salle de\nconcert, non? C'est ce qu'un pote a dit."
+    "texte_fr": "Hé, c'est quoi le Cercle masqué ?[1205][U+000F] Ce sont\neux qui ont incendié la salle de concert,\nnon ? C'est ce qu'un pote a dit."
   },
   {
     "id": 11,
@@ -184,7 +184,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Even[SP]their[SP]name[SP]sounds[SP]suspicious.[1205][U+000F][SP]If[SP]they're\nactually[SP]starting[SP]shit[SP]like[SP]this,[SP]they[SP]must\nreally[SP]be[SP]dangerous.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Même leur nom est louche.[1205][U+000F] S'ils\nfont vraiment ce genre de trucs,\nils doivent être hyper dangereux."
+    "texte_fr": "Même leur nom est louche.[1205][U+000F] S'ils font\nvraiment ce genre de trucs, ils doivent\nêtre hyper dangereux."
   },
   {
     "id": 12,
@@ -199,7 +199,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Hey,[SP]is[SP]it[SP]true[SP]the[SP]terrorists[SP]targeted\nSmile[SP]Hirasaka[SP]too?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Hé, les terroristes ont\naussi ciblé Smile Hirasaka?"
+    "texte_fr": "Hé, les terroristes ont aussi ciblé\nSmile Hirasaka ?"
   },
   {
     "id": 13,
@@ -215,7 +215,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "I-I'm[SP]starting[SP]to[SP]think[SP]this[SP]place[SP]isn't[SP]safe\neither...[1205][U+000F][SP]Are[SP]we[SP]gonna[SP]be[SP]okay?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "J-Je pense qu'ici non plus c'est\npas sûr...[1205][U+000F] On va s'en sortir?"
+    "texte_fr": "J-Je pense qu'ici non plus c'est pas sûr...[1205][U+000F]\nOn va s'en sortir ?"
   },
   {
     "id": 14,
@@ -231,7 +231,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Is[SP]it[SP]true[SP]the[SP]terrorists[SP]bombed[SP]Smile\nHirasaka?[SP]Dude,[SP]seriously...?[1205][U+000A][SP]They[SP]could\nhit[SP]here[SP]next![1205][U+000F][SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]run.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ils ont vraiment bombardé Smile\nHirasaka? Sérieux?[1205][U+000A] Ils pourraient\nviser ici! [1205][U+000F]Je devrais fuir."
+    "texte_fr": "Ils ont vraiment bombardé Smile Hirasaka ?\nSérieux ?[1205][U+000A] Ils pourraient viser ici !\n[1205][U+000F]Je devrais fuir."
   },
   {
     "id": 15,
@@ -247,7 +247,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "What,[SP]they[SP]even[SP]targeted[SP]GOLD!?[1205][U+000F][SP]Does[SP]that[SP]mean\nYumezaki's[SP]not[SP]safe[SP]either!?[SP]When[SP]will[SP]someone\ndo[SP]something[SP]about[SP]this...?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Quoi, ils ont même ciblé GOLD!?[1205][U+000F] Ça\nveut dire que Yumezaki n'est pas sûr\nnon plus!? Quand vont-ils agir...?"
+    "texte_fr": "Quoi, ils ont même ciblé GOLD !?[1205][U+000F] Ça\nveut dire que Yumezaki n'est pas sûr\nnon plus !? Quand vont-ils agir... ?"
   },
   {
     "id": 16,
@@ -263,7 +263,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "O-Oh[SP]shit,[SP]they[SP]got[SP]GOLD[SP]too...[1205][U+000F][SP]H-Hey,[SP]where\nare[SP]they[SP]gonna[SP]strike[SP]next!?[1205][U+000F][SP]If[SP]I[SP]don't[SP]know\nthat...[SP]I[SP]don't[SP]know[SP]where[SP]to[SP]run[SP]to...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "M-Merde, ils ont eu GOLD aussi...[1205][U+000F] H-Hé,\noù vont-ils frapper ensuite!?[1205][U+000F] Si je ne\nle sais pas... je ne sais pas où fuir..."
+    "texte_fr": "M-Merde, ils ont eu GOLD aussi...[1205][U+000F] H-Hé,\noù vont-ils frapper ensuite !?[1205][U+000F] Si je ne le\nsais pas... je ne sais pas où fuir..."
   },
   {
     "id": 17,
@@ -279,7 +279,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "They've[SP]posted[SP]composite[SP]sketches[SP]of[SP]the[SP]suspects,\nright?[1205][U+000F][SP]Looks[SP]like[SP]crime[SP]doesn't[SP]pay[SP]after[SP]all.\nBut[SP]wasn't[SP]it[SP]the[SP]Masked[SP]Circle[SP]who[SP]did[SP]this?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ils ont publié les portraits-robots des\nsuspects, non?[1205][U+000F] Le crime ne paie pas.\nMais n'était-ce pas le Cercle masqué?"
+    "texte_fr": "Ils ont publié les portraits-robots des\nsuspects, non ?[1205][U+000F] Le crime ne paie pas.\nMais n'était-ce pas le Cercle masqué ?"
   },
   {
     "id": 18,
@@ -294,7 +294,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "H-Hey,[SP]I[SP]saw[SP]the[SP]news...[SP]What[SP]do[SP]you[SP]think?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Hé, j'ai vu les infos... T'en dis quoi?"
+    "texte_fr": "Hé, j'ai vu les infos... T'en dis quoi ?"
   },
   {
     "id": 19,
@@ -310,7 +310,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Are[SP]those[SP]guys[SP]not[SP]the[SP]culprits?[1205][U+000F][SP]Or[SP]are[SP]they\nreally[SP]terrorists[SP]after[SP]all?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ils sont innocents?[1205][U+000F] Ou de vrais terroristes?"
+    "texte_fr": "Ils sont innocents ?[1205][U+000F] Ou\nde vrais terroristes ?"
   },
   {
     "id": 20,
@@ -326,7 +326,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Dude,[SP]shit[SP]keeps[SP]going[SP]down[SP]right[SP]and[SP]left!\nWhat's[SP]going[SP]on!?[1205][U+000F][SP]Were[SP]those[SP]guys[SP]terrorists\nor[SP]not!?[SP]What[SP]are[SP]they[SP]doing[SP]to[SP]our[SP]city!?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Mec, c'est le bordel de partout! Il se\npasse quoi!?[1205][U+000F] Ces gars étaient des\nterroristes ou pas!? Ils font quoi ici!?"
+    "texte_fr": "Mec, c'est le bordel de partout !\nIl se passe quoi !?[1205][U+000F] Ces gars étaient des\nterroristes ou pas !? Ils font quoi ici !?"
   },
   {
     "id": 21,
@@ -357,7 +357,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Was[SP]he[SP]a[SP]Cuss[SP]High[SP]student?[SP]He[SP]had[SP]a[SP]really\ncute[SP]girl[SP]with[SP]him,[SP]though...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Un élève de Kakasu? Il était\navec une fille mignonne..."
+    "texte_fr": "Un élève de Kakasu ? Il était avec\nune fille mignonne..."
   },
   {
     "id": 23,
@@ -372,7 +372,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Hm?[SP]Are[SP]you[SP]hitting[SP]on[SP]me?[1205][U+000F][SP]If[SP]you[SP]are,[SP]I[SP]hate\nto[SP]break[SP]it[SP]to[SP]you,[SP]but[SP]I'm[SP]a[SP]little[SP]busy.",
     "nom_fr": "Femme active",
-    "texte_fr": "Hm? Tu me dragues?[1205][U+000F] Si c'est le cas, désolée\nde te décevoir, mais je suis occupée."
+    "texte_fr": "Hm ? Tu me dragues ?[1205][U+000F] Si c'est le cas,\ndésolée de te décevoir, mais je suis occupée."
   },
   {
     "id": 24,
@@ -387,7 +387,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Oh,[SP]you[SP]weren't?[SP]Haha,[SP]sorry[SP]about[SP]that,[SP]then.[1205][U+000F]\nThat[SP]reminds[SP]me,[SP]do[SP]you[SP]go[SP]to[SP]Cuss[SP]High?",
     "nom_fr": "Femme active",
-    "texte_fr": "Oh, ce n'était pas ça? Haha, désolée.[1205][U+000F]\nÇa me rappelle, tu vas au lycée Kakasu?"
+    "texte_fr": "Oh, ce n'était pas ça ? Haha, désolée.[1205][U+000F]\nÇa me rappelle, tu vas au lycée Kakasu ?"
   },
   {
     "id": 25,
@@ -403,7 +403,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Because[SP]I[SP]saw[SP]a[SP]group[SP]of[SP]Cuss[SP]High[SP]kids[SP]going\ninto[SP]Zodiac[SP]a[SP]moment[SP]ago.[1205][U+000F][SP]Do[SP]you[SP]know[SP]what\nthey're[SP]up[SP]to[SP]in[SP]there?",
     "nom_fr": "Femme active",
-    "texte_fr": "J'ai vu un groupe de Kakasu entrer\ndans Zodiac.[1205][U+000F] Tu sais ce qu'ils y font?"
+    "texte_fr": "J'ai vu un groupe de Kakasu entrer dans\nZodiac.[1205][U+000F] Tu sais ce qu'ils y font ?"
   },
   {
     "id": 26,
@@ -419,7 +419,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "That[SP]reminds[SP]me,[SP]rumor[SP]has[SP]it[SP]there's[SP]a[SP]secret\nlounge[SP]deep[SP]inside[SP]Zodiac.[1205][U+000F][SP]I've[SP]never[SP]gone[SP]to\nsee[SP]it,[SP]though...",
     "nom_fr": "Femme active",
-    "texte_fr": "D'ailleurs, la rumeur dit qu'il y a\nun salon secret au fond de Zodiac.[1205][U+000F] Je\nn'y suis jamais allée, par contre..."
+    "texte_fr": "D'ailleurs, la rumeur dit qu'il y a un salon\nsecret au fond de Zodiac.[1205][U+000F] Je n'y suis\njamais allée, par contre..."
   },
   {
     "id": 27,
@@ -434,7 +434,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Someone[SP]from[SP]Cuss[SP]High[SP]came[SP]to[SP]sell[SP]tickets[SP]to\nthe[SP]masquerade[SP]just[SP]now.",
     "nom_fr": "Femme active",
-    "texte_fr": "Un gars de Kakasu est venu\nvendre des billets pour le bal."
+    "texte_fr": "Un gars de Kakasu est venu vendre\ndes billets pour le bal."
   },
   {
     "id": 28,
@@ -466,7 +466,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Young[SP]kids[SP]tend[SP]to[SP]gather[SP]here,[SP]so[SP]TV[SP]stations\nsend[SP]reporters[SP]to[SP]interview[SP]them[SP]and[SP]hold\nevents.[1205][U+000F][SP]Aren't[SP]they[SP]having[SP]one[SP]at[SP]Mu[SP]today?",
     "nom_fr": "Femme active",
-    "texte_fr": "Les jeunes traînent ici, donc la télé\nenvoie des reporters pour les interviewer\net faire des trucs.[1205][U+000F] C'est à Mu aujourd'hui?"
+    "texte_fr": "Les jeunes traînent ici, donc la télé\nenvoie des reporters pour les interviewer\net faire des trucs.[1205][U+000F] C'est à Mu aujourd'hui ?"
   },
   {
     "id": 30,
@@ -481,7 +481,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Is[SP]Muses[SP]still[SP]keeping[SP]their[SP]third[SP]member[SP]a\nsecret?[1205][U+000F][SP]I[SP]know[SP]it's[SP]a[SP]marketing[SP]strategy,[SP]but\nI[SP]wish[SP]they'd[SP]stop[SP]fanning[SP]the[SP]flames.",
     "nom_fr": "Femme active",
-    "texte_fr": "Muses garde toujours sa troisième membre\nsecrète?[1205][U+000F] Je sais que c'est du marketing,\nmais j'aimerais qu'ils arrêtent ce teasing."
+    "texte_fr": "Muses garde toujours sa troisième membre\nsecrète ?[1205][U+000F] Je sais que c'est du marketing,\nmais j'aimerais qu'ils arrêtent ce teasing."
   },
   {
     "id": 31,
@@ -497,7 +497,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Or[SP]are[SP]they[SP]planning[SP]on[SP]making[SP]an[SP]announcement\nduring[SP]the[SP]recording[SP]today?",
     "nom_fr": "Femme active",
-    "texte_fr": "Ou comptent-ils faire une annonce\npendant l'enregistrement aujourd'hui?"
+    "texte_fr": "Ou comptent-ils faire une annonce\npendant l'enregistrement aujourd'hui ?"
   },
   {
     "id": 32,
@@ -512,7 +512,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "They[SP]just[SP]revealed[SP]the[SP]third[SP]member,[SP]and[SP]they're\nalready[SP]giving[SP]a[SP]concert?[1205][U+000F][SP]That's[SP]pretty[SP]sudden.",
     "nom_fr": "Femme active",
-    "texte_fr": "Ils viennent de révéler la troisième membre\net ils donnent déjà un concert?[1205][U+000F] Rapide."
+    "texte_fr": "Ils viennent de révéler la troisième membre\net ils donnent déjà un concert ?[1205][U+000F] Rapide."
   },
   {
     "id": 33,
@@ -559,7 +559,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "They[SP]won't[SP]attack[SP]here,[SP]right...?[1205][U+000F][SP]I[SP]worry\nabout[SP]that[SP]a[SP]lot.",
     "nom_fr": "Femme active",
-    "texte_fr": "Ils n'attaqueront pas ici,\nnon...?[1205][U+000F] Ça m'inquiète beaucoup."
+    "texte_fr": "Ils n'attaqueront pas ici, non... ?[1205][U+000F]\nÇa m'inquiète beaucoup."
   },
   {
     "id": 36,
@@ -589,7 +589,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "I've[SP]got[SP]a[SP]huge[SP]backlog[SP]at[SP]work[SP]and[SP]there's\nno[SP]sign[SP]that[SP]this[SP]place[SP]will[SP]be[SP]bombed.",
     "nom_fr": "Femme active",
-    "texte_fr": "J'ai une tonne de boulot en retard et rien\nn'indique qu'il y aura une bombe ici."
+    "texte_fr": "J'ai une tonne de boulot en retard et\nrien n'indique qu'il y aura une bombe ici."
   },
   {
     "id": 38,
@@ -651,7 +651,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "What[SP]on[SP]Earth[SP]is[SP]my[SP]idiot[SP]boss[SP]thinking!?\nI'm[SP]giving[SP]notice[SP]as[SP]soon[SP]as[SP]I[SP]get[SP]back!",
     "nom_fr": "Femme active",
-    "texte_fr": "À quoi pense mon idiot de patron!?\nJe démissionne dès que je rentre!"
+    "texte_fr": "À quoi pense mon idiot de patron !?\nJe démissionne dès que je rentre !"
   },
   {
     "id": 42,
@@ -666,7 +666,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "[1432][NULL][NULL][0014]They[SP]went[SP]after[SP]GOLD,[SP]so[SP]our[SP]building's\nsafe[1432][NULL][NULL][0014]!?[SP]Is[SP]he[SP]serious!?",
     "nom_fr": "Femme active",
-    "texte_fr": "[1432][NULL][NULL][0014]Ils ont visé GOLD, donc on\nest saufs[1432][NULL][NULL][0014]!? Il est sérieux!?"
+    "texte_fr": "[1432][NULL][NULL][0014]Ils ont visé GOLD, donc on est\nsaufs[1432][NULL][NULL][0014] !? Il est sérieux !?"
   },
   {
     "id": 43,
@@ -682,7 +682,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "What[SP]on[SP]Earth[SP]is[SP]my[SP]idiot[SP]boss[SP]thinking!?[1205][U+000F]\nI'm[SP]giving[SP]notice[SP]as[SP]soon[SP]as[SP]I[SP]get[SP]back!",
     "nom_fr": "Femme active",
-    "texte_fr": "À quoi pense mon idiot de patron!?[1205][U+000F]\nJe démissionne dès que je rentre!"
+    "texte_fr": "À quoi pense mon idiot de patron !?[1205][U+000F]\nJe démissionne dès que je rentre !"
   },
   {
     "id": 44,
@@ -698,7 +698,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Huh.[1205][U+000F][SP]Those[SP]kids[SP]were[SP]soaking[SP]wet[SP]and[SP]said[SP]the\npeople[SP]in[SP]the[SP]news[SP]were[SP]heroes[SP]fighting[SP]the\nMasked[SP]Circle...[1205][0014][SP]Who[SP]do[SP]I[SP]believe?",
     "nom_fr": "Femme active",
-    "texte_fr": "Huh.[1205][U+000F] Ces jeunes étaient trempés et disaient\nque les gars aux infos étaient des héros\ncontre le Cercle masqué...[1205][0014] Qui croire?"
+    "texte_fr": "Huh.[1205][U+000F] Ces jeunes étaient trempés et disaient\nque les gars aux infos étaient des héros\ncontre le Cercle masqué...[1205][0014] Qui croire ?"
   },
   {
     "id": 45,
@@ -729,7 +729,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "If[SP]they're[SP]here,[SP]then[SP]the[SP]secret[SP]treasure[SP]of\nSumaru[SP]City[SP]must[SP]also[SP]exist.[1205][U+000F][SP]Which[SP]means[SP]that\nOracle[SP]thing[SP]is[SP]true...",
     "nom_fr": "Femme active",
-    "texte_fr": "S'ils sont là, le trésor secret de\nSumaru doit aussi exister.[1205][U+000F] Ce qui\nsignifie que cet Oracle dit vrai..."
+    "texte_fr": "S'ils sont là, le trésor secret de Sumaru\ndoit aussi exister.[1205][U+000F] Ce qui signifie que\ncet Oracle dit vrai..."
   },
   {
     "id": 47,
@@ -745,7 +745,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "The[SP]next[SP]line[SP]was,[SP][1432][NULL][NULL][0014]The[SP]lion's[SP]roar[SP]echoes[SP]far\nand[SP]wide,[1432][NULL][NULL][0014][SP]right?[1205][U+000F][SP]Wh-What's[SP]that[SP]supposed[SP]to\nmean?[1205][U+000F][SP]I[SP]don't[SP]understand...",
     "nom_fr": "Femme active",
-    "texte_fr": "La suite c'était: [1432][NULL][NULL][0014]Le rugissement du lion\nrésonne[1432][NULL][NULL][0014]?[1205][U+000F] Ça veut dire quoi?[1205][U+000F] Je pige pas..."
+    "texte_fr": "La suite c'était : [1432][NULL][NULL][0014]Le rugissement\ndu lion résonne[1432][NULL][NULL][0014] ?[1205][U+000F]\nÇa veut dire quoi ?[1205][U+000F] Je pige pas..."
   },
   {
     "id": 48,
@@ -761,7 +761,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "D-Did[SP]you[SP]see[SP]those[SP]meteors?[1205][U+000F][SP]One[SP]of[SP]the[SP]Masked\nCircle[SP]said[SP]they[SP]were[SP]the[SP][1432][NULL][NULL][0014]lion's[SP]roar[1432][NULL][NULL][0014]![1205][U+000F][SP]That's\nwhat[SP]that[SP]line[SP]in[SP]the[SP]Oracle[SP]was[SP]about!",
     "nom_fr": "Femme active",
-    "texte_fr": "T-Tu as vu ces météores?[1205][U+000F] Quelqu'un du\nCercle a dit que c'était le [1432][NULL][NULL][0014]rugissement du\nlion[1432][NULL][NULL][0014]![1205][U+000F] C'est de ça que parlait l'Oracle!"
+    "texte_fr": "T-Tu as vu ces météores ?[1205][U+000F] Quelqu'un du Cercle\na dit que c'était le [1432][NULL][NULL][0014]rugissement du lion[1432][NULL][NULL][0014] ![1205][U+000F]\nC'est de ça que parlait l'Oracle !"
   },
   {
     "id": 49,
@@ -776,7 +776,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "A[SP]temple[SP]like[SP]that[SP]one[SP]appeared[SP]in[SP]Hirasaka\nand[SP]Aoba[SP]too,[SP]right?",
     "nom_fr": "Femme active",
-    "texte_fr": "Un temple est apparu à Hirasaka et Aoba, non?"
+    "texte_fr": "Un temple est apparu à Hirasaka et Aoba, non ?"
   },
   {
     "id": 50,
@@ -792,7 +792,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "What[SP]are[SP]those[SP]things...?[1205][U+000F][SP]The[SP]scorpion[SP]mark\ndrawn[SP]on[SP]it[SP]is[SP]kind[SP]of[SP]disturbing...",
     "nom_fr": "Femme active",
-    "texte_fr": "C'est quoi...?[1205][U+000F] La marque de\nscorpion dessus est perturbante..."
+    "texte_fr": "C'est quoi... ?[1205][U+000F] La marque de\nscorpion dessus est perturbante..."
   },
   {
     "id": 51,
@@ -807,7 +807,7 @@
     "nom_orig": "Man",
     "texte_orig": "A[SP]city[SP]for[SP]the[SP]young...[1205][U+000F][SP]That's[SP]what[SP]those\nlayabouts[SP]think.[SP]For[SP]us[SP]men[SP]making[SP]an[SP]honest\nday's[SP]pay,[SP]this[SP]place[SP]is[SP]part[SP]of[SP]society[SP]too.",
     "nom_fr": "Homme",
-    "texte_fr": "Une ville pour jeunes...[1205][U+000F] C'est ce que\npensent ces fainéants. Pour nous qui\nbossons, ça fait partie de la société."
+    "texte_fr": "Une ville pour jeunes...[1205][U+000F] C'est ce que\npensent ces fainéants. Pour nous qui bossons,\nça fait partie de la société."
   },
   {
     "id": 52,
@@ -823,7 +823,7 @@
     "nom_orig": "Man",
     "texte_orig": "By[SP]the[SP]way,[SP]are[SP]you[SP]from[SP]Kasugayama[SP]High?[1205][U+000F]\nThis[SP]place[SP]is[SP]usually[SP]packed[SP]with[SP]Sevens[SP]kids,\nbut[SP]I[SP]rarely[SP]see[SP]them[SP]anymore.",
     "nom_fr": "Homme",
-    "texte_fr": "Au fait, tu viens du lycée Kakasu?[1205][U+000F] C'est\nsouvent plein de gamins de Seven ici,\nmais je les vois rarement désormais."
+    "texte_fr": "Au fait, tu viens du lycée Kakasu ?[1205][U+000F]\nC'est souvent plein de gamins de Seven ici,\nmais je les vois rarement désormais."
   },
   {
     "id": 53,
@@ -838,7 +838,7 @@
     "nom_orig": "Man",
     "texte_orig": "A[SP]secret[SP]lounge?[1205][U+000F][SP]Oh,[SP]you[SP]mean[SP]the[SP]place[SP]you\ncan't[SP]get[SP]into[SP]without[SP]one[SP]of[SP]those[SP]masks?",
     "nom_fr": "Homme",
-    "texte_fr": "Un salon secret?[1205][U+000F] Oh, tu parles de l'endroit\noù on ne peut pas entrer sans masque?"
+    "texte_fr": "Un salon secret ?[1205][U+000F] Oh, tu parles de l'endroit\noù on ne peut pas entrer sans masque ?"
   },
   {
     "id": 54,
@@ -869,7 +869,7 @@
     "nom_orig": "Man",
     "texte_orig": "Guess[SP]all[SP]our[SP]customers[SP]are[SP]off[SP]at[SP]Cuss[SP]High's\nschool[SP]festival...[SP]Oh[SP]well.",
     "nom_fr": "Homme",
-    "texte_fr": "Nos clients sont au festival\nde Kakasu... Tant pis."
+    "texte_fr": "Nos clients sont au festival de Kakasu... Tant pis."
   },
   {
     "id": 56,
@@ -885,7 +885,7 @@
     "nom_orig": "Man",
     "texte_orig": "Festivals[SP]like[SP]that[SP]do[SP]only[SP]come[SP]once[SP]a[SP]year,\nso[SP]I[SP]shouldn't[SP]complain.",
     "nom_fr": "Homme",
-    "texte_fr": "Ce festival n'a lieu qu'une\nfois par an, je me plains pas."
+    "texte_fr": "Ce festival n'a lieu qu'une fois\npar an, je me plains pas."
   },
   {
     "id": 57,
@@ -916,7 +916,7 @@
     "nom_orig": "Man",
     "texte_orig": "Is[SP]their[SP]producer[SP]that[SP]good?",
     "nom_fr": "Homme",
-    "texte_fr": "Leur prod est si doué?"
+    "texte_fr": "Leur prod est si doué ?"
   },
   {
     "id": 59,
@@ -932,7 +932,7 @@
     "nom_orig": "Man",
     "texte_orig": "A[SP]crowd's[SP]forming[SP]at[SP]Giga[SP]Macho,[SP]but[SP]they're\nnot[SP]interested[SP]in[SP]anything[SP]but[SP]Ginji[SP]Sasaki\nand[SP]the[SP]last[SP]member[SP]of[SP]Muses.",
     "nom_fr": "Homme",
-    "texte_fr": "Une foule se forme à Giga Macho, mais\nils ne s'intéressent qu'à Ginji Sasaki\net à la dernière membre de Muses."
+    "texte_fr": "Une foule se forme à Giga Macho, mais ils ne\ns'intéressent qu'à Ginji Sasaki et à la\ndernière membre de Muses."
   },
   {
     "id": 60,
@@ -963,7 +963,7 @@
     "nom_orig": "Man",
     "texte_orig": "I[SP]envy[SP]them[SP]their[SP]popularity...[SP]It's[SP]a[SP]tough\nthing[SP]to[SP]see[SP]for[SP]those[SP]of[SP]us[SP]who've[SP]fallen\non[SP]hard[SP]times.",
     "nom_fr": "Homme",
-    "texte_fr": "J'envie leur succès... C'est dur pour\nnous qui avons traversé des crises."
+    "texte_fr": "J'envie leur succès... C'est dur pour nous\nqui avons traversé des crises."
   },
   {
     "id": 62,
@@ -978,7 +978,7 @@
     "nom_orig": "Man",
     "texte_orig": "Some[SP]people[SP]are[SP]saying[SP]the[SP]Masked[SP]Circle[SP]is[SP]to\nblame[SP]for[SP]the[SP]chaos,[SP]but[SP]are[SP]they[SP]really[SP]the\nculprits[SP]here?[1205][U+000F][SP]Granted,[SP]they're[SP]suspicious...",
     "nom_fr": "Homme",
-    "texte_fr": "Certains accusent le Cercle masqué pour\nce chaos, mais sont-ils vraiment les\ncoupables?[1205][U+000F] Certes, ils sont louches..."
+    "texte_fr": "Certains accusent le Cercle masqué pour\nce chaos, mais sont-ils vraiment les\ncoupables ?[1205][U+000F] Certes, ils sont louches..."
   },
   {
     "id": 63,
@@ -1009,7 +1009,7 @@
     "nom_orig": "Man",
     "texte_orig": "The[SP]Masked[SP]Circle[SP]and[SP]the[SP]group[SP]of[SP]five...[1205][U+000F]\nThey're[SP]both[SP]suspects[SP]behind[SP]the[SP]terrorist\nattacks,[SP]but[SP]there's[SP]no[SP]proof...",
     "nom_fr": "Homme",
-    "texte_fr": "Le Cercle masqué et le groupe...[1205][U+000F] Tous\ndeux sont suspects, mais sans preuves..."
+    "texte_fr": "Le Cercle masqué et le groupe...[1205][U+000F]\nTous deux sont suspects, mais sans preuves..."
   },
   {
     "id": 65,
@@ -1024,7 +1024,7 @@
     "nom_orig": "Man",
     "texte_orig": "That's[SP]a[SP]dangerous[SP]situation.[SP]People[SP]here[SP]in\ntown[SP]want[SP]a[SP]quick[SP]end[SP]to[SP]things[SP]like[SP]this,\nso[SP]they're[SP]eager[SP]to[SP]toss[SP]blame[SP]around...",
     "nom_fr": "Homme",
-    "texte_fr": "C'est une situation dangereuse. Les gens\nici veulent que ça se termine vite, alors\nils sont pressés de jeter le blâme..."
+    "texte_fr": "C'est une situation dangereuse. Les gens ici\nveulent que ça se termine vite, alors\nils sont pressés de jeter le blâme..."
   },
   {
     "id": 66,
@@ -1055,7 +1055,7 @@
     "nom_orig": "Man",
     "texte_orig": "Now[SP]people[SP]are[SP]saying[SP]the[SP]terrorists[SP]behind\nthese[SP]attacks[SP]are[SP]a[SP]special[SP]unit[SP]called[SP]the\nLast[SP]Battalion.[1205][U+000F]",
     "nom_fr": "Homme",
-    "texte_fr": "On dit que les terroristes sont\nune unité appelée le Bataillon.[1205][U+000F]"
+    "texte_fr": "On dit que les terroristes sont une unité\nappelée le Bataillon.[1205][U+000F]"
   },
   {
     "id": 68,
@@ -1116,7 +1116,7 @@
     "nom_orig": "Man",
     "texte_orig": "Oh,[SP]no,[SP]I[SP]completely[SP]understand[SP]it's[SP]a[SP]trumped-\nup[SP]charge[SP]and[SP]those[SP]are[SP]just[SP]people[SP]in[SP]the\nwrong[SP]place[SP]at[SP]the[SP]wrong[SP]time.",
     "nom_fr": "Homme",
-    "texte_fr": "Oh, je comprends que ce sont de fausses\naccusations, juste des gens au mauvais\nendroit."
+    "texte_fr": "Oh, je comprends que ce sont\nde fausses accusations, juste des gens\nau mauvais endroit."
   },
   {
     "id": 72,
@@ -1163,7 +1163,7 @@
     "nom_orig": "Man",
     "texte_orig": "The[SP]new[SP]rumor[SP]is[SP]that[SP]the[SP]group[SP]of[SP]five[SP]is\nactually[SP]fighting[SP]against[SP]the[SP]Masked[SP]Circle.\nDid[SP]you[SP]guys[SP]spread[SP]that[SP]one?[1205][U+000F][SP]Very[SP]clever.",
     "nom_fr": "Homme",
-    "texte_fr": "La nouvelle rumeur dit que le groupe de\ncinq combat en fait le Cercle masqué.\nC'est vous qui l'avez lancée?[1205][U+000F] Très malin."
+    "texte_fr": "La nouvelle rumeur dit que le groupe de cinq\ncombat en fait le Cercle masqué.\nC'est vous qui l'avez lancée ?[1205][U+000F] Très malin."
   },
   {
     "id": 75,
@@ -1179,7 +1179,7 @@
     "nom_orig": "Man",
     "texte_orig": "This[SP]feels[SP]a[SP]lot[SP]like[SP]the[SP]final[SP]push.[1205][U+000F][SP]I[SP]don't\nthink[SP]anyone[SP]doubts[SP]the[SP]In[SP]Lak'ech[SP]anymore.",
     "nom_fr": "Homme",
-    "texte_fr": "Ça sent la fin.[1205][U+000F] Plus personne\nne doute de l'In Lak'ech."
+    "texte_fr": "Ça sent la fin.[1205][U+000F] Plus personne ne doute\nde l'In Lak'ech."
   },
   {
     "id": 76,
@@ -1194,7 +1194,7 @@
     "nom_orig": "Man",
     "texte_orig": "Now[SP]where[SP]did[SP]that[SP]monstrosity[SP]come[SP]from...?[1205][U+000A]\nThe[SP]Masked[SP]Circle[SP]and[SP]the[SP]Last[SP]Battalion[SP]are\nhaving[SP]it[SP]out[SP]in[SP]there[SP]now.",
     "nom_fr": "Homme",
-    "texte_fr": "D'où sort cette monstruosité...?[1205][U+000A]\nLe Cercle masqué et le Bataillon\nse battent là-dedans maintenant."
+    "texte_fr": "D'où sort cette monstruosité... ?[1205][U+000A]\nLe Cercle masqué et le Bataillon se\nbattent là-dedans maintenant."
   },
   {
     "id": 77,
@@ -1210,7 +1210,7 @@
     "nom_orig": "Man",
     "texte_orig": "Fighting[SP]up[SP]here,[SP]destruction[SP]below...[1205][U+000F]\nDoes[SP]anyone[SP]care[SP]what[SP]happens[SP]down[SP]there\nanymore?",
     "nom_fr": "Homme",
-    "texte_fr": "Se battre en haut, détruire en bas...[1205][U+000F]\nPlus personne ne se soucie d'ici?"
+    "texte_fr": "Se battre en haut, détruire en bas...[1205][U+000F]\nPlus personne ne se soucie d'ici ?"
   },
   {
     "id": 78,
@@ -1225,7 +1225,7 @@
     "nom_orig": "Man",
     "texte_orig": "From[SP]what[SP]I've[SP]heard,[SP]a[SP]meteor[SP]shower[SP]will\nrain[SP]down[SP]on[SP]the[SP]Earth[SP]when[SP]the[SP]Grand[SP]Cross\nhappens.",
     "nom_fr": "Homme",
-    "texte_fr": "On dit qu'une pluie de météores\ns'abattra avec la Croix Cosmique."
+    "texte_fr": "On dit qu'une pluie de météores s'abattra\navec la Croix Cosmique."
   },
   {
     "id": 79,
@@ -1256,7 +1256,7 @@
     "nom_orig": "Man",
     "texte_orig": "I'm[SP]sure[SP]you[SP]know[SP]already,[SP]but[SP]there[SP]are\nseveral[SP]theories[SP]in[SP]Sumaru[SP]about[SP]how[SP]life\ndown[SP]there[SP]on[SP]Earth[SP]will[SP]end.",
     "nom_fr": "Homme",
-    "texte_fr": "Tu le sais, mais il y a plusieurs\nthéories sur la fin du monde."
+    "texte_fr": "Tu le sais, mais il y a\nplusieurs théories sur la fin du monde."
   },
   {
     "id": 81,
@@ -1272,7 +1272,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]long[SP]as[SP]there[SP]are[SP]competing[SP]theories,\nit[SP]should[SP]be[SP]fine.[1205][U+000A][SP]It's[SP]when[SP]everyone[SP]starts\nto[SP]agree[SP]that[SP]we're[SP]in[SP]trouble...",
     "nom_fr": "Homme",
-    "texte_fr": "Tant qu'il y a des théories\ndivergentes, ça va.[1205][U+000A] C'est quand\ntous sont d'accord que ça craint..."
+    "texte_fr": "Tant qu'il y a des théories divergentes,\nça va.[1205][U+000A] C'est quand tous\nsont d'accord que ça craint..."
   },
   {
     "id": 82,
@@ -1318,7 +1318,7 @@
     "nom_orig": "Man",
     "texte_orig": "And[SP]there[SP]was[SP]a[SP]line[SP]like[SP]that[SP]in[SP]the\nIn[SP]Lak'ech,[SP]so[SP]I[SP]guess[SP]it's[SP]decided.",
     "nom_fr": "Homme",
-    "texte_fr": "Une phrase de l'In Lak'ech\nle dit, donc c'est acté."
+    "texte_fr": "Une phrase de l'In Lak'ech le dit,\ndonc c'est acté."
   },
   {
     "id": 85,
@@ -1349,7 +1349,7 @@
     "nom_orig": "Man",
     "texte_orig": "Things[SP]are[SP]getting[SP]out[SP]of[SP]hand...[SP]I'm[SP]hearing\nnow[SP]that[SP]the[SP]second[SP]floor[SP]of[SP]Zodiac[SP]has[SP]become\na[SP]gigantic[SP]dungeon.",
     "nom_fr": "Homme",
-    "texte_fr": "Ça dégénère... J'entends dire maintenant\nque le deuxième étage de Zodiac est\ndevenu un gigantesque donjon."
+    "texte_fr": "Ça dégénère... J'entends dire maintenant\nque le deuxième étage de Zodiac est devenu\nun gigantesque donjon."
   },
   {
     "id": 87,
@@ -1365,7 +1365,7 @@
     "nom_orig": "Man",
     "texte_orig": "Rumor[SP]is[SP]that[SP]there's[SP]a[SP]ton[SP]of[SP]great[SP]items[SP]in\nthere,[SP]but[SP]exploring[SP]inside[SP]a[SP]club?[SP]You'd[SP]think\npeople[SP]would[SP]be[SP]shocked,[SP]but[SP]I[SP]guess[SP]not.",
     "nom_fr": "Homme",
-    "texte_fr": "Y a plein de super objets dedans, mais\nexplorer un club? Ça ne choque même plus."
+    "texte_fr": "Y a plein de super objets dedans, mais\nexplorer un club ? Ça ne choque même plus."
   },
   {
     "id": 88,
@@ -1381,7 +1381,7 @@
     "nom_orig": "Man",
     "texte_orig": "It[SP]never[SP]rains[SP]but[SP]it[SP]pours...[1205][U+000F][SP]That's[SP]how[SP]the\nsaying[SP]goes,[SP]but[SP]come[SP]on.[1205][U+000F][SP]Hanako[SP]now?[SP]This[SP]has\nbeen[SP]one[SP]unlucky[SP]year[SP]for[SP]Sevens.",
     "nom_fr": "Homme",
-    "texte_fr": "Un malheur n'arrive jamais seul...[1205][U+000F]\nHanako? C'est une année noire pour Seven."
+    "texte_fr": "Un malheur n'arrive jamais seul...[1205][U+000F] Hanako ?\nC'est une année noire pour Seven."
   },
   {
     "id": 89,
@@ -1396,7 +1396,7 @@
     "nom_orig": "Man",
     "texte_orig": "It[SP]sounds[SP]like[SP]there's[SP]a[SP]ghost[SP]named[SP]Bukimi\nappearing[SP]in[SP]Kasugayama[SP]High.",
     "nom_fr": "Homme",
-    "texte_fr": "On dirait qu'un fantôme nommé\nBukimi apparaît au lycée Kakasu."
+    "texte_fr": "On dirait qu'un fantôme nommé Bukimi\napparaît au lycée Kakasu."
   },
   {
     "id": 90,
@@ -1411,7 +1411,7 @@
     "nom_orig": "Man",
     "texte_orig": "There's[SP]always[SP]a[SP]backlash[SP]like[SP]this[SP]when\nanything[SP]becomes[SP]popular.[SP]The[SP]ugliest[SP]rumors\ntend[SP]to[SP]crop[SP]up...",
     "nom_fr": "Homme",
-    "texte_fr": "Il y a toujours un revers au succès.\nLes pires rumeurs surgissent..."
+    "texte_fr": "Il y a toujours un revers au succès. Les\npires rumeurs surgissent..."
   },
   {
     "id": 91,
@@ -1427,7 +1427,7 @@
     "nom_orig": "Man",
     "texte_orig": "I[SP]doubt[SP]there's[SP]actually[SP]any[SP]such[SP]thing[SP]over\nthere.[1205][U+000F][SP]R-Right?",
     "nom_fr": "Homme",
-    "texte_fr": "Je doute qu'il y ait ça là-bas.[1205][U+000F] P-Pas vrai?"
+    "texte_fr": "Je doute qu'il y ait ça là-bas.[1205][U+000F] P-Pas vrai ?"
   },
   {
     "id": 92,
@@ -1474,7 +1474,7 @@
     "nom_orig": "Man",
     "texte_orig": "But[SP]I[SP]doubt[SP]it's[SP]this[SP]one.[1205][U+000F][SP]R-Right?",
     "nom_fr": "Homme",
-    "texte_fr": "Mais j'en doute.[1205][U+000F] Pas vrai?"
+    "texte_fr": "Mais j'en doute.[1205][U+000F] Pas vrai ?"
   },
   {
     "id": 95,
@@ -1522,7 +1522,7 @@
     "nom_orig": "Man",
     "texte_orig": "Now[SP]they're[SP]saying[SP]Jumping[SP]Geezer[SP]is[SP]a[SP]real\nthing[SP]that[SP]chases[SP]cars[SP]down[SP]mountain[SP]passes.\nIs[SP]there[SP]anything[SP]like[SP]that[SP]at[SP]Mt.[SP]Katatsumuri?",
     "nom_fr": "Homme",
-    "texte_fr": "Maintenant on dit que le Vieux Sauteur est\nune vraie chose qui poursuit les voitures\nen montagne. Y a-t-il ça au Mt Katatsumuri?"
+    "texte_fr": "Maintenant on dit que le Vieux Sauteur est une\nvraie chose qui poursuit les voitures en\nmontagne. Y a-t-il ça au Mt Katatsumuri ?"
   },
   {
     "id": 98,
@@ -1538,7 +1538,7 @@
     "nom_orig": "Man",
     "texte_orig": "M-Most[SP]things[SP]don't[SP]bother[SP]me...[SP]But[SP]this...\nHave[SP]you[SP]heard?[SP]That...[SP]Kudan...[SP]Ugh,[SP]I[SP]wish\nI'd[SP]never[SP]heard[SP]of[SP]it.",
     "nom_fr": "Homme",
-    "texte_fr": "La plupart des choses m'indiffèrent... Mais\nce... Kudan... Ugh, je préférerais l'ignorer."
+    "texte_fr": "La plupart des choses m'indiffèrent...\nMais ce... Kudan... Ugh, je\npréférerais l'ignorer."
   },
   {
     "id": 99,
@@ -1569,7 +1569,7 @@
     "nom_orig": "Man",
     "texte_orig": "What[SP]kind[SP]of[SP]music's[SP]on[SP]it?[SP]Well,[SP]you'll[SP]have\nto[SP]find[SP]that[SP]out[SP]for[SP]yourself.",
     "nom_fr": "Homme",
-    "texte_fr": "Quelle musique dessus? Tu\ndevras le découvrir toi-même."
+    "texte_fr": "Quelle musique dessus ? Tu devras\nle découvrir toi-même."
   },
   {
     "id": 101,
@@ -1585,7 +1585,7 @@
     "nom_orig": "Man",
     "texte_orig": "There's[SP]some[SP]creature[SP]called[SP]a[SP]Dresser[SP]Hag[SP]at\nthe[SP]abandoned[SP]factory.[SP]It[SP]yells,[SP][1432][NULL][NULL][0014]Get[SP]in[SP]here![1432][NULL][NULL][0014]\nat[SP]anyone[SP]who[SP]passes[SP]by.[SP]Scary,[SP]huh...?",
     "nom_fr": "Homme",
-    "texte_fr": "Il y a une créature appelée Mégère à\nCommode à l'usine. Elle crie [1432][NULL][NULL][0014]Viens\nici![1432][NULL][NULL][0014] aux passants. Effrayant, non...?"
+    "texte_fr": "Il y a une créature appelée Mégère à\nCommode à l'usine. Elle crie [1432][NULL][NULL][0014]Viens ici ![1432][NULL][NULL][0014]\naux passants. Effrayant, non... ?"
   },
   {
     "id": 102,
@@ -1616,7 +1616,7 @@
     "nom_orig": "Man",
     "texte_orig": "As[SP]I[SP]recall,[SP]word[SP]is[SP]their[SP]quality[SP]and[SP]prices\nare[SP]average.[1205][U+000F][SP]Me,[SP]I[SP]think[SP]it's[SP]an[SP]ingenious\nway[SP]to[SP]do[SP]business.",
     "nom_fr": "Homme",
-    "texte_fr": "Qualité et prix moyens.[1205][U+000F] Perso, je\ntrouve que c'est malin de faire ça."
+    "texte_fr": "Qualité et prix moyens.[1205][U+000F] Perso, je trouve\nque c'est malin de faire ça."
   },
   {
     "id": 104,
@@ -1647,7 +1647,7 @@
     "nom_orig": "Man",
     "texte_orig": "As[SP]I[SP]recall,[SP]word[SP]is[SP]their[SP]quality[SP]is[SP]good,\nbut[SP]their[SP]prices[SP]are[SP]high.[1205][U+000F][SP]Me,[SP]I[SP]think[SP]it's[SP]an\ningenious[SP]way[SP]to[SP]do[SP]business.",
     "nom_fr": "Homme",
-    "texte_fr": "Qualité bonne, mais cher.[1205][U+000F] Perso, je\ntrouve que c'est malin de faire ça."
+    "texte_fr": "Qualité bonne, mais cher.[1205][U+000F] Perso, je trouve\nque c'est malin de faire ça."
   },
   {
     "id": 106,
@@ -1678,7 +1678,7 @@
     "nom_orig": "Man",
     "texte_orig": "As[SP]I[SP]recall,[SP]word[SP]is[SP]they're[SP]cheap,[SP]but[SP]not\ngreat[SP]quality.[1205][U+000F][SP]Me,[SP]I[SP]think[SP]it's[SP]an[SP]ingenious\nway[SP]to[SP]do[SP]business.",
     "nom_fr": "Homme",
-    "texte_fr": "Pas cher mais mauvaise qualité.[1205][U+000F]\nPerso, c'est très malin."
+    "texte_fr": "Pas cher mais mauvaise qualité.[1205][U+000F] Perso, c'est\ntrès malin."
   },
   {
     "id": 108,
@@ -1758,7 +1758,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]selection\nis[SP]bad,[SP]but[SP]the[SP]buyback[SP]prices[SP]are[SP]great.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F] Ils ont\ndes difficultés financières aussi?[1205][U+000F] Choix\nlimité, mais d'excellents prix de rachat."
+    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nIls ont des difficultés financières aussi ?[1205][U+000F] Choix\nlimité, mais d'excellents prix de rachat."
   },
   {
     "id": 113,
@@ -1774,7 +1774,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]prices\nare[SP]just[SP]right,[SP]but[SP]the[SP]quality[SP]is[SP]so-so.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F] Les prix\nsont corrects, mais la qualité est moyenne."
+    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nLes prix sont corrects, mais la qualité est moyenne."
   },
   {
     "id": 114,
@@ -1790,7 +1790,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]quality\nis[SP]great,[SP]but[SP]the[SP]prices[SP]are[SP]pretty[SP]high.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F] La\nqualité est top, mais les prix sont élevés."
+    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nLa qualité est top, mais les prix sont élevés."
   },
   {
     "id": 115,
@@ -1806,7 +1806,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]selection\nis[SP]great,[SP]but[SP]the[SP]buyback[SP]prices[SP]aren't[SP]much.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F] Ils ont\ndes difficultés financières aussi?[1205][U+000F] Choix\nexcellent, mais prix de rachat dérisoires."
+    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nIls ont des difficultés financières aussi ?[1205][U+000F] Choix\nexcellent, mais prix de rachat dérisoires."
   },
   {
     "id": 116,
@@ -1822,7 +1822,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]quality\nand[SP]prices[SP]are[SP]average,[SP]I[SP]hear.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F] La\nqualité et les prix sont moyens, paraît-il."
+    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nLa qualité et les prix sont moyens, paraît-il."
   },
   {
     "id": 117,
@@ -1838,7 +1838,7 @@
     "nom_orig": "Man",
     "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.\nThey[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]their[SP]prices\nand[SP]quality[SP]are[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Jolly Roger vend des armes. Ils s'y\nmettent tard. Prix et qualité moyens."
+    "texte_fr": "Même Jolly Roger vend des armes.\nIls s'y mettent tard. Prix et qualité moyens."
   },
   {
     "id": 118,
@@ -1854,7 +1854,7 @@
     "nom_orig": "Man",
     "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.\nThey[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]their[SP]prices\nare[SP]low,[SP]but[SP]so[SP]is[SP]the[SP]quality.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Jolly Roger vend des armes. Ils s'y\nmettent tard. Prix bas, faible qualité."
+    "texte_fr": "Même Jolly Roger vend des armes.\nIls s'y mettent tard. Prix bas, faible qualité."
   },
   {
     "id": 119,
@@ -1870,7 +1870,7 @@
     "nom_orig": "Man",
     "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.\nThey[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]the[SP]buyback\nprices[SP]are[SP]low,[SP]but[SP]their[SP]selection's[SP]great.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Jolly Roger vend des armes. Le\nrachat est bas, mais super sélection."
+    "texte_fr": "Même Jolly Roger vend des armes.\nLe rachat est bas, mais super sélection."
   },
   {
     "id": 120,
@@ -1886,7 +1886,7 @@
     "nom_orig": "Man",
     "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.\nThey[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]the[SP]buyback\nprices[SP]are[SP]good,[SP]but[SP]their[SP]selection's[SP]bad.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Jolly Roger vend des armes. Le\nrachat est bon, mais mauvaise sélection."
+    "texte_fr": "Même Jolly Roger vend des armes.\nLe rachat est bon, mais mauvaise sélection."
   },
   {
     "id": 121,
@@ -1902,7 +1902,7 @@
     "nom_orig": "Man",
     "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.\nThey[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]their[SP]prices\nare[SP]high,[SP]but[SP]you[SP]get[SP]good-quality[SP]stuff.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Jolly Roger vend des armes. Les prix\nsont élevés, mais la qualité est là."
+    "texte_fr": "Même Jolly Roger vend des armes.\nLes prix sont élevés, mais la qualité est là."
   },
   {
     "id": 122,
@@ -1934,7 +1934,7 @@
     "nom_orig": "Man",
     "texte_orig": "Huh,[SP]so[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]is[SP]getting[SP]in\non[SP]the[SP]armor[SP]market.[1205][U+000F][SP]It[SP]seems[SP]the[SP]quality\nis[SP]low,[SP]but[SP]it's[SP]cheap,[SP]at[SP]least.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida se lance dans les armures.[1205][U+000F]\nQualité faible, mais c'est pas cher."
+    "texte_fr": "Rosa Candida se lance dans les\narmures.[1205][U+000F] Qualité faible, mais c'est pas cher."
   },
   {
     "id": 124,
@@ -1950,7 +1950,7 @@
     "nom_orig": "Man",
     "texte_orig": "Huh,[SP]so[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]is[SP]getting[SP]in\non[SP]the[SP]armor[SP]market.[1205][U+000F][SP]It[SP]seems[SP]the[SP]quality\nis[SP]great,[SP]but[SP]you[SP]pay[SP]through[SP]the[SP]nose.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida se lance dans les armures.[1205][U+000F]\nQualité top, mais ça coûte un bras."
+    "texte_fr": "Rosa Candida se lance dans les\narmures.[1205][U+000F] Qualité top, mais ça coûte un bras."
   },
   {
     "id": 125,
@@ -1966,7 +1966,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][U+000F][SP]I'm\nsurprised,[SP]I[SP]admit.[SP]They[SP]say[SP]their[SP]quality[SP]and\nprices[SP]are[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Donc Anima Mundi vend des armures...[1205][U+000F] Je\nsuis surpris. Qualité et prix moyens."
+    "texte_fr": "Donc Anima Mundi vend des armures...[1205][U+000F]\nJe suis surpris. Qualité et prix moyens."
   },
   {
     "id": 126,
@@ -1998,7 +1998,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][U+000F][SP]I'm\nsurprised,[SP]I[SP]admit.[SP]They[SP]say[SP]their[SP]selection[SP]is\nfantastic,[SP]but[SP]their[SP]buyback[SP]prices[SP]are[SP]low.",
     "nom_fr": "Homme",
-    "texte_fr": "Anima Mundi vend des armures...[1205][U+000F] Choix\nfantastique, mais prix de rachat bas."
+    "texte_fr": "Anima Mundi vend des armures...[1205][U+000F]\nChoix fantastique, mais prix de rachat bas."
   },
   {
     "id": 128,
@@ -2014,7 +2014,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][U+000F][SP]I'm\nsurprised,[SP]I[SP]admit.[SP]They[SP]say[SP]the[SP]quality[SP]is\ngreat,[SP]but[SP]it's[SP]expensive[SP]stuff.",
     "nom_fr": "Homme",
-    "texte_fr": "Anima Mundi vend des armures...[1205][U+000F] Qualité\nsuper, mais matos hors de prix."
+    "texte_fr": "Anima Mundi vend des armures...[1205][U+000F]\nQualité super, mais matos hors de prix."
   },
   {
     "id": 129,
@@ -2030,7 +2030,7 @@
     "nom_orig": "Man",
     "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]selection[SP]is[SP]bad,\nbut[SP]they[SP]have[SP]high[SP]buyback[SP]prices.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les armures?[1205][U+000F]\nMauvais choix, mais bon rachat."
+    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Mauvais choix, mais bon rachat."
   },
   {
     "id": 130,
@@ -2046,7 +2046,7 @@
     "nom_orig": "Man",
     "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]quality[SP]and\nprices[SP]are[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les armures?[1205][U+000F]\nQualité et prix dans la moyenne."
+    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Qualité et prix dans la moyenne."
   },
   {
     "id": 131,
@@ -2062,7 +2062,7 @@
     "nom_orig": "Man",
     "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]quality[SP]is[SP]great,\nbut[SP]their[SP]prices[SP]are[SP]pretty[SP]high.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les armures?[1205][U+000F]\nQualité géniale, mais très cher."
+    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Qualité géniale, mais très cher."
   },
   {
     "id": 132,
@@ -2078,7 +2078,7 @@
     "nom_orig": "Man",
     "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]stuff[SP]is[SP]cheap,\nbut[SP]not[SP]the[SP]best[SP]quality.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les armures?[1205][U+000F]\nPas cher, mais de mauvaise qualité."
+    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Pas cher, mais de mauvaise qualité."
   },
   {
     "id": 133,
@@ -2094,7 +2094,7 @@
     "nom_orig": "Man",
     "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]selection[SP]is[SP]pretty\ngood,[SP]but[SP]they[SP]have[SP]low[SP]buyback[SP]prices.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les\narmures?[1205][U+000F] Bon choix, mais rachat bas."
+    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Bon choix, mais rachat bas."
   },
   {
     "id": 134,
@@ -2110,7 +2110,7 @@
     "nom_orig": "Man",
     "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner\nis[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]the[SP]selection\nis[SP]good,[SP]but[SP]their[SP]buyback[SP]prices[SP]are[SP]low.",
     "nom_fr": "Homme",
-    "texte_fr": "Des armures chez London Clothier?\nPatron malin. Bon choix, rachat bas."
+    "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Bon choix, rachat bas."
   },
   {
     "id": 135,
@@ -2126,7 +2126,7 @@
     "nom_orig": "Man",
     "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner\nis[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]it's[SP]cheap,\nbut[SP]not[SP]the[SP]greatest[SP]quality.",
     "nom_fr": "Homme",
-    "texte_fr": "Des armures chez London Clothier? Patron\nmalin. Pas cher, qualité moyenne."
+    "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Pas cher, qualité moyenne."
   },
   {
     "id": 136,
@@ -2142,7 +2142,7 @@
     "nom_orig": "Man",
     "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner\nis[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]it's[SP]high-\nquality[SP]stuff,[SP]but[SP]expensive.",
     "nom_fr": "Homme",
-    "texte_fr": "Des armures chez London Clothier?\nPatron malin. Haute qualité, très cher."
+    "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Haute qualité, très cher."
   },
   {
     "id": 137,
@@ -2158,7 +2158,7 @@
     "nom_orig": "Man",
     "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner\nis[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]the[SP]quality\nand[SP]prices[SP]there[SP]are[SP]pretty[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Des armures chez London Clothier?\nPatron malin. Qualité et prix moyens."
+    "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Qualité et prix moyens."
   },
   {
     "id": 138,
@@ -2174,7 +2174,7 @@
     "nom_orig": "Man",
     "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner\nis[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]the[SP]selection\nis[SP]bad,[SP]but[SP]their[SP]buyback[SP]prices[SP]are[SP]high.",
     "nom_fr": "Homme",
-    "texte_fr": "Des armures chez London Clothier? Patron\nmalin. Mauvais choix, bon rachat."
+    "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Mauvais choix, bon rachat."
   },
   {
     "id": 139,
@@ -2189,7 +2189,7 @@
     "nom_orig": "Man",
     "texte_orig": "Why[SP]don't[SP]you[SP]enter[SP]the[SP]magazine[SP]sweepstakes\nsometime?",
     "nom_fr": "Homme",
-    "texte_fr": "Fais les concours des magazines un jour."
+    "texte_fr": "Fais les concours\ndes magazines un jour."
   },
   {
     "id": 140,
@@ -2205,7 +2205,7 @@
     "nom_orig": "Man",
     "texte_orig": "Winners[SP]get[SP]real[SP]weapons[SP]and[SP]items.[SP]As[SP]I\nrecall,[SP]it's[SP]hard[SP]to[SP]win,[SP]but[SP]you[SP]can[SP]get\nsome[SP]nice[SP]stuff[SP]if[SP]you[SP]do.",
     "nom_fr": "Homme",
-    "texte_fr": "On y gagne des armes et objets. C'est\ndur de gagner, mais les prix sont beaux."
+    "texte_fr": "On y gagne des armes et objets.\nC'est dur de gagner, mais les prix sont beaux."
   },
   {
     "id": 141,
@@ -2220,7 +2220,7 @@
     "nom_orig": "Man",
     "texte_orig": "Why[SP]don't[SP]you[SP]enter[SP]the[SP]magazine[SP]sweepstakes\nsometime?",
     "nom_fr": "Homme",
-    "texte_fr": "Fais les concours des magazines un jour."
+    "texte_fr": "Fais les concours\ndes magazines un jour."
   },
   {
     "id": 142,
@@ -2236,7 +2236,7 @@
     "nom_orig": "Man",
     "texte_orig": "Winners[SP]get[SP]real[SP]weapons[SP]and[SP]items.[SP]As[SP]I\nrecall,[SP]you[SP]rarely[SP]win,[SP]but[SP]you[SP]can[SP]get\nsome[SP]rare[SP]stuff[SP]if[SP]you[SP]do.",
     "nom_fr": "Homme",
-    "texte_fr": "On y gagne des armes et objets. C'est\nrare de gagner, mais c'est du rare."
+    "texte_fr": "On y gagne des armes et objets.\nC'est rare de gagner, mais c'est du rare."
   },
   {
     "id": 143,
@@ -2251,7 +2251,7 @@
     "nom_orig": "Man",
     "texte_orig": "Why[SP]don't[SP]you[SP]enter[SP]the[SP]magazine[SP]sweepstakes\nsometime?",
     "nom_fr": "Homme",
-    "texte_fr": "Fais les concours des magazines un jour."
+    "texte_fr": "Fais les concours\ndes magazines un jour."
   },
   {
     "id": 144,
@@ -2267,7 +2267,7 @@
     "nom_orig": "Man",
     "texte_orig": "Winners[SP]get[SP]real[SP]weapons[SP]and[SP]items.[SP]As[SP]I\nrecall,[SP]it's[SP]not[SP]hard[SP]to[SP]win,[SP]but[SP]you[SP]won't\nget[SP]anything[SP]good.",
     "nom_fr": "Homme",
-    "texte_fr": "On y gagne des armes et objets. C'est\nfacile de gagner, mais c'est pas ouf."
+    "texte_fr": "On y gagne des armes et objets.\nC'est facile de gagner, mais c'est pas ouf."
   },
   {
     "id": 145,
@@ -2283,7 +2283,7 @@
     "nom_orig": "Man",
     "texte_orig": "Sounds[SP]like[SP]Mu[SP]opened[SP]a[SP]casino.[SP]Well,[SP]no[SP]one\never[SP]went[SP]broke[SP]running[SP]a[SP]gambling[SP]parlor...\nI[SP]hear[SP]it's[SP]easy[SP]to[SP]win[SP]at[SP]poker.",
     "nom_fr": "Homme",
-    "texte_fr": "Mu a ouvert un casino. Personne n'a\njamais fait faillite avec ça... On\ngagne facilement au poker."
+    "texte_fr": "Mu a ouvert un casino. Personne n'a\njamais fait faillite avec ça...\nOn gagne facilement au poker."
   },
   {
     "id": 146,
@@ -2299,7 +2299,7 @@
     "nom_orig": "Man",
     "texte_orig": "Sounds[SP]like[SP]Mu[SP]opened[SP]a[SP]casino.[SP]Well,[SP]no[SP]one\never[SP]went[SP]broke[SP]running[SP]a[SP]gambling[SP]parlor...\nI[SP]hear[SP]it's[SP]easy[SP]to[SP]win[SP]at[SP]the[SP]slots.",
     "nom_fr": "Homme",
-    "texte_fr": "Mu a ouvert un casino. Personne n'a\njamais fait faillite avec ça... On\ngagne facilement aux machines."
+    "texte_fr": "Mu a ouvert un casino. Personne n'a\njamais fait faillite avec ça...\nOn gagne facilement aux machines."
   },
   {
     "id": 147,
@@ -2315,7 +2315,7 @@
     "nom_orig": "Man",
     "texte_orig": "Sounds[SP]like[SP]Mu[SP]opened[SP]a[SP]casino.[SP]Well,[SP]no[SP]one\never[SP]went[SP]broke[SP]running[SP]a[SP]gambling[SP]parlor...\nI[SP]hear[SP]it's[SP]easy[SP]to[SP]win[SP]at[SP]blackjack.",
     "nom_fr": "Homme",
-    "texte_fr": "Mu a ouvert un casino. Personne n'a\njamais fait faillite avec ça... On\ngagne facilement au blackjack."
+    "texte_fr": "Mu a ouvert un casino. Personne n'a\njamais fait faillite avec ça...\nOn gagne facilement au blackjack."
   },
   {
     "id": 148,
@@ -2331,7 +2331,7 @@
     "nom_orig": "Man",
     "texte_orig": "I[SP]wonder[SP]if[SP]there's[SP]really[SP]any[SP]such[SP]thing[SP]as\na[SP]legendary[SP]weapon.[SP]It's[SP]just[SP]that[SP]I[SP]heard[SP]a\nrumor[SP]they[SP]have[SP]one[SP]at[SP]Shiraishi[SP]Ramen...",
     "nom_fr": "Homme",
-    "texte_fr": "Une arme légendaire, ça existe vraiment? Une\nrumeur dit que Shiraishi Ramen en aurait\nune..."
+    "texte_fr": "Une arme légendaire, ça existe vraiment ?\nUne rumeur dit que Shiraishi Ramen en aurait une..."
   },
   {
     "id": 149,
@@ -2347,7 +2347,7 @@
     "nom_orig": "Man",
     "texte_orig": "Do[SP]you[SP]believe[SP]in[SP]legendary[SP]weapons?[SP]Wanna[SP]go\nsee[SP]one[SP]for[SP]yourself?[SP]Go[SP]check[SP]out[SP]Clair[SP]de\nLune,[SP]I[SP]hear[SP]they[SP]have[SP]one.",
     "nom_fr": "Homme",
-    "texte_fr": "Tu crois aux armes légendaires? Tu veux en\nvoir une? Clair de Lune en a une, paraît-il."
+    "texte_fr": "Tu crois aux armes légendaires ? Tu veux\nen voir une ? Clair de Lune en a une, paraît-il."
   },
   {
     "id": 150,
@@ -2363,7 +2363,7 @@
     "nom_orig": "Man",
     "texte_orig": "Rumor[SP]has[SP]it[SP]the[SP]owner[SP]of[SP]Time[SP]Castle[SP]won't\nadmit[SP]he[SP]has[SP]a[SP]legendary[SP]weapon.[SP]They[SP]say[SP]he's\ntrying[SP]to[SP]drive[SP]up[SP]the[SP]price...[SP]Shrewd[SP]man.",
     "nom_fr": "Homme",
-    "texte_fr": "Le proprio de Time Castle n'admet\npas avoir une arme légendaire. Il\nveut faire monter le prix."
+    "texte_fr": "Le proprio de Time Castle n'admet pas avoir\nune arme légendaire. Il veut faire monter le prix."
   },
   {
     "id": 151,
@@ -2379,7 +2379,7 @@
     "nom_orig": "Man",
     "texte_orig": "Time[SP]Castle[SP]doesn't[SP]have[SP]its[SP]legendary[SP]weapon\nyet,[SP]I[SP]hear.[SP]The[SP]seller[SP]is[SP]still[SP]waiting[SP]at\nthe[SP]abandoned[SP]factory[SP]for[SP]it[SP]to[SP]be[SP]picked[SP]up.",
     "nom_fr": "Homme",
-    "texte_fr": "Time Castle n'a pas encore son arme\nlégendaire. Le vendeur l'attend à l'usine\nabandonnée."
+    "texte_fr": "Time Castle n'a pas encore son arme légendaire.\nLe vendeur l'attend à l'usine abandonnée."
   },
   {
     "id": 152,
@@ -2395,7 +2395,7 @@
     "nom_orig": "Man",
     "texte_orig": "Wanna[SP]hear[SP]a[SP]bizarre[SP]rumor?[SP]Demons[SP]stole[SP]the\nlegendary[SP]weapon[SP]at[SP]Time[SP]Castle.[SP]Pretty[SP]hard\nto[SP]swallow,[SP]isn't[SP]it?",
     "nom_fr": "Homme",
-    "texte_fr": "Rumeur bizarre: des démons ont volé l'arme\nlégendaire de Time Castle. Dur à avaler, non?"
+    "texte_fr": "Rumeur bizarre : des démons ont volé l'arme\nlégendaire de Time Castle. Dur à avaler, non ?"
   },
   {
     "id": 153,
@@ -2442,7 +2442,7 @@
     "nom_orig": "Man",
     "texte_orig": "Giving[SP]a[SP]weapon[SP]to[SP]a[SP]lady[SP]as[SP]a[SP]present...[1205][U+000F]\nThese[SP]are[SP]crazy[SP]times[SP]we[SP]live[SP]in.",
     "nom_fr": "Homme",
-    "texte_fr": "Offrir une arme à une\ndame...[1205][U+000F] Quelle époque folle."
+    "texte_fr": "Offrir une arme à une dame...[1205][U+000F]\nQuelle époque folle."
   },
   {
     "id": 156,
@@ -2458,7 +2458,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "If[SP]I'm[SP]gonna[SP]date[SP]someone[SP]new,[SP]I'd[SP]rather[SP]go\nwith[SP]a[SP]Cuss[SP]High[SP]guy.[1205][U+000F][SP]Everyone[SP]at[SP]Sevens[SP]is\nunder[SP]the[SP]principal's[SP]thumb.[SP]Snooooore!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Quitte à sortir avec un gars, je\npréfère Kakasu.[1205][U+000F] À Seven, ils sont\ntous sous la coupe de Hanya. Nul!"
+    "texte_fr": "Quitte à sortir avec un gars, je préfère Kakasu.[1205][U+000F]\nÀ Seven, ils sont tous sous la coupe de Hanya. Nul !"
   },
   {
     "id": 157,
@@ -2489,7 +2489,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Oohhhh...[SP]I[SP]wish[SP]I[SP]could[SP]go.[SP]But[SP]I[SP]don't[SP]have\na[SP]mask...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "J'aimerais y aller. Mais\nje n'ai pas de masque."
+    "texte_fr": "J'aimerais y aller.\nMais je n'ai pas de masque."
   },
   {
     "id": 159,
@@ -2504,7 +2504,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Yeee![SP]I[SP]did[SP]it,[SP]I[SP]did[SP]it![1205][U+000F][SP]I[SP]got[SP]tickets[SP]to\nthe[SP]masquerade![1205][U+000F][SP]It's[SP]the[SP]perfect[SP]chance[SP]to\nget[SP]a[SP]Cuss[SP]High[SP]boyfriend!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Yeee! J'ai eu des billets pour le bal masqué![1205][U+000F]\nParfait pour trouver un petit ami de Kakasu!"
+    "texte_fr": "Yeee ! J'ai eu des billets pour le bal masqué ![1205][U+000F]\nParfait pour trouver un petit ami de Kakasu !"
   },
   {
     "id": 160,
@@ -2520,7 +2520,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]gotta[SP]make[SP]sure[SP]to[SP]dress[SP]up.[1205][U+000F][SP]Oh[SP]yeah,[SP]and\nI[SP]should[SP]invite[SP]my[SP]friends[SP]too!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Faut que je sois bien habillée.[1205][U+000F] Et\nje devrais inviter mes copines!"
+    "texte_fr": "Faut que je sois bien habillée.[1205][U+000F]\nEt je devrais inviter mes copines !"
   },
   {
     "id": 161,
@@ -2535,7 +2535,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "*sigh*[SP]Muses[SP]is[SP]made[SP]up[SP]of[SP]Sevens[SP]students,\nright?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "*soupir* Muses n'a que\ndes filles de Seven, non?"
+    "texte_fr": "*soupir* Muses n'a que des filles\nde Seven, non ?"
   },
   {
     "id": 162,
@@ -2551,7 +2551,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "So[SP]they're[SP]all[SP]around[SP]my[SP]age.[1205][U+000F][SP]They're[SP]so[SP]lucky,\ngetting[SP]to[SP]make[SP]their[SP]idol[SP]debuts...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Elles ont mon âge.[1205][U+000F] Trop de chance\nde débuter comme idoles..."
+    "texte_fr": "Elles ont mon âge.[1205][U+000F] Trop de chance de\ndébuter comme idoles..."
   },
   {
     "id": 163,
@@ -2583,7 +2583,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]wonder[SP]what[SP]nationality[SP]that[SP]third[SP]member[SP]is.\nShe[SP]looked[SP]white,[SP]but[SP]her[SP]Japanese[SP]was[SP]really\ngood.[SP]Maybe[SP]she[SP]grew[SP]up[SP]here.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "De quelle nationalité est la 3e membre?\nElle a l'air blanche, mais parle bien\njaponais. Elle a grandi ici?"
+    "texte_fr": "De quelle nationalité est la 3e membre ?\nElle a l'air blanche, mais parle bien\njaponais. Elle a grandi ici ?"
   },
   {
     "id": 165,
@@ -2598,7 +2598,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]there[SP]was[SP]a[SP]Muses[SP]show[SP]at[SP]the[SP]outdoor\nconcert[SP]hall,[SP]right?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Il y a eu un concert de Muses\nà la salle en plein air, non?"
+    "texte_fr": "Il y a eu un concert de Muses à la\nsalle en plein air, non ?"
   },
   {
     "id": 166,
@@ -2613,7 +2613,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "And[SP]Muses[SP]was[SP]a[SP]trio,[SP]right?[1205][U+000F][SP]Huh...\nThat's[SP]weird...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Et Muses était un trio, non?[1205][U+000F] Huh... Étrange..."
+    "texte_fr": "Et Muses était un trio, non ?[1205][U+000F]\nHuh... Étrange..."
   },
   {
     "id": 167,
@@ -2645,7 +2645,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Everyone's[SP]panicking[SP]about[SP]terrorists[SP]and[SP]that\nstuff,[SP]but[SP]why[SP]worry[SP]so[SP]much?[1205][U+000F][SP]I[SP]bet[SP]it'll[SP]all\ntake[SP]care[SP]of[SP]itself.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Tout le monde panique à cause des terroristes.\nMais pourquoi?[1205][U+000F] Ça va s'arranger tout seul."
+    "texte_fr": "Tout le monde panique à cause des terroristes.\nMais pourquoi ?[1205][U+000F] Ça va s'arranger tout seul."
   },
   {
     "id": 169,
@@ -2691,7 +2691,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]can't[SP]believe[SP]they[SP]blew[SP]up[SP]GOLD...[1205][U+000F][SP]This\ncan't[SP]be[SP]real.[SP]I[SP]mean,[SP]nothing[SP]bad[SP]ever\nhappened[SP]here[SP]before[SP]now.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ils ont fait exploser GOLD...[1205][U+000F] C'est\nfaux. Rien de mal n'arrive jamais ici."
+    "texte_fr": "Ils ont fait exploser GOLD...[1205][U+000F]\nC'est faux. Rien de mal n'arrive jamais ici."
   },
   {
     "id": 172,
@@ -2707,7 +2707,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "What's[SP]going[SP]to[SP]happen[SP]to[SP]us?[SP]We'll[SP]be[SP]okay,\nwon't[SP]we?[1205][U+000A][SP]They're[SP]gonna[SP]catch[SP]the[SP]terrorists\nand[SP]make[SP]everything[SP]all[SP]right[SP]again,[SP]right?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Qu'est-ce qui va nous arriver? On va s'en\nsortir, non?[1205][U+000A] Ils vont attraper les terroristes\net tout va redevenir comme avant, hein?"
+    "texte_fr": "Qu'est-ce qui va nous arriver ? On va s'en sortir,\nnon ?[1205][U+000A] Ils vont attraper les terroristes\net tout va redevenir comme avant, hein ?"
   },
   {
     "id": 173,
@@ -2738,7 +2738,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "But[SP]I[SP]hear[SP]they[SP]have[SP]a[SP]suspect[SP]already,[SP]so[SP]this\nterrorist[SP]stuff[SP]will[SP]be[SP]over[SP]soon.[1205][U+000F][SP]Right?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Mais ils ont déjà un suspect, alors\nce sera bientôt fini.[1205][U+000F] N'est-ce pas?"
+    "texte_fr": "Mais ils ont déjà un suspect, alors ce sera\nbientôt fini.[1205][U+000F] N'est-ce pas ?"
   },
   {
     "id": 175,
@@ -2753,7 +2753,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Huh?[SP]The[SP]In[SP]Lak'ech?[1205][U+000F][SP]Yeah...[SP]I[SP]saw[SP]that[SP]on[SP]the\nnews[SP]and[SP]rushed[SP]to[SP]the[SP]bookstore,[SP]but[SP]they\nwere[SP]all[SP]sold[SP]out.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hein? L'In Lak'ech?[1205][U+000F] J'ai vu aux infos et j'ai\ncouru à la librairie, mais rupture de stock."
+    "texte_fr": "Hein ? L'In Lak'ech ?[1205][U+000F] J'ai vu aux infos\net j'ai couru à la librairie, mais rupture de stock."
   },
   {
     "id": 176,
@@ -2800,7 +2800,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "The[SP]end[SP]of[SP]the[SP]world's[SP]pretty[SP]harsh,[SP]but[SP]doesn't\nit[SP]feel[SP]nice,[SP]in[SP]a[SP]way?[1205][U+000F][SP]It's[SP]not[SP]like[SP]anything\ngood[SP]happened[SP]down[SP]there[SP]anyway.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "La fin du monde c'est dur, mais\nça fait du bien, non?[1205][U+000F] Rien de bon\nne se passe ici, de toute façon."
+    "texte_fr": "La fin du monde c'est dur, mais ça fait du bien,\nnon ?[1205][U+000F] Rien de bon ne se passe ici, de toute façon."
   },
   {
     "id": 179,
@@ -2862,7 +2862,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Will[SP]that[SP]really[SP]kill[SP]everyone[SP]down[SP]there?[1205][U+000A]\nMaybe[SP]they'll[SP]all[SP]just[SP]be[SP]kept[SP]alive,[SP]but\nfrozen[SP]solid.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ça tuera tout le monde en bas?[1205][U+000A] Peut-être\nqu'ils seront maintenus en vie, mais gelés."
+    "texte_fr": "Ça tuera tout le monde en bas ?[1205][U+000A] Peut-être\nqu'ils seront maintenus en vie, mais gelés."
   },
   {
     "id": 183,
@@ -2877,7 +2877,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]heard[SP]from[SP]someone[SP]else[SP]that[SP]once[SP]the[SP]Grand\nCross[SP]happens,[SP]gas[SP]from[SP]the[SP]other[SP]planets[SP]is\ngonna[SP]cover[SP]the[SP]Earth.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "J'ai entendu dire que quand la\nCroix aura lieu, les gaz des autres\nplanètes vont recouvrir la Terre."
+    "texte_fr": "J'ai entendu dire que quand la Croix\naura lieu, les gaz des autres planètes\nvont recouvrir la Terre."
   },
   {
     "id": 184,
@@ -2893,7 +2893,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Some[SP]planets[SP]are[SP]mostly[SP]made[SP]of[SP]gases,[SP]right?[1205][U+000A]\nThose[SP]gases[SP]are[SP]supposedly[SP]poison[SP]to[SP]humans,\nand[SP]that's[SP]how[SP]everyone[SP]down[SP]there'll[SP]die.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Certaines planètes sont faites\nde gaz, non?[1205][U+000A] Ils sont toxiques,\net tout le monde en bas mourra."
+    "texte_fr": "Certaines planètes sont faites de gaz, non ?[1205][U+000A]\nIls sont toxiques, et tout le monde en bas mourra."
   },
   {
     "id": 185,
@@ -2908,7 +2908,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]heard[SP]some[SP]people[SP]around[SP]say[SP]that[SP]when[SP]the\nGrand[SP]Cross[SP]is[SP]complete,[SP]the[SP]balance[SP]of[SP]gravity\nwill[SP]be[SP]thrown[SP]off[SP]and[SP]stop[SP]Earth's[SP]rotation.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Avec la Croix Cosmique, l'équilibre\nde la gravité sera rompu et\narrêtera la rotation de la Terre."
+    "texte_fr": "Avec la Croix Cosmique, l'équilibre de la gravité\nsera rompu et arrêtera la rotation de la Terre."
   },
   {
     "id": 186,
@@ -2924,7 +2924,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "The[SP]Earth[SP]rotates[SP]really[SP]fast,[SP]doesn't[SP]it?[1205][U+000F]\nIf[SP]that[SP]stops[SP]all[SP]of[SP]a[SP]sudden,[SP]no[SP]wonder[SP]the\nworld[SP]down[SP]there[SP]will[SP]be[SP]a[SP]mess.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "La Terre tourne vite, non?[1205][U+000F] Si ça s'arrête\nd'un coup, le monde sera un vrai chaos."
+    "texte_fr": "La Terre tourne vite, non ?[1205][U+000F] Si ça s'arrête\nd'un coup, le monde sera un vrai chaos."
   },
   {
     "id": 187,
@@ -2940,7 +2940,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]heard[SP]there[SP]are[SP]talking[SP]flowers[SP]growing[SP]in\nAoba[SP]Park.[SP]It's[SP]like[SP]a[SP]fairy[SP]tale![SP]I[SP]wonder\nif[SP]I[SP]should[SP]go[SP]to[SP]them[SP]for[SP]advice.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Des fleurs parlent au parc Aoba.\nC'est comme un conte de fées! Je\ndevrais leur demander conseil."
+    "texte_fr": "Des fleurs parlent au parc Aoba.\nC'est comme un conte de fées !\nJe devrais leur demander conseil."
   },
   {
     "id": 188,
@@ -2955,7 +2955,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]you[SP]think[SP]it's[SP]true[SP]that[SP]Zodiac's[SP]second\nfloor[SP]is[SP]a[SP]dungeon[SP]now?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "C'est vrai que le 2e étage de\nZodiac est devenu un donjon?"
+    "texte_fr": "C'est vrai que le 2e étage de Zodiac\nest devenu un donjon ?"
   },
   {
     "id": 189,
@@ -2971,7 +2971,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "My[SP]friends[SP]rave[SP]about[SP]all[SP]the[SP]items[SP]there...[1205][U+000F]\nBut[SP]it[SP]sucks![SP]Why[SP]a[SP]dungeon!?[SP]My[SP]favorite\nclub's[SP]all[SP]messed[SP]up[SP]now!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Mes amies adorent les objets\nlà-bas...[1205][U+000F] Mais c'est nul! Pourquoi\nun donjon!? Mon club est gâché!"
+    "texte_fr": "Mes amies adorent les objets là-bas...[1205][U+000F]\nMais c'est nul ! Pourquoi un donjon !? Mon club\nest gâché !"
   },
   {
     "id": 190,
@@ -2986,7 +2986,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]is[SP]it[SP]true[SP]the[SP]ghost[SP]of[SP]Hanako[SP]is\nhaunting[SP]Sevens?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, c'est vrai que le fantôme\nde Hanako hante Seven?"
+    "texte_fr": "Hé, c'est vrai que le fantôme de Hanako\nhante Seven ?"
   },
   {
     "id": 191,
@@ -3002,7 +3002,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hanako[SP]is[SP]that[SP]girl[SP]they[SP]tell[SP]ghost[SP]stories\nabout[SP]at[SP]school,[SP]right?[1205][U+000F][SP]Wow![SP]I[SP]wanna[SP]see[SP]her!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hanako, c'est cette histoire de fantôme\nà l'école, non?[1205][U+000F] Waouh! Je veux la voir!"
+    "texte_fr": "Hanako, c'est cette histoire de fantôme\nà l'école, non ?[1205][U+000F] Waouh ! Je veux la voir !"
   },
   {
     "id": 192,
@@ -3018,7 +3018,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]Bukimi?[SP]I[SP]heard[SP]a[SP]rumor[SP]it's\nbeen[SP]appearing[SP]at[SP]Cuss[SP]High.[SP]Is[SP]she[SP]a[SP]ghost\nlike[SP]Hanako?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Connais-tu Bukimi? Elle apparaîtrait à\nKakasu. C'est un fantôme comme Hanako?"
+    "texte_fr": "Connais-tu Bukimi ? Elle apparaîtrait à Kakasu.\nC'est un fantôme comme Hanako ?"
   },
   {
     "id": 193,
@@ -3034,7 +3034,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Do[SP]you[SP]know[SP]the[SP]story[SP]about[SP]some[SP]girl's[SP]ghost\nin[SP]Aoba[SP]Park?[SP]I[SP]heard[SP]from[SP]a[SP]friend[SP]of[SP]a[SP]friend\nthat[SP]she[SP]was[SP]an[SP]idol[SP]when[SP]she[SP]was[SP]alive.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Tu connais le fantôme du parc Aoba? Une\namie d'amie dit qu'elle était une idole."
+    "texte_fr": "Tu connais le fantôme du parc Aoba ?\nUne amie d'amie dit qu'elle était une idole."
   },
   {
     "id": 194,
@@ -3066,7 +3066,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]I[SP]asked[SP]my[SP]friend,[SP]and[SP]he[SP]said[SP]the[SP]thing\nat[SP]the[SP]abandoned[SP]factory[SP]is[SP]actually[SP]a[SP]Cursed\nEscort.[1205][U+0019][SP]Um...[SP]what's[SP]the[SP]difference?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "On m'a dit que le truc à l'usine est une\nEscorte Maudite.[1205][U+0019] Euh... c'est quoi la\ndifférence?"
+    "texte_fr": "On m'a dit que le truc à l'usine est une Escorte\nMaudite.[1205][U+0019] Euh... c'est quoi la différence ?"
   },
   {
     "id": 196,
@@ -3082,7 +3082,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]Kuchisake-onna[SP]is[SP]up[SP]at[SP]Mt.[SP]Iwato,[SP]right?\nI[SP]always[SP]wanted[SP]to[SP]see[SP]if[SP]that[SP]urban[SP]legend\nwas[SP]true...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Kuchisake-onna est au Mt Iwato? Je veux\nsavoir si cette légende est vraie..."
+    "texte_fr": "Kuchisake-onna est au Mt Iwato ?\nJe veux savoir si cette légende est vraie..."
   },
   {
     "id": 197,
@@ -3098,7 +3098,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "So[SP]there[SP]really[SP]was[SP]a[SP]Jumping[SP]Geezer[SP]at\nMt.[SP]Katatsumuri...[1205][U+000F][SP]These[SP]guys[SP]were[SP]talking\nabout[SP]it[SP]on[SP]the[SP]train,[SP]and[SP]it[SP]was[SP]bugging[SP]me.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Il y avait donc vraiment un Vieux Sauteur\nau Mt Katatsumuri...[1205][U+000F] Ces types en parlaient\ndans le train, et ça me tracassait."
+    "texte_fr": "Il y avait donc vraiment un Vieux Sauteur au\nMt Katatsumuri...[1205][U+000F] Ces types en parlaient\ndans le train, et ça me tracassait."
   },
   {
     "id": 198,
@@ -3114,7 +3114,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Yikes...[SP]I[SP]heard[SP]a[SP]really[SP]scary[SP]story...[SP]I-It\nwas[SP]about[SP]Kudan...[SP]No,[SP]don't[SP]make[SP]me[SP]repeat[SP]it!\nWhat[SP]am[SP]I[SP]gonna[SP]do?[SP]How[SP]am[SP]I[SP]gonna[SP]sleep?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Yikes... J'ai entendu une histoire\neffrayante... Sur Kudan... Ne me fais pas la\nrépéter! Je vais faire quoi? Comment je vais\ndormir?"
+    "texte_fr": "Yikes... J'ai entendu une histoire effrayante...\nSur Kudan... Ne me fais pas la répéter !\nJe vais faire quoi ? Comment je vais dormir ?"
   },
   {
     "id": 199,
@@ -3130,7 +3130,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "So[SP]Giga[SP]Macho[SP]really[SP]did[SP]have[SP]a[SP]secret[SP]CD.\nHuh.[SP]A[SP]friend[SP]of[SP]a[SP]friend[SP]of[SP]mine[SP]has[SP]been\nswearing[SP]up[SP]and[SP]down[SP]it's[SP]true.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Giga Macho a vraiment un CD secret.\nL'ami d'un ami a juré que c'était vrai."
+    "texte_fr": "Giga Macho a vraiment un CD secret. L'ami\nd'un ami a juré que c'était vrai."
   },
   {
     "id": 200,
@@ -3146,7 +3146,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]do[SP]you[SP]know[SP]about[SP]the[SP]Dresser[SP]Hag?[SP]They\nsay[SP]she's[SP]at[SP]the[SP]abandoned[SP]factory.[1205][U+000F][SP]What[SP]is\nthat,[SP]some[SP]kinda[SP]monster?[1205][U+000F][SP]Weird[SP]name[SP]for[SP]one.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Tu connais la Mégère à Commode?\nElle serait à l'usine abandonnée.[1205][U+000F]\nC'est un monstre?[1205][U+000F] Drôle de nom."
+    "texte_fr": "Tu connais la Mégère à Commode ? Elle serait à\nl'usine abandonnée.[1205][U+000F] C'est un monstre ?[1205][U+000F]\nDrôle de nom."
   },
   {
     "id": 201,
@@ -3162,7 +3162,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle's[SP]so[SP]cool.[SP]He[SP]sells\nweapons[SP]in[SP]secret,[SP]like[SP]one[SP]of[SP]those[SP]smugglers\nin[SP]spy[SP]movies.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Le boss de Time Castle est trop\ncool. Il vend des armes en secret,\ncomme un contrebandier de film."
+    "texte_fr": "Le boss de Time Castle est trop cool.\nIl vend des armes en secret, comme un\ncontrebandier de film."
   },
   {
     "id": 202,
@@ -3177,7 +3177,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle's[SP]so[SP]cool.[SP]He[SP]sells\nweapons[SP]in[SP]secret,[SP]like[SP]one[SP]of[SP]those[SP]smugglers\nin[SP]spy[SP]movies.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Le boss de Time Castle est trop\ncool. Il vend des armes en secret,\ncomme un contrebandier de film."
+    "texte_fr": "Le boss de Time Castle est trop cool.\nIl vend des armes en secret, comme un\ncontrebandier de film."
   },
   {
     "id": 203,
@@ -3193,7 +3193,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Looks[SP]like[SP]his[SP]stuff[SP]is[SP]expensive,[SP]but[SP]nice.\nJust[SP]like[SP]I[SP]thought[SP]it'd[SP]be!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ce qu'il a coûte cher, mais c'est\nbien. Exactement ce que je pensais!"
+    "texte_fr": "Ce qu'il a coûte cher, mais c'est bien.\nExactement ce que je pensais !"
   },
   {
     "id": 204,
@@ -3208,7 +3208,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle's[SP]so[SP]cool.[SP]He[SP]sells\nweapons[SP]in[SP]secret,[SP]like[SP]one[SP]of[SP]those[SP]smugglers\nin[SP]spy[SP]movies.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Le boss de Time Castle est trop\ncool. Il vend des armes en secret,\ncomme un contrebandier de film."
+    "texte_fr": "Le boss de Time Castle est trop cool.\nIl vend des armes en secret, comme un\ncontrebandier de film."
   },
   {
     "id": 205,
@@ -3224,7 +3224,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Looks[SP]like[SP]his[SP]stuff[SP]is[SP]cheap[SP]and[SP]crappy.\nThat's[SP]not[SP]really[SP]how[SP]I[SP]thought[SP]it'd[SP]be...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ses trucs sont pas chers et\nmerdiques. Je ne m'y attendais pas..."
+    "texte_fr": "Ses trucs sont pas chers et merdiques.\nJe ne m'y attendais pas..."
   },
   {
     "id": 206,
@@ -3239,7 +3239,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after\nall,[SP]huh?[1205][U+000F][SP]I[SP]knew[SP]it.[1205][U+000F][SP]I[SP]could[SP]tell[SP]in[SP]my\ngut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ce Tony était un contrebandier\nd'armes?[1205][U+000F] Je le savais.[1205][U+000F] Je sentais\nqu'il préparait un mauvais coup."
+    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup."
   },
   {
     "id": 207,
@@ -3255,7 +3255,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]hear[SP]his[SP]selection's[SP]good,[SP]but[SP]the[SP]resale\nvalue[SP]sucks.[SP]Like,[SP]he'll[SP]pay[SP]you[SP]barely[SP]anything\nand[SP]make[SP]a[SP]bundle[SP]selling[SP]it.[1205][U+000F][SP]What[SP]a[SP]creep.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Il a du choix, mais paie une\nmisère. Il achète rien et se fait\nun paquet en revendant.[1205][U+000F] Sale type."
+    "texte_fr": "Il a du choix, mais paie une misère.\nIl achète rien et se fait un paquet en\nrevendant.[1205][U+000F] Sale type."
   },
   {
     "id": 208,
@@ -3270,7 +3270,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after\nall,[SP]huh?[1205][U+000F][SP]I[SP]knew[SP]it.[1205][U+000F][SP]I[SP]could[SP]tell[SP]in[SP]my\ngut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ce Tony était un contrebandier\nd'armes?[1205][U+000F] Je le savais.[1205][U+000F] Je sentais\nqu'il préparait un mauvais coup."
+    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup."
   },
   {
     "id": 209,
@@ -3286,7 +3286,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]hear[SP]he[SP]sells[SP]basically[SP]junk[SP]for[SP]almost[SP]no\nmoney.[1205][U+000F][SP]That[SP]totally[SP]sounds[SP]like[SP]him.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Il vend des merdes pour presque\nrien.[1205][U+000F] Ça lui ressemble bien."
+    "texte_fr": "Il vend des merdes pour presque rien.[1205][U+000F]\nÇa lui ressemble bien."
   },
   {
     "id": 210,
@@ -3301,7 +3301,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after\nall,[SP]huh?[1205][U+000F][SP]I[SP]knew[SP]it.[1205][U+000F][SP]I[SP]could[SP]tell[SP]in[SP]my\ngut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ce Tony était un contrebandier\nd'armes?[1205][U+000F] Je le savais.[1205][U+000F] Je sentais\nqu'il préparait un mauvais coup."
+    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup."
   },
   {
     "id": 211,
@@ -3317,7 +3317,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]hear[SP]his[SP]selection[SP]and[SP]stuff's[SP]all[SP]average.\nIt's[SP]so[SP]weird[SP]he[SP]sells[SP]weapons,[SP]but[SP]they're\nall[SP]ordinary.[1205][U+000F][SP]He[SP]would,[SP]though.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ses articles sont dans la moyenne.\nC'est bizarre qu'il vende des armes\nordinaires.[1205][U+000F] C'est tout lui ça."
+    "texte_fr": "Ses articles sont dans la moyenne. C'est bizarre\nqu'il vende des armes ordinaires.[1205][U+000F]\nC'est tout lui ça."
   },
   {
     "id": 212,
@@ -3332,7 +3332,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after\nall,[SP]huh?[1205][U+000F][SP]I[SP]knew[SP]it.[1205][U+000F][SP]I[SP]could[SP]tell[SP]in[SP]my\ngut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ce Tony était un contrebandier\nd'armes?[1205][U+000F] Je le savais.[1205][U+000F] Je sentais\nqu'il préparait un mauvais coup."
+    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup."
   },
   {
     "id": 213,
@@ -3348,7 +3348,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]hear[SP]he[SP]has[SP]good[SP]stuff,[SP]but[SP]his[SP]prices[SP]are\na[SP]ripoff.[1205][U+000F][SP]That[SP]totally[SP]sounds[SP]like[SP]him.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Il a de bons trucs, mais c'est une\narnaque.[1205][U+000F] Ça lui ressemble tout à fait."
+    "texte_fr": "Il a de bons trucs, mais c'est une arnaque.[1205][U+000F]\nÇa lui ressemble tout à fait."
   },
   {
     "id": 214,
@@ -3363,7 +3363,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend des armes, non?"
+    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?"
   },
   {
     "id": 215,
@@ -3394,7 +3394,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "But[SP]they[SP]don't[SP]sell[SP]much.[SP]Trade-ins[SP]seem[SP]to[SP]be\ntheir[SP]main[SP]thing.[SP]I[SP]bet[SP]they[SP]ship[SP]the[SP]weapons\nthey[SP]buy[SP]back[SP]to[SP]the[SP]Mafia.[SP]Brrrr...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Mais ils vendent peu. Les échanges\nsont leur truc. Ils envoient les\narmes à la Mafia. Brrrr..."
+    "texte_fr": "Mais ils vendent peu. Les échanges sont\nleur truc. Ils envoient les armes à la Mafia. Brrrr..."
   },
   {
     "id": 217,
@@ -3409,7 +3409,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend des armes, non?"
+    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?"
   },
   {
     "id": 218,
@@ -3440,7 +3440,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]hear[SP]they're[SP]cheap,[SP]but[SP]low[SP]quality.[SP]The[SP]cops\nhave[SP]been[SP]cracking[SP]down,[SP]so[SP]I[SP]bet[SP]they're[SP]selling\nwhatever[SP]they[SP]can[SP]to[SP]raise[SP]money.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Pas cher, mais de mauvaise qualité.\nLes flics sévissent, ils vendent\ntout pour amasser de l'argent."
+    "texte_fr": "Pas cher, mais de mauvaise qualité. Les flics\nsévissent, ils vendent tout pour amasser de l'argent."
   },
   {
     "id": 220,
@@ -3455,7 +3455,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend des armes, non?"
+    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?"
   },
   {
     "id": 221,
@@ -3486,7 +3486,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]hear[SP]their[SP]quality's[SP]good,[SP]but[SP]it's[SP]really\nexpensive.[SP]Which[SP]means[SP]they'll[SP]sell[SP]anything\nas[SP]long[SP]as[SP]you[SP]have[SP]the[SP]cash.[SP]Brrrr...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Qualité bonne, mais vraiment cher. Ils\nvendront n'importe quoi pour de l'argent.\nBrrrr..."
+    "texte_fr": "Qualité bonne, mais vraiment cher. Ils vendront\nn'importe quoi pour de l'argent. Brrrr..."
   },
   {
     "id": 223,
@@ -3501,7 +3501,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend des armes, non?"
+    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?"
   },
   {
     "id": 224,
@@ -3532,7 +3532,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "They[SP]focus[SP]on[SP]selling,[SP]so[SP]their[SP]selection[SP]is\ngood,[SP]but[SP]they[SP]don't[SP]pay[SP]much[SP]for[SP]stuff[SP]you\nsell[SP]them.[SP]Pretty[SP]suspicious,[SP]if[SP]you[SP]ask[SP]me.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Leur sélection est bonne, mais ils\npaient mal. C'est louche, à mon avis."
+    "texte_fr": "Leur sélection est bonne, mais ils paient mal.\nC'est louche, à mon avis."
   },
   {
     "id": 226,
@@ -3547,7 +3547,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend des armes, non?"
+    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?"
   },
   {
     "id": 227,
@@ -3578,7 +3578,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]hear[SP]their[SP]quality[SP]and[SP]prices[SP]are[SP]average.\nWhat's[SP]scary[SP]is[SP]that[SP]even[SP]details[SP]like[SP]that\nare[SP]part[SP]of[SP]the[SP]rumor.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Qualité et prix moyens. Ce qui\nest effrayant, c'est que de tels\ndétails soient dans la rumeur."
+    "texte_fr": "Qualité et prix moyens. Ce qui est effrayant,\nc'est que de tels détails soient dans la rumeur."
   },
   {
     "id": 229,
@@ -3593,7 +3593,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear\nJolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Yikes... Tu veux avoir peur? On dit\nque Jolly Roger vend des armes."
+    "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes."
   },
   {
     "id": 230,
@@ -3609,7 +3609,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]Anyway,[SP]his[SP]weapons\nare[SP]supposed[SP]to[SP]be[SP]average[SP]as[SP]far[SP]as[SP]the\nquality[SP]and[SP]price[SP]goes.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "C'est un vrai pirate? Ses armes sont\nmoyennes en qualité et en prix."
+    "texte_fr": "C'est un vrai pirate ? Ses armes sont\nmoyennes en qualité et en prix."
   },
   {
     "id": 231,
@@ -3624,7 +3624,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear\nJolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Yikes... Tu veux avoir peur? On dit\nque Jolly Roger vend des armes."
+    "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes."
   },
   {
     "id": 232,
@@ -3640,7 +3640,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]His[SP]weapons[SP]are\nsupposed[SP]to[SP]be[SP]cheap,[SP]but[SP]not[SP]great[SP]quality.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "C'est un vrai pirate? Ses armes sont\nbon marché, mais de mauvaise qualité."
+    "texte_fr": "C'est un vrai pirate ? Ses armes sont\nbon marché, mais de mauvaise qualité."
   },
   {
     "id": 233,
@@ -3655,7 +3655,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear\nJolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Yikes... Tu veux avoir peur? On dit\nque Jolly Roger vend des armes."
+    "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes."
   },
   {
     "id": 234,
@@ -3671,7 +3671,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]He's[SP]supposed[SP]to[SP]have\na[SP]great[SP]selection,[SP]but[SP]he[SP]barely[SP]pays[SP]anything\nfor[SP]what[SP]you[SP]sell[SP]him.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "C'est un vrai pirate? Super\nsélection, mais il paie une misère."
+    "texte_fr": "C'est un vrai pirate ? Super sélection,\nmais il paie une misère."
   },
   {
     "id": 235,
@@ -3686,7 +3686,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear\nJolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Yikes... Tu veux avoir peur? On dit\nque Jolly Roger vend des armes."
+    "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes."
   },
   {
     "id": 236,
@@ -3702,7 +3702,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]He's[SP]supposed[SP]to[SP]have\na[SP]crappy[SP]selection,[SP]but[SP]he'll[SP]pay[SP]a[SP]lot[SP]for\nwhatever[SP]you[SP]have[SP]to[SP]sell.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "C'est un vrai pirate? Mauvaise\nsélection, mais il paie beaucoup."
+    "texte_fr": "C'est un vrai pirate ? Mauvaise sélection,\nmais il paie beaucoup."
   },
   {
     "id": 237,
@@ -3717,7 +3717,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear\nJolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Yikes... Tu veux avoir peur? On dit\nque Jolly Roger vend des armes."
+    "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes."
   },
   {
     "id": 238,
@@ -3733,7 +3733,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]His[SP]weapons[SP]are\nsupposed[SP]to[SP]be[SP]good[SP]quality,[SP]but[SP]really\nexpensive.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "C'est un vrai pirate? Ses armes\nsont de bonne qualité, mais chères."
+    "texte_fr": "C'est un vrai pirate ? Ses armes sont\nde bonne qualité, mais chères."
   },
   {
     "id": 239,
@@ -3748,7 +3748,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "No[SP]way...[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]actually\nsells[SP]real[SP]armor?[SP]I[SP]wonder[SP]if[SP]that's[SP]gonna\nbe[SP]the[SP]next[SP]trend.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Rosa Candida vend de vraies armures?\nCe sera la prochaine tendance."
+    "texte_fr": "Rosa Candida vend de vraies\narmures ? Ce sera la prochaine tendance."
   },
   {
     "id": 240,
@@ -3764,7 +3764,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "The[SP]prices[SP]and[SP]quality[SP]there[SP]are[SP]pretty[SP]average.\nI[SP]wonder[SP]if[SP]I[SP]should[SP]go[SP]check[SP]it[SP]out...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Les prix et la qualité y sont\nmoyens. Je devrais aller voir..."
+    "texte_fr": "Les prix et la qualité y sont moyens.\nJe devrais aller voir..."
   },
   {
     "id": 241,
@@ -3779,7 +3779,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "No[SP]way...[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]actually\nsells[SP]real[SP]armor?[SP]I[SP]wonder[SP]if[SP]that's[SP]gonna\nbe[SP]the[SP]next[SP]trend.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Rosa Candida vend de vraies armures?\nCe sera la prochaine tendance."
+    "texte_fr": "Rosa Candida vend de vraies\narmures ? Ce sera la prochaine tendance."
   },
   {
     "id": 242,
@@ -3795,7 +3795,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Their[SP]quality's[SP]kinda[SP]sketchy,[SP]but[SP]you[SP]can't\nbeat[SP]those[SP]prices.[SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]go\ncheck[SP]them[SP]out...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Qualité douteuse, mais prix\nimbattables. Je devrais aller voir..."
+    "texte_fr": "Qualité douteuse, mais prix imbattables.\nJe devrais aller voir..."
   },
   {
     "id": 243,
@@ -3810,7 +3810,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "No[SP]way...[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]actually\nsells[SP]real[SP]armor?[SP]I[SP]wonder[SP]if[SP]that's[SP]gonna\nbe[SP]the[SP]next[SP]trend.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Rosa Candida vend de vraies armures?\nCe sera la prochaine tendance."
+    "texte_fr": "Rosa Candida vend de vraies\narmures ? Ce sera la prochaine tendance."
   },
   {
     "id": 244,
@@ -3826,7 +3826,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "It's[SP]on[SP]the[SP]expensive[SP]side,[SP]but[SP]the[SP]quality's\nsupposed[SP]to[SP]be[SP]great.[SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]go\ncheck[SP]them[SP]out...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "C'est cher, mais la qualité est\nsuper. Je devrais aller voir..."
+    "texte_fr": "C'est cher, mais la qualité est super.\nJe devrais aller voir..."
   },
   {
     "id": 245,
@@ -3842,7 +3842,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Anima[SP]Mundi[SP]sells[SP]armor?[SP]I[SP]go[SP]there[SP]all[SP]the\ntime[SP]and[SP]I[SP]never[SP]knew[SP]that.[SP]Well,[SP]their[SP]stuff\nis[SP]average[SP]quality[SP]for[SP]average[SP]prices.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Anima Mundi vend des armures? J'y vais tout le\ntemps sans le savoir. Qualité et prix moyens."
+    "texte_fr": "Anima Mundi vend des armures ? J'y vais tout le\ntemps sans le savoir. Qualité et prix moyens."
   },
   {
     "id": 246,
@@ -3858,7 +3858,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Anima[SP]Mundi[SP]sells[SP]armor?[SP]I[SP]go[SP]there[SP]all[SP]the\ntime[SP]and[SP]I[SP]never[SP]knew[SP]that.[SP]It's[SP]pretty[SP]cheap,\nbut[SP]the[SP]quality's[SP]lousy.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Anima Mundi vend des armures? J'y\nvais tout le temps sans le savoir.\nPas cher, mais qualité nulle."
+    "texte_fr": "Anima Mundi vend des armures ? J'y vais tout le\ntemps sans le savoir. Pas cher, mais qualité nulle."
   },
   {
     "id": 247,
@@ -3873,7 +3873,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Anima[SP]Mundi[SP]sells[SP]armor?[SP]I[SP]go[SP]there[SP]all[SP]the\ntime[SP]and[SP]I[SP]never[SP]knew[SP]that.[SP]That[SP]store's[SP]got\na[SP]really[SP]great[SP]selection.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Anima Mundi vend des armures? J'y vais\ntout le temps et je n'en savais rien.\nCe magasin a une super sélection."
+    "texte_fr": "Anima Mundi vend des armures ? J'y vais tout le\ntemps et je n'en savais rien. Ce magasin a\nune super sélection."
   },
   {
     "id": 248,
@@ -3889,7 +3889,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Huh?[SP]Their[SP]buyback[SP]prices?[SP]I[SP]dunno...[SP]I[SP]didn't\nhear[SP]much[SP]about[SP]that.[SP]I[SP]wouldn't[SP]get[SP]my[SP]hopes\nup[SP]if[SP]I[SP]were[SP]you,[SP]though.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Quoi? Les prix de rachat? J'en sais rien...\nJe ne me ferais pas trop d'illusions."
+    "texte_fr": "Quoi ? Les prix de rachat ? J'en sais rien...\nJe ne me ferais pas trop d'illusions."
   },
   {
     "id": 249,
@@ -3904,7 +3904,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Anima[SP]Mundi[SP]sells[SP]armor?[SP]I[SP]go[SP]there[SP]all[SP]the\ntime[SP]and[SP]I[SP]never[SP]knew[SP]that.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Anima Mundi vend des armures?\nJ'y vais souvent sans le savoir."
+    "texte_fr": "Anima Mundi vend des armures ? J'y vais\nsouvent sans le savoir."
   },
   {
     "id": 250,
@@ -3920,7 +3920,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]store's[SP]got[SP]really[SP]great[SP]stuff,[SP]but[SP]it's\nkinda[SP]out[SP]of[SP]my[SP]price[SP]range.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ce magasin a de superbes trucs, mais\nc'est un peu hors de mon budget."
+    "texte_fr": "Ce magasin a de superbes trucs, mais c'est\nun peu hors de mon budget."
   },
   {
     "id": 251,
@@ -3936,7 +3936,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they\nsell[SP]real[SP]armor.[SP]Their[SP]selection's[SP]not[SP]great,\nbut[SP]the[SP]buyback[SP]prices[SP]are[SP]the[SP]best.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "T'es allé chez Rosa Candida à Aoba? Ils\nvendent des armures. Mauvais choix, super\nrachat."
+    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Mauvais choix, super rachat."
   },
   {
     "id": 252,
@@ -3952,7 +3952,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they\nsell[SP]real[SP]armor.[SP]Their[SP]quality[SP]and[SP]prices[SP]are\naverage,[SP]so[SP]they[SP]say.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "T'es allé chez Rosa Candida à Aoba? Ils\nvendent des armures. Qualité et prix moyens."
+    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Qualité et prix moyens."
   },
   {
     "id": 253,
@@ -3968,7 +3968,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they\nsell[SP]real[SP]armor.[SP]Their[SP]quality's[SP]pretty[SP]good,\nbut[SP]it's[SP]all[SP]really[SP]expensive.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "T'es allé chez Rosa Candida à Aoba? Ils\nvendent des armures. Qualité bonne, mais très\ncher."
+    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Qualité bonne, mais très cher."
   },
   {
     "id": 254,
@@ -3984,7 +3984,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they\nsell[SP]real[SP]armor.[SP]Supposedly[SP]their[SP]stuff's[SP]super\ncheap,[SP]but[SP]really[SP]low[SP]quality.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "T'es allé chez Rosa Candida à Aoba? Ils\nvendent des armures. Pas cher, mauvaise\nqualité."
+    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Pas cher, mauvaise qualité."
   },
   {
     "id": 255,
@@ -4000,7 +4000,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they\nsell[SP]real[SP]armor.[SP]Their[SP]selection's[SP]really[SP]good,\nbut[SP]the[SP]buyback[SP]prices[SP]are[SP]pretty[SP]low.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "T'es allé chez Rosa Candida à\nAoba? Ils vendent des armures.\nSuper sélection, mauvais rachat."
+    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Super sélection, mauvais rachat."
   },
   {
     "id": 256,
@@ -4048,7 +4048,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Even[SP]London[SP]Clothier[SP]sells[SP]armor[SP]now.[SP]I[SP]guess\nthey[SP]get[SP]special[SP]orders.[SP]Their[SP]stuff[SP]is\nhigh[SP]quality,[SP]but[SP]really[SP]expensive.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "London Clothier vend des armures.\nSûrement des commandes spéciales.\nSuper qualité, très cher."
+    "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Super qualité, très cher."
   },
   {
     "id": 259,
@@ -4080,7 +4080,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Even[SP]London[SP]Clothier[SP]sells[SP]armor[SP]now.[SP]I[SP]guess\nthey[SP]get[SP]special[SP]orders.[SP]Their[SP]selection's\ncrappy,[SP]but[SP]the[SP]buyback[SP]price[SP]is[SP]great.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "London Clothier vend des armures.\nSûrement des commandes spéciales.\nMauvais choix, rachat top."
+    "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Mauvais choix, rachat top."
   },
   {
     "id": 261,
@@ -4095,7 +4095,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]reminds[SP]me,[SP]a[SP]friend[SP]of[SP]a[SP]friend[SP]won[SP]a\nsweepstakes[SP]and[SP]got[SP]a[SP]real[SP]weapon[SP]in[SP]the[SP]mail.\nI[SP]was[SP]like,[SP]whoa,[SP]is[SP]that[SP]legal!?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "L'ami d'un ami a gagné à une\nloterie et a reçu une véritable\narme par la poste. C'est légal ça!?"
+    "texte_fr": "L'ami d'un ami a gagné à une loterie et a reçu une\nvéritable arme par la poste. C'est légal ça !?"
   },
   {
     "id": 262,
@@ -4111,7 +4111,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]think[SP]she[SP]said[SP]it[SP]was[SP]a[SP]magazine[SP]sweepstakes.\nYou[SP]can[SP]win[SP]pretty[SP]good[SP]stuff,[SP]but[SP]you[SP]won't\nwin[SP]too[SP]often.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "C'était un concours de magazine. Tu peux\ngagner de bons trucs, mais c'est rare."
+    "texte_fr": "C'était un concours de magazine.\nTu peux gagner de bons trucs, mais c'est rare."
   },
   {
     "id": 263,
@@ -4126,7 +4126,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]reminds[SP]me,[SP]a[SP]friend[SP]of[SP]a[SP]friend[SP]won[SP]a\nsweepstakes[SP]and[SP]got[SP]a[SP]real[SP]weapon[SP]in[SP]the[SP]mail.\nI[SP]was[SP]like,[SP]whoa,[SP]is[SP]that[SP]legal!?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "L'ami d'un ami a gagné à une\nloterie et a reçu une véritable\narme par la poste. C'est légal ça!?"
+    "texte_fr": "L'ami d'un ami a gagné à une loterie et a reçu une\nvéritable arme par la poste. C'est légal ça !?"
   },
   {
     "id": 264,
@@ -4142,7 +4142,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]think[SP]she[SP]said[SP]it[SP]was[SP]a[SP]magazine[SP]sweepstakes.\nYou[SP]hardly[SP]ever[SP]win,[SP]but[SP]when[SP]you[SP]do,[SP]you[SP]can\nget[SP]really[SP]rare[SP]stuff.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "C'était un concours de magazine. C'est\nrare, mais tu peux obtenir des trucs rares."
+    "texte_fr": "C'était un concours de magazine.\nC'est rare, mais tu peux obtenir des trucs rares."
   },
   {
     "id": 265,
@@ -4157,7 +4157,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]reminds[SP]me,[SP]a[SP]friend[SP]of[SP]a[SP]friend[SP]won[SP]a\nsweepstakes[SP]and[SP]got[SP]a[SP]real[SP]weapon[SP]in[SP]the[SP]mail.\nI[SP]was[SP]like,[SP]whoa,[SP]is[SP]that[SP]legal!?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "L'ami d'un ami a gagné à une\nloterie et a reçu une véritable\narme par la poste. C'est légal ça!?"
+    "texte_fr": "L'ami d'un ami a gagné à une loterie et a reçu une\nvéritable arme par la poste. C'est légal ça !?"
   },
   {
     "id": 266,
@@ -4173,7 +4173,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]think[SP]she[SP]said[SP]it[SP]was[SP]a[SP]magazine[SP]sweepstakes.\nThere's[SP]lots[SP]of[SP]winners,[SP]but[SP]no[SP]one[SP]ever[SP]gets\nanything[SP]really[SP]good.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "C'était un concours de magazine. Plein\nde gagnants, mais rien de vraiment bien."
+    "texte_fr": "C'était un concours de magazine.\nPlein de gagnants, mais rien de vraiment bien."
   },
   {
     "id": 267,
@@ -4188,7 +4188,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]didja[SP]know[SP]there's[SP]a[SP]casino[SP]in[SP]Mu[SP]now?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, tu savais pour le casino dans Mu?"
+    "texte_fr": "Hé, tu savais pour le casino dans Mu ?"
   },
   {
     "id": 268,
@@ -4219,7 +4219,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Just[SP]between[SP]you[SP]and[SP]me,[SP]poker[SP]seems[SP]like[SP]the\nbest[SP]bet.[SP]Rumor[SP]has[SP]it[SP]you[SP]can[SP]win[SP]big[SP]at\nmachine[SP]#5.[SP]My[SP]gamer[SP]friend[SP]told[SP]me.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Le poker est le meilleur pari. On\ngagne le gros lot à la machine\n#5. Un ami joueur me l'a dit."
+    "texte_fr": "Le poker est le meilleur pari. On gagne le gros\nlot à la machine #5. Un ami joueur me l'a dit."
   },
   {
     "id": 270,
@@ -4234,7 +4234,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]didja[SP]know[SP]there's[SP]a[SP]casino[SP]in[SP]Mu[SP]now?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, tu savais pour le casino dans Mu?"
+    "texte_fr": "Hé, tu savais pour le casino dans Mu ?"
   },
   {
     "id": 271,
@@ -4265,7 +4265,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Just[SP]between[SP]you[SP]and[SP]me,[SP]slots[SP]seems[SP]like[SP]the\nbest[SP]bet.[SP]Rumor[SP]has[SP]it[SP]you[SP]can[SP]win[SP]big[SP]at\nmachine[SP]#1.[SP]My[SP]gamer[SP]friend[SP]told[SP]me.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Les machines à sous sont le meilleur pari. On\ngagne le gros lot à la #1. Un ami me l'a dit."
+    "texte_fr": "Les machines à sous sont le meilleur pari.\nOn gagne le gros lot à la #1. Un ami me l'a dit."
   },
   {
     "id": 273,
@@ -4280,7 +4280,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]didja[SP]know[SP]there's[SP]a[SP]casino[SP]in[SP]Mu[SP]now?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, tu savais pour le casino dans Mu?"
+    "texte_fr": "Hé, tu savais pour le casino dans Mu ?"
   },
   {
     "id": 274,
@@ -4327,7 +4327,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Huh,[SP]so[SP]Shiraishi[SP]Ramen[SP]in[SP]Hirasaka[SP]has[SP]a\nlegendary[SP]weapon[SP]for[SP]sale.[1205][U+000F][SP]I[SP]wonder[SP]if[SP]she\npicked[SP]it[SP]up[SP]on[SP]one[SP]of[SP]her[SP]spying[SP]missions.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Shiraishi Ramen vend une arme légendaire.[1205][U+000F]\nObtenue lors d'une mission d'espionnage?"
+    "texte_fr": "Shiraishi Ramen vend une arme légendaire.[1205][U+000F]\nObtenue lors d'une mission d'espionnage ?"
   },
   {
     "id": 277,
@@ -4342,7 +4342,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]wouldn't[SP]be[SP]surprised[SP]if[SP]Clair[SP]de[SP]Lune[SP]had\na[SP]legendary[SP]weapon[SP]lying[SP]around.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Clair de Lune pourrait\navoir une arme légendaire."
+    "texte_fr": "Clair de Lune pourrait avoir une arme\nlégendaire."
   },
   {
     "id": 278,
@@ -4373,7 +4373,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "But[SP]I[SP]like[SP]the[SP]idea[SP]of[SP]them[SP]selling[SP]weapons.\nI[SP]feel[SP]like[SP]I'll[SP]get[SP]shot[SP]if[SP]I'm[SP]not[SP]careful\naround[SP]them.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Vendre des armes? Je vais me faire tirer\ndessus si je ne fais pas attention."
+    "texte_fr": "Vendre des armes ? Je vais me faire tirer\ndessus si je ne fais pas attention."
   },
   {
     "id": 280,
@@ -4388,7 +4388,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "There's[SP]a[SP]really[SP]nasty[SP]rumor[SP]going[SP]around.[SP]The\nowner[SP]of[SP]Time[SP]Castle's[SP]keeping[SP]his[SP]legendary\nweapon[SP]under[SP]wraps[SP]to[SP]jack[SP]up[SP]the[SP]price.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Une vilaine rumeur court. Le patron de\nTime Castle garde son arme légendaire\npour faire monter les prix."
+    "texte_fr": "Une vilaine rumeur court. Le patron de Time Castle\ngarde son arme légendaire pour faire monter les prix."
   },
   {
     "id": 281,
@@ -4404,7 +4404,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "A[SP]cool[SP]guy[SP]like[SP]that[SP]would[SP]never[SP]pull[SP]such\na[SP]jerk[SP]move![SP]Sheesh,[SP]the[SP]people[SP]in[SP]this[SP]city\ndon't[SP]know[SP]him[SP]at[SP]all!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Un mec cool ne ferait pas ça! Les gens\nd'ici ne le connaissent pas du tout!"
+    "texte_fr": "Un mec cool ne ferait pas ça ! Les gens d'ici\nne le connaissent pas du tout !"
   },
   {
     "id": 282,
@@ -4419,7 +4419,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "There's[SP]a[SP]really[SP]nasty[SP]rumor[SP]going[SP]around![1205][U+000F][SP]They\nsay[SP]the[SP]Time[SP]Castle[SP]owner[SP]doesn't[SP]have[SP]his\nlegendary[SP]weapon[SP]'cause[SP]he's[SP]too[SP]chicken.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Vilaine rumeur![1205][U+000F] Le patron de Time Castle\nn'a pas son arme car il a la trouille."
+    "texte_fr": "Vilaine rumeur ![1205][U+000F] Le patron de Time Castle\nn'a pas son arme car il a la trouille."
   },
   {
     "id": 283,
@@ -4435,7 +4435,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Like,[SP]he[SP]won't[SP]go[SP]to[SP]the[SP]abandoned[SP]factory[SP]to\npick[SP]it[SP]up[SP]from[SP]the[SP]seller.[SP]There's[SP]no[SP]way[SP]a\nguy[SP]that[SP]cool[SP]is[SP]a[SP]coward![SP]I-It's[SP]a[SP]mistake!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Il n'ose pas aller à l'usine pour\nla récupérer. Un mec aussi cool\nn'est pas lâche! C'est faux!"
+    "texte_fr": "Il n'ose pas aller à l'usine pour la récupérer.\nUn mec aussi cool n'est pas lâche ! C'est faux !"
   },
   {
     "id": 284,
@@ -4451,7 +4451,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Did[SP]a[SP]demon[SP]steal[SP]the[SP]legendary[SP]weapon[SP]at\nTime[SP]Castle?[1205][U+000F][SP]That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]but...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Un démon a volé l'arme de Time\nCastle?[1205][U+000F] C'est la rumeur, mais..."
+    "texte_fr": "Un démon a volé l'arme de Time Castle ?[1205][U+000F]\nC'est la rumeur, mais..."
   },
   {
     "id": 285,
@@ -4497,7 +4497,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Awww,[SP]I'm[SP]really[SP]bummed...[SP]The[SP]owner[SP]of[SP]Time\nCastle[SP]gave[SP]his[SP]legendary[SP]weapon[SP]to[SP]some[SP]girl.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Je suis dégoûtée... Le patron de Time Castle\na donné son arme légendaire à une fille."
+    "texte_fr": "Je suis dégoûtée... Le patron de Time\nCastle a donné son arme légendaire à une fille."
   },
   {
     "id": 288,
@@ -4513,7 +4513,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]can[SP]only[SP]mean[SP]one[SP]thing,[SP]huh?[SP]I[SP]wonder\nwhat[SP]kind[SP]of[SP]girl[SP]she[SP]is?[SP]All[SP]I[SP]heard[SP]about\nher[SP]is[SP]that[SP]she's[SP]got[SP]short[SP]hair.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ça veut dire quoi? Elle est\ncomment? Tout ce que je sais, c'est\nqu'elle a les cheveux courts."
+    "texte_fr": "Ça veut dire quoi ? Elle est comment ?\nTout ce que je sais, c'est qu'elle a les cheveux courts."
   },
   {
     "id": 289,
@@ -4528,7 +4528,7 @@
     "nom_orig": "Sevens[SP]High[SP]male[SP]student",
     "texte_orig": "Oh,[SP]L-Lisa-san![1205][U+000A][SP]I[SP]finally[SP]found[SP]you.[1205][U+000A]\nI-I[SP]saw[SP]the[SP]poster![1205][U+000A][SP]Th-That[SP]silhouette\nis[SP]you,[SP]right?",
     "nom_fr": "Lycéen de Seven",
-    "texte_fr": "Oh, L-Lisa-san![1205][U+000A] Enfin trouvée.[1205][U+000A] J-J'ai vu\nl'affiche![1205][U+000A] C-Cette silhouette c'est toi?"
+    "texte_fr": "Oh, L-Lisa-san ![1205][U+000A] Enfin trouvée.[1205][U+000A]\nJ-J'ai vu l'affiche ![1205][U+000A] C-Cette silhouette\nc'est toi ?"
   },
   {
     "id": 290,
@@ -4544,7 +4544,7 @@
     "nom_orig": "Sevens[SP]High[SP]male[SP]student",
     "texte_orig": "I-I[SP]had[SP]it[SP]figured[SP]out[SP]as[SP]soon[SP]as[SP]I[SP]saw[SP]it.[1205][U+000A]\nI-I[SP]mean,[SP]since[SP]I've[SP]always[SP]been[SP]watching\nyou[SP]and[SP]all...[1205][U+000A][SP]I'm[SP]right,[SP]aren't[SP]I?",
     "nom_fr": "Lycéen de Seven",
-    "texte_fr": "J-J'ai tout de suite compris en la\nvoyant.[1205][U+000A] E-Enfin, puisque je t'ai toujours\nobservée et tout...[1205][U+000A] J'ai raison, non?"
+    "texte_fr": "J-J'ai tout de suite compris en la voyant.[1205][U+000A]\nE-Enfin, puisque je t'ai toujours\nobservée et tout...[1205][U+000A] J'ai raison, non ?"
   },
   {
     "id": 291,
@@ -4560,7 +4560,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Poster?[1205][U+000F][SP]Silhouette?[1205][U+000F][SP]I,[SP]uh,[SP]have[SP]no[SP]idea[SP]what\nyou're[SP]talking[SP]about.[SP]Whatever[SP]it[SP]is,[SP]it's\nnot[SP]me.[SP]You've[SP]got[SP]the[SP]wrong[SP]girl,[SP]dude.",
     "nom_fr": "Ginko",
-    "texte_fr": "Affiche?[1205][U+000F] Silhouette?[1205][U+000F] Je vois pas\nde quoi tu parles. Ce n'est pas\nmoi. Tu te trompes de fille."
+    "texte_fr": "Affiche ?[1205][U+000F] Silhouette ?[1205][U+000F] Je vois pas de quoi\ntu parles. Ce n'est pas moi. Tu te trompes de fille."
   },
   {
     "id": 292,
@@ -4607,7 +4607,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "T-Toche...[1205][U+000F][SP]But[SP]I[SP]think[SP]this[SP]is[SP]just[SP]a[SP]big\nmisunderstanding.[SP]I-I[SP]never[SP]said[SP]I[SP]was[SP]going\nto[SP]be[SP]debuting.",
     "nom_fr": "Ginko",
-    "texte_fr": "T-Toche...[1205][U+000F] Mais c'est un grand malentendu.\nJ-Je n'ai jamais dit que j'allais débuter."
+    "texte_fr": "T-Toche...[1205][U+000F] Mais c'est un grand\nmalentendu. J-Je n'ai jamais dit que j'allais\ndébuter."
   },
   {
     "id": 295,
@@ -4623,7 +4623,7 @@
     "nom_orig": "Sevens[SP]High[SP]male[SP]student",
     "texte_orig": "Oh,[SP]L-Lisa-san,[SP]are[SP]you[SP]going[SP]to[SP]Mu?[1205][U+000A][SP]There's\ngoing[SP]to[SP]be[SP]a[SP]promo[SP]video[SP]shoot[SP]there,[SP]right?[1205][U+000A]\nG-Good[SP]luck.",
     "nom_fr": "Lycéen de Seven",
-    "texte_fr": "Oh, L-Lisa-san, tu vas à Mu?[1205][U+000A] Il va\ny avoir le tournage d'une vidéo\npromo, c'est ça?[1205][U+000A] B-Bonne chance."
+    "texte_fr": "Oh, L-Lisa-san, tu vas à Mu ?[1205][U+000A] Il va y\navoir le tournage d'une vidéo promo, c'est ça ?[1205][U+000A]\nB-Bonne chance."
   },
   {
     "id": 296,
@@ -4638,7 +4638,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Wh-Whoa,[SP]if[SP]you[SP]think[SP]I'm[SP]debuting[SP]because[SP]you\nsaw[SP]some[SP]poster,[SP]you're[SP]way[SP]off[SP]base.[1205][U+000F][SP]I[SP]am[SP]NOT\nbecoming[SP]an[SP]idol.",
     "nom_fr": "Ginko",
-    "texte_fr": "Wh-Whoa, si tu penses ça à cause d'une\naffiche, tu te plantes.[1205][U+000F] Je ne deviens PAS une\nidole."
+    "texte_fr": "Wh-Whoa, si tu penses ça à cause d'une\naffiche, tu te plantes.[1205][U+000F] Je ne\ndeviens PAS une idole."
   },
   {
     "id": 297,
@@ -4654,7 +4654,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "The[SP]reason[SP]I'm[SP]going[SP]to[SP]Mu[SP]is[SP]to[SP]set[SP]the[SP]record\nstraight[SP]on[SP]that!",
     "nom_fr": "Ginko",
-    "texte_fr": "Je vais à Mu pour remettre\nles pendules à l'heure!"
+    "texte_fr": "Je vais à Mu pour remettre les pendules à l'heure !"
   },
   {
     "id": 298,
@@ -4670,7 +4670,7 @@
     "nom_orig": "Sevens[SP]High[SP]male[SP]student",
     "texte_orig": "Y-You're[SP]the[SP]hero[SP]of[SP]S-Sevens,[SP]Lisa-san...[1205][U+000F]\nPlease[SP]bring[SP]back[SP]S-Sevens'[SP]popularity...[1205][U+000F]\nW-We're[SP]counting[SP]on[SP]you...",
     "nom_fr": "Lycéen de Seven",
-    "texte_fr": "T-Tu es l'héroïne de S-Seven, Lisa-san...[1205][U+000F]\nS'il te plaît, rends à S-Seven sa\npopularité...[1205][U+000F] O-On compte sur toi..."
+    "texte_fr": "T-Tu es l'héroïne de S-Seven, Lisa-san...[1205][U+000F]\nS'il te plaît, rends à S-Seven sa popularité...[1205][U+000F]\nO-On compte sur toi..."
   },
   {
     "id": 299,
@@ -4685,7 +4685,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![SP]Enough[SP]of[SP]this[SP]bullshit![1205][U+000F][SP]You[SP]don't[SP]know\nwhat[SP]I'm[SP]going[SP]through!",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei! Assez de ces conneries![1205][U+000F] Tu\nne sais pas ce que je traverse!"
+    "texte_fr": "Kehhei ! Assez de ces conneries ![1205][U+000F] Tu ne sais\npas ce que je traverse !"
   },
   {
     "id": 300,
@@ -4701,7 +4701,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I'll[SP]never[SP]debut[SP]as[SP]an[SP]idol,[SP]and[SP]I[SP]don't[SP]give\na[SP]shit[SP]about[SP]Sevens!",
     "nom_fr": "Ginko",
-    "texte_fr": "Jamais idole, je m'en fiche de Seven!"
+    "texte_fr": "Jamais idole, je\nm'en fiche de Seven !"
   },
   {
     "id": 301,
@@ -4716,7 +4716,7 @@
     "nom_orig": "Sevens[SP]High[SP]male[SP]student",
     "texte_orig": "I-I[SP]went[SP]to[SP]th-the[SP]outdoor[SP]concert[SP]hall\na[SP]second[SP]ago.[1205][U+000A][SP]E-Everyone's[SP]so[SP]excited,\nthere[SP]was[SP]a[SP]huge[SP]l-line[SP]at[SP]the[SP]entrance.",
     "nom_fr": "Lycéen de Seven",
-    "texte_fr": "J-Je suis allé à la salle de concert il y\na une seconde.[1205][U+000A] T-Tout le monde est excité,\nune énorme f-file d'attente à l'entrée."
+    "texte_fr": "J-Je suis allé à la salle de concert\nil y a une seconde.[1205][U+000A] T-Tout le monde est excité,\nune énorme f-file d'attente à l'entrée."
   },
   {
     "id": 302,
@@ -4732,7 +4732,7 @@
     "nom_orig": "Sevens[SP]High[SP]male[SP]student",
     "texte_orig": "Y-You're[SP]amazing,[SP]Lisa-san...[1205][U+000A][SP]But[SP][1113]-\nsenpai[SP]is[SP]more[SP]than[SP]just[SP]a[SP]friend[SP]to[SP]you...[1205][U+000A]\nI'm[SP]so[SP]jealous...[1205][U+000A][SP]So[SP]envious...",
     "nom_fr": "Lycéen de Seven",
-    "texte_fr": "T-Tu es incroyable, Lisa-san...[1205][U+000A] Mais [1113]-\nsenpai est plus qu'un ami pour toi...[1205][U+000A] Je suis\nsi jaloux...[1205][U+000A] Tellement envieux..."
+    "texte_fr": "T-Tu es incroyable, Lisa-san...[1205][U+000A] Mais [1113]-\nsenpai est plus qu'un ami pour toi...[1205][U+000A]\nJe suis si jaloux...[1205][U+000A] Tellement envieux..."
   },
   {
     "id": 303,
@@ -4748,7 +4748,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Wh...[SP]Why[SP]won't[SP]the[SP]executives[SP]come[SP]back[SP]to\nhelp[SP]us!?[1205][U+000F][SP]There's[SP]no[SP]way[SP]we[SP]can[SP]protect[SP]the\npeople[SP]of[SP]Sumaru[SP]alone![1205][U+000F][SP]S-Someone[SP]help[SP]us!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Qu... Pourquoi les cadres ne reviennent\npas aider!?[1205][U+000F] On ne pourra jamais protéger\nles habitants seuls![1205][U+000F] Qu-Qu'on nous aide!"
+    "texte_fr": "Qu... Pourquoi les cadres ne reviennent pas\naider !?[1205][U+000F] On ne pourra jamais protéger les\nhabitants seuls ![1205][U+000F] Qu-Qu'on nous aide !"
   },
   {
     "id": 304,
@@ -4764,7 +4764,7 @@
     "nom_orig": "Last[SP]Battalion",
     "texte_orig": "We[SP]are[SP]the[SP]mightiest.[SP]We[SP]stand[SP]unrivalled.[1205][U+000F]\nThose[SP]who[SP]dare[SP]stand[SP]in[SP]the[SP]way[SP]of[SP]our[SP]march\nshall[SP]be[SP]crushed[SP]by[SP]the[SP]holy[SP]lance.",
     "nom_fr": "Bataillon",
-    "texte_fr": "Nous sommes les plus forts, sans\négal.[1205][U+000F] Ceux sur notre chemin seront\nécrasés par la lance sacrée."
+    "texte_fr": "Nous sommes les plus forts, sans égal.[1205][U+000F]\nCeux sur notre chemin seront écrasés par\nla lance sacrée."
   },
   {
     "id": 305,
@@ -4779,7 +4779,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Zodiac's[SP]a[SP]club,[SP]but[SP]you've[SP]never[SP]been[SP]inside,\nhave[SP]you,[SP]Chinyan?[SP]I[SP]haven't[SP]been[SP]around[SP]here\nlately[SP]either...",
     "nom_fr": "Lisa",
-    "texte_fr": "Zodiac est un club, tu n'y es\njamais entré, Chinyan? Je ne suis\npas venue dans le coin non plus..."
+    "texte_fr": "Zodiac est un club, tu n'y es jamais entré,\nChinyan ? Je ne suis pas venue dans le\ncoin non plus..."
   },
   {
     "id": 306,
@@ -4795,7 +4795,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "You[SP]know[SP]how[SP]guys[SP]from[SP]Sevens[SP]can't[SP]come[SP]here\nanymore[SP]because[SP]of[SP]that[SP]disease?[SP]I[SP]hear[SP]Cuss\nHigh[SP]students[SP]have[SP]stepped[SP]up[SP]instead.",
     "nom_fr": "Lisa",
-    "texte_fr": "Les gars de Seven ne viennent plus à\ncause de la maladie? Les élèves de\nKakasu les ont remplacés, on dirait."
+    "texte_fr": "Les gars de Seven ne viennent plus à cause de\nla maladie ? Les élèves de Kakasu les ont\nremplacés, on dirait."
   },
   {
     "id": 307,
@@ -4810,7 +4810,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Zodiac's[SP]a[SP]club,[SP]but[SP]you've[SP]never[SP]been[SP]inside,\nhave[SP]you,[SP]Chinyan?[SP]I[SP]haven't[SP]been[SP]around[SP]here\nlately[SP]either...",
     "nom_fr": "Ginko",
-    "texte_fr": "Zodiac est un club, tu n'y es\njamais entré, Chinyan? Je ne suis\npas venue dans le coin non plus..."
+    "texte_fr": "Zodiac est un club, tu n'y es jamais entré,\nChinyan ? Je ne suis pas venue dans le\ncoin non plus..."
   },
   {
     "id": 308,
@@ -4826,7 +4826,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "You[SP]know[SP]how[SP]guys[SP]from[SP]Sevens[SP]can't[SP]come[SP]here\nanymore[SP]because[SP]of[SP]that[SP]disease?[SP]I[SP]hear[SP]Cuss\nHigh[SP]students[SP]have[SP]stepped[SP]up[SP]instead.",
     "nom_fr": "Lisa",
-    "texte_fr": "Les gars de Seven ne viennent plus à\ncause de la maladie? Les élèves de\nKakasu les ont remplacés, on dirait."
+    "texte_fr": "Les gars de Seven ne viennent plus à cause de\nla maladie ? Les élèves de Kakasu les ont\nremplacés, on dirait."
   },
   {
     "id": 309,
@@ -4842,7 +4842,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]don't[SP]think[SP]that's[SP]the[SP]best[SP]idea[SP]after[SP]we\nbusted[SP]heads[SP]in[SP]there.[SP]Let's[SP]go[SP]somewhere[SP]else.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mauvaise idée après avoir cassé des\ntêtes là-dedans. Allons ailleurs."
+    "texte_fr": "Mauvaise idée après avoir cassé des têtes\nlà-dedans. Allons ailleurs."
   },
   {
     "id": 310,
@@ -4858,7 +4858,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What[SP]if[SP]someone[SP]catches[SP]us[SP]wandering[SP]around\nlike[SP]this,[SP][1113]?[SP]We[SP]should[SP]hurry[SP]to[SP]the\ndetective[SP]agency.",
     "nom_fr": "Ginko",
-    "texte_fr": "Et si on nous voit traîner par ici,\n[1113]? Vite à l'agence de détectives."
+    "texte_fr": "Et si on nous voit traîner par ici, [1113] ?\nVite à l'agence de détectives."
   },
   {
     "id": 311,
@@ -4874,7 +4874,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "There's[SP]nothing[SP]we[SP]have[SP]to[SP]do[SP]here,[SP]is[SP]there?\nSo[SP]let's[SP]get[SP]going.",
     "nom_fr": "Eikichi",
-    "texte_fr": "On n'a rien à faire ici, non? Alors on y va."
+    "texte_fr": "On n'a rien à faire ici, non ?\nAlors on y va."
   },
   {
     "id": 312,
@@ -4890,7 +4890,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "This[SP]is[SP]a[SP]CD[SP]store[SP]called[SP]Giga[SP]Macho.\nThey[SP]have[SP]all[SP]kinds[SP]of[SP]music[SP]here.[SP]I[SP]used\nto[SP]come[SP]here[SP]a[SP]lot[SP]with[SP]Sheba[SP]and[SP]Mee-ho...",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est un disquaire, Giga Macho. Toutes\nsortes de musiques ici. Je venais\nsouvent avec Sheba et Mee-ho..."
+    "texte_fr": "C'est un disquaire, Giga Macho.\nToutes sortes de musiques ici. Je venais\nsouvent avec Sheba et Mee-ho..."
   },
   {
     "id": 313,
@@ -4906,7 +4906,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "GOLD...?[SP]Dude,[SP]this[SP]is[SP]a[SP]fitness[SP]center.",
     "nom_fr": "Eikichi",
-    "texte_fr": "GOLD...? C'est un centre de fitness."
+    "texte_fr": "GOLD... ? C'est un centre de fitness."
   },
   {
     "id": 314,
@@ -4922,7 +4922,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ohhh,[SP]I[SP]get[SP]it.[SP]You[SP]think[SP]you[SP]can[SP]compete\nwith[SP]me[SP]there,[SP]huh?[SP]Well,[SP]I[SP]think[SP]you'll\nfind[SP]your[SP]efforts[SP]will[SP]go[SP]to[SP]waste!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Oh, tu crois que tu peux rivaliser\navec moi là-bas? Tu verras que tes\nefforts ne serviront à rien!"
+    "texte_fr": "Oh, tu crois que tu peux rivaliser avec\nmoi là-bas ? Tu verras que tes\nefforts ne serviront à rien !"
   },
   {
     "id": 315,
@@ -4938,7 +4938,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Haha...[SP]I[SP]wonder[SP]if[SP]she's[SP]still[SP]at[SP]it...\nOh,[SP]sorry,[SP]it's[SP]nothing.[SP]Hahaha...",
     "nom_fr": "Maya",
-    "texte_fr": "Haha... Je me demande si elle y est\nencore... Oh, désolée. Hahaha..."
+    "texte_fr": "Haha... Je me demande si elle y est encore...\nOh, désolée. Hahaha..."
   },
   {
     "id": 316,
@@ -4954,7 +4954,7 @@
     "nom_orig": "Maya",
     "texte_orig": "GOLD,[SP]huh...?[SP]Could[SP]this[SP]be[SP]the[SP]next[SP]target?\nOr...?[1205][U+000F]",
     "nom_fr": "Maya",
-    "texte_fr": "GOLD, hein...? C'est la\nprochaine cible? Ou...?[1205][U+000F]"
+    "texte_fr": "GOLD, hein... ? C'est la prochaine cible ?\nOu... ?[1205][U+000F]"
   },
   {
     "id": 317,
@@ -4970,7 +4970,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Where[SP]else[SP]could[SP]it[SP]be?[1205][U+000F][SP]Let's[SP]just[SP]hurry[SP]up\nand[SP]get[SP]inside.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Où d'autre?[1205][U+000F] Dépêchons-nous d'entrer."
+    "texte_fr": "Où d'autre ?[1205][U+000F] Dépêchons-nous\nd'entrer."
   },
   {
     "id": 318,
@@ -4986,7 +4986,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]can't[SP]afford[SP]to[SP]make[SP]another[SP]mistake.[1205][U+000F]\nIs[SP]GOLD[SP]where[SP]we[SP]should[SP]go,[SP]or...?",
     "nom_fr": "Maya",
-    "texte_fr": "On n'a pas le droit à l'erreur.[1205][U+000F]\nC'est GOLD la cible, ou...?"
+    "texte_fr": "On n'a pas le droit à l'erreur.[1205][U+000F]\nC'est GOLD la cible, ou... ?"
   },
   {
     "id": 319,
@@ -5002,7 +5002,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Dammit,[SP]which[SP]one[SP]is[SP]it?[1205][U+000F][SP]Choices[SP]like[SP]this[SP]make\nme[SP]queasy.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Bordel, c'est où?[1205][U+000F] Choisir me donne la nausée."
+    "texte_fr": "Bordel, c'est où ?[1205][U+000F] Choisir me\ndonne la nausée."
   },
   {
     "id": 320,
@@ -5018,7 +5018,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?\n[1208][0002][1432][NULL][NULL][0014]Yeah,[SP]let's[SP]check[SP]it[SP]out.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]No,[SP]this[SP]isn't[SP]the[SP]place.[1432][NULL][NULL][0014]",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun?[1205][U+000F] On fouille ici?[E1][E2][E3]On fouille ici?\n[1208][0002][1432][NULL][NULL][0014]Ouais, allons voir.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas ici.[1432][NULL][NULL][0014]",
+    "texte_fr": "[1113]-kun ?[1205][U+000F] On fouille ici ?[E1][E2][E3]On fouille ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, allons voir.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas ici.[1432][NULL][NULL][0014]",
     "question_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?",
     "choix_orig": [
       "Yeah,[SP]let's[SP]check[SP]it[SP]out.",
@@ -5044,7 +5044,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Okay,[SP]we'll[SP]trust[SP][1113]'s[SP]instincts.\nThere's[SP]no[SP]use[SP]hemming[SP]and[SP]hawing[SP]over[SP]it\nanymore.[SP]Let's[SP]go!",
     "nom_fr": "Yukino",
-    "texte_fr": "Ok, on va se fier à l'instinct de [1113].\nInutile d'hésiter plus longtemps. On y va!"
+    "texte_fr": "Ok, on va se fier à l'instinct de [1113].\nInutile d'hésiter plus longtemps.\nOn y va !"
   },
   {
     "id": 322,
@@ -5060,7 +5060,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Alright.[SP]Then[SP]let's[SP]get[SP]to[SP]Pachinko[SP]Silver!",
     "nom_fr": "Yukino",
-    "texte_fr": "D'accord. Direction Pachinko Silver!"
+    "texte_fr": "D'accord. Direction Pachinko Silver !"
   },
   {
     "id": 323,
@@ -5075,7 +5075,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Wow,[SP]that[SP]Ulala[SP]lady[SP]was[SP]something[SP]else.[SP]She\nscared[SP]even[SP]me[SP]a[SP]little...[SP]But[SP]we[SP]stopped[SP]the\nbombs,[SP]so[SP]I[SP]guess[SP]it[SP]worked[SP]out[SP]in[SP]the[SP]end.",
     "nom_fr": "Yukino",
-    "texte_fr": "Waouh, cette Ulala c'était quelque\nchose. Mais on a arrêté les bombes,\ndonc tout est bien qui finit bien."
+    "texte_fr": "Waouh, cette Ulala c'était quelque chose.\nMais on a arrêté les bombes, donc tout\nest bien qui finit bien."
   },
   {
     "id": 324,
@@ -5091,7 +5091,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Well,[SP]all[SP]that's[SP]left[SP]is[SP]King[SP]Leo[SP]and[SP]the\nAerospace[SP]Museum.[SP]He's[SP]had[SP]us[SP]wrapped[SP]around\nhis[SP]finger[SP]for[SP]so[SP]long,[SP]it's[SP]time[SP]for[SP]payback!",
     "nom_fr": "Yukino",
-    "texte_fr": "Il ne reste que le Roi Lion et le Musée\nde l'Aérospatiale. Il s'est moqué de\nnous, c'est l'heure de la revanche!"
+    "texte_fr": "Il ne reste que le Roi Lion et le Musée de\nl'Aérospatiale. Il s'est moqué de nous, c'est\nl'heure de la revanche !"
   },
   {
     "id": 325,
@@ -5107,7 +5107,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Does[SP]King[SP]Leo[SP]think[SP]this[SP]is[SP]all[SP]a[SP]game...!?\nThat[SP]bastard's[SP]dead[SP]when[SP]I[SP]find[SP]him![SP]Let's[SP]go,\n[1113]![SP]To[SP]the[SP]Aerospace[SP]Museum!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ce Lion croit jouer!? Il est mort quand\nje l'aurai! En route, [1113]! Au Musée!"
+    "texte_fr": "Ce Lion croit jouer !?\nIl est mort quand je l'aurai !\nEn route, [1113] ! Au Musée !"
   },
   {
     "id": 326,
@@ -5123,7 +5123,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]wonder[SP]if[SP]this[SP]was[SP]their[SP]will,[SP]too...\nBut[SP]they[SP]were[SP]so[SP]kind[SP]back[SP]then...",
     "nom_fr": "Ginko",
-    "texte_fr": "C'était aussi leur volonté...?\nMais ils étaient si gentils..."
+    "texte_fr": "C'était aussi leur volonté... ?\nMais ils étaient si gentils..."
   },
   {
     "id": 327,
@@ -5139,7 +5139,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yeah...[SP]Jun[SP]would[SP]never[SP]have[SP]done[SP]this.[SP]We[SP]gotta\nstop[SP]him,[SP][1114]!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ouais... Jun n'aurait jamais\nfait ça. Il faut l'arrêter, [1114]!"
+    "texte_fr": "Ouais... Jun n'aurait jamais fait ça. Il faut\nl'arrêter, [1114] !"
   },
   {
     "id": 328,
@@ -5155,7 +5155,7 @@
     "nom_orig": "Maya",
     "texte_orig": "PACHINKO[SP]SILVERRRRRR!",
     "nom_fr": "Maya",
-    "texte_fr": "PACHINKO SILVER!"
+    "texte_fr": "PACHINKO SILVER !"
   },
   {
     "id": 329,
@@ -5171,7 +5171,7 @@
     "nom_orig": "Maya",
     "texte_orig": "...I[SP]mean,[SP]hold[SP]it,[SP][1113]-kun.[SP]You're[SP]still\na[SP]high[SP]schooler.",
     "nom_fr": "Maya",
-    "texte_fr": "... Je veux dire, attends,\n[1113]-kun. T'es encore lycéen."
+    "texte_fr": "...Je veux dire, attends, [1113]-kun. T'es encore\nlycéen."
   },
   {
     "id": 330,
@@ -5187,7 +5187,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Pachinko[SP]Silver,[SP]huh...?[1205][U+000F][SP]I'd[SP]hate[SP]to[SP]see[SP]this\nplace[SP]go,[SP]that's[SP]for[SP]sure.[SP]But[SP]it[SP]might[SP]not\nbe[SP]the[SP]target...",
     "nom_fr": "Maya",
-    "texte_fr": "Pachinko Silver...?[1205][U+000F] Je détesterais voir ça\ndisparaître. Mais c'est peut-être pas la\ncible..."
+    "texte_fr": "Pachinko Silver... ?[1205][U+000F] Je détesterais voir ça\ndisparaître. Mais c'est peut-être pas la cible..."
   },
   {
     "id": 331,
@@ -5203,7 +5203,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "In[SP]any[SP]case,[SP]we[SP]gotta[SP]move.[1205][U+000F][SP]Let's[SP]stop[SP]second-\nguessing[SP]ourselves[SP]and[SP]get[SP]this[SP]done!",
     "nom_fr": "Eikichi",
-    "texte_fr": "En tout cas, faut bouger.[1205][U+000F] Arrêtons\nde douter et finissons-en!"
+    "texte_fr": "En tout cas, faut bouger.[1205][U+000F] Arrêtons de\ndouter et finissons-en !"
   },
   {
     "id": 332,
@@ -5219,7 +5219,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]can't[SP]make[SP]the[SP]same[SP]mistake[SP]again.[SP]Is[SP]this\nthe[SP]target?[1205][U+000F][SP]It[SP]could[SP]always[SP]be[SP]GOLD...",
     "nom_fr": "Maya",
-    "texte_fr": "On ne peut pas répéter l'erreur. Est-ce\nla cible?[1205][U+000F] Ça pourrait être GOLD..."
+    "texte_fr": "On ne peut pas répéter l'erreur. Est-ce\nla cible ?[1205][U+000F] Ça pourrait être GOLD..."
   },
   {
     "id": 333,
@@ -5251,7 +5251,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?\n[1208][0002][1432][NULL][NULL][0014]Yeah,[SP]let's[SP]check[SP]it[SP]out.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]No,[SP]this[SP]isn't[SP]the[SP]place.[1432][NULL][NULL][0014]",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun?[1205][U+000F] On fouille ici?[E1][E2][E3]On fouille ici?\n[1208][0002][1432][NULL][NULL][0014]Ouais, allons voir.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas ici.[1432][NULL][NULL][0014]",
+    "texte_fr": "[1113]-kun ?[1205][U+000F] On fouille ici ?[E1][E2][E3]On fouille ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, allons voir.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas ici.[1432][NULL][NULL][0014]",
     "question_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?",
     "choix_orig": [
       "Yeah,[SP]let's[SP]check[SP]it[SP]out.",
@@ -5277,7 +5277,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Not[SP]here,[SP]then.[SP]Alright,[SP]off[SP]to[SP]GOLD!",
     "nom_fr": "Yukino",
-    "texte_fr": "Pas ici, alors. En route pour GOLD!"
+    "texte_fr": "Pas ici, alors. En route pour GOLD !"
   },
   {
     "id": 336,
@@ -5324,7 +5324,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Ulala![1205][U+000F][SP]What're[SP]you[SP]doing[SP]here?[SP]Did[SP]something\nhappen?",
     "nom_fr": "Maya",
-    "texte_fr": "Ulala![1205][U+000F] Que fais-tu ici? Un problème?"
+    "texte_fr": "Ulala ![1205][U+000F] Que fais-tu ici ?\nUn problème ?"
   },
   {
     "id": 339,
@@ -5339,7 +5339,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "Can't[SP]you[SP]tell?[1205][U+000F][SP]I[SP]had[SP]a[SP]feeling[SP]luck[SP]was[SP]on[SP]my\nside[SP]today![SP]And[SP]sure[SP]enough,[SP]I[SP]hit[SP]the[SP]jackpot!",
     "nom_fr": "Ulala",
-    "texte_fr": "Ça se voit pas?[1205][U+000F] La chance me souriait!\nEt bingo, j'ai touché le gros lot!"
+    "texte_fr": "Ça se voit pas ?[1205][U+000F] La chance me souriait !\nEt bingo, j'ai touché le gros lot !"
   },
   {
     "id": 340,
@@ -5371,7 +5371,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Wait[SP]a[SP]sec![1205][U+000F][SP]Your[SP]fitness[SP]club[SP]was[SP]GOLD!",
     "nom_fr": "Maya",
-    "texte_fr": "Attends![1205][U+000F] Ton club c'était GOLD!"
+    "texte_fr": "Attends ![1205][U+000F] Ton club c'était GOLD !"
   },
   {
     "id": 342,
@@ -5387,7 +5387,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "Yep![SP]That's[SP]right!",
     "nom_fr": "Ulala",
-    "texte_fr": "Ouais! Exact!"
+    "texte_fr": "Ouais ! Exact !"
   },
   {
     "id": 343,
@@ -5403,7 +5403,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "If[SP]we'd[SP]searched[SP]this[SP]place,[SP]we[SP]wouldn't[SP]have\nbeen[SP]able[SP]to[SP]stop[SP]GOLD[SP]from[SP]going[SP]down...\nThat's[SP]my[SP]Chinyan!",
     "nom_fr": "Ginko",
-    "texte_fr": "Si on avait fouillé cet endroit, on\nn'aurait pas pu empêcher l'explosion\nde GOLD... T'es géniale!"
+    "texte_fr": "Si on avait fouillé cet endroit, on n'aurait pas pu\nempêcher l'explosion de GOLD... T'es géniale !"
   },
   {
     "id": 344,
@@ -5419,7 +5419,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![SP]If[SP]this[SP]place[SP]didn't[SP]exist,[SP]we[SP]would\nhave[SP]stopped[SP]GOLD[SP]from[SP]going[SP]down!",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei! Sans ce lieu, on aurait\nempêché la chute de GOLD!"
+    "texte_fr": "Kehhei ! Sans ce lieu, on aurait\nempêché la chute de GOLD !"
   },
   {
     "id": 345,
@@ -5483,7 +5483,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We[SP]got[SP]the[SP]crystal[SP]skull[SP]and[SP]we[SP]saved[SP]Miyabi.\nI[SP]don't[SP]think[SP]we[SP]need[SP]to[SP]go[SP]in[SP]there[SP]anymore.",
     "nom_fr": "Eikichi",
-    "texte_fr": "On a le crâne de cristal et on a sauvé\nMiyabi. Plus besoin d'y retourner."
+    "texte_fr": "On a le crâne de cristal et on a sauvé Miyabi.\nPlus besoin d'y retourner."
   },
   {
     "id": 349,
@@ -5499,7 +5499,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "Noooooo![1205][U+000F][SP]GOOOOOLD![1205][U+000F][SP]My[SP]gym!",
     "nom_fr": "Ulala",
-    "texte_fr": "Non![1205][U+000F] GOLD![1205][U+000F] Ma gym!"
+    "texte_fr": "Non ![1205][U+000F] GOLD ![1205][U+000F] Ma gym !"
   },
   {
     "id": 350,
@@ -5515,7 +5515,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh?[SP]Why?[1205][U+000F][SP]Pachinko[SP]Silver[SP]wasn't[SP]the[SP]target?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein?[1205][U+000F] Silver pas visé?"
+    "texte_fr": "Hein ?[1205][U+000F] Silver pas visé ?"
   },
   {
     "id": 351,
@@ -5531,7 +5531,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "Did[SP]the[SP]terrorists[SP]do[SP]this!?[1205][U+000F][SP]This[SP]isn't[SP]funny!\nI[SP]just[SP]joined[SP]this[SP]place![1205][U+000F][SP]And[SP]I[SP]fully[SP]paid[SP]my\nmembership[SP]in[SP]advance!",
     "nom_fr": "Ulala",
-    "texte_fr": "Les terroristes ont fait ça!?[1205][U+000F] Pas drôle! Je\nviens de m'inscrire![1205][U+000F] J'ai payé d'avance!"
+    "texte_fr": "Les terroristes ont fait ça !?[1205][U+000F] Pas drôle !\nJe viens de m'inscrire ![1205][U+000F] J'ai payé d'avance !"
   },
   {
     "id": 352,
@@ -5562,7 +5562,7 @@
     "nom_orig": "Elly's[SP]voice",
     "texte_orig": "Hello?[SP]Elly[SP]here.[1205][U+000F][SP]I've[SP]figured[SP]out[SP]the[SP]last\ntarget.[1205][U+000F][SP]It's[SP]south-southeast[SP]of[SP]Sevens...",
     "nom_fr": "Voix d'Elly",
-    "texte_fr": "Allô? C'est Elly.[1205][U+000F] J'ai découvert la dernière\ncible.[1205][U+000F] C'est au sud-sud-est de Seven..."
+    "texte_fr": "Allô ? C'est Elly.[1205][U+000F] J'ai découvert la dernière\ncible.[1205][U+000F] C'est au sud-sud-est de Seven..."
   },
   {
     "id": 354,
@@ -5578,7 +5578,7 @@
     "nom_orig": "Elly's[SP]voice",
     "texte_orig": "There's[SP]only[SP]one[SP]building[SP]in[SP]that[SP]direction:[1205][U+000F]\nThe[SP]Aerospace[SP]Museum[SP]in[SP]Kounan.[SP]You[SP]must[SP]hurry!",
     "nom_fr": "Voix d'Elly",
-    "texte_fr": "Un seul bâtiment dans cette direction:[1205][U+000F]\nLe Musée de l'Aérospatiale. Faites vite!"
+    "texte_fr": "Un seul bâtiment dans cette direction :[1205][U+000F]\nLe Musée de l'Aérospatiale. Faites vite !"
   },
   {
     "id": 355,
@@ -5594,7 +5594,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "You[SP]hear[SP]that,[SP]guys?[1205][U+000F][SP]We[SP]finally[SP]got[SP]a[SP]concrete\nclue.[SP]The[SP]last[SP]target's[SP]the[SP]Aerospace[SP]Museum!",
     "nom_fr": "Yukino",
-    "texte_fr": "Vous avez entendu?[1205][U+000F] On a une piste. La dernière\ncible est le Musée de l'Aérospatiale!"
+    "texte_fr": "Vous avez entendu ?[1205][U+000F] On a une piste. La\ndernière cible est le Musée de l'Aérospatiale !"
   },
   {
     "id": 356,
@@ -5610,7 +5610,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That[SP]King[SP]Leo[SP]bastard[SP]hasn't[SP]shown[SP]himself[SP]since\nthe[SP]concert[SP]hall,[SP]but...[SP]You[SP]really[SP]think[SP]he'll\nstay[SP]that[SP]quiet?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ce fumier de Roi Lion ne s'est pas\nmontré depuis la salle de concert...\nTu crois qu'il va rester tranquille?"
+    "texte_fr": "Ce fumier de Roi Lion ne s'est pas montré\ndepuis la salle de concert... Tu crois qu'il\nva rester tranquille ?"
   },
   {
     "id": 357,
@@ -5626,7 +5626,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]agree...[SP]If[SP]the[SP]Aerospace[SP]Museum[SP]is[SP]the[SP]last\ntarget,[SP]you[SP]can[SP]bet[SP]King[SP]Leo[SP]will[SP]be[SP]there.[1205][U+000F]\nLet's[SP]put[SP]an[SP]end[SP]to[SP]this!",
     "nom_fr": "Maya",
-    "texte_fr": "D'accord... Si le Musée est la\ndernière cible, le Roi Lion y\nsera.[1205][U+000F] Mettons un terme à tout ça!"
+    "texte_fr": "D'accord... Si le Musée est la dernière\ncible, le Roi Lion y sera.[1205][U+000F] Mettons\nun terme à tout ça !"
   },
   {
     "id": 358,
@@ -5642,7 +5642,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Whoa,[SP]hold[SP]your[SP]horses.[SP]We[SP]haven't[SP]gotten[SP]the\nskull[SP]at[SP]Leo[SP]Temple[SP]yet,[SP]right?[SP]Let's[SP]take\ncare[SP]of[SP]that[SP]before[SP]we[SP]jump[SP]in[SP]here.",
     "nom_fr": "Maya",
-    "texte_fr": "Whoa, doucement. On n'a pas encore\nrécupéré le crâne au Temple du Lion, non?\nOccupons-nous de ça avant de foncer ici."
+    "texte_fr": "Whoa, doucement. On n'a pas encore récupéré le crâne\nau Temple du Lion, non ? Occupons-nous de ça\navant de foncer ici."
   },
   {
     "id": 359,
@@ -5658,7 +5658,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Wait[SP]a[SP]sec,[SP]Chinyan![SP]We[SP]don't[SP]have[SP]the[SP]skull\nfrom[SP]Taurus[SP]Temple[SP]yet.[SP]We[SP]should[SP]stop[SP]by\nthere[SP]first.",
     "nom_fr": "Ginko",
-    "texte_fr": "Attends, Chinyan! On n'a pas encore\nle crâne du Temple du Taureau. On\ndevrait commencer par là."
+    "texte_fr": "Attends, Chinyan ! On n'a pas encore le crâne\ndu Temple du Taureau. On devrait commencer par là."
   },
   {
     "id": 360,
@@ -5673,6 +5673,6 @@
     "nom_orig": "Jun",
     "texte_orig": "Hold[SP]on[SP]a[SP]moment.[SP]We're[SP]still[SP]not[SP]done[SP]with\nthe[SP]Aquarius[SP]Temple.",
     "nom_fr": "Jun",
-    "texte_fr": "Une seconde. On n'en a pas fini\navec le Temple du Verseau."
+    "texte_fr": "Une seconde. On n'en a pas fini avec\nle Temple du Verseau."
   }
 ]

--- a/traduction/MMAP03.json
+++ b/traduction/MMAP03.json
@@ -1,4476 +1,4476 @@
 [
-  {
-    "id": 0,
-    "offset": 276502,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Hm?[SP]The[SP]outdoor[SP]concert[SP]hall?[SP]Oh,[SP]it's[SP]over[SP]in\nAoba[SP]Park.[SP]Are[SP]you[SP]going[SP]to[SP]see[SP]the[SP]show?",
-    "nom_fr": "Employé",
-    "texte_fr": "La salle de concert ? Dans le parc\nd'Aoba. Tu vas voir le spectacle ?"
-  },
-  {
-    "id": 1,
-    "offset": 276718,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "The[SP]Muses[SP]sure[SP]got[SP]popular[SP]fast.[SP]I[SP]was[SP]curious,\nbut[SP]the[SP]tickets[SP]are[SP]all[SP]sold[SP]out.[SP]I[SP]guess[SP]it\nwasn't[SP]meant[SP]to[SP]be.",
-    "nom_fr": "Employé",
-    "texte_fr": "Les Muses sont devenues populaires vite.\nJ'étais curieux, mais complet. Pas pour moi."
-  },
-  {
-    "id": 2,
-    "offset": 276984,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "I...[SP]I[SP]can't[SP]believe[SP]the[SP]concert[SP]hall[SP]burned\ndown...[1205][U+000F][SP]Wh-What[SP]happened[SP]in[SP]there?[SP]Is[SP]the\naudience[SP]okay?",
-    "nom_fr": "Employé",
-    "texte_fr": "Je… La salle a brûlé…[1205][000F] Que s'est-il\npassé ? Le public va bien ?"
-  },
-  {
-    "id": 3,
-    "offset": 277232,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]from[SP]a[SP]friend[SP]that[SP]Smile[SP]Hirasaka[SP]and\nGOLD[SP]were[SP]targeted[SP]by[SP]terrorists[SP]too.[1205][U+000F][SP]Luckily,\nboth[SP]attacks[SP]were[SP]thwarted...",
-    "nom_fr": "Employé",
-    "texte_fr": "Un ami m'a dit que Smile Hirasaka et\nGOLD ont aussi été visés.[1205][000F] Heureusement,\nles deux ont été évités..."
-  },
-  {
-    "id": 4,
-    "offset": 277520,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "But[SP]they[SP]were[SP]both[SP]packed[SP]with[SP]people.[1205][U+000F]\nWho'd[SP]want[SP]to[SP]bomb[SP]someplace[SP]like[SP]that?\nThe[SP]culprit[SP]is[SP]inhuman...!",
-    "nom_fr": "Employé",
-    "texte_fr": "Mais ils étaient bondés.[1205][000F] Qui voudrait\nbombarder ça ? Le coupable est inhumain !"
-  },
-  {
-    "id": 5,
-    "offset": 277776,
-    "data_size": 250,
-    "slot_size": 254,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "My[SP]friend[SP]told[SP]me[SP]that[SP]the[SP]terrorists[SP]even[SP]blew\nup[SP]Smile[SP]Hirasaka.[1205][U+000F][SP]I[SP]hear[SP]the[SP]death[SP]toll[SP]was\ntremendous.",
-    "nom_fr": "Employé",
-    "texte_fr": "Mon ami dit que les terroristes ont fait\nsauter Smile Hirasaka.[1205][000F] De nombreux morts."
-  },
-  {
-    "id": 6,
-    "offset": 278030,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "There[SP]were[SP]lots[SP]of[SP]people[SP]at[SP]that[SP]concert[SP]hall,\ntoo...[1205][U+000F][SP]Who'd[SP]want[SP]to[SP]blow[SP]up[SP]someplace[SP]like\nthat?[SP]The[SP]culprit[SP]is[SP]inhuman...!",
-    "nom_fr": "Employé",
-    "texte_fr": "Beaucoup de monde aussi...[1205][000F]\nPourquoi bombarder ça ? Inhumain !"
-  },
-  {
-    "id": 7,
-    "offset": 278324,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "My[SP]friend[SP]told[SP]me[SP]that[SP]the[SP]terrorists[SP]even[SP]blew\nup[SP]GOLD[SP]in[SP]Yumezaki.[1205][U+000F][SP]I[SP]hear[SP]the[SP]death[SP]toll[SP]was\ntremendous.",
-    "nom_fr": "Employé",
-    "texte_fr": "Mon ami dit qu'ils ont fait sauter\nGOLD à Yumezaki.[1205][000F] Beaucoup de morts."
-  },
-  {
-    "id": 8,
-    "offset": 278580,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "There[SP]were[SP]lots[SP]of[SP]people[SP]at[SP]that[SP]concert[SP]hall,\ntoo...[1205][U+000F][SP]Who'd[SP]want[SP]to[SP]blow[SP]up[SP]someplace[SP]like\nthat?[SP]The[SP]culprit[SP]is[SP]inhuman...!",
-    "nom_fr": "Employé",
-    "texte_fr": "Beaucoup de monde aussi...[1205][000F]\nPourquoi bombarder ça ? Inhumain !"
-  },
-  {
-    "id": 9,
-    "offset": 278874,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]from[SP]a[SP]friend[SP]that[SP]terrorists[SP]struck\nat[SP]both[SP]Smile[SP]Hirasaka[SP]and[SP]GOLD.[1205][U+000F][SP]So[SP]many\npeople[SP]died...",
-    "nom_fr": "Employé",
-    "texte_fr": "Un ami m'a dit que les terroristes ont frappé\nSmile Hirasaka et GOLD.[1205][000F] Tant de morts…"
-  },
-  {
-    "id": 10,
-    "offset": 279118,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "They[SP]were[SP]both[SP]packed[SP]with[SP]people.[SP]Who'd[SP]want[1205][U+000F]\nto[SP]bomb[SP]someplace[SP]like[SP]that?[SP]The[SP]culprit[SP]is\ninhuman...!",
-    "nom_fr": "Employé",
-    "texte_fr": "Bondés. Qui voudrait[1205][000F] bombarder ça ? Inhumain !"
-  },
-  {
-    "id": 11,
-    "offset": 279366,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Even[SP]the[SP]Aerospace[SP]Museum[SP]was[SP]bombed...[1205][U+000F]\nThat's[SP]already[SP]six[SP]attacks[SP]in[SP]total.[1205][U+000F]",
-    "nom_fr": "Employé",
-    "texte_fr": "Même le musée aérospatial a été\nbombardé…[1205][000F] Six attaques au total.[1205][000F]"
-  },
-  {
-    "id": 12,
-    "offset": 279568,
-    "data_size": 156,
-    "slot_size": 160,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "How[SP]many[SP]deaths[SP]will[SP]it[SP]take[SP]to[SP]satisfy[SP]that\ngang[SP]of[SP]five!?",
-    "nom_fr": "Employé",
-    "texte_fr": "Combien de morts pour cette bande de cinq !?"
-  },
-  {
-    "id": 13,
-    "offset": 279728,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "The[SP]paper's[SP]reporting[SP]now[SP]that[SP]the[SP]Masked\nCircle[SP]and[SP]the[SP]Last[SP]Battalion[SP]are[SP]fighting\nover[SP]the[SP]secret[SP]treasure[SP]of[SP]Sumaru.",
-    "nom_fr": "Employé",
-    "texte_fr": "Le journal dit que le Cercle Masqué\net le Dernier Bataillon se battent\npour le trésor secret de Sumaru."
-  },
-  {
-    "id": 14,
-    "offset": 280008,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Looks[SP]like[SP]that[SP]was[SP]the[SP]reason[SP]for[SP]the[SP]terror\nwave,[SP]too.[1205][U+000F][SP]Honestly,[SP]one[SP]of[SP]them[SP]should[SP]just\ntake[SP]it[SP]and[SP]go.[SP]We[SP]don't[SP]need[SP]them[SP]here!",
-    "nom_fr": "Employé",
-    "texte_fr": "C'était la raison de la vague de\nterreur aussi.[1205][000F] Qu'ils le prennent et\ns'en aillent. On n'en a pas besoin !"
-  },
-  {
-    "id": 15,
-    "offset": 280316,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Th-That[SP]mark...![1205][U+000F][SP]Why[SP]are[SP]soldiers[SP]with[SP]that\ninsignia[SP]coming[SP]to[SP]Sumaru[SP]now!?[SP]It[SP]makes\nno[SP]sense!",
-    "nom_fr": "Employé",
-    "texte_fr": "Ce symbole…![1205][000F] Pourquoi ces soldats\nviennent à Sumaru ? Insensé !"
-  },
-  {
-    "id": 16,
-    "offset": 280550,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "D-Did[SP]the[SP]Masked[SP]Circle[SP]and[SP]the[SP]Last[SP]Battalion\ncause[SP]those[SP]temples[SP]to[SP]appear,[SP]too?",
-    "nom_fr": "Employé",
-    "texte_fr": "Le Cercle Masqué et le Dernier Bataillon\nont-ils aussi fait apparaître ces temples ?"
-  },
-  {
-    "id": 17,
-    "offset": 280756,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Because[SP]I[SP]mean,[SP]once[SP]those[SP]things[SP]showed[SP]up,\nthey[SP]all[SP]rushed[SP]inside.",
-    "nom_fr": "Employé",
-    "texte_fr": "Une fois apparus, ils se sont\ntous précipités à l'intérieur."
-  },
-  {
-    "id": 18,
-    "offset": 280934,
-    "data_size": 210,
-    "slot_size": 214,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Ugh...[SP]This[SP]is[SP]too[SP]much...[1205][U+000F][SP]I[SP]feel[SP]like[SP]I'm\ngoing[SP]to[SP]go[SP]insane[SP]before[SP]I[SP]can[SP]evolve...",
-    "nom_fr": "Employé",
-    "texte_fr": "Ugh… C'en est trop…[1205][000F] Je\ndeviendrai fou avant d'évoluer…"
-  },
-  {
-    "id": 19,
-    "offset": 281148,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Aoba[SP]is[SP]famous[SP]for[SP]its[SP]outdoor[SP]concert[SP]hall,\nbut[SP]that's[SP]not[SP]the[SP]only[SP]thing[SP]we're[SP]known[SP]for.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Aoba est célèbre pour sa salle de concert,\nmais ce n'est pas notre seule fierté."
-  },
-  {
-    "id": 20,
-    "offset": 281372,
-    "data_size": 184,
-    "slot_size": 188,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Kismet[SP]Publishing,[SP]publishers[SP]of[SP]Coolest,\nand[SP]Sumaru[SP]TV[SP]are[SP]in[SP]this[SP]ward.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Kismet Publishing (Coolest) et\nSumaru TV sont dans ce quartier."
-  },
-  {
-    "id": 21,
-    "offset": 281560,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "It[SP]may[SP]not[SP]have[SP]Yumezaki's[SP]pizazz,[SP]but[SP]I[SP]think\nthis[SP]ward[SP]is[SP]the[SP]beating[SP]heart[SP]that[SP]feeds\ninformation[SP]across[SP]Sumaru[SP]City.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Ça n'a pas le peps de Yumezaki, mais ce\nquartier est le cœur qui alimente Sumaru en\ninfos."
-  },
-  {
-    "id": 22,
-    "offset": 281842,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "I[SP]just[SP]saw[SP]a[SP]Masked[SP]Circle[SP]member[SP]in[SP]a[SP]store.[1205][U+000F]\nHe[SP]was[SP]saying[SP]some[SP]scary[SP]stuff...",
-    "nom_fr": "Femme active",
-    "texte_fr": "Je viens de voir un membre du Cercle\nMasqué.[1205][000F] Il disait des trucs effrayants…"
-  },
-  {
-    "id": 23,
-    "offset": 282046,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "There's[SP]no[SP]doubt[SP]that[SP]it[SP]was[SP]them[SP]who[SP]set[SP]fire\nto[SP]the[SP]outdoor[SP]concert[SP]hall.[SP]They're[SP]a[SP]menace,\njust[SP]like[SP]the[SP]rumors[SP]said.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Nul doute que c'est eux qui ont\nincendié la salle. Une menace,\ncomme les rumeurs le disaient."
-  },
-  {
-    "id": 24,
-    "offset": 282328,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Some[SP]kids[SP]came[SP]by[SP]just[SP]now[SP]and[SP]said[SP]the[SP]five\nsuspects[SP]are[SP]actually[SP]heroes[SP]fighting[SP]against\nthe[SP]Masked[SP]Circle...",
-    "nom_fr": "Femme active",
-    "texte_fr": "Des gamins ont dit que les cinq suspects sont\ndes héros qui combattent le Cercle Masqué…"
-  },
-  {
-    "id": 25,
-    "offset": 282592,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "I-I[SP]knew[SP]all[SP]along.[SP]The[SP]culprits[SP]were[SP]the\nMasked[SP]Circle,[SP]of[SP]course![1205][U+000F][SP]But[SP]I[SP]didn't[SP]know\nthose[SP]five[SP]were[SP]fighting[SP]against[SP]them...",
-    "nom_fr": "Femme active",
-    "texte_fr": "Je le savais. Les coupables sont\nle Cercle Masqué ![1205][000F] Mais j'ignorais\nque ces cinq les combattaient…"
-  },
-  {
-    "id": 26,
-    "offset": 282890,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "I-I[SP]heard[SP]the[SP]Oracle[SP]in[SP]the[SP]In[SP]Lak'ech[SP]talks\nabout[SP]everything[SP]that's[SP]happened[SP]lately,\nbut[SP]that's[SP]just[SP]a[SP]marketing[SP]angle.",
-    "nom_fr": "Femme active",
-    "texte_fr": "L'Oracle dans l'In Lak'ech parle de tout,\nmais ce n'est qu'un argument marketing."
-  },
-  {
-    "id": 27,
-    "offset": 283170,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "I[SP]mean,[SP]it's[SP]not[SP]like[SP]it's[SP]some[SP]grand[SP]prophecy.\nThat[SP]would[SP]just[SP]be[SP]ridiculous...",
-    "nom_fr": "Femme active",
-    "texte_fr": "Ce n'est pas une grande\nprophétie. Ce serait ridicule…"
-  },
-  {
-    "id": 28,
-    "offset": 283372,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "D-Don't[SP]you[SP]think[SP]so?[1205][U+000F][SP]I-I'm[SP]right,[SP]aren't[SP]I?",
-    "nom_fr": "Femme active",
-    "texte_fr": "Tu ne crois pas ?[1205][000F] J'ai raison, non ?"
-  },
-  {
-    "id": 29,
-    "offset": 283506,
-    "data_size": 318,
-    "slot_size": 322,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Why[SP]are[SP]soldiers[SP]raining[SP]from[SP]the[SP]sky!?[SP]Is[SP]this\nthing[SP]saying[SP]there's[SP]some[SP]secret[SP]treasure[SP]here\nin[SP]Sumaru!?[1205][U+000F][SP]I-I[SP]refuse[SP]to[SP]believe[SP]that![SP]No!",
-    "nom_fr": "Femme active",
-    "texte_fr": "Pourquoi les soldats pleuvent du ciel !?\nCe truc dit qu'il y a un trésor secret à\nSumaru !?[1205][000F] Je refuse de le croire ! Non !"
-  },
-  {
-    "id": 30,
-    "offset": 283828,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Huh!?[1205][U+000A][SP]Didn't[SP]you[SP]just[SP]go[SP]into[SP]that[SP]temple?[1205][U+000F]\nYeah,[SP]carrying[SP]this[SP]weird[SP]skull...[1205][U+000F][SP]A-Am[SP]I\nseeing[SP]things...?",
-    "nom_fr": "Femme active",
-    "texte_fr": "Hein ?[1205][000A] Tu n'es pas entré dans ce\ntemple ?[1205][000F] Oui, avec ce drôle de\ncrâne…[1205][000F] J'ai des hallucinations ?"
-  },
-  {
-    "id": 31,
-    "offset": 284086,
-    "data_size": 326,
-    "slot_size": 330,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Ever[SP]hear[SP]the[SP]rumor[SP]that[SP]Rosa[SP]Candida[SP]sells\nreal[SP]armor?[1205][U+000F][SP]An[SP]office[SP]mate[SP]of[SP]mine[SP]told[SP]me\nabout[SP]it,[SP]and[SP]I've[SP]been[SP]curious[SP]ever[SP]since.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tu as entendu que Rosa Candida vend\nde vraies armures ?[1205][000F] Un collègue\nm'en a parlé, je suis curieux."
-  },
-  {
-    "id": 32,
-    "offset": 284416,
-    "data_size": 148,
-    "slot_size": 152,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "It[SP]seems[SP]he[SP]got[SP]the[SP]story[SP]online[SP]somewhere.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Il a dû voir ça sur Internet."
-  },
-  {
-    "id": 33,
-    "offset": 284568,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "If[SP]you[SP]go[SP]to[SP]Double[SP]Slash,[SP]you[SP]can[SP]use[SP]their\nPCs[SP]to[SP]browse[SP]the[SP]Internet.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Au Double Slash, on peut utiliser\nleurs PC pour surfer sur Internet."
-  },
-  {
-    "id": 34,
-    "offset": 284778,
-    "data_size": 322,
-    "slot_size": 326,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Even[SP]an[SP]old[SP]man[SP]like[SP]me[SP]could[SP]look[SP]it[SP]up[SP]there\nif[SP]I[SP]wanted...[1205][U+000F][SP]But[SP]I'm[SP]no[SP]good[SP]with[SP]computers.[1205][U+000F]\nJust[SP]one[SP]of[SP]my[SP]hangups,[SP]I[SP]guess.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Même un vieux comme moi pourrait\nchercher,[1205][000F] mais je suis nul en\ninformatique.[1205][000F] Un de mes travers."
-  },
-  {
-    "id": 35,
-    "offset": 285104,
-    "data_size": 338,
-    "slot_size": 342,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]the[SP]Masked[SP]Circle[SP]did[SP]this,[SP]but[SP]I\nalso[SP]hear[SP]there[SP]was[SP]a[SP]group[SP]of[SP]five[SP]suspicious\npeople[SP]seen[SP]around[SP]the[SP]outdoor[SP]concert[SP]hall.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "On dit que c'est le Cercle Masqué, mais j'ai\naussi entendu qu'un groupe de cinq suspects\na été vu près de la salle de concert."
-  },
-  {
-    "id": 36,
-    "offset": 285446,
-    "data_size": 136,
-    "slot_size": 140,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Shouldn't[SP]those[SP]guys[SP]be[SP]suspects[SP]too?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Ils ne devraient pas être suspects aussi ?"
-  },
-  {
-    "id": 37,
-    "offset": 285586,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "I[SP]can't[SP]believe[SP]such[SP]a[SP]terrible[SP]tragedy\nhappened...[1205][U+000F][SP]But[SP]if[SP]sketches[SP]of[SP]the[SP]culprits[SP]are\nout,[SP]it[SP]won't[SP]be[SP]long[SP]before[SP]they're[SP]arrested.",
-    "nom_fr": "Homme",
-    "texte_fr": "Je n'arrive pas à croire qu'une telle\ntragédie soit arrivée.[1205][000F] Mais avec les\nportraits-robots, ils seront bientôt arrêtés."
-  },
-  {
-    "id": 38,
-    "offset": 285880,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "My[SP]entire[SP]office[SP]is[SP]buzzing[SP]about[SP]whether[SP]or\nnot[SP]the[SP]In[SP]Lak'ech[SP]is[SP]true.[1205][U+000F][SP]All[SP]the[SP]younger\nemployees[SP]seem[SP]to[SP]believe[SP]in[SP]it.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tout le bureau parle de si l'In Lak'ech\nest vrai.[1205][000F] Les jeunes y croient."
-  },
-  {
-    "id": 39,
-    "offset": 286192,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Most[SP]of[SP]those[SP]soldiers[SP]were[SP]heading[SP]to\nMt.[SP]Katatsumuri.[1205][U+000F][SP]But[SP]why[SP]would[SP]they[SP]go[SP]there?\nI[SP]don't[SP]understand.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "La plupart des soldats allaient au mont\nKatatsumuri.[1205][000F] Pourquoi ? Je ne comprends pas."
-  },
-  {
-    "id": 40,
-    "offset": 286470,
-    "data_size": 316,
-    "slot_size": 320,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "How[SP]can[SP]such[SP]nonsensical[SP]things[SP]be[SP]happening?[1205][U+000A]\nW-Well,[SP]I've[SP]seen[SP]it[SP]for[SP]myself...[1205][U+000A][SP]I[SP]don't\nhave[SP]a[SP]choice[SP]but[SP]to[SP]believe[SP]it...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Comment de telles absurdités arrivent\n?[1205][000A] Je l'ai vu de mes yeux…[1205][000A] Je n'ai pas\nle choix, je dois y croire…"
-  },
-  {
-    "id": 41,
-    "offset": 286790,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "But[SP]in[SP]that[SP]case,[SP]this[SP]talk[SP]about[SP]the[SP]Earth\nbeing[SP]annihilated[SP]must[SP]be[SP]true,[SP]too...[1205][U+000F][SP]What\nexactly[SP]is[SP]going[SP]to[SP]happen?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Alors cette histoire de Terre\nanéantie doit être vraie aussi…[1205][000F]\nQue va-t-il exactement se passer ?"
-  },
-  {
-    "id": 42,
-    "offset": 287090,
-    "data_size": 348,
-    "slot_size": 352,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "My[SP]men[SP]say[SP]that[SP]the[SP]Grand[SP]Cross[SP]will[SP]cause[SP]the\nmantle's[SP]temperature[SP]to[SP]rise,[SP]making[SP]the[SP]Earth\na[SP]scorching[SP]hell...[1205][U+000F][SP]Is[SP]that[SP]how[SP]the[SP]world[SP]ends?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Mes collègues disent que la Grande Croix fera\nmonter la température, transformant la Terre\nen enfer…[1205][000F] C'est ainsi que le monde finit ?"
-  },
-  {
-    "id": 43,
-    "offset": 287442,
-    "data_size": 316,
-    "slot_size": 320,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "A[SP]colleague[SP]of[SP]mine[SP]says[SP]the[SP]Grand[SP]Cross[SP]will\nresult[SP]in[SP]the[SP]gravitational[SP]pull[SP]of[SP]the[SP]other\nplanets[SP]causing[SP]a[SP]gigantic[SP]tsunami.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un collègue dit que la Grande Croix\nprovoquera l'attraction des autres\nplanètes, causant un tsunami géant."
-  },
-  {
-    "id": 44,
-    "offset": 287762,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]don't[SP]know[SP]much[SP]about[SP]science...[1205][U+000F][SP]Is[SP]that\neven[SP]possible?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Je ne connais pas bien la science…[1205][000F]\nEst-ce seulement possible ?"
-  },
-  {
-    "id": 45,
-    "offset": 287946,
-    "data_size": 318,
-    "slot_size": 322,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "That[SP]was[SP]strange.[1205][U+000A][SP]My[SP]men[SP]had[SP]all[SP]been[SP]arguing\nover[SP]how[SP]the[SP]world[SP]down[SP]there[SP]would[SP]end,[SP]when\nsuddenly[SP]they[SP]settled[SP]on[SP]one[SP]idea.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "C'était étrange.[1205][000A] Ils discutaient de la\nfin du monde en bas, quand soudain ils\nse sont mis d'accord sur une idée."
-  },
-  {
-    "id": 46,
-    "offset": 288268,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "They[SP]think[SP]the[SP]Grand[SP]Cross[SP]will[SP]cause[SP]the\nEarth[SP]to[SP]stop[SP]rotating.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Ils pensent que la Grande Croix\narrêtera la rotation de la Terre."
-  },
-  {
-    "id": 47,
-    "offset": 288464,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]couldn't[SP]follow[SP]their[SP]explanations,[SP]but[SP]the\nupshot[SP]was[SP]that[SP]everything[SP]on[SP]Earth[SP]will[SP]be\nblasted[SP]away[SP]at[SP]high[SP]speed,[SP]right?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Je n'ai pas suivi, mais tout sur\nTerre sera emporté à grande vitesse ?"
-  },
-  {
-    "id": 48,
-    "offset": 288778,
-    "data_size": 334,
-    "slot_size": 338,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "So[SP]there[SP]are[SP]talking[SP]flowers[SP]in[SP]Aoba[SP]Park...\nWhen[SP]I[SP]first[SP]heard,[SP]I[SP]thought[SP]it[SP]was[SP]a[SP]joke.[1205][U+000F]\nI'm[SP]curious[SP]to[SP]know[SP]what[SP]plants[SP]think[SP]about.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Des fleurs qui parlent dans le parc d'Aoba…\nJ'ai d'abord cru à une blague.[1205][000F] Curieux de\nsavoir à quoi pensent les plantes."
-  },
-  {
-    "id": 49,
-    "offset": 289116,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "It[SP]seems[SP]Zodiac's[SP]second[SP]floor[SP]has[SP]become[SP]a\ngiant[SP]dungeon.[1205][U+000F][SP]The[SP]rumor[SP]is[SP]that[SP]there's[SP]tons\nof[SP]great[SP]items[SP]there...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Il paraît que le deuxième étage\nde Zodiac est devenu un immense\ndonjon.[1205][000F] Beaucoup de bons objets…"
-  },
-  {
-    "id": 50,
-    "offset": 289412,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]this[SP]some[SP]new[SP]marketing[SP]stunt?[SP]What[SP]do\nyou[SP]think?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un nouveau coup de pub ? Qu'en pensez-vous ?"
-  },
-  {
-    "id": 51,
-    "offset": 289582,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]the[SP]ghost[SP]of[SP]an[SP]idol[SP]has[SP]been[SP]seen\nin[SP]Aoba[SP]Park.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "On a vu le fantôme d'une\nidole dans le parc d'Aoba."
-  },
-  {
-    "id": 52,
-    "offset": 289760,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "If[SP]enough[SP]people[SP]say[SP]so,[SP]it[SP]must[SP]be[SP]true...[1205][U+000F]\nBrrr![SP]I[SP]just[SP]felt[SP]a[SP]chill[SP]down[SP]my[SP]spine.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Si assez de gens le disent, ça doit\nêtre vrai…[1205][000F] Brrr ! J'ai eu un frisson."
-  },
-  {
-    "id": 53,
-    "offset": 289998,
-    "data_size": 330,
-    "slot_size": 334,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]there[SP]something[SP]called[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the\nabandoned[SP]factory?[1205][U+000F][SP]Yikes,[SP]now[SP]I[SP]can't[SP]even[SP]take\na[SP]taxi[SP]ride[SP]without[SP]worrying[SP]anymore.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un Taxi Maudit à l'usine abandonnée\n?[1205][000F] Ouf, je ne peux même plus prendre\nun taxi sans m'inquiéter."
-  },
-  {
-    "id": 54,
-    "offset": 290332,
-    "data_size": 182,
-    "slot_size": 186,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]there's[SP]some[SP]Cursed[SP]Escort[SP]at[SP]the\nabandoned[SP]factory.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "J'ai entendu qu'il y a une Escorte\nMaudite à l'usine abandonnée."
-  },
-  {
-    "id": 55,
-    "offset": 290518,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "A[SP]taxi[SP]driver[SP]told[SP]me[SP]about[SP]it.[1205][U+000F][SP]He[SP]said[SP]he's\nhaving[SP]trouble[SP]getting[SP]customers[SP]because\nof[SP]that[SP]thing.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un chauffeur de taxi m'en a parlé.[1205][000F] Il a du\nmal à trouver des clients à cause de ça."
-  },
-  {
-    "id": 56,
-    "offset": 290788,
-    "data_size": 316,
-    "slot_size": 320,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "It[SP]seems[SP]the[SP]real[SP]Kuchisake-onna[SP]has[SP]shown[SP]up\nat[SP]Mt.[SP]Iwato.[SP]First[SP]terrorists,[SP]now[SP]Kuchisake-\nonna...[SP]This[SP]city's[SP]falling[SP]apart.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "La vraie Kuchisake-onna est apparue au\nmont Iwato. D'abord les terroristes,\nmaintenant elle… Cette ville s'écroule."
-  },
-  {
-    "id": 57,
-    "offset": 291108,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "There's[SP]a[SP]Jumping[SP]Geezer[SP]at[SP]Mt.[SP]Katatsumuri?\nIsn't[SP]that[SP]just[SP]one[SP]of[SP]those[SP]Last[SP]Battalion\nguys?[1205][U+000F][SP]Yeah,[SP]I[SP]bet[SP]that's[SP]all[SP]it[SP]is.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un Sauteur Vieux au mont Katatsumuri ?\nC'est juste un gars du Dernier\nBataillon, non ?[1205][000F] Ouais, ça doit être ça."
-  },
-  {
-    "id": 58,
-    "offset": 291426,
-    "data_size": 344,
-    "slot_size": 348,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]can't[SP]believe[SP]they[SP]still[SP]tell[SP]that[SP]story...\nKudan,[SP]huh...?[1205][U+000F][SP]Even[SP]at[SP]my[SP]age,[SP]I'm[SP]afraid[SP]of\nthat[SP]thing...[1205][U+000F][SP]Brrr![SP]Still[SP]gives[SP]me[SP]the[SP]creeps.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Je n'arrive pas à croire qu'on raconte encore\nça… Kudan…[1205][000F] Même à mon âge, j'en ai peur.[1205][000F] Brrr\n! Ça me donne toujours des frissons."
-  },
-  {
-    "id": 59,
-    "offset": 291774,
-    "data_size": 332,
-    "slot_size": 336,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "There's[SP]a[SP]secret[SP]CD[SP]at[SP]Giga[SP]Macho?[SP]Stores[SP]have\nbeen[SP]coming[SP]up[SP]with[SP]odd[SP]promotional[SP]stunts\nlately.[1205][U+000F][SP]Though[SP]it[SP]does[SP]pique[SP]my[SP]interest...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un CD secret chez Giga Macho ? Les\nmagasins ont des promotions\nbizarres.[1205][000F] Cela pique ma curiosité…"
-  },
-  {
-    "id": 60,
-    "offset": 292110,
-    "data_size": 324,
-    "slot_size": 328,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Do[SP]you[SP]know[SP]the[SP]Dresser[SP]Hag?[1205][U+000F][SP]There's[SP]a[SP]creature\ncalled[SP]that[SP]at[SP]the[SP]abandoned[SP]factory.[1205][U+000F][SP]Does[SP]that\nmean[SP]it[SP]lives[SP]inside[SP]a[SP]dresser?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tu connais la Sorcière du Buffet ?[1205][000F]\nElle serait à l'usine abandonnée.[1205][000F]\nElle vit dans un buffet ?"
-  },
-  {
-    "id": 61,
-    "offset": 292438,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]it[SP]true[SP]Time[SP]Castle[SP]sells[SP]real[SP]weapons?\nI[SP]heard[SP]my[SP]coworkers[SP]say[SP]their[SP]quality[SP]and\nprices[SP]were[SP]average...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Time Castle vend de vraies armes ? Des\ncollègues disent qualité et prix moyens…"
-  },
-  {
-    "id": 62,
-    "offset": 292720,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]it[SP]true[SP]Time[SP]Castle[SP]sells[SP]real[SP]weapons?\nI[SP]heard[SP]my[SP]coworkers[SP]say[SP]their[SP]quality[SP]was\ngood,[SP]but[SP]they[SP]were[SP]expensive...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Time Castle vend de vraies armes ? Bonne\nqualité mais chères, disent mes collègues."
-  },
-  {
-    "id": 63,
-    "offset": 293022,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]it[SP]true[SP]Time[SP]Castle[SP]sells[SP]real[SP]weapons?\nI[SP]heard[SP]my[SP]coworkers[SP]say[SP]their[SP]prices[SP]were\nlow,[SP]but[SP]so[SP]was[SP]the[SP]quality...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Time Castle vend de vraies armes\n? Prix bas, qualité basse aussi."
-  },
-  {
-    "id": 64,
-    "offset": 293320,
-    "data_size": 328,
-    "slot_size": 332,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells\nweapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]his[SP]selection's\ngreat,[SP]but[SP]his[SP]resale[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tony, le vendeur à Yumezaki, vend des armes\nà la sauvette. Bon choix, reprises basses."
-  },
-  {
-    "id": 65,
-    "offset": 293652,
-    "data_size": 334,
-    "slot_size": 338,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells\nweapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]his[SP]prices[SP]are\ngood,[SP]but[SP]the[SP]quality[SP]of[SP]his[SP]stock[SP]isn't.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tony vend des armes à la sauvette.\nPrix corrects, qualité médiocre."
-  },
-  {
-    "id": 66,
-    "offset": 293990,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells\nweapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]his[SP]stock's\nof[SP]average[SP]quality[SP]and[SP]price.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tony vend des armes en plein\nrue. Qualité et prix moyens."
-  },
-  {
-    "id": 67,
-    "offset": 294298,
-    "data_size": 332,
-    "slot_size": 336,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells\nweapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]he[SP]keeps[SP]his\nquality[SP]high,[SP]but[SP]his[SP]prices[SP]are[SP]high[SP]too.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tony : armes de qualité, prix élevés."
-  },
-  {
-    "id": 68,
-    "offset": 294634,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Clair de Lune… J'y suis allé avec\nun associé. Ils vendent des armes ?"
-  },
-  {
-    "id": 69,
-    "offset": 294886,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]their[SP]selection[SP]isn't[SP]great,\nbut[SP]they[SP]offer[SP]good[SP]resale[SP]prices.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Peu de choix, mais bonnes reprises."
-  },
-  {
-    "id": 70,
-    "offset": 295104,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Clair de Lune… J'y suis allé avec\nun associé. Ils vendent des armes ?"
-  },
-  {
-    "id": 71,
-    "offset": 295356,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]their[SP]prices[SP]are[SP]affordable,\nbut[SP]their[SP]stuff's[SP]low[SP]quality.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Prix abordables, qualité basse."
-  },
-  {
-    "id": 72,
-    "offset": 295566,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Clair de Lune… J'y suis allé avec\nun associé. Ils vendent des armes ?"
-  },
-  {
-    "id": 73,
-    "offset": 295818,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]their[SP]stuff[SP]is[SP]top-tier,\nbut[SP]it's[SP]not[SP]exactly[SP]affordable.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qualité premium, mais cher."
-  },
-  {
-    "id": 74,
-    "offset": 296024,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Clair de Lune… J'y suis allé avec\nun associé. Ils vendent des armes ?"
-  },
-  {
-    "id": 75,
-    "offset": 296276,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]their[SP]selection[SP]is[SP]great,\nbut[SP]they[SP]offer[SP]low[SP]resale[SP]prices.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Grand choix, reprises basses."
-  },
-  {
-    "id": 76,
-    "offset": 296486,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Clair de Lune… J'y suis allé avec\nun associé. Ils vendent des armes ?"
-  },
-  {
-    "id": 77,
-    "offset": 296738,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]their[SP]prices[SP]and[SP]quality\nare[SP]average.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qualité et prix moyens."
-  },
-  {
-    "id": 78,
-    "offset": 296904,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Average[SP]quality[SP]and[SP]prices,[SP]huh...?[1205][U+000F][SP]I'd[SP]never\nhave[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real[SP]weapons.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qualité et prix moyens ?[1205][000F] Jamais imaginé\nque Jolly Roger vendait des armes."
-  },
-  {
-    "id": 79,
-    "offset": 297152,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qu'est-il arrivé à cette ville ?"
-  },
-  {
-    "id": 80,
-    "offset": 297296,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Low[SP]prices,[SP]but[SP]low[SP]quality,[SP]huh...?[1205][U+000F][SP]I'd[SP]never\nhave[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real[SP]weapons.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Prix bas, qualité basse ?[1205][000F] Jamais imaginé\nque Jolly Roger vendait des armes."
-  },
-  {
-    "id": 81,
-    "offset": 297546,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qu'est-il arrivé à cette ville ?"
-  },
-  {
-    "id": 82,
-    "offset": 297690,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Great[SP]selection,[SP]but[SP]low[SP]resale[SP]prices,[SP]huh...?[1205][U+000F]\nI'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real\nweapons.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Bon choix, reprises basses ?[1205][000F] Jamais\nimaginé que Jolly Roger vendait des armes."
-  },
-  {
-    "id": 83,
-    "offset": 297962,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qu'est-il arrivé à cette ville ?"
-  },
-  {
-    "id": 84,
-    "offset": 298106,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Poor[SP]selection,[SP]but[SP]great[SP]resale[SP]prices,[SP]eh...?[1205][U+000F]\nI'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real\nweapons.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Peu de choix, bonnes reprises ?[1205][000F] Jamais\nimaginé que Jolly Roger vendait des armes."
-  },
-  {
-    "id": 85,
-    "offset": 298378,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qu'est-il arrivé à cette ville ?"
-  },
-  {
-    "id": 86,
-    "offset": 298522,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Great[SP]quality,[SP]but[SP]high[SP]prices,[SP]huh...?[1205][U+000F]\nI'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold\nreal[SP]weapons.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Bonne qualité, prix élevés ?[1205][000F] Jamais\nimaginé que Jolly Roger vendait des armes."
-  },
-  {
-    "id": 87,
-    "offset": 298778,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qu'est-il arrivé à cette ville ?"
-  },
-  {
-    "id": 88,
-    "offset": 298922,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor\nas[SP]well[SP]as[SP]clothes?[1205][U+000F][SP]I[SP]heard[SP]their[SP]quality[SP]and\nprices[SP]are[SP]average.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "La boutique de Rengedai vend armures\net vêtements ? Qualité et prix moyens."
-  },
-  {
-    "id": 89,
-    "offset": 299218,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "*sigh*[SP]Does[SP]that[SP]mean[SP]it[SP]isn't[SP]enough[SP]just\nto[SP]sell[SP]clothes[SP]in[SP]this[SP]economy?[SP]Now[SP]that's\nscary...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "*soupir* Vendre seulement des vêtements\nne suffit plus ? Ça fait peur…"
-  },
-  {
-    "id": 90,
-    "offset": 299474,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor\nas[SP]well[SP]as[SP]clothes?[1205][U+000F][SP]I[SP]heard[SP]their[SP]prices[SP]are\nlow,[SP]but[SP]so[SP]is[SP]the[SP]quality.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Boutique de Rengedai : armures.\nPrix bas, qualité basse."
-  },
-  {
-    "id": 91,
-    "offset": 299784,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "*sigh*[SP]Does[SP]that[SP]mean[SP]it[SP]isn't[SP]enough[SP]just\nto[SP]sell[SP]clothes[SP]in[SP]this[SP]economy?[SP]Now[SP]that's\nscary...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "*soupir* Vendre seulement des vêtements\nne suffit plus ? Ça fait peur…"
-  },
-  {
-    "id": 92,
-    "offset": 300040,
-    "data_size": 312,
-    "slot_size": 316,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor\nas[SP]well[SP]as[SP]clothes?[1205][U+000F][SP]I[SP]heard[SP]their[SP]quality[SP]is\nhigh,[SP]but[SP]so[SP]are[SP]their[SP]prices.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Boutique de Rengedai : armures.\nHaute qualité, prix élevés."
-  },
-  {
-    "id": 93,
-    "offset": 300356,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "*sigh*[SP]Does[SP]that[SP]mean[SP]it[SP]isn't[SP]enough[SP]just\nto[SP]sell[SP]clothes[SP]in[SP]this[SP]economy?[SP]Now[SP]that's\nscary...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "*soupir* Vendre seulement des vêtements\nne suffit plus ? Ça fait peur…"
-  },
-  {
-    "id": 94,
-    "offset": 300612,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that\nthe[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]quality\nand[SP]prices[SP]are[SP]average.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Anima Mundi vend des armures. Nouvelle\nmode ? Qualité et prix moyens."
-  },
-  {
-    "id": 95,
-    "offset": 300896,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that\nthe[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]goods[SP]are\ncheap,[SP]but[SP]low[SP]in[SP]quality.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Anima Mundi vend des armures.\nBon marché, qualité basse."
-  },
-  {
-    "id": 96,
-    "offset": 301190,
-    "data_size": 322,
-    "slot_size": 326,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that\nthe[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]selection\nis[SP]great,[SP]but[SP]their[SP]resale[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Anima Mundi : grand choix, reprises basses."
-  },
-  {
-    "id": 97,
-    "offset": 301516,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that\nthe[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]quality[SP]is\nhigh,[SP]but[SP]they're[SP]very[SP]expensive.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Anima Mundi : haute qualité, très cher."
-  },
-  {
-    "id": 98,
-    "offset": 301826,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nThey[SP]don't[SP]have[SP]a[SP]great[SP]selection,[SP]but[SP]their\nresale[SP]prices[SP]are[SP]worth[SP]it.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba vend des armures.\nPeu de choix, reprises intéressantes."
-  },
-  {
-    "id": 99,
-    "offset": 302126,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Des boutiques qui vendent des armures\n? Des restaurants qui vendent des\narmes ? Cette ville devient folle."
-  },
-  {
-    "id": 100,
-    "offset": 302394,
-    "data_size": 228,
-    "slot_size": 232,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nTheir[SP]quality[SP]and[SP]prices[SP]seem[SP]average.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba : armures,\nqualité et prix moyens."
-  },
-  {
-    "id": 101,
-    "offset": 302626,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Des boutiques qui vendent des armures\n? Des restaurants qui vendent des\narmes ? Cette ville devient folle."
-  },
-  {
-    "id": 102,
-    "offset": 302894,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nTheir[SP]quality[SP]is[SP]great,[SP]but[SP]I[SP]hear[SP]they're\nexpensive.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba : bonne qualité, cher."
-  },
-  {
-    "id": 103,
-    "offset": 303156,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Des boutiques qui vendent des armures\n? Des restaurants qui vendent des\narmes ? Cette ville devient folle."
-  },
-  {
-    "id": 104,
-    "offset": 303424,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nTheir[SP]prices[SP]are[SP]certainly[SP]right,[SP]but[SP]there's\na[SP]certain[SP]lack[SP]of[SP]quality[SP]there.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba : prix corrects,\nmais qualité insuffisante."
-  },
-  {
-    "id": 105,
-    "offset": 303736,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Des boutiques qui vendent des armures\n? Des restaurants qui vendent des\narmes ? Cette ville devient folle."
-  },
-  {
-    "id": 106,
-    "offset": 304004,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nThey[SP]have[SP]a[SP]great[SP]selection,[SP]but[SP]their[SP]resale\nprices[SP]seem[SP]low.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba : grand\nchoix, reprises basses."
-  },
-  {
-    "id": 107,
-    "offset": 304284,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Des boutiques qui vendent des armures\n? Des restaurants qui vendent des\narmes ? Cette ville devient folle."
-  },
-  {
-    "id": 108,
-    "offset": 304552,
-    "data_size": 334,
-    "slot_size": 338,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]selection\nis[SP]great[SP]there,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "J'ai fait faire ce manteau chez London\nClothier. Ils vendent aussi des armures\n! Bon choix, mais reprises basses."
-  },
-  {
-    "id": 109,
-    "offset": 304890,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]Their[SP]prices\nare[SP]low,[SP]but[SP]so[SP]is[SP]the[SP]quality.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "London Clothier fait aussi des\narmures. Prix bas, qualité basse."
-  },
-  {
-    "id": 110,
-    "offset": 305196,
-    "data_size": 320,
-    "slot_size": 324,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]quality[SP]is\nfantastic,[SP]but[SP]the[SP]prices[SP]are[SP]so[SP]high.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "London Clothier : ils vendent des armures.\nQualité fantastique, prix très élevés."
-  },
-  {
-    "id": 111,
-    "offset": 305520,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]quality\nand[SP]prices[SP]of[SP]their[SP]goods[SP]are[SP]average.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "London Clothier vend des\narmures. Qualité et prix moyens."
-  },
-  {
-    "id": 112,
-    "offset": 305838,
-    "data_size": 334,
-    "slot_size": 338,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]selection\nis[SP]poor[SP]there,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]good.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "London Clothier : peu de\nchoix, mais bonnes reprises."
-  },
-  {
-    "id": 113,
-    "offset": 306176,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][U+000F][SP]But[SP]I\nhear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll\nget[SP]real[SP]weapons[SP]and[SP]items.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Je n'ai jamais gagné de concours.[1205][000F] Mais\ngagner donne de vraies armes et objets."
-  },
-  {
-    "id": 114,
-    "offset": 306490,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]it's[SP]hard[SP]to[SP]win,[SP]but[SP]you[SP]get\nnice[SP]prizes[SP]if[SP]you[SP]do.[SP]I[SP]wonder[SP]if[SP]I[SP]should\ngive[SP]it[SP]another[SP]try.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Difficile à gagner, mais lots sympas.\nJe devrais peut-être réessayer."
-  },
-  {
-    "id": 115,
-    "offset": 306770,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][U+000F][SP]But[SP]I\nhear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll\nget[SP]real[SP]weapons[SP]and[SP]items.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais gagné de concours.[1205][000F] Mais gagner\ndonne de vraies armes et objets."
-  },
-  {
-    "id": 116,
-    "offset": 307084,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]it's[SP]very[SP]rare[SP]for[SP]anyone[SP]to[SP]win,\nbut[SP]you[SP]get[SP]amazing[SP]prizes[SP]if[SP]you[SP]do.[SP]I[SP]wonder\nif[SP]I[SP]should[SP]give[SP]it[SP]another[SP]try.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Très rare de gagner, lots\nincroyables. Je devrais réessayer."
-  },
-  {
-    "id": 117,
-    "offset": 307402,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][U+000F][SP]But[SP]I\nhear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll\nget[SP]real[SP]weapons[SP]and[SP]items.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais gagné de concours.[1205][000F] Mais gagner\ndonne de vraies armes et objets."
-  },
-  {
-    "id": 118,
-    "offset": 307716,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]it's[SP]easy[SP]to[SP]win,[SP]but[SP]you[SP]get\njunk[SP]for[SP]prizes.[SP]And[SP]I've[SP]still[SP]never[SP]won...\nI[SP]must[SP]have[SP]the[SP]worst[SP]luck.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Facile à gagner, prix pourris. Je n'ai\njamais gagné. J'ai la pire chance."
-  },
-  {
-    "id": 119,
-    "offset": 308012,
-    "data_size": 328,
-    "slot_size": 332,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it\nseems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][U+000F][SP]I[SP]get[SP]a[SP]tingle[SP]of\nexcitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais intéressé par les arcades, mais Mu a un\ncasino maintenant.[1205][000F] L'idée de jouer m'excite…"
-  },
-  {
-    "id": 120,
-    "offset": 308344,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "A[SP]friend[SP]of[SP]mine[SP]went...[1205][U+000F][SP]He[SP]said[SP]you[SP]can[SP]win\nbig[SP]at[SP]the[SP]#5[SP]poker[SP]machine.[SP]Unfortunately,\nI[SP]don't[SP]know[SP]how[SP]to[SP]play[SP]poker.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un ami y est allé.[1205][000F] On peut gagner\ngros à la machine de poker n°5.\nJe ne sais pas jouer au poker."
-  },
-  {
-    "id": 121,
-    "offset": 308654,
-    "data_size": 328,
-    "slot_size": 332,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it\nseems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][U+000F][SP]I[SP]get[SP]a[SP]tingle[SP]of\nexcitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais intéressé par les arcades, mais Mu a un\ncasino maintenant.[1205][000F] L'idée de jouer m'excite…"
-  },
-  {
-    "id": 122,
-    "offset": 308986,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "A[SP]friend[SP]of[SP]mine[SP]went...[1205][U+000F][SP]He[SP]said[SP]you[SP]can[SP]win\nbig[SP]at[SP]the[SP]slot[SP]machine[SP]at[SP]the[SP]end.[SP]I[SP]wonder,\ndid[SP]he[SP]mean[SP]the[SP]#1[SP]or[SP]#8[SP]machine?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un ami y est allé.[1205][000F] On peut gagner gros\nà la machine à sous du fond. #1 ou #8 ?"
-  },
-  {
-    "id": 123,
-    "offset": 309304,
-    "data_size": 328,
-    "slot_size": 332,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it\nseems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][U+000F][SP]I[SP]get[SP]a[SP]tingle[SP]of\nexcitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais intéressé par les arcades, mais Mu a un\ncasino maintenant.[1205][000F] L'idée de jouer m'excite…"
-  },
-  {
-    "id": 124,
-    "offset": 309636,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "A[SP]friend[SP]of[SP]mine[SP]went...[SP]He[SP]said[SP]you[SP]can[SP]win\nbig[SP]at[SP]blackjack.[1205][U+000F][SP]Then[SP]again,[SP]it[SP]would[SP]be[SP]bad\nif[SP]my[SP]wife[SP]found[SP]out...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un ami y est allé. On peut gagner\ngros au blackjack.[1205][000F] Mais ce serait\nmal si ma femme le savait…"
-  },
-  {
-    "id": 125,
-    "offset": 309934,
-    "data_size": 336,
-    "slot_size": 340,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]may[SP]not[SP]look[SP]it,[SP]but[SP]I[SP]love[SP]antiques.[SP]I[SP]used\nto[SP]frequent[SP]places[SP]like[SP]Time[SP]Castle.[1205][U+000F][SP]By[SP]the\nway,[SP]do[SP]you[SP]know[SP]what[SP]a[SP]legendary[SP]weapon[SP]is?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "J'adore les antiquités. Je fréquentais\nTime Castle.[1205][000F] Au fait, savez-vous ce\nqu'est une arme légendaire ?"
-  },
-  {
-    "id": 126,
-    "offset": 310274,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]Shiraishi[SP]Ramen[SP]has[SP]one.[SP]If[SP]it's[SP]true,\nI'd[SP]love[SP]to[SP]at[SP]least[SP]get[SP]a[SP]glimpse...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Shiraishi Ramen en aurait une.\nJ'aimerais au moins la voir."
-  },
-  {
-    "id": 127,
-    "offset": 310508,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "It[SP]seems[SP]there's[SP]a[SP]legendary[SP]weapon[SP]at\nClair[SP]de[SP]Lune.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Une arme légendaire au Clair de Lune."
-  },
-  {
-    "id": 128,
-    "offset": 310680,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I'm[SP]quite[SP]fond[SP]of[SP]antiques,[SP]so[SP]I[SP]hope[SP]to[SP]at\nleast[SP]get[SP]a[SP]glimpse[SP]of[SP]what[SP]it[SP]looks[SP]like.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "J'aime les antiquités.\nJ'espère au moins la voir."
-  },
-  {
-    "id": 129,
-    "offset": 310918,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "It[SP]seems[SP]there's[SP]a[SP]legendary[SP]weapon[SP]at[SP]Time\nCastle,[SP]but[SP]the[SP]owner[SP]is[SP]playing[SP]dumb[SP]to[SP]jack\nup[SP]the[SP]price.[SP]What[SP]a[SP]miser!",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Une arme légendaire à Time Castle.\nLe propriétaire fait le sourd pour\nfaire monter le prix. Quel avare !"
-  },
-  {
-    "id": 130,
-    "offset": 311218,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "No[SP]wonder[SP]there's[SP]nothing[SP]like[SP]a[SP]legendary\nweapon[SP]at[SP]Time[SP]Castle.[SP]Apparently,[SP]it[SP]hasn't\nbeen[SP]delivered[SP]yet.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Pas étonnant qu'il n'y ait pas d'arme\nlégendaire. Elle n'a pas encore été livrée."
-  },
-  {
-    "id": 131,
-    "offset": 311498,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "The[SP]seller[SP]is[SP]waiting[SP]at[SP]the[SP]abandoned\nfactory,[SP]but[SP]the[SP]owner's[SP]afraid[SP]of[SP]monsters\nand[SP]won't[SP]go[SP]meet[SP]him.[SP]What[SP]a[SP]coward!",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Le vendeur attend à l'usine\nabandonnée, mais le propriétaire\na peur des monstres. Quel lâche !"
-  },
-  {
-    "id": 132,
-    "offset": 311804,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Hmmm...[SP]I[SP]heard[SP]a[SP]rumor[SP]that[SP]demons[SP]stole[SP]the\nlegendary[SP]weapon[SP]from[SP]Time[SP]Castle.[SP]Is[SP]it[SP]true?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "J'ai entendu que des démons ont volé\nl'arme légendaire. C'est vrai ?"
-  },
-  {
-    "id": 133,
-    "offset": 312054,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Augh,[SP]I[SP]was[SP]too[SP]late...[SP]Apparently[SP]a[SP]terribly\nunlucky[SP]woman[SP]bought[SP]Time[SP]Castle's[SP]legendary\nweapon[SP]before[SP]I[SP]could[SP]see[SP]it.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Trop tard. Une femme malchanceuse a acheté\nl'arme légendaire avant que je puisse la voir."
-  },
-  {
-    "id": 134,
-    "offset": 312360,
-    "data_size": 312,
-    "slot_size": 316,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Must[SP]have[SP]been[SP]a[SP]fellow[SP]antique[SP]lover.[SP]If[SP]only\nI[SP]had[SP]made[SP]up[SP]my[SP]mind[SP]earlier,[SP]I[SP]could[SP]have\ngotten[SP]there[SP]first...[SP]What[SP]a[SP]pity.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un autre amateur d'antiquités. Si\nj'avais décidé plus tôt, j'aurais\nété premier. Quel dommage."
-  },
-  {
-    "id": 135,
-    "offset": 312676,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Honestly,[SP]of[SP]all[SP]the[SP]luck.[SP]It[SP]seems[SP]the[SP]owner\nof[SP]Time[SP]Castle[SP]gave[SP]away[SP]that[SP]legendary[SP]weapon.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Quelle malchance. Le propriétaire\na donné l'arme légendaire."
-  },
-  {
-    "id": 136,
-    "offset": 312928,
-    "data_size": 318,
-    "slot_size": 322,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "To[SP]some[SP]girl[SP]with[SP]short[SP]hair,[SP]supposedly...\nBut[SP]that's[SP]too[SP]vague[SP]a[SP]hint[SP]to[SP]go[SP]on.[SP]*sigh*\nIf[SP]only[SP]I[SP]bought[SP]it[SP]before[SP]it[SP]was[SP]gone!",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "À une fille aux cheveux courts,\ndit-on. Indice trop vague. *soupir*\nSi seulement je l'avais achetée !"
-  },
-  {
-    "id": 137,
-    "offset": 313250,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Have[SP]you[SP]heard[SP]the[SP]rumor[SP]that[SP]a[SP]woman's[SP]ghost\nis[SP]appearing[SP]in[SP]Aoba[SP]Park?[1205][U+000F]",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu as entendu ? Le fantôme d'une\nfemme apparaît dans le parc d'Aoba.[1205][000F]"
-  },
-  {
-    "id": 138,
-    "offset": 313440,
-    "data_size": 176,
-    "slot_size": 180,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Do[SP]you[SP]think[SP]it's[SP]true?[1205][U+000F][SP]If[SP]it[SP]is,[SP]I[SP]ought[SP]to\nchange[SP]my[SP]daily[SP]route.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu crois que c'est vrai ?[1205][000F] Je\ndevrais changer mon itinéraire."
-  },
-  {
-    "id": 139,
-    "offset": 313620,
-    "data_size": 176,
-    "slot_size": 180,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Wh-What[SP]are[SP]we[SP]going[SP]to[SP]do...?[SP]Even[SP]the[SP]fire\ndepartment[SP]was[SP]bombed...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qu'allons-nous faire… ? Même\nles pompiers ont été bombardés…"
-  },
-  {
-    "id": 140,
-    "offset": 313800,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "There's[SP]no[SP]one[SP]left[SP]to[SP]put[SP]out[SP]the[SP]flames[SP]in\ncase[SP]of[SP]another[SP]attack!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Personne pour éteindre les flammes\nen cas de nouvelle attaque !"
-  },
-  {
-    "id": 141,
-    "offset": 313978,
-    "data_size": 312,
-    "slot_size": 316,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Do[SP]you[SP]know[SP]what[SP]this[SP]Last[SP]Battalion[SP]thing[SP]is?[1205][U+000F]\nI[SP]hear[SP]they're[SP]the[SP]terrorists[SP]responsible[SP]for\nthe[SP]attacks,[SP]but[SP]I've[SP]never[SP]heard[SP]of[SP]them.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu sais ce qu'est le Dernier Bataillon ?[1205][000F] On\ndit qu'ils sont les terroristes responsables,\nmais je n'en ai jamais entendu parler."
-  },
-  {
-    "id": 142,
-    "offset": 314294,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Are[SP]the[SP]Masked[SP]Circle[SP]not[SP]the[SP]only[SP]guys[SP]like\nthat[SP]walking[SP]around?[1205][U+000F][SP]If[SP]so,[SP]why[SP]are[SP]they\nattacking[SP]the[SP]city!?[SP]I[SP]don't[SP]know[SP]what[SP]to[SP]do!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le Cercle Masqué n'est pas le seul\ngroupe ?[1205][000F] Pourquoi attaquent-ils la\nville !? Je ne sais pas quoi faire !"
-  },
-  {
-    "id": 143,
-    "offset": 314602,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]heard[SP]they[SP]posted[SP]composite[SP]sketches[SP]of[SP]the\nsuspects.[SP]So[SP]are[SP]they[SP]Masked[SP]Circle?[1205][U+000F][SP]Or[SP]Last\nBattalion?[1205][U+000F][SP]I'm[SP]just[SP]so[SP]confused.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils ont affiché des portraits-robots.\nIls sont du Cercle Masqué ?[1205][000F] Ou du\nDernier Bataillon ?[1205][000F] Je suis perdue."
-  },
-  {
-    "id": 144,
-    "offset": 314898,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Geez![SP]I[SP]wish[SP]they'd[SP]be[SP]more[SP]specific[SP]with[SP]the\nnews[SP]broadcasts.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Dommage qu'ils ne soient\npas plus précis aux infos."
-  },
-  {
-    "id": 145,
-    "offset": 315064,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "They're[SP]just[SP]going[SP]to[SP]end[SP]up[SP]confusing[SP]more\npeople[SP]about[SP]who[SP]the[SP]terrorists[SP]are!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils ne font que semer plus de\nconfusion sur les terroristes !"
-  },
-  {
-    "id": 146,
-    "offset": 315266,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]wonder[SP]if[SP]it's[SP]safe[SP]to[SP]be[SP]out[SP]like[SP]this.[1205][U+000F]\nB-But[SP]where[SP]would[SP]I[SP]hide?[SP]We[SP]can't[SP]rely[SP]on\nthe[SP]police[SP]anymore,[SP]after[SP]all...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Est-ce sûr d'être dehors ?[1205][000F] Mais où me cacher\n? On ne peut plus compter sur la police…"
-  },
-  {
-    "id": 147,
-    "offset": 315548,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Whew...[1205][U+000A][SP]Now[SP]that[SP]we're[SP]in[SP]the[SP]sky,[SP]my[SP]options\nfor[SP]walking[SP]are[SP]limited.[1205][U+000F][SP]Huh?[SP]Now's[SP]not[SP]the\ntime[SP]for[SP]that?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ouf…[1205][000A] Dans le ciel, mes options de marche sont\nlimitées.[1205][000F] Hein ? Ce n'est pas le moment ?"
-  },
-  {
-    "id": 148,
-    "offset": 315806,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "But[SP]there's[SP]no[SP]use[SP]panicking[SP]if[SP]things[SP]have\ngotten[SP]this[SP]bad.[1205][U+000F][SP]I[SP]don't[SP]care[SP]anymore[SP]if[SP]we\nevolve[SP]or[SP]all[SP]die[SP]off.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Inutile de paniquer. Ça a déjà trop empiré.[1205][000F]\nJe m'en fiche qu'on évolue ou qu'on meure."
-  },
-  {
-    "id": 149,
-    "offset": 316072,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Have[SP]you[SP]heard?[1205][U+000F][SP]There[SP]are[SP]countless[SP]rumors\nflying[SP]around[SP]about[SP]what[SP]kind[SP]of[SP]end[SP]the\npeople[SP]below[SP]will[SP]face.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu as entendu ?[1205][000F] Des rumeurs\nsur la fin des gens d'en bas."
-  },
-  {
-    "id": 150,
-    "offset": 316332,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]latest[SP]is[SP]that[SP]when[SP]the[SP]Grand[SP]Cross[SP]is\ncomplete,[SP]an[SP]intense[SP]magnetic[SP]storm[SP]will[SP]arise\nand[SP]scorch[SP]the[SP]Earth's[SP]surface.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "La dernière : la Grande Croix provoquera\nune tempête magnétique brûlant la Terre."
-  },
-  {
-    "id": 151,
-    "offset": 316616,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]did[SP]you[SP]hear?[1205][U+000A][SP]When[SP]the[SP]Grand[SP]Cross[SP]is\ncomplete,[SP]a[SP]plasma[SP]vortex[SP]will[SP]form[SP]and[SP]the\nwhole[SP]Earth[SP]will[SP]look[SP]like[SP]those[SP]crop[SP]circles.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Hé, tu as entendu ?[1205][000A] La Grande Croix\ncréera un vortex de plasma, la Terre\nressemblera à des crop circles."
-  },
-  {
-    "id": 152,
-    "offset": 316928,
-    "data_size": 322,
-    "slot_size": 326,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]seems[SP]like[SP]when[SP]the[SP]Grand[SP]Cross[SP]is[SP]over,[SP]the\nbalance[SP]of[SP]gravity[SP]will[SP]crumble[SP]and[SP]the[SP]Earth's\nrotation[SP]will[SP]stop.[1205][U+000F][SP]Then[SP]the[SP]world[SP]will[SP]end.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Après la Grande Croix, la gravité\ns'effondrera, la Terre s'arrêtera.[1205][000F] Alors le\nmonde finira."
-  },
-  {
-    "id": 153,
-    "offset": 317254,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]have[SP]you[SP]heard[SP]about[SP]Zodiac?[SP]Their[SP]second\nfloor[SP]is[SP]a[SP]huge[SP]dungeon[SP]now,[SP]filled[SP]with[SP]items.[1205][U+000F]\nWhat[SP]a[SP]weird[SP]club.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu as entendu parler de Zodiac ?\nLeur deuxième étage est devenu un\ndonjon rempli d'objets.[1205][000F] Bizarre."
-  },
-  {
-    "id": 154,
-    "offset": 317526,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]talking[SP]flowers[SP]in[SP]Aoba\nPark?[SP]How[SP]gossipy[SP]would[SP]they[SP]be...?[SP]Guess[SP]you\ncan't[SP]try[SP]anything[SP]funny[SP]there[SP]after[SP]all.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu connais les fleurs qui parlent à\nAoba ? Comme elles seraient bavardes…\nOn ne peut rien tenter de drôle là-bas."
-  },
-  {
-    "id": 155,
-    "offset": 317834,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "H-Hey,[SP]the[SP]rumor[SP]about[SP]that[SP]idol's[SP]ghost[SP]in\nAoba[SP]Park[SP]was[SP]real,[SP]wasn't[SP]it?[1205][U+000F][SP]I[SP]heard[SP]people\nin[SP]the[SP]city[SP]talking[SP]about[SP]it[SP]too!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Hé, le fantôme de l'idole à Aoba était\nréel ?[1205][000F] J'ai entendu des gens en parler !"
-  },
-  {
-    "id": 156,
-    "offset": 318126,
-    "data_size": 210,
-    "slot_size": 214,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Ugh,[SP]what[SP]should[SP]I[SP]do...?[1205][U+000F][SP]This[SP]has[SP]always[SP]been\npart[SP]of[SP]the[SP]route[SP]I[SP]take[SP]on[SP]my[SP]walks.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qu'est-ce que je fais ?[1205][000F] Cela a toujours\nfait partie de mon itinéraire."
-  },
-  {
-    "id": 157,
-    "offset": 318340,
-    "data_size": 238,
-    "slot_size": 242,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]don't[SP]want[SP]to[SP]get[SP]possessed[SP]by[SP]some[SP]evil\nspirit...[1205][U+000F][SP]I-I'm[SP]gonna[SP]stop[SP]passing[SP]by[SP]here\nfrom[SP]now[SP]on.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je ne veux pas me faire posséder.[1205][000F] Je\nvais éviter de passer par ici désormais."
-  },
-  {
-    "id": 158,
-    "offset": 318582,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Did[SP]you[SP]know[SP]there's[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the\nabandoned[SP]factory?[SP]I[SP]heard[SP]it[SP]goes[SP]into[SP]the\ncity[SP]at[SP]night[SP]to[SP]kill.[SP]Scary...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Un Taxi Maudit à l'usine abandonnée ?\nIl tue la nuit en ville. Effrayant…"
-  },
-  {
-    "id": 159,
-    "offset": 318858,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Huh?[1205][U+000F][SP]It[SP]wasn't[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the[SP]abandoned\nfactory,[SP]it[SP]was[SP]a[SP]Cursed[SP]Escort?[1205][U+000F][SP]But[SP]don't[SP]they\nwork[SP]pretty[SP]much[SP]the[SP]same[SP]way?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Hein ?[1205][000F] C'est une Escorte Maudite, pas un\nTaxi ?[1205][000F] Mais ça revient au même, non ?"
-  },
-  {
-    "id": 160,
-    "offset": 319156,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]does[SP]Kuchisake-onna[SP]really[SP]exist?[SP]I[SP]heard\nshe's[SP]shown[SP]up[SP]at[SP]Mt.[SP]Iwato![1205][U+000F][SP]Now[SP]I[SP]can't[SP]go\nwalking[SP]there[SP]anymore[SP]either...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Kuchisake-onna existe ? Elle serait au mont\nIwato ![1205][000F] Je ne peux plus y aller non plus…"
-  },
-  {
-    "id": 161,
-    "offset": 319446,
-    "data_size": 250,
-    "slot_size": 254,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]what's[SP]a[SP]Jumping[SP]Geezer?[1205][U+000F][SP]Because[SP]I[SP]heard\na[SP]rumor[SP]there's[SP]a[SP]creature[SP]called[SP]that[SP]at\nMt.[SP]Katatsumuri.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "C'est quoi un Sauteur Vieux ?[1205][000F] Il y\nen aurait un au mont Katatsumuri."
-  },
-  {
-    "id": 162,
-    "offset": 319700,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Well,[SP]with[SP]the[SP]soldiers[SP]patrolling[SP]there,\nI[SP]wasn't[SP]going[SP]near[SP]that[SP]mountain[SP]to[SP]begin\nwith.[1205][U+000F][SP]It's[SP]just[SP]one[SP]thing[SP]after[SP]another...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Avec les soldats, je ne m'approchais\ndéjà pas. C'est une chose après l'autre…"
-  },
-  {
-    "id": 163,
-    "offset": 320000,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]am[SP]I[SP]going[SP]to[SP]do!?[1205][U+000F][SP]I[SP]can't[SP]sleep[SP]alone\nafter[SP]hearing[SP]a[SP]story[SP]like[SP]that![SP]I[SP]need[SP]to\ntry[SP]and[SP]put[SP]Kudan[SP]out[SP]of[SP]my[SP]mind...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je vais faire quoi !?[1205][000F] Je ne peux\nplus dormir seule après ça ! Il faut\nque je chasse Kudan de mon esprit…"
-  },
-  {
-    "id": 164,
-    "offset": 320290,
-    "data_size": 136,
-    "slot_size": 140,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Giga[SP]Macho[SP]carries[SP]a\nsecret[SP]CD?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Giga Macho a un CD secret."
-  },
-  {
-    "id": 165,
-    "offset": 320430,
-    "data_size": 172,
-    "slot_size": 176,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]special[SP]track[SP]on[SP]it[SP]you\ncan't[SP]hear[SP]any[SP]other[SP]way.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Il contient un morceau spécial\nqu'on n'entend nulle part ailleurs."
-  },
-  {
-    "id": 166,
-    "offset": 320606,
-    "data_size": 194,
-    "slot_size": 198,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]Dresser[SP]Hag's[SP]that[SP]monster[SP]that's[SP]an[SP]old\nwoman[SP]living[SP]in[SP]a[SP]dresser,[SP]right?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "La Sorcière du Buffet, c'est la vieille\nfemme qui vit dans un buffet, c'est ça ?"
-  },
-  {
-    "id": 167,
-    "offset": 320804,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Why[SP]would[SP]something[SP]like[SP]that[SP]be[SP]at[SP]the\nabandoned[SP]factory...?[1205][U+000F][SP]Well,[SP]guess[SP]I'm[SP]not\ngoing[SP]near[SP]there[SP]anymore.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Pourquoi à l'usine abandonnée\n?[1205][000F] Je ne m'en approcherai plus."
-  },
-  {
-    "id": 168,
-    "offset": 321064,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][U+000F][SP]I[SP]mean,\nan[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rengedai doit être effrayant.[1205][000F] Une boutique\nd'antiquités qui vend des armes ?"
-  },
-  {
-    "id": 169,
-    "offset": 321274,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "People[SP]say[SP]their[SP]quality[SP]and[SP]prices[SP]are\njust[SP]average.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qualité et prix moyens."
-  },
-  {
-    "id": 170,
-    "offset": 321422,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][U+000F][SP]I[SP]mean,\nan[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rengedai doit être effrayant.[1205][000F] Une boutique\nd'antiquités qui vend des armes ?"
-  },
-  {
-    "id": 171,
-    "offset": 321632,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "People[SP]say[SP]their[SP]quality's[SP]great,[SP]but[SP]it's\nexpensive.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qualité excellente, cher."
-  },
-  {
-    "id": 172,
-    "offset": 321780,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][U+000F][SP]I[SP]mean,\nan[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rengedai doit être effrayant.[1205][000F] Une boutique\nd'antiquités qui vend des armes ?"
-  },
-  {
-    "id": 173,
-    "offset": 321990,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "People[SP]say[SP]their[SP]quality's[SP]not[SP]great,[SP]but[SP]at\nleast[SP]they're[SP]cheap.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qualité moyenne, mais bon marché."
-  },
-  {
-    "id": 174,
-    "offset": 322162,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off\nthe[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]the[SP]selection's\ngood,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Effrayant d'acheter des armes en pleine rue\nà Yumezaki. Bon choix, reprises basses."
-  },
-  {
-    "id": 175,
-    "offset": 322462,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what\nare[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the\ncity[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ceux qui les utilisent sont en faute,\nmais à quoi pensent les commerçants ? La\nville devient de plus en plus dangereuse."
-  },
-  {
-    "id": 176,
-    "offset": 322764,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off\nthe[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]their[SP]quality's\nnot[SP]much,[SP]but[SP]the[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Effrayant d'acheter des armes en rue à\nYumezaki. Qualité médiocre, prix bas."
-  },
-  {
-    "id": 177,
-    "offset": 323058,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what\nare[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the\ncity[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ceux qui les utilisent sont en faute,\nmais à quoi pensent les commerçants ? La\nville devient de plus en plus dangereuse."
-  },
-  {
-    "id": 178,
-    "offset": 323360,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off\nthe[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]their[SP]quality\nand[SP]prices[SP]are[SP]average.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Effrayant d'acheter des armes en rue\nà Yumezaki. Qualité et prix moyens."
-  },
-  {
-    "id": 179,
-    "offset": 323630,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what\nare[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the\ncity[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ceux qui les utilisent sont en faute,\nmais à quoi pensent les commerçants ? La\nville devient de plus en plus dangereuse."
-  },
-  {
-    "id": 180,
-    "offset": 323932,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off\nthe[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]they're[SP]pretty\nexpensive,[SP]but[SP]very[SP]high[SP]quality.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Effrayant d'acheter des armes en rue à\nYumezaki. Chères, mais très haute qualité."
-  },
-  {
-    "id": 181,
-    "offset": 324224,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what\nare[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the\ncity[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ceux qui les utilisent sont en faute,\nmais à quoi pensent les commerçants ? La\nville devient de plus en plus dangereuse."
-  },
-  {
-    "id": 182,
-    "offset": 324526,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Clair de Lune, le restau français ?"
-  },
-  {
-    "id": 183,
-    "offset": 324654,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]their[SP]selection[SP]is[SP]slim,[SP]but[SP]their\nresale[SP]prices[SP]are[SP]great.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils vendent des armes ?[1205][000F] Peu de\nchoix, reprises excellentes."
-  },
-  {
-    "id": 184,
-    "offset": 324914,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "On commande des armes au menu ? Quoi\nqu'il en soit, ce restau est détraqué."
-  },
-  {
-    "id": 185,
-    "offset": 325148,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Clair de Lune, le restau français ?"
-  },
-  {
-    "id": 186,
-    "offset": 325276,
-    "data_size": 222,
-    "slot_size": 226,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]they're[SP]cheap,[SP]but[SP]sell[SP]low-quality\ngoods.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils vendent des armes ?[1205][000F] Bon\nmarché, mais basse qualité."
-  },
-  {
-    "id": 187,
-    "offset": 325502,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "On commande des armes au menu ? Quoi\nqu'il en soit, ce restau est détraqué."
-  },
-  {
-    "id": 188,
-    "offset": 325736,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Clair de Lune, le restau français ?"
-  },
-  {
-    "id": 189,
-    "offset": 325864,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]their[SP]quality's[SP]great,[SP]but[SP]expensive,\njust[SP]like[SP]the[SP]food[SP]they[SP]serve.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils vendent des armes ?[1205][000F] Qualité\nexcellente, cher, comme leur nourriture."
-  },
-  {
-    "id": 190,
-    "offset": 326142,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "On commande des armes au menu ? Quoi\nqu'il en soit, ce restau est détraqué."
-  },
-  {
-    "id": 191,
-    "offset": 326376,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Clair de Lune, le restau français ?"
-  },
-  {
-    "id": 192,
-    "offset": 326504,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]their[SP]selection[SP]is[SP]great,[SP]but[SP]their\nresale[SP]prices[SP]are[SP]pretty[SP]low.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils vendent des armes ?[1205][000F] Grand\nchoix, reprises assez basses."
-  },
-  {
-    "id": 193,
-    "offset": 326776,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "On commande des armes au menu ? Quoi\nqu'il en soit, ce restau est détraqué."
-  },
-  {
-    "id": 194,
-    "offset": 327010,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Clair de Lune, le restau français ?"
-  },
-  {
-    "id": 195,
-    "offset": 327138,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]their[SP]quality[SP]and[SP]prices[SP]are[SP]average.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils vendent des armes ?[1205][000F]\nQualité et prix moyens."
-  },
-  {
-    "id": 196,
-    "offset": 327354,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "On commande des armes au menu ? Quoi\nqu'il en soit, ce restau est détraqué."
-  },
-  {
-    "id": 197,
-    "offset": 327588,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]I[SP]hear[SP]the[SP]quality\nand[SP]prices[SP]are[SP]average,[SP]though.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car\nil était pirate. Qualité et prix moyens."
-  },
-  {
-    "id": 198,
-    "offset": 327886,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]I[SP]hear[SP]they're\ncheap,[SP]but[SP]low[SP]quality.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car\nil était pirate. Bon marché, basse qualité."
-  },
-  {
-    "id": 199,
-    "offset": 328160,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]His[SP]selection[SP]is\ngreat,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car\nil était pirate. Grand choix, reprises basses."
-  },
-  {
-    "id": 200,
-    "offset": 328466,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]His[SP]selection[SP]is\nskimpy,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]great.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des\narmes car il était pirate. Peu de\nchoix, reprises excellentes."
-  },
-  {
-    "id": 201,
-    "offset": 328778,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]I[SP]hear[SP]the[SP]quality\nis[SP]great,[SP]but[SP]his[SP]stuff[SP]is[SP]expensive.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car\nil était pirate. Qualité excellente, cher."
-  },
-  {
-    "id": 202,
-    "offset": 329088,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Rengedai\nsells[SP]real[SP]armor.[SP]Their[SP]quality[SP]and[SP]prices\nseem[SP]to[SP]be[SP]average.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le Rosa Candida de Rengedai vend des\narmures. Qualité et prix moyens."
-  },
-  {
-    "id": 203,
-    "offset": 329346,
-    "data_size": 236,
-    "slot_size": 240,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]don't[SP]know[SP]how[SP]much[SP]of[SP]that[SP]is[SP]true,\nbut[SP]I'm[SP]thinking[SP]of[SP]checking[SP]it[SP]out.\nIt[SP]sounds[SP]interesting.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je ne sais si c'est vrai, mais\nje vais vérifier. Intéressant."
-  },
-  {
-    "id": 204,
-    "offset": 329586,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Rengedai\nsells[SP]real[SP]armor.[SP]Their[SP]quality[SP]seems[SP]low,\nbut[SP]at[SP]least[SP]their[SP]prices[SP]are[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida vend des armures.\nQualité basse, prix bas."
-  },
-  {
-    "id": 205,
-    "offset": 329874,
-    "data_size": 236,
-    "slot_size": 240,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]don't[SP]know[SP]how[SP]much[SP]of[SP]that[SP]is[SP]true,\nbut[SP]I'm[SP]thinking[SP]of[SP]checking[SP]it[SP]out.\nIt[SP]sounds[SP]interesting.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je ne sais si c'est vrai, mais\nje vais vérifier. Intéressant."
-  },
-  {
-    "id": 206,
-    "offset": 330114,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Rengedai\nsells[SP]real[SP]armor.[SP]They're[SP]expensive,[SP]but[SP]the\nquality[SP]is[SP]amazing.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida vend des armures.\nCher, mais qualité incroyable."
-  },
-  {
-    "id": 207,
-    "offset": 330376,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]don't[SP]know[SP]how[SP]much[SP]of[SP]that[SP]is[SP]true,\nbut[SP]I'm[SP]thinking[SP]of[SP]checking[SP]it[SP]out.\nIt[SP]sounds[SP]interesting.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je ne sais si c'est vrai, mais\nje vais vérifier. Intéressant."
-  },
-  {
-    "id": 208,
-    "offset": 330614,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They\nsell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]their\nquality[SP]and[SP]prices[SP]are[SP]average.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ma fille va souvent chez Anima Mundi. Ils\nvendent des armures ? Qualité et prix moyens."
-  },
-  {
-    "id": 209,
-    "offset": 330886,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything\nweird...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "J'espère qu'elle n'achète rien de bizarre…"
-  },
-  {
-    "id": 210,
-    "offset": 331030,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They\nsell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]their\nquality's[SP]not[SP]great,[SP]but[SP]they're[SP]cheap.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ma fille va chez Anima Mundi. Armures\n: qualité moyenne, bon marché."
-  },
-  {
-    "id": 211,
-    "offset": 331318,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything\nweird...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "J'espère qu'elle n'achète rien de bizarre…"
-  },
-  {
-    "id": 212,
-    "offset": 331462,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They\nsell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]their[SP]resale\nprices[SP]are[SP]low,[SP]but[SP]the[SP]selection's[SP]great.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ma fille va chez Anima Mundi. Armures\n: reprises basses, mais grand choix."
-  },
-  {
-    "id": 213,
-    "offset": 331770,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything\nweird...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "J'espère qu'elle n'achète rien de bizarre…"
-  },
-  {
-    "id": 214,
-    "offset": 331914,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They\nsell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]they're\nexpensive,[SP]but[SP]the[SP]quality's[SP]amazing.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ma fille va chez Anima Mundi. Armures\n: chères, qualité incroyable."
-  },
-  {
-    "id": 215,
-    "offset": 332202,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything\nweird...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "J'espère qu'elle n'achète rien de bizarre…"
-  },
-  {
-    "id": 216,
-    "offset": 332346,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida ici vend aussi des armures."
-  },
-  {
-    "id": 217,
-    "offset": 332494,
-    "data_size": 236,
-    "slot_size": 240,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their\nselection's[SP]not[SP]great,[SP]but[SP]their[SP]resale\nprices[SP]seem[SP]high.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Peu de choix, reprises élevées."
-  },
-  {
-    "id": 218,
-    "offset": 332734,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida ici vend aussi des armures."
-  },
-  {
-    "id": 219,
-    "offset": 332882,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their\nquality[SP]and[SP]prices[SP]seem[SP]average.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qualité et prix moyens."
-  },
-  {
-    "id": 220,
-    "offset": 333072,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida ici vend aussi des armures."
-  },
-  {
-    "id": 221,
-    "offset": 333220,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their\nquality's[SP]great,[SP]but[SP]they[SP]seem[SP]expensive.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qualité excellente, cher."
-  },
-  {
-    "id": 222,
-    "offset": 333428,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida ici vend aussi des armures."
-  },
-  {
-    "id": 223,
-    "offset": 333576,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]They're\ncheap,[SP]but[SP]their[SP]goods[SP]seem[SP]rather[SP]low[SP]quality.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Bon marché, qualité plutôt basse."
-  },
-  {
-    "id": 224,
-    "offset": 333800,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida ici vend aussi des armures."
-  },
-  {
-    "id": 225,
-    "offset": 333948,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their\nselection's[SP]great,[SP]but[SP]their[SP]resale[SP]prices\nseem[SP]to[SP]be[SP]on[SP]the[SP]low[SP]side.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Grand choix, reprises basses."
-  },
-  {
-    "id": 226,
-    "offset": 334214,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][000F]\nMais ils vendent aussi des armures ?"
-  },
-  {
-    "id": 227,
-    "offset": 334480,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]know[SP]their[SP]selection's[SP]great,[SP]but[SP]I[SP]don't\nsee[SP]why[SP]they[SP]need[SP]to[SP]sell[SP]armor[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Et si c'est ce qu'il me fabrique ?[1205][000F]\nPourquoi vendre aussi des armures ?"
-  },
-  {
-    "id": 228,
-    "offset": 334772,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][000F]\nMais ils vendent aussi des armures ?"
-  },
-  {
-    "id": 229,
-    "offset": 335038,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]know[SP]it'll[SP]be[SP]cheap,[SP]but[SP]I[SP]can't[SP]go[SP]to[SP]work\nwearing[SP]a[SP]suit[SP]of[SP]armor!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Et si c'est ce qu'il me fabrique ?[1205][000F] Bon marché,\nmais je ne peux pas travailler en armure !"
-  },
-  {
-    "id": 230,
-    "offset": 335310,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][000F]\nMais ils vendent aussi des armures ?"
-  },
-  {
-    "id": 231,
-    "offset": 335576,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]know[SP]the[SP]quality[SP]will[SP]be[SP]great,[SP]but[SP]that\nwon't[SP]do[SP]me[SP]any[SP]good[SP]if[SP]it[SP]bankrupts[SP]me!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Et si c'est ce qu'il me fabrique ?[1205][000F] Qualité\nexcellente, mais si ça me ruine, à quoi bon !"
-  },
-  {
-    "id": 232,
-    "offset": 335874,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][000F]\nMais ils vendent aussi des armures ?"
-  },
-  {
-    "id": 233,
-    "offset": 336140,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]hear[SP]their[SP]quality[SP]and[SP]prices[SP]are[SP]both\nreasonable,[SP]but[SP]that's[SP]not[SP]the[SP]problem.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Et si c'est ce qu'il me fabrique\n?[1205][000F] Qualité et prix raisonnables,\nmais ce n'est pas le problème."
-  },
-  {
-    "id": 234,
-    "offset": 336432,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][000F]\nMais ils vendent aussi des armures ?"
-  },
-  {
-    "id": 235,
-    "offset": 336698,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]know[SP]their[SP]resale[SP]prices[SP]are[SP]great,[SP]but[SP]I\nstill[SP]can't[SP]get[SP]a[SP]full[SP]refund,[SP]right?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Et si c'est ce qu'il me fabrique ?[1205][000F] Bonnes\nreprises, mais pas de remboursement intégral,\nsi ?"
-  },
-  {
-    "id": 236,
-    "offset": 336992,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][U+000F]\nI[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu connais les concours de magazines\n?[1205][000F] On peut gagner de vraies armes."
-  },
-  {
-    "id": 237,
-    "offset": 337210,
-    "data_size": 118,
-    "slot_size": 122,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]sounds[SP]interesting,[SP]and[SP]exciting[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Intéressant et excitant."
-  },
-  {
-    "id": 238,
-    "offset": 337332,
-    "data_size": 242,
-    "slot_size": 246,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hear[SP]you[SP]don't[SP]win[SP]often,[SP]but[SP]they[SP]send[SP]you\nnice[SP]things[SP]when[SP]you[SP]do.[1205][U+000F][SP]Why[SP]don't[SP]you[SP]give\nit[SP]a[SP]shot?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "On gagne rarement, mais beaux\nlots.[1205][000F] Pourquoi ne pas essayer ?"
-  },
-  {
-    "id": 239,
-    "offset": 337578,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][U+000F]\nI[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu connais les concours de magazines\n?[1205][000F] On peut gagner de vraies armes."
-  },
-  {
-    "id": 240,
-    "offset": 337796,
-    "data_size": 118,
-    "slot_size": 122,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]sounds[SP]interesting,[SP]and[SP]exciting[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Intéressant et excitant."
-  },
-  {
-    "id": 241,
-    "offset": 337918,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hear[SP]you[SP]very[SP]rarely[SP]win,[SP]but[SP]they[SP]send[SP]you\nincredible[SP]things[SP]when[SP]you[SP]do.[1205][U+000F][SP]Why[SP]don't[SP]you\ngive[SP]it[SP]a[SP]shot?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Très rare de gagner, lots incroyables.[1205][000F]\nPourquoi ne pas essayer ?"
-  },
-  {
-    "id": 242,
-    "offset": 338176,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][U+000F]\nI[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu connais les concours de magazines\n?[1205][000F] On peut gagner de vraies armes."
-  },
-  {
-    "id": 243,
-    "offset": 338394,
-    "data_size": 118,
-    "slot_size": 122,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]sounds[SP]interesting,[SP]and[SP]exciting[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Intéressant et excitant."
-  },
-  {
-    "id": 244,
-    "offset": 338516,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hear[SP]you[SP]can[SP]win[SP]quite[SP]easily,[SP]but[SP]the[SP]things\nthey[SP]send[SP]you[SP]as[SP]prizes[SP]aren't[SP]very[SP]good.[1205][U+000F]\nWell,[SP]why[SP]not[SP]give[SP]it[SP]a[SP]shot[SP]anyway?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Facile à gagner, lots moyens.[1205][000F]\nPourquoi ne pas essayer quand même ?"
-  },
-  {
-    "id": 245,
-    "offset": 338814,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the\narcade?[1205][U+000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was\nhorrified[SP]to[SP]hear[SP]about[SP]it!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Un casino dans la salle d'arcade ?[1205][000F]\nC'est comme ça que les bons enfants\ndeviennent mauvais ! Horrible !"
-  },
-  {
-    "id": 246,
-    "offset": 339084,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "[1432][NULL][NULL][0014]You[SP]can[SP]win[SP]big[SP]at[SP]poker![1432][NULL][NULL][0014][SP]That's[SP]not[SP]an\nappropriate[SP]conversation[SP]for[SP]high[SP]schoolers[SP]to\nbe[SP]having![SP]I[SP]should[SP]report[SP]this[SP]to[SP]the[SP]PTA!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "[1432][NULL][NULL][0014]On peut gagner gros au poker ![1432][NULL][NULL][0014] Pas une\nconversation pour des lycéens ! Je devrais le\nsignaler à l'association de parents d'élèves !"
-  },
-  {
-    "id": 247,
-    "offset": 339402,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the\narcade?[1205][U+000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was\nhorrified[SP]to[SP]hear[SP]about[SP]it!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Un casino dans la salle d'arcade ?[1205][000F]\nC'est comme ça que les bons enfants\ndeviennent mauvais ! Horrible !"
-  },
-  {
-    "id": 248,
-    "offset": 339672,
-    "data_size": 320,
-    "slot_size": 324,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "[1432][NULL][NULL][0014]You[SP]can[SP]win[SP]big[SP]at[SP]slots[SP]#1![1432][NULL][NULL][0014][SP]That's[SP]not[SP]an\nappropriate[SP]conversation[SP]for[SP]high[SP]schoolers[SP]to\nbe[SP]having![SP]I[SP]should[SP]report[SP]this[SP]to[SP]the[SP]PTA!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "[1432][NULL][NULL][0014]Gros lots aux machines n°1 ![1432][NULL][NULL][0014] Pas\npour des lycéens ! À signaler à\nl'association de parents d'élèves !"
-  },
-  {
-    "id": 249,
-    "offset": 339996,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the\narcade?[1205][U+000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was\nhorrified[SP]to[SP]hear[SP]about[SP]it!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Un casino dans la salle d'arcade ?[1205][000F]\nC'est comme ça que les bons enfants\ndeviennent mauvais ! Horrible !"
-  },
-  {
-    "id": 250,
-    "offset": 340266,
-    "data_size": 250,
-    "slot_size": 254,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Where[SP]did[SP]I[SP]hear[SP]this?[SP]There[SP]was[SP]a[SP]young[SP]man\nbragging[SP]about[SP]winning[SP]big[SP]at[SP]blackjack[SP]while\nwalking[SP]around.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Où ai-je entendu ça ? Un jeune homme se\nvantait d'avoir gagné gros au blackjack."
-  },
-  {
-    "id": 251,
-    "offset": 340520,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]wonder[SP]what[SP]this[SP]legendary[SP]weapon[SP]at\nShiraishi[SP]Ramen[SP]is[SP]all[SP]about.[SP]I[SP]bet[SP]it's\ndangerous...[SP]But[SP]I'm[SP]still[SP]a[SP]little[SP]curious.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "L'arme légendaire du Shiraishi Ramen\n? Dangereuse, mais je suis curieuse."
-  },
-  {
-    "id": 252,
-    "offset": 340810,
-    "data_size": 190,
-    "slot_size": 194,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Did[SP]you[SP]hear?[SP]There's[SP]a[SP]legendary[SP]weapon[SP]at\nClair[SP]de[SP]Lune.[SP]Have[SP]you[SP]seen[SP]it?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Une arme légendaire au Clair\nde Lune. Tu l'as vue ?"
-  },
-  {
-    "id": 253,
-    "offset": 341004,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]have[SP]you[SP]heard?[SP]The[SP]owner[SP]of[SP]Time[SP]Castle\nis[SP]supposedly[SP]hiding[SP]his[SP]legendary[SP]weapon[SP]so\nhe[SP]can[SP]inflate[SP]the[SP]price.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio de Time Castle cache son arme\nlégendaire pour faire monter le prix."
-  },
-  {
-    "id": 254,
-    "offset": 341276,
-    "data_size": 78,
-    "slot_size": 82,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]a[SP]terrible[SP]man.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Quel homme terrible."
-  },
-  {
-    "id": 255,
-    "offset": 341358,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "From[SP]what[SP]I've[SP]heard,[SP]the[SP]seller[SP]with[SP]Time\nCastle's[SP]legendary[SP]weapon[SP]is[SP]waiting[SP]at[SP]the\nabandoned[SP]factory,[SP]but[SP]the[SP]owner[SP]won't[SP]come.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le vendeur de l'arme légendaire attend à\nl'usine, mais le proprio ne vient pas."
-  },
-  {
-    "id": 256,
-    "offset": 341660,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]think[SP]that's[SP]smart[SP]of[SP]him.[SP]They[SP]say[SP]that\nabandoned[SP]factory[SP]is[SP]teeming[SP]with[SP]monsters\nand[SP]demons...[SP]It[SP]sounds[SP]dangerous,[SP]anyway.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "C'est malin. L'usine grouille de\nmonstres. Dangereux, de toute façon."
-  },
-  {
-    "id": 257,
-    "offset": 341958,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Oh,[SP]did[SP]you[SP]hear?[SP]A[SP]demon[SP]stole[SP]that[SP]legendary\nweapon[SP]at[SP]Time[SP]Castle.[SP]Not[SP]long[SP]ago,[SP]I'd[SP]never\nhave[SP]believed[SP]it...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Un démon a volé l'arme légendaire de Time\nCastle. Je ne l'aurais jamais cru avant."
-  },
-  {
-    "id": 258,
-    "offset": 342226,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "But[SP]look[SP]at[SP]us.[SP]We're[SP]standing[SP]on[SP]top[SP]of[SP]a\nfloating[SP]city![SP]I[SP]bet[SP]demons[SP]exist,[SP]too!\nBrrr...[SP]That's[SP]really[SP]scary.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Mais regarde-nous : on est sur une\nville flottante ! Les démons\nexistent forcément. Brrr… Effrayant."
-  },
-  {
-    "id": 259,
-    "offset": 342490,
-    "data_size": 222,
-    "slot_size": 226,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle[SP]was[SP]sold.\nPeople[SP]keep[SP]asking[SP]me,[SP][1432][NULL][NULL][0014]Did[SP]you[SP]buy[SP]it?[1432][NULL][NULL][0014]",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "L'arme légendaire a été vendue. On me demande\nsans cesse : [1432][NULL][NULL][0014]C'est toi qui l'as achetée ?[1432][NULL][NULL][0014]"
-  },
-  {
-    "id": 260,
-    "offset": 342716,
-    "data_size": 190,
-    "slot_size": 194,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "But[SP]no,[SP]some[SP]unlucky[SP]woman[SP]bought[SP]it...[1205][U+000F]\nI[SP]don't[SP]look[SP]that[SP]desperate,[SP]do[SP]I?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Non, une femme l'a achetée.[1205][000F] Je\nn'ai pas l'air si désespérée, si ?"
-  },
-  {
-    "id": 261,
-    "offset": 342910,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle[SP]gave[SP]away[SP]that\nlegendary[SP]weapon[SP]to[SP]a[SP]girl[SP]with[SP]short[SP]hair.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio a donné l'arme à\nune fille aux cheveux courts."
-  },
-  {
-    "id": 262,
-    "offset": 343116,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Leaving[SP]aside[SP]that[SP]it's[SP]a[SP]weapon...[SP]That's[SP]a\nnice[SP]gesture.[SP]I[SP]wish[SP]I[SP]got[SP]presents[SP]sometimes.\nMy[SP]husband[SP]barely[SP]knows[SP]I'm[SP]alive.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "C'est un joli geste, malgré tout.\nJ'aimerais recevoir des cadeaux parfois.\nMon mari sait à peine que j'existe."
-  },
-  {
-    "id": 263,
-    "offset": 343410,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Would[SP]you[SP]believe[SP]me[SP]if[SP]I[SP]said[SP][E4][NULL][NULL][U+0006]flowers[SP]can\ntalk[E4][NULL][NULL][0002]?[1205][U+000F][SP]Most[SP]people[SP]wouldn't.[SP]But[SP]there[SP]is\nsomeone[SP]in[SP]this[SP]park[SP]who[SP]speaks[SP]to[SP]flowers.",
-    "nom_fr": "Homme",
-    "texte_fr": "Croirais-tu que [E4][NULL][NULL][0006]les fleurs peuvent\nparler[E4][NULL][NULL][0002] ?[1205][000F] La plupart non. Mais\nquelqu'un ici parle aux fleurs."
-  },
-  {
-    "id": 264,
-    "offset": 343706,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "He[SP]takes[SP]care[SP]of[SP]the[SP]flowers[SP]here,[SP]and[SP]whenever\nI[SP]see[SP]him,[SP]he's[SP]talking[SP]to[SP]them.[1205][U+000F][SP]Rumor[SP]has[SP]it\nthat[SP]the[SP]flowers[SP]in[SP]Aoba[SP]Park[SP]talk[SP]back.",
-    "nom_fr": "Homme",
-    "texte_fr": "Il s'occupe des fleurs et leur parle.[1205][000F]\nOn dit qu'elles lui répondent."
-  },
-  {
-    "id": 265,
-    "offset": 344000,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "In[SP]the[SP]end,[SP]you[SP]decide[SP]what's[SP]real[SP]and[SP]what's\na[SP]dream.[1205][U+000F][SP]If[SP]you're[SP]tired[SP]of[SP]this[SP]dreary\nreality...[SP]try[SP]talking[SP]with[SP]the[SP]flowers.",
-    "nom_fr": "Homme",
-    "texte_fr": "Au final, c'est toi qui décides du\nréel.[1205][000F] Si tu es fatigué de cette\ntriste réalité, parle aux fleurs."
-  },
-  {
-    "id": 266,
-    "offset": 344278,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Masked[SP]Circle[SP]member",
-    "texte_orig": "Dammit,[SP]that[SP]Joker[SP]ran[SP]off[SP]to[SP]Caracol[SP]along\nwith[SP]the[SP]executives![1205][U+000F][SP]He's[SP]left[SP]us[SP]holding[SP]the\nbag[SP]here!",
-    "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Joker s'est enfui à Caracol avec les\ncadres ![1205][000F] Il nous a laissés dans la merde !"
-  },
-  {
-    "id": 267,
-    "offset": 344534,
-    "data_size": 312,
-    "slot_size": 316,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Masked[SP]Circle[SP]member",
-    "texte_orig": "Having[SP]our[SP]ideals[SP]granted[SP]will[SP]make[SP]us[SP]happy?\nBullshit![SP]All[SP]he[SP]wanted[SP]was[SP]to[SP]suck[SP]away[SP]our\nIdeal[SP]Energy[SP]to[SP]realize[SP]his[SP]own[SP]dreams!",
-    "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Nos idéaux exaucés ? N'importe quoi\n! Il a juste aspiré notre Énergie\nIdéale pour ses propres rêves !"
-  },
-  {
-    "id": 268,
-    "offset": 344850,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Last[SP]Battalion",
-    "texte_orig": "The[SP]holy[SP]lance[SP]is[SP]the[SP]emblem[SP]of[SP]our[SP]strength.\nIt[SP]shall[SP]crush[SP]all[SP]hindrances,[SP]along[SP]with[SP]the\nother[SP]self[SP]that[SP]lies[SP]within...",
-    "nom_fr": "Dernier Bataillon",
-    "texte_fr": "La lance sacrée, emblème de notre\nforce, écrasera tout obstacle et\nl'autre soi qui sommeille en nous."
-  },
-  {
-    "id": 269,
-    "offset": 345138,
-    "data_size": 172,
-    "slot_size": 176,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "To[SP]hell[SP]with[SP]that[SP]King[SP]Leo[SP]asshole!\nHe's[SP]through[SP]doing[SP]whatever[SP]he[SP]wants!",
-    "nom_fr": "Michel",
-    "texte_fr": "Au diable cet enculé de Roi Lion ! Il\nen a fini de faire ce qu'il veut !"
-  },
-  {
-    "id": 270,
-    "offset": 345314,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Uh-oh,[SP][1113].[SP]If[SP]we[SP]keep[SP]standing[SP]around\nlike[SP]this,[SP]people[SP]will[SP]get[SP]more[SP]suspicious.\nLet's[SP]get[SP]to[SP]the[SP]detective[SP]agency.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Uh-oh, [1113]. Si on traîne, les gens vont\nse méfier. Allons à l'agence de détectives."
-  },
-  {
-    "id": 271,
-    "offset": 345570,
-    "data_size": 88,
-    "slot_size": 92,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Huh?[SP]It[SP]says,[SP][1432][NULL][NULL][0014]No[SP]entry.[1432][NULL][NULL][0014]",
-    "nom_fr": "Michel",
-    "texte_fr": "Hein ?[SP][1432][NULL][NULL][0014] Entrée interdite.[1432][NULL][NULL][0014]"
-  },
-  {
-    "id": 272,
-    "offset": 345662,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "The[SP]fire[SP]department[SP]burned[SP]down...[SP]Don't[SP]tell\nme[SP]King[SP]Leo[SP]planned[SP]ahead![SP]No...!",
-    "nom_fr": "Maya",
-    "texte_fr": "Les pompiers ont brûlé… Dis-moi que non.\nLe Roi Lion a tout planifié ? Non… !"
-  },
-  {
-    "id": 273,
-    "offset": 345844,
-    "data_size": 232,
-    "slot_size": 236,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukiko",
-    "texte_orig": "He[SP]did[SP]this[SP]to[SP]prevent[SP]anyone[SP]from[SP]stopping\nhis[SP]plan...[SP]Now[SP]there's[SP]no[SP]one[SP]but[SP]us[SP]left\nto[SP]deal[SP]with[SP]him.",
-    "nom_fr": "Yukiko",
-    "texte_fr": "Il a fait ça pour qu'on ne l'arrête\npas. Il ne reste plus que nous."
-  },
-  {
-    "id": 274,
-    "offset": 346080,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Yeah,[SP]that's[SP]been[SP]the[SP]plan[SP]all[SP]along![SP]You[SP]can\nbet[SP]we're[SP]taking[SP]down[SP]that[SP]bastard[SP]ourselves!",
-    "nom_fr": "Michel",
-    "texte_fr": "Oui, c'était le plan depuis le début !\nOn va abattre ce salaud nous-mêmes !"
-  },
-  {
-    "id": 275,
-    "offset": 346292,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "King[SP]Leo[SP]will[SP]stop[SP]at[SP]nothing[SP]to[SP]fulfill[SP]the\nOracle.[SP]If[SP]we[SP]don't[SP]take[SP]him[SP]down[SP]now,[SP]there\nwill[SP]only[SP]be[SP]more[SP]casualties...",
-    "nom_fr": "Maya",
-    "texte_fr": "Roi Lion ne reculera devant rien. Si on ne\nl'arrête pas, il y aura plus de victimes…"
-  },
-  {
-    "id": 276,
-    "offset": 346558,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "We[SP]couldn't[SP]stop[SP]any[SP]of[SP]them[SP]from[SP]burning\ndown...[SP]I'm[SP]so[SP]mad[SP]at[SP]myself...",
-    "nom_fr": "Ginko",
-    "texte_fr": "On a pu empêcher aucun incendie… Je\nsuis tellement en colère contre moi…"
-  },
-  {
-    "id": 277,
-    "offset": 346730,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "I[SP]understand[SP]how[SP]you[SP]feel,[SP][1113],[SP]but\nwe're[SP]fugitives[SP]now.[SP]We[SP]shouldn't[SP]stay[SP]in\none[SP]place[SP]too[SP]long.",
-    "nom_fr": "Yukino",
-    "texte_fr": "Je comprends, [1113], mais nous\nsommes fugitifs. Ne restons pas\ntrop longtemps au même endroit."
-  },
-  {
-    "id": 278,
-    "offset": 346948,
-    "data_size": 118,
-    "slot_size": 122,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "There's[SP]no[SP]point[SP]being[SP]here[SP]anymore.\nLet's[SP]go.",
-    "nom_fr": "Michel",
-    "texte_fr": "Cela ne sert plus à rien d'être ici. Allons-y."
-  },
-  {
-    "id": 279,
-    "offset": 347070,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "We've[SP]already[SP]got[SP]the[SP]crystal[SP]skull[SP]here.\nLet's[SP]hurry[SP]and[SP]find[SP]the[SP]others.",
-    "nom_fr": "Maya",
-    "texte_fr": "Nous avons déjà le crâne de\ncristal. Trouvons les autres."
-  },
-  {
-    "id": 280,
-    "offset": 347242,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "I[SP]can[SP]hear[SP]voices...[SP]The[SP]fighting's[SP]still\ngoing[SP]on[SP]inside.[SP]We[SP]need[SP]to[SP]hurry[SP]and[SP]put\na[SP]stop[SP]to[SP]it.",
-    "nom_fr": "Maya",
-    "texte_fr": "J'entends des voix. Le combat\ncontinue. Il faut y mettre fin."
-  },
-  {
-    "id": 281,
-    "offset": 347460,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "[1113],[SP]now's[SP]not[SP]the[SP]time[SP]for[SP]detours.\nEveryone's[SP]waiting...[SP]We[SP]have[SP]to[SP]go[SP]to[SP]the\ndetective[SP]agency.",
-    "nom_fr": "Ginko",
-    "texte_fr": "[1113], pas de détours. Tout le\nmonde attend. Allons à l'agence."
-  },
-  {
-    "id": 282,
-    "offset": 347676,
-    "data_size": 170,
-    "slot_size": 174,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Huh?[SP]It's[SP]closed.[SP]I[SP]wonder[SP]what's[SP]up...\nOh[SP]well,[SP]let's[SP]go[SP]somewhere[SP]else.",
-    "nom_fr": "Ginko",
-    "texte_fr": "C'est fermé. Je me demande\npourquoi… Bon, allons ailleurs."
-  },
-  {
-    "id": 283,
-    "offset": 347850,
-    "data_size": 232,
-    "slot_size": 236,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "[1113],[SP]I[SP]kinda[SP]feel[SP]bad[SP]making[SP]everyone\nwait[SP]while[SP]we[SP]wander[SP]around.[SP]We[SP]should[SP]hurry\nto[SP]the[SP]detective[SP]agency.",
-    "nom_fr": "Ginko",
-    "texte_fr": "[1113], je me sens mal de faire attendre tout\nle monde. Dépêchons-nous d'aller à l'agence."
-  },
-  {
-    "id": 284,
-    "offset": 348086,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Wait[SP]a[SP]sec,[SP]Chinyan![SP]We[SP]don't[SP]have[SP]the[SP]skull\nfrom[SP]Taurus[SP]Temple[SP]yet.[SP]We[SP]should[SP]stop[SP]by\nthere[SP]first.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Attends, Chinyan ! On n'a pas encore le crâne\ndu temple du Taureau. Allons-y d'abord."
-  },
-  {
-    "id": 285,
-    "offset": 348310,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "H-Hold[SP]the[SP]phone,[SP]man.[1205][U+000F][SP]We're[SP]still[SP]not[SP]done\nwith[SP]Scorpio[SP]Temple.[1205][U+000F][SP]Let's[SP]go[SP]grab[SP]the[SP]skull\nfrom[SP]there[SP]first.",
-    "nom_fr": "Michel",
-    "texte_fr": "A-Attends, mec.[1205][000F] On n'a pas fini avec temple\ndu Scorpion.[1205][000F] Prenons ce crâne d'abord."
-  },
-  {
-    "id": 286,
-    "offset": 348560,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Jun",
-    "texte_orig": "Hold[SP]on[SP]a[SP]moment.[SP]We're[SP]still[SP]not[SP]done[SP]with\nthe[SP]Aquarius[SP]Temple.",
-    "nom_fr": "Jun",
-    "texte_fr": "Attends. On n'a pas fini\navec le temple du Verseau."
-  }
+   {
+      "id":0,
+      "offset":276502,
+      "data_size":212,
+      "slot_size":216,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"Hm?[SP]The[SP]outdoor[SP]concert[SP]hall?[SP]Oh,[SP]it's[SP]over[SP]in\nAoba[SP]Park.[SP]Are[SP]you[SP]going[SP]to[SP]see[SP]the[SP]show?",
+      "nom_fr":"Employé",
+      "texte_fr":"La salle de concert ? Dans le parc d'Aoba.\nTu vas voir le spectacle ?"
+   },
+   {
+      "id":1,
+      "offset":276718,
+      "data_size":262,
+      "slot_size":266,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"The[SP]Muses[SP]sure[SP]got[SP]popular[SP]fast.[SP]I[SP]was[SP]curious,\nbut[SP]the[SP]tickets[SP]are[SP]all[SP]sold[SP]out.[SP]I[SP]guess[SP]it\nwasn't[SP]meant[SP]to[SP]be.",
+      "nom_fr":"Employé",
+      "texte_fr":"Les Muses sont devenues populaires vite.\nJ'étais curieux, mais complet. Pas pour moi."
+   },
+   {
+      "id":2,
+      "offset":276984,
+      "data_size":244,
+      "slot_size":248,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"I...[SP]I[SP]can't[SP]believe[SP]the[SP]concert[SP]hall[SP]burned\ndown...[1205][U+000F][SP]Wh-What[SP]happened[SP]in[SP]there?[SP]Is[SP]the\naudience[SP]okay?",
+      "nom_fr":"Employé",
+      "texte_fr":"Je… La salle a brûlé…[1205][U+000F]\nQue s'est-il passé ? Le public va bien ?"
+   },
+   {
+      "id":3,
+      "offset":277232,
+      "data_size":284,
+      "slot_size":288,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"I[SP]heard[SP]from[SP]a[SP]friend[SP]that[SP]Smile[SP]Hirasaka[SP]and\nGOLD[SP]were[SP]targeted[SP]by[SP]terrorists[SP]too.[1205][U+000F][SP]Luckily,\nboth[SP]attacks[SP]were[SP]thwarted...",
+      "nom_fr":"Employé",
+      "texte_fr":"Un ami m'a dit que Smile Hirasaka et GOLD ont aussi été visés.[1205][U+000F]\nHeureusement, les deux ont été évités..."
+   },
+   {
+      "id":4,
+      "offset":277520,
+      "data_size":252,
+      "slot_size":256,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"But[SP]they[SP]were[SP]both[SP]packed[SP]with[SP]people.[1205][U+000F]\nWho'd[SP]want[SP]to[SP]bomb[SP]someplace[SP]like[SP]that?\nThe[SP]culprit[SP]is[SP]inhuman...!",
+      "nom_fr":"Employé",
+      "texte_fr":"Mais ils étaient bondés.[1205][U+000F]\nQui voudrait bombarder ça ? Le coupable est inhumain !"
+   },
+   {
+      "id":5,
+      "offset":277776,
+      "data_size":250,
+      "slot_size":254,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"My[SP]friend[SP]told[SP]me[SP]that[SP]the[SP]terrorists[SP]even[SP]blew\nup[SP]Smile[SP]Hirasaka.[1205][U+000F][SP]I[SP]hear[SP]the[SP]death[SP]toll[SP]was\ntremendous.",
+      "nom_fr":"Employé",
+      "texte_fr":"Mon ami dit que les terroristes ont fait sauter Smile Hirasaka.[1205][U+000F]\nDe nombreux morts."
+   },
+   {
+      "id":6,
+      "offset":278030,
+      "data_size":290,
+      "slot_size":294,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"There[SP]were[SP]lots[SP]of[SP]people[SP]at[SP]that[SP]concert[SP]hall,\ntoo...[1205][U+000F][SP]Who'd[SP]want[SP]to[SP]blow[SP]up[SP]someplace[SP]like\nthat?[SP]The[SP]culprit[SP]is[SP]inhuman...!",
+      "nom_fr":"Employé",
+      "texte_fr":"Beaucoup de monde aussi...[1205][U+000F]\nPourquoi bombarder ça ? Inhumain !"
+   },
+   {
+      "id":7,
+      "offset":278324,
+      "data_size":252,
+      "slot_size":256,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"My[SP]friend[SP]told[SP]me[SP]that[SP]the[SP]terrorists[SP]even[SP]blew\nup[SP]GOLD[SP]in[SP]Yumezaki.[1205][U+000F][SP]I[SP]hear[SP]the[SP]death[SP]toll[SP]was\ntremendous.",
+      "nom_fr":"Employé",
+      "texte_fr":"Mon ami dit qu'ils ont fait sauter GOLD à Yumezaki.[1205][U+000F]\nBeaucoup de morts."
+   },
+   {
+      "id":8,
+      "offset":278580,
+      "data_size":290,
+      "slot_size":294,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"There[SP]were[SP]lots[SP]of[SP]people[SP]at[SP]that[SP]concert[SP]hall,\ntoo...[1205][U+000F][SP]Who'd[SP]want[SP]to[SP]blow[SP]up[SP]someplace[SP]like\nthat?[SP]The[SP]culprit[SP]is[SP]inhuman...!",
+      "nom_fr":"Employé",
+      "texte_fr":"Beaucoup de monde aussi...[1205][U+000F]\nPourquoi bombarder ça ? Inhumain !"
+   },
+   {
+      "id":9,
+      "offset":278874,
+      "data_size":240,
+      "slot_size":244,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"I[SP]heard[SP]from[SP]a[SP]friend[SP]that[SP]terrorists[SP]struck\nat[SP]both[SP]Smile[SP]Hirasaka[SP]and[SP]GOLD.[1205][U+000F][SP]So[SP]many\npeople[SP]died...",
+      "nom_fr":"Employé",
+      "texte_fr":"Un ami m'a dit que les terroristes ont frappé\n Smile Hirasaka et GOLD.[1205][U+000F] Tant de morts…"
+   },
+   {
+      "id":10,
+      "offset":279118,
+      "data_size":244,
+      "slot_size":248,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"They[SP]were[SP]both[SP]packed[SP]with[SP]people.[SP]Who'd[SP]want[1205][U+000F]\nto[SP]bomb[SP]someplace[SP]like[SP]that?[SP]The[SP]culprit[SP]is\ninhuman...!",
+      "nom_fr":"Employé",
+      "texte_fr":"Bondés. Qui voudrait[1205][U+000F]\nbombarder ça ? Inhumain !"
+   },
+   {
+      "id":11,
+      "offset":279366,
+      "data_size":198,
+      "slot_size":202,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"Even[SP]the[SP]Aerospace[SP]Museum[SP]was[SP]bombed...[1205][U+000F]\nThat's[SP]already[SP]six[SP]attacks[SP]in[SP]total.[1205][U+000F]",
+      "nom_fr":"Employé",
+      "texte_fr":"Même le musée aérospatial a été bombardé…[1205][U+000F]\nSix attaques au total.[1205][U+000F]"
+   },
+   {
+      "id":12,
+      "offset":279568,
+      "data_size":156,
+      "slot_size":160,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"How[SP]many[SP]deaths[SP]will[SP]it[SP]take[SP]to[SP]satisfy[SP]that\ngang[SP]of[SP]five!?",
+      "nom_fr":"Employé",
+      "texte_fr":"Combien de morts pour cette bande de cinq !?"
+   },
+   {
+      "id":13,
+      "offset":279728,
+      "data_size":276,
+      "slot_size":280,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"The[SP]paper's[SP]reporting[SP]now[SP]that[SP]the[SP]Masked\nCircle[SP]and[SP]the[SP]Last[SP]Battalion[SP]are[SP]fighting\nover[SP]the[SP]secret[SP]treasure[SP]of[SP]Sumaru.",
+      "nom_fr":"Employé",
+      "texte_fr":"Le journal dit que le Cercle Masqué\n et le Dernier Bataillon se battent\n pour le trésor secret de Sumaru."
+   },
+   {
+      "id":14,
+      "offset":280008,
+      "data_size":304,
+      "slot_size":308,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"Looks[SP]like[SP]that[SP]was[SP]the[SP]reason[SP]for[SP]the[SP]terror\nwave,[SP]too.[1205][U+000F][SP]Honestly,[SP]one[SP]of[SP]them[SP]should[SP]just\ntake[SP]it[SP]and[SP]go.[SP]We[SP]don't[SP]need[SP]them[SP]here!",
+      "nom_fr":"Employé",
+      "texte_fr":"C'était la raison de la vague de terreur aussi.[1205][U+000F]\nQu'ils le prennent et s'en aillent. On n'en a pas besoin !"
+   },
+   {
+      "id":15,
+      "offset":280316,
+      "data_size":230,
+      "slot_size":234,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"Th-That[SP]mark...![1205][U+000F][SP]Why[SP]are[SP]soldiers[SP]with[SP]that\ninsignia[SP]coming[SP]to[SP]Sumaru[SP]now!?[SP]It[SP]makes\nno[SP]sense!",
+      "nom_fr":"Employé",
+      "texte_fr":"Ce symbole…![1205][U+000F]\nPourquoi ces soldats viennent à Sumaru ? Insensé !"
+   },
+   {
+      "id":16,
+      "offset":280550,
+      "data_size":202,
+      "slot_size":206,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"D-Did[SP]the[SP]Masked[SP]Circle[SP]and[SP]the[SP]Last[SP]Battalion\ncause[SP]those[SP]temples[SP]to[SP]appear,[SP]too?",
+      "nom_fr":"Employé",
+      "texte_fr":"Le Cercle Masqué et le Dernier Bataillon\n ont-ils aussi fait apparaître ces temples ?"
+   },
+   {
+      "id":17,
+      "offset":280756,
+      "data_size":174,
+      "slot_size":178,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"Because[SP]I[SP]mean,[SP]once[SP]those[SP]things[SP]showed[SP]up,\nthey[SP]all[SP]rushed[SP]inside.",
+      "nom_fr":"Employé",
+      "texte_fr":"Une fois apparus,\n ils se sont tous précipités à l'intérieur."
+   },
+   {
+      "id":18,
+      "offset":280934,
+      "data_size":210,
+      "slot_size":214,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Office[SP]worker",
+      "texte_orig":"Ugh...[SP]This[SP]is[SP]too[SP]much...[1205][U+000F][SP]I[SP]feel[SP]like[SP]I'm\ngoing[SP]to[SP]go[SP]insane[SP]before[SP]I[SP]can[SP]evolve...",
+      "nom_fr":"Employé",
+      "texte_fr":"Ugh… C'en est trop…[1205][U+000F]\nJe deviendrai fou avant d'évoluer…"
+   },
+   {
+      "id":19,
+      "offset":281148,
+      "data_size":220,
+      "slot_size":224,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Working[SP]woman",
+      "texte_orig":"Aoba[SP]is[SP]famous[SP]for[SP]its[SP]outdoor[SP]concert[SP]hall,\nbut[SP]that's[SP]not[SP]the[SP]only[SP]thing[SP]we're[SP]known[SP]for.",
+      "nom_fr":"Femme active",
+      "texte_fr":"Aoba est célèbre pour sa salle de concert,\n mais ce n'est pas notre seule fierté."
+   },
+   {
+      "id":20,
+      "offset":281372,
+      "data_size":184,
+      "slot_size":188,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Working[SP]woman",
+      "texte_orig":"Kismet[SP]Publishing,[SP]publishers[SP]of[SP]Coolest,\nand[SP]Sumaru[SP]TV[SP]are[SP]in[SP]this[SP]ward.",
+      "nom_fr":"Femme active",
+      "texte_fr":"Kismet Publishing (Coolest) et Sumaru TV\n sont dans ce quartier."
+   },
+   {
+      "id":21,
+      "offset":281560,
+      "data_size":278,
+      "slot_size":282,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Working[SP]woman",
+      "texte_orig":"It[SP]may[SP]not[SP]have[SP]Yumezaki's[SP]pizazz,[SP]but[SP]I[SP]think\nthis[SP]ward[SP]is[SP]the[SP]beating[SP]heart[SP]that[SP]feeds\ninformation[SP]across[SP]Sumaru[SP]City.",
+      "nom_fr":"Femme active",
+      "texte_fr":"Ça n'a pas le peps de Yumezaki,\n mais ce quartier est le cœur\n qui alimente Sumaru en infos."
+   },
+   {
+      "id":22,
+      "offset":281842,
+      "data_size":200,
+      "slot_size":204,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Working[SP]woman",
+      "texte_orig":"I[SP]just[SP]saw[SP]a[SP]Masked[SP]Circle[SP]member[SP]in[SP]a[SP]store.[1205][U+000F]\nHe[SP]was[SP]saying[SP]some[SP]scary[SP]stuff...",
+      "nom_fr":"Femme active",
+      "texte_fr":"Je viens de voir un membre du Cercle Masqué.[1205][U+000F]\nIl disait des trucs effrayants…"
+   },
+   {
+      "id":23,
+      "offset":282046,
+      "data_size":278,
+      "slot_size":282,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Working[SP]woman",
+      "texte_orig":"There's[SP]no[SP]doubt[SP]that[SP]it[SP]was[SP]them[SP]who[SP]set[SP]fire\nto[SP]the[SP]outdoor[SP]concert[SP]hall.[SP]They're[SP]a[SP]menace,\njust[SP]like[SP]the[SP]rumors[SP]said.",
+      "nom_fr":"Femme active",
+      "texte_fr":"Nul doute que c'est eux qui ont incendié la salle.\nUne menace, comme les rumeurs le disaient."
+   },
+   {
+      "id":24,
+      "offset":282328,
+      "data_size":260,
+      "slot_size":264,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Working[SP]woman",
+      "texte_orig":"Some[SP]kids[SP]came[SP]by[SP]just[SP]now[SP]and[SP]said[SP]the[SP]five\nsuspects[SP]are[SP]actually[SP]heroes[SP]fighting[SP]against\nthe[SP]Masked[SP]Circle...",
+      "nom_fr":"Femme active",
+      "texte_fr":"Des gamins ont dit que les cinq suspects sont\n des héros qui combattent le Cercle Masqué…"
+   },
+   {
+      "id":25,
+      "offset":282592,
+      "data_size":294,
+      "slot_size":298,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Working[SP]woman",
+      "texte_orig":"I-I[SP]knew[SP]all[SP]along.[SP]The[SP]culprits[SP]were[SP]the\nMasked[SP]Circle,[SP]of[SP]course![1205][U+000F][SP]But[SP]I[SP]didn't[SP]know\nthose[SP]five[SP]were[SP]fighting[SP]against[SP]them...",
+      "nom_fr":"Femme active",
+      "texte_fr":"Je le savais. Les coupables sont le Cercle Masqué ![1205][U+000F]\nMais j'ignorais que ces cinq les combattaient…"
+   },
+   {
+      "id":26,
+      "offset":282890,
+      "data_size":276,
+      "slot_size":280,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Working[SP]woman",
+      "texte_orig":"I-I[SP]heard[SP]the[SP]Oracle[SP]in[SP]the[SP]In[SP]Lak'ech[SP]talks\nabout[SP]everything[SP]that's[SP]happened[SP]lately,\nbut[SP]that's[SP]just[SP]a[SP]marketing[SP]angle.",
+      "nom_fr":"Femme active",
+      "texte_fr":"L'Oracle dans l'In Lak'ech parle de tout,\n mais ce n'est qu'un argument marketing."
+   },
+   {
+      "id":27,
+      "offset":283170,
+      "data_size":198,
+      "slot_size":202,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Working[SP]woman",
+      "texte_orig":"I[SP]mean,[SP]it's[SP]not[SP]like[SP]it's[SP]some[SP]grand[SP]prophecy.\nThat[SP]would[SP]just[SP]be[SP]ridiculous...",
+      "nom_fr":"Femme active",
+      "texte_fr":"Ce n'est pas une grande prophétie.\nCe serait ridicule…"
+   },
+   {
+      "id":28,
+      "offset":283372,
+      "data_size":130,
+      "slot_size":134,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Working[SP]woman",
+      "texte_orig":"D-Don't[SP]you[SP]think[SP]so?[1205][U+000F][SP]I-I'm[SP]right,[SP]aren't[SP]I?",
+      "nom_fr":"Femme active",
+      "texte_fr":"Tu ne crois pas ?[1205][U+000F]\nJ'ai raison, non ?"
+   },
+   {
+      "id":29,
+      "offset":283506,
+      "data_size":318,
+      "slot_size":322,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Working[SP]woman",
+      "texte_orig":"Why[SP]are[SP]soldiers[SP]raining[SP]from[SP]the[SP]sky!?[SP]Is[SP]this\nthing[SP]saying[SP]there's[SP]some[SP]secret[SP]treasure[SP]here\nin[SP]Sumaru!?[1205][U+000F][SP]I-I[SP]refuse[SP]to[SP]believe[SP]that![SP]No!",
+      "nom_fr":"Femme active",
+      "texte_fr":"Pourquoi les soldats pleuvent du ciel !?\nCe truc dit qu'il y a un trésor secret à Sumaru !?[1205][U+000F]\nJe refuse de le croire ! Non !"
+   },
+   {
+      "id":30,
+      "offset":283828,
+      "data_size":254,
+      "slot_size":258,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Working[SP]woman",
+      "texte_orig":"Huh!?[1205][U+000A][SP]Didn't[SP]you[SP]just[SP]go[SP]into[SP]that[SP]temple?[1205][U+000F]\nYeah,[SP]carrying[SP]this[SP]weird[SP]skull...[1205][U+000F][SP]A-Am[SP]I\nseeing[SP]things...?",
+      "nom_fr":"Femme active",
+      "texte_fr":"Hein ?[1205][U+000A] Tu n'es pas entré dans ce temple ?[1205][U+000F]\nOui, avec ce drôle de crâne…[1205][U+000F]\nJ'ai des hallucinations ?"
+   },
+   {
+      "id":31,
+      "offset":284086,
+      "data_size":326,
+      "slot_size":330,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Ever[SP]hear[SP]the[SP]rumor[SP]that[SP]Rosa[SP]Candida[SP]sells\nreal[SP]armor?[1205][U+000F][SP]An[SP]office[SP]mate[SP]of[SP]mine[SP]told[SP]me\nabout[SP]it,[SP]and[SP]I've[SP]been[SP]curious[SP]ever[SP]since.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Tu as entendu que Rosa Candida vend de vraies armures ?[1205][U+000F]\nUn collègue m'en a parlé, je suis curieux."
+   },
+   {
+      "id":32,
+      "offset":284416,
+      "data_size":148,
+      "slot_size":152,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"It[SP]seems[SP]he[SP]got[SP]the[SP]story[SP]online[SP]somewhere.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Il a dû voir ça sur Internet."
+   },
+   {
+      "id":33,
+      "offset":284568,
+      "data_size":206,
+      "slot_size":210,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"If[SP]you[SP]go[SP]to[SP]Double[SP]Slash,[SP]you[SP]can[SP]use[SP]their\nPCs[SP]to[SP]browse[SP]the[SP]Internet.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Au Double Slash, on peut utiliser leurs PC\n pour surfer sur Internet."
+   },
+   {
+      "id":34,
+      "offset":284778,
+      "data_size":322,
+      "slot_size":326,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Even[SP]an[SP]old[SP]man[SP]like[SP]me[SP]could[SP]look[SP]it[SP]up[SP]there\nif[SP]I[SP]wanted...[1205][U+000F][SP]But[SP]I'm[SP]no[SP]good[SP]with[SP]computers.[1205][U+000F]\nJust[SP]one[SP]of[SP]my[SP]hangups,[SP]I[SP]guess.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Même un vieux comme moi pourrait chercher,[1205][U+000F]\nmais je suis nul en informatique.[1205][U+000F]\nUn de mes travers."
+   },
+   {
+      "id":35,
+      "offset":285104,
+      "data_size":338,
+      "slot_size":342,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Rumor[SP]has[SP]it[SP]the[SP]Masked[SP]Circle[SP]did[SP]this,[SP]but[SP]I\nalso[SP]hear[SP]there[SP]was[SP]a[SP]group[SP]of[SP]five[SP]suspicious\npeople[SP]seen[SP]around[SP]the[SP]outdoor[SP]concert[SP]hall.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"On dit que c'est le Cercle Masqué,\n mais j'ai aussi entendu qu'un groupe de cinq suspects\n a été vu près de la salle de concert."
+   },
+   {
+      "id":36,
+      "offset":285446,
+      "data_size":136,
+      "slot_size":140,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Shouldn't[SP]those[SP]guys[SP]be[SP]suspects[SP]too?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Ils ne devraient pas être suspects aussi ?"
+   },
+   {
+      "id":37,
+      "offset":285586,
+      "data_size":290,
+      "slot_size":294,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Man",
+      "texte_orig":"I[SP]can't[SP]believe[SP]such[SP]a[SP]terrible[SP]tragedy\nhappened...[1205][U+000F][SP]But[SP]if[SP]sketches[SP]of[SP]the[SP]culprits[SP]are\nout,[SP]it[SP]won't[SP]be[SP]long[SP]before[SP]they're[SP]arrested.",
+      "nom_fr":"Homme",
+      "texte_fr":"Je n'arrive pas à croire qu'une telle tragédie soit arrivée.[1205][U+000F]\nMais avec les portraits-robots, ils seront bientôt arrêtés."
+   },
+   {
+      "id":38,
+      "offset":285880,
+      "data_size":308,
+      "slot_size":312,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"My[SP]entire[SP]office[SP]is[SP]buzzing[SP]about[SP]whether[SP]or\nnot[SP]the[SP]In[SP]Lak'ech[SP]is[SP]true.[1205][U+000F][SP]All[SP]the[SP]younger\nemployees[SP]seem[SP]to[SP]believe[SP]in[SP]it.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Tout le bureau parle de si l'In Lak'ech est vrai.[1205][U+000F]\nLes jeunes y croient."
+   },
+   {
+      "id":39,
+      "offset":286192,
+      "data_size":274,
+      "slot_size":278,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Most[SP]of[SP]those[SP]soldiers[SP]were[SP]heading[SP]to\nMt.[SP]Katatsumuri.[1205][U+000F][SP]But[SP]why[SP]would[SP]they[SP]go[SP]there?\nI[SP]don't[SP]understand.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"La plupart des soldats allaient au mont Katatsumuri.[1205][U+000F]\nPourquoi ? Je ne comprends pas."
+   },
+   {
+      "id":40,
+      "offset":286470,
+      "data_size":316,
+      "slot_size":320,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"How[SP]can[SP]such[SP]nonsensical[SP]things[SP]be[SP]happening?[1205][U+000A]\nW-Well,[SP]I've[SP]seen[SP]it[SP]for[SP]myself...[1205][U+000A][SP]I[SP]don't\nhave[SP]a[SP]choice[SP]but[SP]to[SP]believe[SP]it...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Comment de telles absurdités arrivent ?[1205][U+000A]\nJe l'ai vu de mes yeux…[1205][U+000A]\nJe n'ai pas le choix, je dois y croire…"
+   },
+   {
+      "id":41,
+      "offset":286790,
+      "data_size":296,
+      "slot_size":300,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"But[SP]in[SP]that[SP]case,[SP]this[SP]talk[SP]about[SP]the[SP]Earth\nbeing[SP]annihilated[SP]must[SP]be[SP]true,[SP]too...[1205][U+000F][SP]What\nexactly[SP]is[SP]going[SP]to[SP]happen?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Alors cette histoire de Terre anéantie doit être vraie aussi…[1205][U+000F]\nQue va-t-il exactement se passer ?"
+   },
+   {
+      "id":42,
+      "offset":287090,
+      "data_size":348,
+      "slot_size":352,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"My[SP]men[SP]say[SP]that[SP]the[SP]Grand[SP]Cross[SP]will[SP]cause[SP]the\nmantle's[SP]temperature[SP]to[SP]rise,[SP]making[SP]the[SP]Earth\na[SP]scorching[SP]hell...[1205][U+000F][SP]Is[SP]that[SP]how[SP]the[SP]world[SP]ends?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Mes collègues disent que la Grande Croix fera monter\n la température, transformant la Terre en enfer…[1205][U+000F]\nC'est ainsi que le monde finit ?"
+   },
+   {
+      "id":43,
+      "offset":287442,
+      "data_size":316,
+      "slot_size":320,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"A[SP]colleague[SP]of[SP]mine[SP]says[SP]the[SP]Grand[SP]Cross[SP]will\nresult[SP]in[SP]the[SP]gravitational[SP]pull[SP]of[SP]the[SP]other\nplanets[SP]causing[SP]a[SP]gigantic[SP]tsunami.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Un collègue dit que la Grande Croix provoquera\n l'attraction des autres planètes,\n causant un tsunami géant."
+   },
+   {
+      "id":44,
+      "offset":287762,
+      "data_size":180,
+      "slot_size":184,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]don't[SP]know[SP]much[SP]about[SP]science...[1205][U+000F][SP]Is[SP]that\neven[SP]possible?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Je ne connais pas bien la science…[1205][U+000F]\nEst-ce seulement possible ?"
+   },
+   {
+      "id":45,
+      "offset":287946,
+      "data_size":318,
+      "slot_size":322,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"That[SP]was[SP]strange.[1205][U+000A][SP]My[SP]men[SP]had[SP]all[SP]been[SP]arguing\nover[SP]how[SP]the[SP]world[SP]down[SP]there[SP]would[SP]end,[SP]when\nsuddenly[SP]they[SP]settled[SP]on[SP]one[SP]idea.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"C'était étrange.[1205][U+000A]\nIls discutaient de la fin du monde en bas,\n quand soudain ils se sont mis d'accord sur une idée."
+   },
+   {
+      "id":46,
+      "offset":288268,
+      "data_size":192,
+      "slot_size":196,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"They[SP]think[SP]the[SP]Grand[SP]Cross[SP]will[SP]cause[SP]the\nEarth[SP]to[SP]stop[SP]rotating.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Ils pensent que la Grande Croix\n arrêtera la rotation de la Terre."
+   },
+   {
+      "id":47,
+      "offset":288464,
+      "data_size":310,
+      "slot_size":314,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]couldn't[SP]follow[SP]their[SP]explanations,[SP]but[SP]the\nupshot[SP]was[SP]that[SP]everything[SP]on[SP]Earth[SP]will[SP]be\nblasted[SP]away[SP]at[SP]high[SP]speed,[SP]right?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Je n'ai pas suivi,\n mais tout sur Terre sera emporté à grande vitesse ?"
+   },
+   {
+      "id":48,
+      "offset":288778,
+      "data_size":334,
+      "slot_size":338,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"So[SP]there[SP]are[SP]talking[SP]flowers[SP]in[SP]Aoba[SP]Park...\nWhen[SP]I[SP]first[SP]heard,[SP]I[SP]thought[SP]it[SP]was[SP]a[SP]joke.[1205][U+000F]\nI'm[SP]curious[SP]to[SP]know[SP]what[SP]plants[SP]think[SP]about.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Des fleurs qui parlent dans le parc d'Aoba…\nJ'ai d'abord cru à une blague.[1205][U+000F]\nCurieux de savoir à quoi pensent les plantes."
+   },
+   {
+      "id":49,
+      "offset":289116,
+      "data_size":292,
+      "slot_size":296,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"It[SP]seems[SP]Zodiac's[SP]second[SP]floor[SP]has[SP]become[SP]a\ngiant[SP]dungeon.[1205][U+000F][SP]The[SP]rumor[SP]is[SP]that[SP]there's[SP]tons\nof[SP]great[SP]items[SP]there...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Il paraît que le deuxième étage de Zodiac est devenu\n un immense donjon.[1205][U+000F] Beaucoup de bons objets…"
+   },
+   {
+      "id":50,
+      "offset":289412,
+      "data_size":166,
+      "slot_size":170,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Is[SP]this[SP]some[SP]new[SP]marketing[SP]stunt?[SP]What[SP]do\nyou[SP]think?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Un nouveau coup de pub ? Qu'en pensez-vous ?"
+   },
+   {
+      "id":51,
+      "offset":289582,
+      "data_size":174,
+      "slot_size":178,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]heard[SP]the[SP]ghost[SP]of[SP]an[SP]idol[SP]has[SP]been[SP]seen\nin[SP]Aoba[SP]Park.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"On a vu le fantôme d'une idole dans le parc d'Aoba."
+   },
+   {
+      "id":52,
+      "offset":289760,
+      "data_size":234,
+      "slot_size":238,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"If[SP]enough[SP]people[SP]say[SP]so,[SP]it[SP]must[SP]be[SP]true...[1205][U+000F]\nBrrr![SP]I[SP]just[SP]felt[SP]a[SP]chill[SP]down[SP]my[SP]spine.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Si assez de gens le disent, ça doit être vrai…[1205][U+000F]\nBrrr ! J'ai eu un frisson."
+   },
+   {
+      "id":53,
+      "offset":289998,
+      "data_size":330,
+      "slot_size":334,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Is[SP]there[SP]something[SP]called[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the\nabandoned[SP]factory?[1205][U+000F][SP]Yikes,[SP]now[SP]I[SP]can't[SP]even[SP]take\na[SP]taxi[SP]ride[SP]without[SP]worrying[SP]anymore.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Un Taxi Maudit à l'usine abandonnée ?[1205][U+000F]\nOuf, je ne peux même plus prendre un taxi sans m'inquiéter."
+   },
+   {
+      "id":54,
+      "offset":290332,
+      "data_size":182,
+      "slot_size":186,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]heard[SP]there's[SP]some[SP]Cursed[SP]Escort[SP]at[SP]the\nabandoned[SP]factory.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"J'ai entendu qu'il y a une Escorte Maudite\n à l'usine abandonnée."
+   },
+   {
+      "id":55,
+      "offset":290518,
+      "data_size":266,
+      "slot_size":270,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"A[SP]taxi[SP]driver[SP]told[SP]me[SP]about[SP]it.[1205][U+000F][SP]He[SP]said[SP]he's\nhaving[SP]trouble[SP]getting[SP]customers[SP]because\nof[SP]that[SP]thing.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Un chauffeur de taxi m'en a parlé.[1205][U+000F]\nIl a du mal à trouver des clients à cause de ça."
+   },
+   {
+      "id":56,
+      "offset":290788,
+      "data_size":316,
+      "slot_size":320,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"It[SP]seems[SP]the[SP]real[SP]Kuchisake-onna[SP]has[SP]shown[SP]up\nat[SP]Mt.[SP]Iwato.[SP]First[SP]terrorists,[SP]now[SP]Kuchisake-\nonna...[SP]This[SP]city's[SP]falling[SP]apart.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"La vraie Kuchisake-onna est apparue au mont Iwato.\nD'abord les terroristes, maintenant elle…\nCette ville s'écroule."
+   },
+   {
+      "id":57,
+      "offset":291108,
+      "data_size":314,
+      "slot_size":318,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"There's[SP]a[SP]Jumping[SP]Geezer[SP]at[SP]Mt.[SP]Katatsumuri?\nIsn't[SP]that[SP]just[SP]one[SP]of[SP]those[SP]Last[SP]Battalion\nguys?[1205][U+000F][SP]Yeah,[SP]I[SP]bet[SP]that's[SP]all[SP]it[SP]is.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Un Sauteur Vieux au mont Katatsumuri ?\nC'est juste un gars du Dernier Bataillon, non ?[1205][U+000F]\nOuais, ça doit être ça."
+   },
+   {
+      "id":58,
+      "offset":291426,
+      "data_size":344,
+      "slot_size":348,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]can't[SP]believe[SP]they[SP]still[SP]tell[SP]that[SP]story...\nKudan,[SP]huh...?[1205][U+000F][SP]Even[SP]at[SP]my[SP]age,[SP]I'm[SP]afraid[SP]of\nthat[SP]thing...[1205][U+000F][SP]Brrr![SP]Still[SP]gives[SP]me[SP]the[SP]creeps.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Je n'arrive pas à croire qu'on raconte encore ça…\nKudan…[1205][U+000F] Même à mon âge, j'en ai peur.[1205][U+000F]\nBrrr ! Ça me donne toujours des frissons."
+   },
+   {
+      "id":59,
+      "offset":291774,
+      "data_size":332,
+      "slot_size":336,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"There's[SP]a[SP]secret[SP]CD[SP]at[SP]Giga[SP]Macho?[SP]Stores[SP]have\nbeen[SP]coming[SP]up[SP]with[SP]odd[SP]promotional[SP]stunts\nlately.[1205][U+000F][SP]Though[SP]it[SP]does[SP]pique[SP]my[SP]interest...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Un CD secret chez Giga Macho ?\nLes magasins ont des promotions bizarres.[1205][U+000F]\nCela pique ma curiosité…"
+   },
+   {
+      "id":60,
+      "offset":292110,
+      "data_size":324,
+      "slot_size":328,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Do[SP]you[SP]know[SP]the[SP]Dresser[SP]Hag?[1205][U+000F][SP]There's[SP]a[SP]creature\ncalled[SP]that[SP]at[SP]the[SP]abandoned[SP]factory.[1205][U+000F][SP]Does[SP]that\nmean[SP]it[SP]lives[SP]inside[SP]a[SP]dresser?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Tu connais la Sorcière du Buffet ?[1205][U+000F]\nElle serait à l'usine abandonnée.[1205][U+000F]\nElle vit dans un buffet ?"
+   },
+   {
+      "id":61,
+      "offset":292438,
+      "data_size":278,
+      "slot_size":282,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Is[SP]it[SP]true[SP]Time[SP]Castle[SP]sells[SP]real[SP]weapons?\nI[SP]heard[SP]my[SP]coworkers[SP]say[SP]their[SP]quality[SP]and\nprices[SP]were[SP]average...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Time Castle vend de vraies armes ?\nDes collègues disent qualité et prix moyens…"
+   },
+   {
+      "id":62,
+      "offset":292720,
+      "data_size":298,
+      "slot_size":302,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Is[SP]it[SP]true[SP]Time[SP]Castle[SP]sells[SP]real[SP]weapons?\nI[SP]heard[SP]my[SP]coworkers[SP]say[SP]their[SP]quality[SP]was\ngood,[SP]but[SP]they[SP]were[SP]expensive...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Time Castle vend de vraies armes ?\nBonne qualité mais chères, disent mes collègues."
+   },
+   {
+      "id":63,
+      "offset":293022,
+      "data_size":294,
+      "slot_size":298,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Is[SP]it[SP]true[SP]Time[SP]Castle[SP]sells[SP]real[SP]weapons?\nI[SP]heard[SP]my[SP]coworkers[SP]say[SP]their[SP]prices[SP]were\nlow,[SP]but[SP]so[SP]was[SP]the[SP]quality...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Time Castle vend de vraies armes ?\nPrix bas, qualité basse aussi."
+   },
+   {
+      "id":64,
+      "offset":293320,
+      "data_size":328,
+      "slot_size":332,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells\nweapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]his[SP]selection's\ngreat,[SP]but[SP]his[SP]resale[SP]prices[SP]are[SP]low.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Tony, le vendeur à Yumezaki, vend des armes à la sauvette.\nBon choix, reprises basses."
+   },
+   {
+      "id":65,
+      "offset":293652,
+      "data_size":334,
+      "slot_size":338,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells\nweapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]his[SP]prices[SP]are\ngood,[SP]but[SP]the[SP]quality[SP]of[SP]his[SP]stock[SP]isn't.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Tony vend des armes à la sauvette.\nPrix corrects, qualité médiocre."
+   },
+   {
+      "id":66,
+      "offset":293990,
+      "data_size":304,
+      "slot_size":308,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells\nweapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]his[SP]stock's\nof[SP]average[SP]quality[SP]and[SP]price.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Tony vend des armes en plein rue.\nQualité et prix moyens."
+   },
+   {
+      "id":67,
+      "offset":294298,
+      "data_size":332,
+      "slot_size":336,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells\nweapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]he[SP]keeps[SP]his\nquality[SP]high,[SP]but[SP]his[SP]prices[SP]are[SP]high[SP]too.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Tony : armes de qualité, prix élevés."
+   },
+   {
+      "id":68,
+      "offset":294634,
+      "data_size":248,
+      "slot_size":252,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Clair de Lune… J'y suis allé avec un associé.\nIls vendent des armes ?"
+   },
+   {
+      "id":69,
+      "offset":294886,
+      "data_size":214,
+      "slot_size":218,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Rumor[SP]has[SP]it[SP]their[SP]selection[SP]isn't[SP]great,\nbut[SP]they[SP]offer[SP]good[SP]resale[SP]prices.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Peu de choix, mais bonnes reprises."
+   },
+   {
+      "id":70,
+      "offset":295104,
+      "data_size":248,
+      "slot_size":252,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Clair de Lune… J'y suis allé avec un associé.\nIls vendent des armes ?"
+   },
+   {
+      "id":71,
+      "offset":295356,
+      "data_size":206,
+      "slot_size":210,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Rumor[SP]has[SP]it[SP]their[SP]prices[SP]are[SP]affordable,\nbut[SP]their[SP]stuff's[SP]low[SP]quality.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Prix abordables, qualité basse."
+   },
+   {
+      "id":72,
+      "offset":295566,
+      "data_size":248,
+      "slot_size":252,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Clair de Lune… J'y suis allé avec un associé.\nIls vendent des armes ?"
+   },
+   {
+      "id":73,
+      "offset":295818,
+      "data_size":202,
+      "slot_size":206,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Rumor[SP]has[SP]it[SP]their[SP]stuff[SP]is[SP]top-tier,\nbut[SP]it's[SP]not[SP]exactly[SP]affordable.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Qualité premium, mais cher."
+   },
+   {
+      "id":74,
+      "offset":296024,
+      "data_size":248,
+      "slot_size":252,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Clair de Lune… J'y suis allé avec un associé.\nIls vendent des armes ?"
+   },
+   {
+      "id":75,
+      "offset":296276,
+      "data_size":206,
+      "slot_size":210,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Rumor[SP]has[SP]it[SP]their[SP]selection[SP]is[SP]great,\nbut[SP]they[SP]offer[SP]low[SP]resale[SP]prices.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Grand choix, reprises basses."
+   },
+   {
+      "id":76,
+      "offset":296486,
+      "data_size":248,
+      "slot_size":252,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Clair de Lune… J'y suis allé avec un associé.\nIls vendent des armes ?"
+   },
+   {
+      "id":77,
+      "offset":296738,
+      "data_size":162,
+      "slot_size":166,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Rumor[SP]has[SP]it[SP]their[SP]prices[SP]and[SP]quality\nare[SP]average.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Qualité et prix moyens."
+   },
+   {
+      "id":78,
+      "offset":296904,
+      "data_size":244,
+      "slot_size":248,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Average[SP]quality[SP]and[SP]prices,[SP]huh...?[1205][U+000F][SP]I'd[SP]never\nhave[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real[SP]weapons.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Qualité et prix moyens ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes."
+   },
+   {
+      "id":79,
+      "offset":297152,
+      "data_size":140,
+      "slot_size":144,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Qu'est-il arrivé à cette ville ?"
+   },
+   {
+      "id":80,
+      "offset":297296,
+      "data_size":246,
+      "slot_size":250,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Low[SP]prices,[SP]but[SP]low[SP]quality,[SP]huh...?[1205][U+000F][SP]I'd[SP]never\nhave[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real[SP]weapons.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Prix bas, qualité basse ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes."
+   },
+   {
+      "id":81,
+      "offset":297546,
+      "data_size":140,
+      "slot_size":144,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Qu'est-il arrivé à cette ville ?"
+   },
+   {
+      "id":82,
+      "offset":297690,
+      "data_size":268,
+      "slot_size":272,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Great[SP]selection,[SP]but[SP]low[SP]resale[SP]prices,[SP]huh...?[1205][U+000F]\nI'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real\nweapons.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Bon choix, reprises basses ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes."
+   },
+   {
+      "id":83,
+      "offset":297962,
+      "data_size":140,
+      "slot_size":144,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Qu'est-il arrivé à cette ville ?"
+   },
+   {
+      "id":84,
+      "offset":298106,
+      "data_size":268,
+      "slot_size":272,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Poor[SP]selection,[SP]but[SP]great[SP]resale[SP]prices,[SP]eh...?[1205][U+000F]\nI'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real\nweapons.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Peu de choix, bonnes reprises ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes."
+   },
+   {
+      "id":85,
+      "offset":298378,
+      "data_size":140,
+      "slot_size":144,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Qu'est-il arrivé à cette ville ?"
+   },
+   {
+      "id":86,
+      "offset":298522,
+      "data_size":252,
+      "slot_size":256,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Great[SP]quality,[SP]but[SP]high[SP]prices,[SP]huh...?[1205][U+000F]\nI'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold\nreal[SP]weapons.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Bonne qualité, prix élevés ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes."
+   },
+   {
+      "id":87,
+      "offset":298778,
+      "data_size":140,
+      "slot_size":144,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Qu'est-il arrivé à cette ville ?"
+   },
+   {
+      "id":88,
+      "offset":298922,
+      "data_size":292,
+      "slot_size":296,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor\nas[SP]well[SP]as[SP]clothes?[1205][U+000F][SP]I[SP]heard[SP]their[SP]quality[SP]and\nprices[SP]are[SP]average.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"La boutique de Rengedai vend armures et vêtements ?\nQualité et prix moyens."
+   },
+   {
+      "id":89,
+      "offset":299218,
+      "data_size":252,
+      "slot_size":256,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"*sigh*[SP]Does[SP]that[SP]mean[SP]it[SP]isn't[SP]enough[SP]just\nto[SP]sell[SP]clothes[SP]in[SP]this[SP]economy?[SP]Now[SP]that's\nscary...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur…"
+   },
+   {
+      "id":90,
+      "offset":299474,
+      "data_size":306,
+      "slot_size":310,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor\nas[SP]well[SP]as[SP]clothes?[1205][U+000F][SP]I[SP]heard[SP]their[SP]prices[SP]are\nlow,[SP]but[SP]so[SP]is[SP]the[SP]quality.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Boutique de Rengedai : armures.\nPrix bas, qualité basse."
+   },
+   {
+      "id":91,
+      "offset":299784,
+      "data_size":252,
+      "slot_size":256,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"*sigh*[SP]Does[SP]that[SP]mean[SP]it[SP]isn't[SP]enough[SP]just\nto[SP]sell[SP]clothes[SP]in[SP]this[SP]economy?[SP]Now[SP]that's\nscary...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur…"
+   },
+   {
+      "id":92,
+      "offset":300040,
+      "data_size":312,
+      "slot_size":316,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor\nas[SP]well[SP]as[SP]clothes?[1205][U+000F][SP]I[SP]heard[SP]their[SP]quality[SP]is\nhigh,[SP]but[SP]so[SP]are[SP]their[SP]prices.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Boutique de Rengedai : armures.\nHaute qualité, prix élevés."
+   },
+   {
+      "id":93,
+      "offset":300356,
+      "data_size":252,
+      "slot_size":256,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"*sigh*[SP]Does[SP]that[SP]mean[SP]it[SP]isn't[SP]enough[SP]just\nto[SP]sell[SP]clothes[SP]in[SP]this[SP]economy?[SP]Now[SP]that's\nscary...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur…"
+   },
+   {
+      "id":94,
+      "offset":300612,
+      "data_size":280,
+      "slot_size":284,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that\nthe[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]quality\nand[SP]prices[SP]are[SP]average.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Anima Mundi vend des armures. Nouvelle mode ?\nQualité et prix moyens."
+   },
+   {
+      "id":95,
+      "offset":300896,
+      "data_size":290,
+      "slot_size":294,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that\nthe[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]goods[SP]are\ncheap,[SP]but[SP]low[SP]in[SP]quality.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Anima Mundi vend des armures.\nBon marché, qualité basse."
+   },
+   {
+      "id":96,
+      "offset":301190,
+      "data_size":322,
+      "slot_size":326,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that\nthe[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]selection\nis[SP]great,[SP]but[SP]their[SP]resale[SP]prices[SP]are[SP]low.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Anima Mundi : grand choix, reprises basses."
+   },
+   {
+      "id":97,
+      "offset":301516,
+      "data_size":306,
+      "slot_size":310,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that\nthe[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]quality[SP]is\nhigh,[SP]but[SP]they're[SP]very[SP]expensive.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Anima Mundi : haute qualité, très cher."
+   },
+   {
+      "id":98,
+      "offset":301826,
+      "data_size":296,
+      "slot_size":300,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nThey[SP]don't[SP]have[SP]a[SP]great[SP]selection,[SP]but[SP]their\nresale[SP]prices[SP]are[SP]worth[SP]it.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Rosa Candida à Aoba vend des armures.\nPeu de choix, reprises intéressantes."
+   },
+   {
+      "id":99,
+      "offset":302126,
+      "data_size":264,
+      "slot_size":268,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+   },
+   {
+      "id":100,
+      "offset":302394,
+      "data_size":228,
+      "slot_size":232,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nTheir[SP]quality[SP]and[SP]prices[SP]seem[SP]average.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Rosa Candida à Aoba : armures,\nqualité et prix moyens."
+   },
+   {
+      "id":101,
+      "offset":302626,
+      "data_size":264,
+      "slot_size":268,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+   },
+   {
+      "id":102,
+      "offset":302894,
+      "data_size":258,
+      "slot_size":262,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nTheir[SP]quality[SP]is[SP]great,[SP]but[SP]I[SP]hear[SP]they're\nexpensive.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Rosa Candida à Aoba :\nbonne qualité, cher."
+   },
+   {
+      "id":103,
+      "offset":303156,
+      "data_size":264,
+      "slot_size":268,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+   },
+   {
+      "id":104,
+      "offset":303424,
+      "data_size":308,
+      "slot_size":312,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nTheir[SP]prices[SP]are[SP]certainly[SP]right,[SP]but[SP]there's\na[SP]certain[SP]lack[SP]of[SP]quality[SP]there.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Rosa Candida à Aoba : prix corrects,\nmais qualité insuffisante."
+   },
+   {
+      "id":105,
+      "offset":303736,
+      "data_size":264,
+      "slot_size":268,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+   },
+   {
+      "id":106,
+      "offset":304004,
+      "data_size":276,
+      "slot_size":280,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nThey[SP]have[SP]a[SP]great[SP]selection,[SP]but[SP]their[SP]resale\nprices[SP]seem[SP]low.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Rosa Candida à Aoba :\ngrand choix, reprises basses."
+   },
+   {
+      "id":107,
+      "offset":304284,
+      "data_size":264,
+      "slot_size":268,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+   },
+   {
+      "id":108,
+      "offset":304552,
+      "data_size":334,
+      "slot_size":338,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]selection\nis[SP]great[SP]there,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"J'ai fait faire ce manteau chez London Clothier.\nIls vendent aussi des armures ! Bon choix,\nmais reprises basses."
+   },
+   {
+      "id":109,
+      "offset":304890,
+      "data_size":302,
+      "slot_size":306,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]Their[SP]prices\nare[SP]low,[SP]but[SP]so[SP]is[SP]the[SP]quality.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"London Clothier fait aussi des armures.\nPrix bas, qualité basse."
+   },
+   {
+      "id":110,
+      "offset":305196,
+      "data_size":320,
+      "slot_size":324,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]quality[SP]is\nfantastic,[SP]but[SP]the[SP]prices[SP]are[SP]so[SP]high.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"London Clothier : ils vendent des armures.\nQualité fantastique, prix très élevés."
+   },
+   {
+      "id":111,
+      "offset":305520,
+      "data_size":314,
+      "slot_size":318,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]quality\nand[SP]prices[SP]of[SP]their[SP]goods[SP]are[SP]average.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"London Clothier vend des armures.\nQualité et prix moyens."
+   },
+   {
+      "id":112,
+      "offset":305838,
+      "data_size":334,
+      "slot_size":338,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]selection\nis[SP]poor[SP]there,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]good.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"London Clothier : peu de choix,\nmais bonnes reprises."
+   },
+   {
+      "id":113,
+      "offset":306176,
+      "data_size":310,
+      "slot_size":314,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][U+000F][SP]But[SP]I\nhear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll\nget[SP]real[SP]weapons[SP]and[SP]items.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Je n'ai jamais gagné de concours.[1205][U+000F]\nMais gagner donne de vraies armes et objets."
+   },
+   {
+      "id":114,
+      "offset":306490,
+      "data_size":276,
+      "slot_size":280,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Rumor[SP]has[SP]it[SP]it's[SP]hard[SP]to[SP]win,[SP]but[SP]you[SP]get\nnice[SP]prizes[SP]if[SP]you[SP]do.[SP]I[SP]wonder[SP]if[SP]I[SP]should\ngive[SP]it[SP]another[SP]try.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Difficile à gagner, mais lots sympas.\nJe devrais peut-être réessayer."
+   },
+   {
+      "id":115,
+      "offset":306770,
+      "data_size":310,
+      "slot_size":314,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][U+000F][SP]But[SP]I\nhear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll\nget[SP]real[SP]weapons[SP]and[SP]items.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Jamais gagné de concours.[1205][U+000F]\nMais gagner donne de vraies armes et objets."
+   },
+   {
+      "id":116,
+      "offset":307084,
+      "data_size":314,
+      "slot_size":318,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Rumor[SP]has[SP]it[SP]it's[SP]very[SP]rare[SP]for[SP]anyone[SP]to[SP]win,\nbut[SP]you[SP]get[SP]amazing[SP]prizes[SP]if[SP]you[SP]do.[SP]I[SP]wonder\nif[SP]I[SP]should[SP]give[SP]it[SP]another[SP]try.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Très rare de gagner, lots incroyables.\nJe devrais réessayer."
+   },
+   {
+      "id":117,
+      "offset":307402,
+      "data_size":310,
+      "slot_size":314,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][U+000F][SP]But[SP]I\nhear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll\nget[SP]real[SP]weapons[SP]and[SP]items.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Jamais gagné de concours.[1205][U+000F]\nMais gagner donne de vraies armes et objets."
+   },
+   {
+      "id":118,
+      "offset":307716,
+      "data_size":292,
+      "slot_size":296,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Rumor[SP]has[SP]it[SP]it's[SP]easy[SP]to[SP]win,[SP]but[SP]you[SP]get\njunk[SP]for[SP]prizes.[SP]And[SP]I've[SP]still[SP]never[SP]won...\nI[SP]must[SP]have[SP]the[SP]worst[SP]luck.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Facile à gagner, prix pourris.\nJe n'ai jamais gagné. J'ai la pire chance."
+   },
+   {
+      "id":119,
+      "offset":308012,
+      "data_size":328,
+      "slot_size":332,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it\nseems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][U+000F][SP]I[SP]get[SP]a[SP]tingle[SP]of\nexcitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][U+000F]\nL'idée de jouer m'excite…"
+   },
+   {
+      "id":120,
+      "offset":308344,
+      "data_size":306,
+      "slot_size":310,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"A[SP]friend[SP]of[SP]mine[SP]went...[1205][U+000F][SP]He[SP]said[SP]you[SP]can[SP]win\nbig[SP]at[SP]the[SP]#5[SP]poker[SP]machine.[SP]Unfortunately,\nI[SP]don't[SP]know[SP]how[SP]to[SP]play[SP]poker.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Un ami y est allé.[1205][U+000F] On peut gagner gros\nà la machine de poker n°5.\nJe ne sais pas jouer au poker."
+   },
+   {
+      "id":121,
+      "offset":308654,
+      "data_size":328,
+      "slot_size":332,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it\nseems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][U+000F][SP]I[SP]get[SP]a[SP]tingle[SP]of\nexcitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][U+000F]\nL'idée de jouer m'excite…"
+   },
+   {
+      "id":122,
+      "offset":308986,
+      "data_size":314,
+      "slot_size":318,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"A[SP]friend[SP]of[SP]mine[SP]went...[1205][U+000F][SP]He[SP]said[SP]you[SP]can[SP]win\nbig[SP]at[SP]the[SP]slot[SP]machine[SP]at[SP]the[SP]end.[SP]I[SP]wonder,\ndid[SP]he[SP]mean[SP]the[SP]#1[SP]or[SP]#8[SP]machine?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Un ami y est allé.[1205][U+000F] On peut gagner gros\nà la machine à sous du fond.\n#1 ou #8 ?"
+   },
+   {
+      "id":123,
+      "offset":309304,
+      "data_size":328,
+      "slot_size":332,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it\nseems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][U+000F][SP]I[SP]get[SP]a[SP]tingle[SP]of\nexcitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][U+000F]\nL'idée de jouer m'excite…"
+   },
+   {
+      "id":124,
+      "offset":309636,
+      "data_size":294,
+      "slot_size":298,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"A[SP]friend[SP]of[SP]mine[SP]went...[SP]He[SP]said[SP]you[SP]can[SP]win\nbig[SP]at[SP]blackjack.[1205][U+000F][SP]Then[SP]again,[SP]it[SP]would[SP]be[SP]bad\nif[SP]my[SP]wife[SP]found[SP]out...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Un ami y est allé. On peut gagner gros\nau blackjack.[1205][U+000F]\nMais ce serait mal si ma femme le savait…"
+   },
+   {
+      "id":125,
+      "offset":309934,
+      "data_size":336,
+      "slot_size":340,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]may[SP]not[SP]look[SP]it,[SP]but[SP]I[SP]love[SP]antiques.[SP]I[SP]used\nto[SP]frequent[SP]places[SP]like[SP]Time[SP]Castle.[1205][U+000F][SP]By[SP]the\nway,[SP]do[SP]you[SP]know[SP]what[SP]a[SP]legendary[SP]weapon[SP]is?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"J'adore les antiquités. Je fréquentais Time Castle.[1205][U+000F]\nAu fait, savez-vous ce qu'est une arme légendaire ?"
+   },
+   {
+      "id":126,
+      "offset":310274,
+      "data_size":230,
+      "slot_size":234,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I[SP]heard[SP]Shiraishi[SP]Ramen[SP]has[SP]one.[SP]If[SP]it's[SP]true,\nI'd[SP]love[SP]to[SP]at[SP]least[SP]get[SP]a[SP]glimpse...",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Shiraishi Ramen en aurait une.\nJ'aimerais au moins la voir."
+   },
+   {
+      "id":127,
+      "offset":310508,
+      "data_size":168,
+      "slot_size":172,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"It[SP]seems[SP]there's[SP]a[SP]legendary[SP]weapon[SP]at\nClair[SP]de[SP]Lune.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Une arme légendaire au Clair de Lune."
+   },
+   {
+      "id":128,
+      "offset":310680,
+      "data_size":234,
+      "slot_size":238,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"I'm[SP]quite[SP]fond[SP]of[SP]antiques,[SP]so[SP]I[SP]hope[SP]to[SP]at\nleast[SP]get[SP]a[SP]glimpse[SP]of[SP]what[SP]it[SP]looks[SP]like.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"J'aime les antiquités.\nJ'espère au moins la voir."
+   },
+   {
+      "id":129,
+      "offset":310918,
+      "data_size":296,
+      "slot_size":300,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"It[SP]seems[SP]there's[SP]a[SP]legendary[SP]weapon[SP]at[SP]Time\nCastle,[SP]but[SP]the[SP]owner[SP]is[SP]playing[SP]dumb[SP]to[SP]jack\nup[SP]the[SP]price.[SP]What[SP]a[SP]miser!",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Une arme légendaire à Time Castle.\nLe propriétaire fait le sourd pour faire monter le prix.\nQuel avare !"
+   },
+   {
+      "id":130,
+      "offset":311218,
+      "data_size":276,
+      "slot_size":280,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"No[SP]wonder[SP]there's[SP]nothing[SP]like[SP]a[SP]legendary\nweapon[SP]at[SP]Time[SP]Castle.[SP]Apparently,[SP]it[SP]hasn't\nbeen[SP]delivered[SP]yet.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Pas étonnant qu'il n'y ait pas d'arme légendaire.\nElle n'a pas encore été livrée."
+   },
+   {
+      "id":131,
+      "offset":311498,
+      "data_size":302,
+      "slot_size":306,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"The[SP]seller[SP]is[SP]waiting[SP]at[SP]the[SP]abandoned\nfactory,[SP]but[SP]the[SP]owner's[SP]afraid[SP]of[SP]monsters\nand[SP]won't[SP]go[SP]meet[SP]him.[SP]What[SP]a[SP]coward!",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Le vendeur attend à l'usine abandonnée,\nmais le propriétaire a peur des monstres.\nQuel lâche !"
+   },
+   {
+      "id":132,
+      "offset":311804,
+      "data_size":246,
+      "slot_size":250,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Hmmm...[SP]I[SP]heard[SP]a[SP]rumor[SP]that[SP]demons[SP]stole[SP]the\nlegendary[SP]weapon[SP]from[SP]Time[SP]Castle.[SP]Is[SP]it[SP]true?",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"J'ai entendu que des démons ont volé l'arme légendaire.\nC'est vrai ?"
+   },
+   {
+      "id":133,
+      "offset":312054,
+      "data_size":302,
+      "slot_size":306,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Augh,[SP]I[SP]was[SP]too[SP]late...[SP]Apparently[SP]a[SP]terribly\nunlucky[SP]woman[SP]bought[SP]Time[SP]Castle's[SP]legendary\nweapon[SP]before[SP]I[SP]could[SP]see[SP]it.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Trop tard. Une femme malchanceuse a acheté\nl'arme légendaire avant que je puisse la voir."
+   },
+   {
+      "id":134,
+      "offset":312360,
+      "data_size":312,
+      "slot_size":316,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Must[SP]have[SP]been[SP]a[SP]fellow[SP]antique[SP]lover.[SP]If[SP]only\nI[SP]had[SP]made[SP]up[SP]my[SP]mind[SP]earlier,[SP]I[SP]could[SP]have\ngotten[SP]there[SP]first...[SP]What[SP]a[SP]pity.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Un autre amateur d'antiquités.\nSi j'avais décidé plus tôt, j'aurais été premier.\nQuel dommage."
+   },
+   {
+      "id":135,
+      "offset":312676,
+      "data_size":248,
+      "slot_size":252,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"Honestly,[SP]of[SP]all[SP]the[SP]luck.[SP]It[SP]seems[SP]the[SP]owner\nof[SP]Time[SP]Castle[SP]gave[SP]away[SP]that[SP]legendary[SP]weapon.",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"Quelle malchance. Le propriétaire a donné\nl'arme légendaire."
+   },
+   {
+      "id":136,
+      "offset":312928,
+      "data_size":318,
+      "slot_size":322,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Middle-aged[SP]office[SP]worker",
+      "texte_orig":"To[SP]some[SP]girl[SP]with[SP]short[SP]hair,[SP]supposedly...\nBut[SP]that's[SP]too[SP]vague[SP]a[SP]hint[SP]to[SP]go[SP]on.[SP]*sigh*\nIf[SP]only[SP]I[SP]bought[SP]it[SP]before[SP]it[SP]was[SP]gone!",
+      "nom_fr":"Employé d'âge moyen",
+      "texte_fr":"À une fille aux cheveux courts, dit-on.\nIndice trop vague. *soupir*\nSi seulement je l'avais achetée !"
+   },
+   {
+      "id":137,
+      "offset":313250,
+      "data_size":186,
+      "slot_size":190,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Have[SP]you[SP]heard[SP]the[SP]rumor[SP]that[SP]a[SP]woman's[SP]ghost\nis[SP]appearing[SP]in[SP]Aoba[SP]Park?[1205][U+000F]",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Tu as entendu ? Le fantôme d'une femme\n apparaît dans le parc d'Aoba.[1205][U+000F]"
+   },
+   {
+      "id":138,
+      "offset":313440,
+      "data_size":176,
+      "slot_size":180,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Do[SP]you[SP]think[SP]it's[SP]true?[1205][U+000F][SP]If[SP]it[SP]is,[SP]I[SP]ought[SP]to\nchange[SP]my[SP]daily[SP]route.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Tu crois que c'est vrai ?[1205][U+000F]\nJe devrais changer mon itinéraire."
+   },
+   {
+      "id":139,
+      "offset":313620,
+      "data_size":176,
+      "slot_size":180,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Wh-What[SP]are[SP]we[SP]going[SP]to[SP]do...?[SP]Even[SP]the[SP]fire\ndepartment[SP]was[SP]bombed...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Qu'allons-nous faire… ?\nMême les pompiers ont été bombardés…"
+   },
+   {
+      "id":140,
+      "offset":313800,
+      "data_size":174,
+      "slot_size":178,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"There's[SP]no[SP]one[SP]left[SP]to[SP]put[SP]out[SP]the[SP]flames[SP]in\ncase[SP]of[SP]another[SP]attack!",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Personne pour éteindre les flammes\n en cas de nouvelle attaque !"
+   },
+   {
+      "id":141,
+      "offset":313978,
+      "data_size":312,
+      "slot_size":316,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Do[SP]you[SP]know[SP]what[SP]this[SP]Last[SP]Battalion[SP]thing[SP]is?[1205][U+000F]\nI[SP]hear[SP]they're[SP]the[SP]terrorists[SP]responsible[SP]for\nthe[SP]attacks,[SP]but[SP]I've[SP]never[SP]heard[SP]of[SP]them.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Tu sais ce qu'est le Dernier Bataillon ?[1205][U+000F]\nOn dit qu'ils sont les terroristes responsables,\nmais je n'en ai jamais entendu parler."
+   },
+   {
+      "id":142,
+      "offset":314294,
+      "data_size":304,
+      "slot_size":308,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Are[SP]the[SP]Masked[SP]Circle[SP]not[SP]the[SP]only[SP]guys[SP]like\nthat[SP]walking[SP]around?[1205][U+000F][SP]If[SP]so,[SP]why[SP]are[SP]they\nattacking[SP]the[SP]city!?[SP]I[SP]don't[SP]know[SP]what[SP]to[SP]do!",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Le Cercle Masqué n'est pas le seul groupe ?[1205][U+000F]\nPourquoi attaquent-ils la ville !?\nJe ne sais pas quoi faire !"
+   },
+   {
+      "id":143,
+      "offset":314602,
+      "data_size":292,
+      "slot_size":296,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]heard[SP]they[SP]posted[SP]composite[SP]sketches[SP]of[SP]the\nsuspects.[SP]So[SP]are[SP]they[SP]Masked[SP]Circle?[1205][U+000F][SP]Or[SP]Last\nBattalion?[1205][U+000F][SP]I'm[SP]just[SP]so[SP]confused.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ils ont affiché des portraits-robots.\nIls sont du Cercle Masqué ?[1205][U+000F] Ou du Dernier Bataillon ?[1205][U+000F]\nJe suis perdue."
+   },
+   {
+      "id":144,
+      "offset":314898,
+      "data_size":162,
+      "slot_size":166,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Geez![SP]I[SP]wish[SP]they'd[SP]be[SP]more[SP]specific[SP]with[SP]the\nnews[SP]broadcasts.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Dommage qu'ils ne soient pas plus précis\naux infos."
+   },
+   {
+      "id":145,
+      "offset":315064,
+      "data_size":198,
+      "slot_size":202,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"They're[SP]just[SP]going[SP]to[SP]end[SP]up[SP]confusing[SP]more\npeople[SP]about[SP]who[SP]the[SP]terrorists[SP]are!",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ils ne font que semer plus de confusion\n sur les terroristes !"
+   },
+   {
+      "id":146,
+      "offset":315266,
+      "data_size":278,
+      "slot_size":282,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]wonder[SP]if[SP]it's[SP]safe[SP]to[SP]be[SP]out[SP]like[SP]this.[1205][U+000F]\nB-But[SP]where[SP]would[SP]I[SP]hide?[SP]We[SP]can't[SP]rely[SP]on\nthe[SP]police[SP]anymore,[SP]after[SP]all...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Est-ce sûr d'être dehors ?[1205][U+000F]\nMais où me cacher ? On ne peut plus compter\n sur la police…"
+   },
+   {
+      "id":147,
+      "offset":315548,
+      "data_size":254,
+      "slot_size":258,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Whew...[1205][U+000A][SP]Now[SP]that[SP]we're[SP]in[SP]the[SP]sky,[SP]my[SP]options\nfor[SP]walking[SP]are[SP]limited.[1205][U+000F][SP]Huh?[SP]Now's[SP]not[SP]the\ntime[SP]for[SP]that?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ouf…[1205][U+000A] Dans le ciel, mes options de marche sont limitées.[1205][U+000F]\nHein ? Ce n'est pas le moment ?"
+   },
+   {
+      "id":148,
+      "offset":315806,
+      "data_size":262,
+      "slot_size":266,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"But[SP]there's[SP]no[SP]use[SP]panicking[SP]if[SP]things[SP]have\ngotten[SP]this[SP]bad.[1205][U+000F][SP]I[SP]don't[SP]care[SP]anymore[SP]if[SP]we\nevolve[SP]or[SP]all[SP]die[SP]off.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Inutile de paniquer. Ça a déjà trop empiré.[1205][U+000F]\nJe m'en fiche qu'on évolue ou qu'on meure."
+   },
+   {
+      "id":149,
+      "offset":316072,
+      "data_size":256,
+      "slot_size":260,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Have[SP]you[SP]heard?[1205][U+000F][SP]There[SP]are[SP]countless[SP]rumors\nflying[SP]around[SP]about[SP]what[SP]kind[SP]of[SP]end[SP]the\npeople[SP]below[SP]will[SP]face.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Tu as entendu ?[1205][U+000F]\nDes rumeurs sur la fin des gens d'en bas."
+   },
+   {
+      "id":150,
+      "offset":316332,
+      "data_size":280,
+      "slot_size":284,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"The[SP]latest[SP]is[SP]that[SP]when[SP]the[SP]Grand[SP]Cross[SP]is\ncomplete,[SP]an[SP]intense[SP]magnetic[SP]storm[SP]will[SP]arise\nand[SP]scorch[SP]the[SP]Earth's[SP]surface.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"La dernière : la Grande Croix provoquera\n une tempête magnétique brûlant la Terre."
+   },
+   {
+      "id":151,
+      "offset":316616,
+      "data_size":308,
+      "slot_size":312,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Hey,[SP]did[SP]you[SP]hear?[1205][U+000A][SP]When[SP]the[SP]Grand[SP]Cross[SP]is\ncomplete,[SP]a[SP]plasma[SP]vortex[SP]will[SP]form[SP]and[SP]the\nwhole[SP]Earth[SP]will[SP]look[SP]like[SP]those[SP]crop[SP]circles.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Hé, tu as entendu ?[1205][U+000A]\nLa Grande Croix créera un vortex de plasma,\n la Terre ressemblera à des crop circles."
+   },
+   {
+      "id":152,
+      "offset":316928,
+      "data_size":322,
+      "slot_size":326,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"It[SP]seems[SP]like[SP]when[SP]the[SP]Grand[SP]Cross[SP]is[SP]over,[SP]the\nbalance[SP]of[SP]gravity[SP]will[SP]crumble[SP]and[SP]the[SP]Earth's\nrotation[SP]will[SP]stop.[1205][U+000F][SP]Then[SP]the[SP]world[SP]will[SP]end.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Après la Grande Croix, la gravité s'effondrera,\n la Terre s'arrêtera.[1205][U+000F]\nAlors le monde finira."
+   },
+   {
+      "id":153,
+      "offset":317254,
+      "data_size":268,
+      "slot_size":272,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Hey,[SP]have[SP]you[SP]heard[SP]about[SP]Zodiac?[SP]Their[SP]second\nfloor[SP]is[SP]a[SP]huge[SP]dungeon[SP]now,[SP]filled[SP]with[SP]items.[1205][U+000F]\nWhat[SP]a[SP]weird[SP]club.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Tu as entendu parler de Zodiac ?\nLeur deuxième étage est devenu un donjon rempli d'objets.[1205][U+000F]\nBizarre."
+   },
+   {
+      "id":154,
+      "offset":317526,
+      "data_size":304,
+      "slot_size":308,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Do[SP]you[SP]know[SP]about[SP]the[SP]talking[SP]flowers[SP]in[SP]Aoba\nPark?[SP]How[SP]gossipy[SP]would[SP]they[SP]be...?[SP]Guess[SP]you\ncan't[SP]try[SP]anything[SP]funny[SP]there[SP]after[SP]all.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Tu connais les fleurs qui parlent à Aoba ?\nComme elles seraient bavardes…\nOn ne peut rien tenter de drôle là-bas."
+   },
+   {
+      "id":155,
+      "offset":317834,
+      "data_size":288,
+      "slot_size":292,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"H-Hey,[SP]the[SP]rumor[SP]about[SP]that[SP]idol's[SP]ghost[SP]in\nAoba[SP]Park[SP]was[SP]real,[SP]wasn't[SP]it?[1205][U+000F][SP]I[SP]heard[SP]people\nin[SP]the[SP]city[SP]talking[SP]about[SP]it[SP]too!",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Hé, le fantôme de l'idole à Aoba était réel ?[1205][U+000F]\nJ'ai entendu des gens en parler !"
+   },
+   {
+      "id":156,
+      "offset":318126,
+      "data_size":210,
+      "slot_size":214,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Ugh,[SP]what[SP]should[SP]I[SP]do...?[1205][U+000F][SP]This[SP]has[SP]always[SP]been\npart[SP]of[SP]the[SP]route[SP]I[SP]take[SP]on[SP]my[SP]walks.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Qu'est-ce que je fais ?[1205][U+000F]\nCela a toujours fait partie de mon itinéraire."
+   },
+   {
+      "id":157,
+      "offset":318340,
+      "data_size":238,
+      "slot_size":242,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]don't[SP]want[SP]to[SP]get[SP]possessed[SP]by[SP]some[SP]evil\nspirit...[1205][U+000F][SP]I-I'm[SP]gonna[SP]stop[SP]passing[SP]by[SP]here\nfrom[SP]now[SP]on.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Je ne veux pas me faire posséder.[1205][U+000F]\nJe vais éviter de passer par ici désormais."
+   },
+   {
+      "id":158,
+      "offset":318582,
+      "data_size":272,
+      "slot_size":276,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Did[SP]you[SP]know[SP]there's[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the\nabandoned[SP]factory?[SP]I[SP]heard[SP]it[SP]goes[SP]into[SP]the\ncity[SP]at[SP]night[SP]to[SP]kill.[SP]Scary...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Un Taxi Maudit à l'usine abandonnée ?\nIl tue la nuit en ville. Effrayant…"
+   },
+   {
+      "id":159,
+      "offset":318858,
+      "data_size":294,
+      "slot_size":298,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Huh?[1205][U+000F][SP]It[SP]wasn't[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the[SP]abandoned\nfactory,[SP]it[SP]was[SP]a[SP]Cursed[SP]Escort?[1205][U+000F][SP]But[SP]don't[SP]they\nwork[SP]pretty[SP]much[SP]the[SP]same[SP]way?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Hein ?[1205][U+000F] C'est une Escorte Maudite, pas un Taxi ?[1205][U+000F]\nMais ça revient au même, non ?"
+   },
+   {
+      "id":160,
+      "offset":319156,
+      "data_size":286,
+      "slot_size":290,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Hey,[SP]does[SP]Kuchisake-onna[SP]really[SP]exist?[SP]I[SP]heard\nshe's[SP]shown[SP]up[SP]at[SP]Mt.[SP]Iwato![1205][U+000F][SP]Now[SP]I[SP]can't[SP]go\nwalking[SP]there[SP]anymore[SP]either...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Kuchisake-onna existe ?\nElle serait au mont Iwato ![1205][U+000F]\nJe ne peux plus y aller non plus…"
+   },
+   {
+      "id":161,
+      "offset":319446,
+      "data_size":250,
+      "slot_size":254,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Hey,[SP]what's[SP]a[SP]Jumping[SP]Geezer?[1205][U+000F][SP]Because[SP]I[SP]heard\na[SP]rumor[SP]there's[SP]a[SP]creature[SP]called[SP]that[SP]at\nMt.[SP]Katatsumuri.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"C'est quoi un Sauteur Vieux ?[1205][U+000F]\nIl y en aurait un au mont Katatsumuri."
+   },
+   {
+      "id":162,
+      "offset":319700,
+      "data_size":296,
+      "slot_size":300,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Well,[SP]with[SP]the[SP]soldiers[SP]patrolling[SP]there,\nI[SP]wasn't[SP]going[SP]near[SP]that[SP]mountain[SP]to[SP]begin\nwith.[1205][U+000F][SP]It's[SP]just[SP]one[SP]thing[SP]after[SP]another...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Avec les soldats, je ne m'approchais déjà pas.\nC'est une chose après l'autre…"
+   },
+   {
+      "id":163,
+      "offset":320000,
+      "data_size":286,
+      "slot_size":290,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"What[SP]am[SP]I[SP]going[SP]to[SP]do!?[1205][U+000F][SP]I[SP]can't[SP]sleep[SP]alone\nafter[SP]hearing[SP]a[SP]story[SP]like[SP]that![SP]I[SP]need[SP]to\ntry[SP]and[SP]put[SP]Kudan[SP]out[SP]of[SP]my[SP]mind...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Je vais faire quoi !?[1205][U+000F]\nJe ne peux plus dormir seule après ça !\nIl faut que je chasse Kudan de mon esprit…"
+   },
+   {
+      "id":164,
+      "offset":320290,
+      "data_size":136,
+      "slot_size":140,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Hey,[SP]did[SP]you[SP]know[SP]Giga[SP]Macho[SP]carries[SP]a\nsecret[SP]CD?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Giga Macho a un CD secret."
+   },
+   {
+      "id":165,
+      "offset":320430,
+      "data_size":172,
+      "slot_size":176,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]heard[SP]there's[SP]a[SP]special[SP]track[SP]on[SP]it[SP]you\ncan't[SP]hear[SP]any[SP]other[SP]way.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Il contient un morceau spécial\nqu'on n'entend nulle part ailleurs."
+   },
+   {
+      "id":166,
+      "offset":320606,
+      "data_size":194,
+      "slot_size":198,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"The[SP]Dresser[SP]Hag's[SP]that[SP]monster[SP]that's[SP]an[SP]old\nwoman[SP]living[SP]in[SP]a[SP]dresser,[SP]right?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"La Sorcière du Buffet, c'est la vieille femme\nqui vit dans un buffet, c'est ça ?"
+   },
+   {
+      "id":167,
+      "offset":320804,
+      "data_size":256,
+      "slot_size":260,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Why[SP]would[SP]something[SP]like[SP]that[SP]be[SP]at[SP]the\nabandoned[SP]factory...?[1205][U+000F][SP]Well,[SP]guess[SP]I'm[SP]not\ngoing[SP]near[SP]there[SP]anymore.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Pourquoi à l'usine abandonnée ?[1205][U+000F]\nJe ne m'en approcherai plus."
+   },
+   {
+      "id":168,
+      "offset":321064,
+      "data_size":206,
+      "slot_size":210,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][U+000F][SP]I[SP]mean,\nan[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Rengedai doit être effrayant.[1205][U+000F]\nUne boutique d'antiquités qui vend des armes ?"
+   },
+   {
+      "id":169,
+      "offset":321274,
+      "data_size":144,
+      "slot_size":148,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"People[SP]say[SP]their[SP]quality[SP]and[SP]prices[SP]are\njust[SP]average.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Qualité et prix moyens."
+   },
+   {
+      "id":170,
+      "offset":321422,
+      "data_size":206,
+      "slot_size":210,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][U+000F][SP]I[SP]mean,\nan[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Rengedai doit être effrayant.[1205][U+000F]\nUne boutique d'antiquités qui vend des armes ?"
+   },
+   {
+      "id":171,
+      "offset":321632,
+      "data_size":144,
+      "slot_size":148,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"People[SP]say[SP]their[SP]quality's[SP]great,[SP]but[SP]it's\nexpensive.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Qualité excellente, cher."
+   },
+   {
+      "id":172,
+      "offset":321780,
+      "data_size":206,
+      "slot_size":210,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][U+000F][SP]I[SP]mean,\nan[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Rengedai doit être effrayant.[1205][U+000F]\nUne boutique d'antiquités qui vend des armes ?"
+   },
+   {
+      "id":173,
+      "offset":321990,
+      "data_size":168,
+      "slot_size":172,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"People[SP]say[SP]their[SP]quality's[SP]not[SP]great,[SP]but[SP]at\nleast[SP]they're[SP]cheap.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Qualité moyenne, mais bon marché."
+   },
+   {
+      "id":174,
+      "offset":322162,
+      "data_size":296,
+      "slot_size":300,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off\nthe[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]the[SP]selection's\ngood,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Effrayant d'acheter des armes en pleine rue à Yumezaki.\nBon choix, reprises basses."
+   },
+   {
+      "id":175,
+      "offset":322462,
+      "data_size":298,
+      "slot_size":302,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what\nare[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the\ncity[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ceux qui les utilisent sont en faute, mais à quoi pensent les commerçants ?\nLa ville devient de plus en plus dangereuse."
+   },
+   {
+      "id":176,
+      "offset":322764,
+      "data_size":290,
+      "slot_size":294,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off\nthe[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]their[SP]quality's\nnot[SP]much,[SP]but[SP]the[SP]prices[SP]are[SP]low.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Effrayant d'acheter des armes en rue à Yumezaki.\nQualité médiocre, prix bas."
+   },
+   {
+      "id":177,
+      "offset":323058,
+      "data_size":298,
+      "slot_size":302,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what\nare[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the\ncity[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ceux qui les utilisent sont en faute, mais à quoi pensent les commerçants ?\nLa ville devient de plus en plus dangereuse."
+   },
+   {
+      "id":178,
+      "offset":323360,
+      "data_size":266,
+      "slot_size":270,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off\nthe[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]their[SP]quality\nand[SP]prices[SP]are[SP]average.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Effrayant d'acheter des armes en rue à Yumezaki.\nQualité et prix moyens."
+   },
+   {
+      "id":179,
+      "offset":323630,
+      "data_size":298,
+      "slot_size":302,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what\nare[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the\ncity[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ceux qui les utilisent sont en faute, mais à quoi pensent les commerçants ?\nLa ville devient de plus en plus dangereuse."
+   },
+   {
+      "id":180,
+      "offset":323932,
+      "data_size":288,
+      "slot_size":292,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off\nthe[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]they're[SP]pretty\nexpensive,[SP]but[SP]very[SP]high[SP]quality.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Effrayant d'acheter des armes en rue à Yumezaki.\nChères, mais très haute qualité."
+   },
+   {
+      "id":181,
+      "offset":324224,
+      "data_size":298,
+      "slot_size":302,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what\nare[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the\ncity[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ceux qui les utilisent sont en faute, mais à quoi pensent les commerçants ?\nLa ville devient de plus en plus dangereuse."
+   },
+   {
+      "id":182,
+      "offset":324526,
+      "data_size":124,
+      "slot_size":128,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Clair de Lune, le restau français ?"
+   },
+   {
+      "id":183,
+      "offset":324654,
+      "data_size":256,
+      "slot_size":260,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]their[SP]selection[SP]is[SP]slim,[SP]but[SP]their\nresale[SP]prices[SP]are[SP]great.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ils vendent des armes ?[1205][U+000F]\nPeu de choix, reprises excellentes."
+   },
+   {
+      "id":184,
+      "offset":324914,
+      "data_size":230,
+      "slot_size":234,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
+   },
+   {
+      "id":185,
+      "offset":325148,
+      "data_size":124,
+      "slot_size":128,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Clair de Lune, le restau français ?"
+   },
+   {
+      "id":186,
+      "offset":325276,
+      "data_size":222,
+      "slot_size":226,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]they're[SP]cheap,[SP]but[SP]sell[SP]low-quality\ngoods.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ils vendent des armes ?[1205][U+000F]\nBon marché, mais basse qualité."
+   },
+   {
+      "id":187,
+      "offset":325502,
+      "data_size":230,
+      "slot_size":234,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
+   },
+   {
+      "id":188,
+      "offset":325736,
+      "data_size":124,
+      "slot_size":128,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Clair de Lune, le restau français ?"
+   },
+   {
+      "id":189,
+      "offset":325864,
+      "data_size":274,
+      "slot_size":278,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]their[SP]quality's[SP]great,[SP]but[SP]expensive,\njust[SP]like[SP]the[SP]food[SP]they[SP]serve.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ils vendent des armes ?[1205][U+000F]\nQualité excellente, cher, comme leur nourriture."
+   },
+   {
+      "id":190,
+      "offset":326142,
+      "data_size":230,
+      "slot_size":234,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
+   },
+   {
+      "id":191,
+      "offset":326376,
+      "data_size":124,
+      "slot_size":128,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Clair de Lune, le restau français ?"
+   },
+   {
+      "id":192,
+      "offset":326504,
+      "data_size":268,
+      "slot_size":272,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]their[SP]selection[SP]is[SP]great,[SP]but[SP]their\nresale[SP]prices[SP]are[SP]pretty[SP]low.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ils vendent des armes ?[1205][U+000F]\nGrand choix, reprises assez basses."
+   },
+   {
+      "id":193,
+      "offset":326776,
+      "data_size":230,
+      "slot_size":234,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
+   },
+   {
+      "id":194,
+      "offset":327010,
+      "data_size":124,
+      "slot_size":128,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Clair de Lune, le restau français ?"
+   },
+   {
+      "id":195,
+      "offset":327138,
+      "data_size":212,
+      "slot_size":216,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]their[SP]quality[SP]and[SP]prices[SP]are[SP]average.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ils vendent des armes ?[1205][U+000F]\nQualité et prix moyens."
+   },
+   {
+      "id":196,
+      "offset":327354,
+      "data_size":230,
+      "slot_size":234,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
+   },
+   {
+      "id":197,
+      "offset":327588,
+      "data_size":294,
+      "slot_size":298,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]I[SP]hear[SP]the[SP]quality\nand[SP]prices[SP]are[SP]average,[SP]though.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Le proprio du Jolly Roger vend des armes car il était pirate.\nQualité et prix moyens."
+   },
+   {
+      "id":198,
+      "offset":327886,
+      "data_size":270,
+      "slot_size":274,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]I[SP]hear[SP]they're\ncheap,[SP]but[SP]low[SP]quality.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Le proprio du Jolly Roger vend des armes car il était pirate.\nBon marché, basse qualité."
+   },
+   {
+      "id":199,
+      "offset":328160,
+      "data_size":302,
+      "slot_size":306,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]His[SP]selection[SP]is\ngreat,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Le proprio du Jolly Roger vend des armes car il était pirate.\nGrand choix, reprises basses."
+   },
+   {
+      "id":200,
+      "offset":328466,
+      "data_size":308,
+      "slot_size":312,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]His[SP]selection[SP]is\nskimpy,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]great.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Le proprio du Jolly Roger vend des armes car il était pirate.\nPeu de choix, reprises excellentes."
+   },
+   {
+      "id":201,
+      "offset":328778,
+      "data_size":306,
+      "slot_size":310,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]I[SP]hear[SP]the[SP]quality\nis[SP]great,[SP]but[SP]his[SP]stuff[SP]is[SP]expensive.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Le proprio du Jolly Roger vend des armes car il était pirate.\nQualité excellente, cher."
+   },
+   {
+      "id":202,
+      "offset":329088,
+      "data_size":254,
+      "slot_size":258,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Hey,[SP]have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Rengedai\nsells[SP]real[SP]armor.[SP]Their[SP]quality[SP]and[SP]prices\nseem[SP]to[SP]be[SP]average.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Le Rosa Candida de Rengedai vend des armures.\nQualité et prix moyens."
+   },
+   {
+      "id":203,
+      "offset":329346,
+      "data_size":236,
+      "slot_size":240,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]don't[SP]know[SP]how[SP]much[SP]of[SP]that[SP]is[SP]true,\nbut[SP]I'm[SP]thinking[SP]of[SP]checking[SP]it[SP]out.\nIt[SP]sounds[SP]interesting.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Je ne sais si c'est vrai,\nmais je vais vérifier. Intéressant."
+   },
+   {
+      "id":204,
+      "offset":329586,
+      "data_size":284,
+      "slot_size":288,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Hey,[SP]have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Rengedai\nsells[SP]real[SP]armor.[SP]Their[SP]quality[SP]seems[SP]low,\nbut[SP]at[SP]least[SP]their[SP]prices[SP]are[SP]too.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Rosa Candida vend des armures.\nQualité basse, prix bas."
+   },
+   {
+      "id":205,
+      "offset":329874,
+      "data_size":236,
+      "slot_size":240,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]don't[SP]know[SP]how[SP]much[SP]of[SP]that[SP]is[SP]true,\nbut[SP]I'm[SP]thinking[SP]of[SP]checking[SP]it[SP]out.\nIt[SP]sounds[SP]interesting.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Je ne sais si c'est vrai,\nmais je vais vérifier. Intéressant."
+   },
+   {
+      "id":206,
+      "offset":330114,
+      "data_size":258,
+      "slot_size":262,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Hey,[SP]have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Rengedai\nsells[SP]real[SP]armor.[SP]They're[SP]expensive,[SP]but[SP]the\nquality[SP]is[SP]amazing.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Rosa Candida vend des armures.\nCher, mais qualité incroyable."
+   },
+   {
+      "id":207,
+      "offset":330376,
+      "data_size":234,
+      "slot_size":238,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]don't[SP]know[SP]how[SP]much[SP]of[SP]that[SP]is[SP]true,\nbut[SP]I'm[SP]thinking[SP]of[SP]checking[SP]it[SP]out.\nIt[SP]sounds[SP]interesting.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Je ne sais si c'est vrai,\nmais je vais vérifier. Intéressant."
+   },
+   {
+      "id":208,
+      "offset":330614,
+      "data_size":268,
+      "slot_size":272,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They\nsell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]their\nquality[SP]and[SP]prices[SP]are[SP]average.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ma fille va souvent chez Anima Mundi.\nIls vendent des armures ? Qualité et prix moyens."
+   },
+   {
+      "id":209,
+      "offset":330886,
+      "data_size":140,
+      "slot_size":144,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything\nweird...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"J'espère qu'elle n'achète rien de bizarre…"
+   },
+   {
+      "id":210,
+      "offset":331030,
+      "data_size":284,
+      "slot_size":288,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They\nsell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]their\nquality's[SP]not[SP]great,[SP]but[SP]they're[SP]cheap.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ma fille va chez Anima Mundi.\nArmures : qualité moyenne, bon marché."
+   },
+   {
+      "id":211,
+      "offset":331318,
+      "data_size":140,
+      "slot_size":144,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything\nweird...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"J'espère qu'elle n'achète rien de bizarre…"
+   },
+   {
+      "id":212,
+      "offset":331462,
+      "data_size":304,
+      "slot_size":308,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They\nsell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]their[SP]resale\nprices[SP]are[SP]low,[SP]but[SP]the[SP]selection's[SP]great.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ma fille va chez Anima Mundi.\nArmures : reprises basses, mais grand choix."
+   },
+   {
+      "id":213,
+      "offset":331770,
+      "data_size":140,
+      "slot_size":144,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything\nweird...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"J'espère qu'elle n'achète rien de bizarre…"
+   },
+   {
+      "id":214,
+      "offset":331914,
+      "data_size":284,
+      "slot_size":288,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They\nsell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]they're\nexpensive,[SP]but[SP]the[SP]quality's[SP]amazing.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Ma fille va chez Anima Mundi.\nArmures : chères, qualité incroyable."
+   },
+   {
+      "id":215,
+      "offset":332202,
+      "data_size":140,
+      "slot_size":144,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything\nweird...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"J'espère qu'elle n'achète rien de bizarre…"
+   },
+   {
+      "id":216,
+      "offset":332346,
+      "data_size":144,
+      "slot_size":148,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Rosa Candida ici vend aussi des armures."
+   },
+   {
+      "id":217,
+      "offset":332494,
+      "data_size":236,
+      "slot_size":240,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their\nselection's[SP]not[SP]great,[SP]but[SP]their[SP]resale\nprices[SP]seem[SP]high.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Peu de choix, reprises élevées."
+   },
+   {
+      "id":218,
+      "offset":332734,
+      "data_size":144,
+      "slot_size":148,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Rosa Candida ici vend aussi des armures."
+   },
+   {
+      "id":219,
+      "offset":332882,
+      "data_size":186,
+      "slot_size":190,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their\nquality[SP]and[SP]prices[SP]seem[SP]average.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Qualité et prix moyens."
+   },
+   {
+      "id":220,
+      "offset":333072,
+      "data_size":144,
+      "slot_size":148,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Rosa Candida ici vend aussi des armures."
+   },
+   {
+      "id":221,
+      "offset":333220,
+      "data_size":204,
+      "slot_size":208,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their\nquality's[SP]great,[SP]but[SP]they[SP]seem[SP]expensive.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Qualité excellente, cher."
+   },
+   {
+      "id":222,
+      "offset":333428,
+      "data_size":144,
+      "slot_size":148,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Rosa Candida ici vend aussi des armures."
+   },
+   {
+      "id":223,
+      "offset":333576,
+      "data_size":220,
+      "slot_size":224,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]They're\ncheap,[SP]but[SP]their[SP]goods[SP]seem[SP]rather[SP]low[SP]quality.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Bon marché, qualité plutôt basse."
+   },
+   {
+      "id":224,
+      "offset":333800,
+      "data_size":144,
+      "slot_size":148,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Rosa Candida ici vend aussi des armures."
+   },
+   {
+      "id":225,
+      "offset":333948,
+      "data_size":262,
+      "slot_size":266,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their\nselection's[SP]great,[SP]but[SP]their[SP]resale[SP]prices\nseem[SP]to[SP]be[SP]on[SP]the[SP]low[SP]side.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Grand choix, reprises basses."
+   },
+   {
+      "id":226,
+      "offset":334214,
+      "data_size":262,
+      "slot_size":266,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?"
+   },
+   {
+      "id":227,
+      "offset":334480,
+      "data_size":288,
+      "slot_size":292,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]know[SP]their[SP]selection's[SP]great,[SP]but[SP]I[SP]don't\nsee[SP]why[SP]they[SP]need[SP]to[SP]sell[SP]armor[SP]too.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nPourquoi vendre aussi des armures ?"
+   },
+   {
+      "id":228,
+      "offset":334772,
+      "data_size":262,
+      "slot_size":266,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?"
+   },
+   {
+      "id":229,
+      "offset":335038,
+      "data_size":268,
+      "slot_size":272,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]know[SP]it'll[SP]be[SP]cheap,[SP]but[SP]I[SP]can't[SP]go[SP]to[SP]work\nwearing[SP]a[SP]suit[SP]of[SP]armor!",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nBon marché, mais je ne peux pas travailler en armure !"
+   },
+   {
+      "id":230,
+      "offset":335310,
+      "data_size":262,
+      "slot_size":266,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?"
+   },
+   {
+      "id":231,
+      "offset":335576,
+      "data_size":294,
+      "slot_size":298,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]know[SP]the[SP]quality[SP]will[SP]be[SP]great,[SP]but[SP]that\nwon't[SP]do[SP]me[SP]any[SP]good[SP]if[SP]it[SP]bankrupts[SP]me!",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nQualité excellente, mais si ça me ruine, à quoi bon !"
+   },
+   {
+      "id":232,
+      "offset":335874,
+      "data_size":262,
+      "slot_size":266,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?"
+   },
+   {
+      "id":233,
+      "offset":336140,
+      "data_size":288,
+      "slot_size":292,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]hear[SP]their[SP]quality[SP]and[SP]prices[SP]are[SP]both\nreasonable,[SP]but[SP]that's[SP]not[SP]the[SP]problem.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nQualité et prix raisonnables, mais ce n'est pas le problème."
+   },
+   {
+      "id":234,
+      "offset":336432,
+      "data_size":262,
+      "slot_size":266,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?"
+   },
+   {
+      "id":235,
+      "offset":336698,
+      "data_size":290,
+      "slot_size":294,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]know[SP]their[SP]resale[SP]prices[SP]are[SP]great,[SP]but[SP]I\nstill[SP]can't[SP]get[SP]a[SP]full[SP]refund,[SP]right?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nBonnes reprises, mais pas de remboursement intégral, si ?"
+   },
+   {
+      "id":236,
+      "offset":336992,
+      "data_size":214,
+      "slot_size":218,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][U+000F]\nI[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Tu connais les concours de magazines ?[1205][U+000F]\nOn peut gagner de vraies armes."
+   },
+   {
+      "id":237,
+      "offset":337210,
+      "data_size":118,
+      "slot_size":122,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"It[SP]sounds[SP]interesting,[SP]and[SP]exciting[SP]too.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Intéressant et excitant."
+   },
+   {
+      "id":238,
+      "offset":337332,
+      "data_size":242,
+      "slot_size":246,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]hear[SP]you[SP]don't[SP]win[SP]often,[SP]but[SP]they[SP]send[SP]you\nnice[SP]things[SP]when[SP]you[SP]do.[1205][U+000F][SP]Why[SP]don't[SP]you[SP]give\nit[SP]a[SP]shot?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"On gagne rarement, mais beaux lots.[1205][U+000F]\nPourquoi ne pas essayer ?"
+   },
+   {
+      "id":239,
+      "offset":337578,
+      "data_size":214,
+      "slot_size":218,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][U+000F]\nI[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Tu connais les concours de magazines ?[1205][U+000F]\nOn peut gagner de vraies armes."
+   },
+   {
+      "id":240,
+      "offset":337796,
+      "data_size":118,
+      "slot_size":122,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"It[SP]sounds[SP]interesting,[SP]and[SP]exciting[SP]too.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Intéressant et excitant."
+   },
+   {
+      "id":241,
+      "offset":337918,
+      "data_size":254,
+      "slot_size":258,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]hear[SP]you[SP]very[SP]rarely[SP]win,[SP]but[SP]they[SP]send[SP]you\nincredible[SP]things[SP]when[SP]you[SP]do.[1205][U+000F][SP]Why[SP]don't[SP]you\ngive[SP]it[SP]a[SP]shot?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Très rare de gagner, lots incroyables.[1205][U+000F]\nPourquoi ne pas essayer ?"
+   },
+   {
+      "id":242,
+      "offset":338176,
+      "data_size":214,
+      "slot_size":218,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][U+000F]\nI[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Tu connais les concours de magazines ?[1205][U+000F]\nOn peut gagner de vraies armes."
+   },
+   {
+      "id":243,
+      "offset":338394,
+      "data_size":118,
+      "slot_size":122,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"It[SP]sounds[SP]interesting,[SP]and[SP]exciting[SP]too.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Intéressant et excitant."
+   },
+   {
+      "id":244,
+      "offset":338516,
+      "data_size":294,
+      "slot_size":298,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]hear[SP]you[SP]can[SP]win[SP]quite[SP]easily,[SP]but[SP]the[SP]things\nthey[SP]send[SP]you[SP]as[SP]prizes[SP]aren't[SP]very[SP]good.[1205][U+000F]\nWell,[SP]why[SP]not[SP]give[SP]it[SP]a[SP]shot[SP]anyway?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Facile à gagner, lots moyens.[1205][U+000F]\nPourquoi ne pas essayer quand même ?"
+   },
+   {
+      "id":245,
+      "offset":338814,
+      "data_size":266,
+      "slot_size":270,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the\narcade?[1205][U+000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was\nhorrified[SP]to[SP]hear[SP]about[SP]it!",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Un casino dans la salle d'arcade ?[1205][U+000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible !"
+   },
+   {
+      "id":246,
+      "offset":339084,
+      "data_size":314,
+      "slot_size":318,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"[1432][NULL][NULL][0014]You[SP]can[SP]win[SP]big[SP]at[SP]poker![1432][NULL][NULL][0014][SP]That's[SP]not[SP]an\nappropriate[SP]conversation[SP]for[SP]high[SP]schoolers[SP]to\nbe[SP]having![SP]I[SP]should[SP]report[SP]this[SP]to[SP]the[SP]PTA!",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"[1432][NULL][NULL][0014]On peut gagner gros au poker ![1432][NULL][NULL][0014]\nPas une conversation pour des lycéens !\nJe devrais le signaler à l'association de parents d'élèves !"
+   },
+   {
+      "id":247,
+      "offset":339402,
+      "data_size":266,
+      "slot_size":270,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the\narcade?[1205][U+000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was\nhorrified[SP]to[SP]hear[SP]about[SP]it!",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Un casino dans la salle d'arcade ?[1205][U+000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible !"
+   },
+   {
+      "id":248,
+      "offset":339672,
+      "data_size":320,
+      "slot_size":324,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"[1432][NULL][NULL][0014]You[SP]can[SP]win[SP]big[SP]at[SP]slots[SP]#1![1432][NULL][NULL][0014][SP]That's[SP]not[SP]an\nappropriate[SP]conversation[SP]for[SP]high[SP]schoolers[SP]to\nbe[SP]having![SP]I[SP]should[SP]report[SP]this[SP]to[SP]the[SP]PTA!",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"[1432][NULL][NULL][0014]Gros lots aux machines n°1 ![1432][NULL][NULL][0014]\nPas pour des lycéens !\nÀ signaler à l'association de parents d'élèves !"
+   },
+   {
+      "id":249,
+      "offset":339996,
+      "data_size":266,
+      "slot_size":270,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the\narcade?[1205][U+000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was\nhorrified[SP]to[SP]hear[SP]about[SP]it!",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Un casino dans la salle d'arcade ?[1205][U+000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible !"
+   },
+   {
+      "id":250,
+      "offset":340266,
+      "data_size":250,
+      "slot_size":254,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Where[SP]did[SP]I[SP]hear[SP]this?[SP]There[SP]was[SP]a[SP]young[SP]man\nbragging[SP]about[SP]winning[SP]big[SP]at[SP]blackjack[SP]while\nwalking[SP]around.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Où ai-je entendu ça ? Un jeune homme se vantait\nd'avoir gagné gros au blackjack."
+   },
+   {
+      "id":251,
+      "offset":340520,
+      "data_size":286,
+      "slot_size":290,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]wonder[SP]what[SP]this[SP]legendary[SP]weapon[SP]at\nShiraishi[SP]Ramen[SP]is[SP]all[SP]about.[SP]I[SP]bet[SP]it's\ndangerous...[SP]But[SP]I'm[SP]still[SP]a[SP]little[SP]curious.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"L'arme légendaire du Shiraishi Ramen ?\nDangereuse, mais je suis curieuse."
+   },
+   {
+      "id":252,
+      "offset":340810,
+      "data_size":190,
+      "slot_size":194,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Did[SP]you[SP]hear?[SP]There's[SP]a[SP]legendary[SP]weapon[SP]at\nClair[SP]de[SP]Lune.[SP]Have[SP]you[SP]seen[SP]it?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Une arme légendaire au Clair de Lune.\nTu l'as vue ?"
+   },
+   {
+      "id":253,
+      "offset":341004,
+      "data_size":268,
+      "slot_size":272,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Hey,[SP]have[SP]you[SP]heard?[SP]The[SP]owner[SP]of[SP]Time[SP]Castle\nis[SP]supposedly[SP]hiding[SP]his[SP]legendary[SP]weapon[SP]so\nhe[SP]can[SP]inflate[SP]the[SP]price.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Le proprio de Time Castle cache son arme légendaire\n pour faire monter le prix."
+   },
+   {
+      "id":254,
+      "offset":341276,
+      "data_size":78,
+      "slot_size":82,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"What[SP]a[SP]terrible[SP]man.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Quel homme terrible."
+   },
+   {
+      "id":255,
+      "offset":341358,
+      "data_size":298,
+      "slot_size":302,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"From[SP]what[SP]I've[SP]heard,[SP]the[SP]seller[SP]with[SP]Time\nCastle's[SP]legendary[SP]weapon[SP]is[SP]waiting[SP]at[SP]the\nabandoned[SP]factory,[SP]but[SP]the[SP]owner[SP]won't[SP]come.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Le vendeur de l'arme légendaire attend à l'usine,\nmais le proprio ne vient pas."
+   },
+   {
+      "id":256,
+      "offset":341660,
+      "data_size":294,
+      "slot_size":298,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"I[SP]think[SP]that's[SP]smart[SP]of[SP]him.[SP]They[SP]say[SP]that\nabandoned[SP]factory[SP]is[SP]teeming[SP]with[SP]monsters\nand[SP]demons...[SP]It[SP]sounds[SP]dangerous,[SP]anyway.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"C'est malin. L'usine grouille de monstres.\nDangereux, de toute façon."
+   },
+   {
+      "id":257,
+      "offset":341958,
+      "data_size":264,
+      "slot_size":268,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Oh,[SP]did[SP]you[SP]hear?[SP]A[SP]demon[SP]stole[SP]that[SP]legendary\nweapon[SP]at[SP]Time[SP]Castle.[SP]Not[SP]long[SP]ago,[SP]I'd[SP]never\nhave[SP]believed[SP]it...",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Un démon a volé l'arme légendaire de Time Castle.\nJe ne l'aurais jamais cru avant."
+   },
+   {
+      "id":258,
+      "offset":342226,
+      "data_size":260,
+      "slot_size":264,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"But[SP]look[SP]at[SP]us.[SP]We're[SP]standing[SP]on[SP]top[SP]of[SP]a\nfloating[SP]city![SP]I[SP]bet[SP]demons[SP]exist,[SP]too!\nBrrr...[SP]That's[SP]really[SP]scary.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Mais regarde-nous : on est sur une ville flottante !\nLes démons existent forcément. Brrr… Effrayant."
+   },
+   {
+      "id":259,
+      "offset":342490,
+      "data_size":222,
+      "slot_size":226,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"The[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle[SP]was[SP]sold.\nPeople[SP]keep[SP]asking[SP]me,[SP][1432][NULL][NULL][0014]Did[SP]you[SP]buy[SP]it?[1432][NULL][NULL][0014]",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"L'arme légendaire a été vendue.\nOn me demande sans cesse : [1432][NULL][NULL][0014]C'est toi qui l'as achetée ?[1432][NULL][NULL][0014]"
+   },
+   {
+      "id":260,
+      "offset":342716,
+      "data_size":190,
+      "slot_size":194,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"But[SP]no,[SP]some[SP]unlucky[SP]woman[SP]bought[SP]it...[1205][U+000F]\nI[SP]don't[SP]look[SP]that[SP]desperate,[SP]do[SP]I?",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Non, une femme l'a achetée.[1205][U+000F]\nJe n'ai pas l'air si désespérée, si ?"
+   },
+   {
+      "id":261,
+      "offset":342910,
+      "data_size":202,
+      "slot_size":206,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"The[SP]owner[SP]of[SP]Time[SP]Castle[SP]gave[SP]away[SP]that\nlegendary[SP]weapon[SP]to[SP]a[SP]girl[SP]with[SP]short[SP]hair.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"Le proprio a donné l'arme à une fille aux cheveux courts."
+   },
+   {
+      "id":262,
+      "offset":343116,
+      "data_size":290,
+      "slot_size":294,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Walking[SP]woman",
+      "texte_orig":"Leaving[SP]aside[SP]that[SP]it's[SP]a[SP]weapon...[SP]That's[SP]a\nnice[SP]gesture.[SP]I[SP]wish[SP]I[SP]got[SP]presents[SP]sometimes.\nMy[SP]husband[SP]barely[SP]knows[SP]I'm[SP]alive.",
+      "nom_fr":"Promeneuse",
+      "texte_fr":"C'est un joli geste, malgré tout.\nJ'aimerais recevoir des cadeaux parfois.\nMon mari sait à peine que j'existe."
+   },
+   {
+      "id":263,
+      "offset":343410,
+      "data_size":292,
+      "slot_size":296,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Man",
+      "texte_orig":"Would[SP]you[SP]believe[SP]me[SP]if[SP]I[SP]said[SP][E4][NULL][NULL][U+0006]flowers[SP]can\ntalk[E4][NULL][NULL][0002]?[1205][U+000F][SP]Most[SP]people[SP]wouldn't.[SP]But[SP]there[SP]is\nsomeone[SP]in[SP]this[SP]park[SP]who[SP]speaks[SP]to[SP]flowers.",
+      "nom_fr":"Homme",
+      "texte_fr":"Croirais-tu que [E4][NULL][NULL][U+0006]les fleurs peuvent parler[E4][NULL][NULL][0002] ?[1205][U+000F]\nLa plupart non. Mais quelqu'un ici parle aux fleurs."
+   },
+   {
+      "id":264,
+      "offset":343706,
+      "data_size":290,
+      "slot_size":294,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Man",
+      "texte_orig":"He[SP]takes[SP]care[SP]of[SP]the[SP]flowers[SP]here,[SP]and[SP]whenever\nI[SP]see[SP]him,[SP]he's[SP]talking[SP]to[SP]them.[1205][U+000F][SP]Rumor[SP]has[SP]it\nthat[SP]the[SP]flowers[SP]in[SP]Aoba[SP]Park[SP]talk[SP]back.",
+      "nom_fr":"Homme",
+      "texte_fr":"Il s'occupe des fleurs et leur parle.[1205][U+000F]\nOn dit qu'elles lui répondent."
+   },
+   {
+      "id":265,
+      "offset":344000,
+      "data_size":274,
+      "slot_size":278,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Man",
+      "texte_orig":"In[SP]the[SP]end,[SP]you[SP]decide[SP]what's[SP]real[SP]and[SP]what's\na[SP]dream.[1205][U+000F][SP]If[SP]you're[SP]tired[SP]of[SP]this[SP]dreary\nreality...[SP]try[SP]talking[SP]with[SP]the[SP]flowers.",
+      "nom_fr":"Homme",
+      "texte_fr":"Au final, c'est toi qui décides du réel.[1205][U+000F]\nSi tu es fatigué de cette triste réalité,\nparle aux fleurs."
+   },
+   {
+      "id":266,
+      "offset":344278,
+      "data_size":252,
+      "slot_size":256,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Masked[SP]Circle[SP]member",
+      "texte_orig":"Dammit,[SP]that[SP]Joker[SP]ran[SP]off[SP]to[SP]Caracol[SP]along\nwith[SP]the[SP]executives![1205][U+000F][SP]He's[SP]left[SP]us[SP]holding[SP]the\nbag[SP]here!",
+      "nom_fr":"Membre du Cercle Masqué",
+      "texte_fr":"Joker s'est enfui à Caracol avec les cadres ![1205][U+000F]\nIl nous a laissés dans la merde !"
+   },
+   {
+      "id":267,
+      "offset":344534,
+      "data_size":312,
+      "slot_size":316,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Masked[SP]Circle[SP]member",
+      "texte_orig":"Having[SP]our[SP]ideals[SP]granted[SP]will[SP]make[SP]us[SP]happy?\nBullshit![SP]All[SP]he[SP]wanted[SP]was[SP]to[SP]suck[SP]away[SP]our\nIdeal[SP]Energy[SP]to[SP]realize[SP]his[SP]own[SP]dreams!",
+      "nom_fr":"Membre du Cercle Masqué",
+      "texte_fr":"Nos idéaux exaucés ? N'importe quoi !\nIl a juste aspiré notre Énergie Idéale\n pour ses propres rêves !"
+   },
+   {
+      "id":268,
+      "offset":344850,
+      "data_size":284,
+      "slot_size":288,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Last[SP]Battalion",
+      "texte_orig":"The[SP]holy[SP]lance[SP]is[SP]the[SP]emblem[SP]of[SP]our[SP]strength.\nIt[SP]shall[SP]crush[SP]all[SP]hindrances,[SP]along[SP]with[SP]the\nother[SP]self[SP]that[SP]lies[SP]within...",
+      "nom_fr":"Dernier Bataillon",
+      "texte_fr":"La lance sacrée, emblème de notre force,\n écrasera tout obstacle et l'autre soi\n qui sommeille en nous."
+   },
+   {
+      "id":269,
+      "offset":345138,
+      "data_size":172,
+      "slot_size":176,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Eikichi",
+      "texte_orig":"To[SP]hell[SP]with[SP]that[SP]King[SP]Leo[SP]asshole!\nHe's[SP]through[SP]doing[SP]whatever[SP]he[SP]wants!",
+      "nom_fr":"Michel",
+      "texte_fr":"Au diable cet enculé de Roi Lion !\nIl en a fini de faire ce qu'il veut !"
+   },
+   {
+      "id":270,
+      "offset":345314,
+      "data_size":252,
+      "slot_size":256,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Ginko",
+      "texte_orig":"Uh-oh,[SP][1113].[SP]If[SP]we[SP]keep[SP]standing[SP]around\nlike[SP]this,[SP]people[SP]will[SP]get[SP]more[SP]suspicious.\nLet's[SP]get[SP]to[SP]the[SP]detective[SP]agency.",
+      "nom_fr":"Ginko",
+      "texte_fr":"Uh-oh, [1113]. Si on traîne, les gens vont se méfier.\nAllons à l'agence de détectives."
+   },
+   {
+      "id":271,
+      "offset":345570,
+      "data_size":88,
+      "slot_size":92,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Eikichi",
+      "texte_orig":"Huh?[SP]It[SP]says,[SP][1432][NULL][NULL][0014]No[SP]entry.[1432][NULL][NULL][0014]",
+      "nom_fr":"Michel",
+      "texte_fr":"Hein ?[SP][1432][NULL][NULL][0014]Entrée interdite.[1432][NULL][NULL][0014]"
+   },
+   {
+      "id":272,
+      "offset":345662,
+      "data_size":178,
+      "slot_size":182,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Maya",
+      "texte_orig":"The[SP]fire[SP]department[SP]burned[SP]down...[SP]Don't[SP]tell\nme[SP]King[SP]Leo[SP]planned[SP]ahead![SP]No...!",
+      "nom_fr":"Maya",
+      "texte_fr":"Les pompiers ont brûlé… Dis-moi que non.\nLe Roi Lion a tout planifié ? Non… !"
+   },
+   {
+      "id":273,
+      "offset":345844,
+      "data_size":232,
+      "slot_size":236,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Yukiko",
+      "texte_orig":"He[SP]did[SP]this[SP]to[SP]prevent[SP]anyone[SP]from[SP]stopping\nhis[SP]plan...[SP]Now[SP]there's[SP]no[SP]one[SP]but[SP]us[SP]left\nto[SP]deal[SP]with[SP]him.",
+      "nom_fr":"Yukiko",
+      "texte_fr":"Il a fait ça pour qu'on ne l'arrête pas.\nIl ne reste plus que nous."
+   },
+   {
+      "id":274,
+      "offset":346080,
+      "data_size":208,
+      "slot_size":212,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Eikichi",
+      "texte_orig":"Yeah,[SP]that's[SP]been[SP]the[SP]plan[SP]all[SP]along![SP]You[SP]can\nbet[SP]we're[SP]taking[SP]down[SP]that[SP]bastard[SP]ourselves!",
+      "nom_fr":"Michel",
+      "texte_fr":"Oui, c'était le plan depuis le début !\nOn va abattre ce salaud nous-mêmes !"
+   },
+   {
+      "id":275,
+      "offset":346292,
+      "data_size":262,
+      "slot_size":266,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Maya",
+      "texte_orig":"King[SP]Leo[SP]will[SP]stop[SP]at[SP]nothing[SP]to[SP]fulfill[SP]the\nOracle.[SP]If[SP]we[SP]don't[SP]take[SP]him[SP]down[SP]now,[SP]there\nwill[SP]only[SP]be[SP]more[SP]casualties...",
+      "nom_fr":"Maya",
+      "texte_fr":"Roi Lion ne reculera devant rien.\nSi on ne l'arrête pas, il y aura plus de victimes…"
+   },
+   {
+      "id":276,
+      "offset":346558,
+      "data_size":168,
+      "slot_size":172,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Ginko",
+      "texte_orig":"We[SP]couldn't[SP]stop[SP]any[SP]of[SP]them[SP]from[SP]burning\ndown...[SP]I'm[SP]so[SP]mad[SP]at[SP]myself...",
+      "nom_fr":"Ginko",
+      "texte_fr":"On a pu empêcher aucun incendie…\nJe suis tellement en colère contre moi…"
+   },
+   {
+      "id":277,
+      "offset":346730,
+      "data_size":214,
+      "slot_size":218,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Yukino",
+      "texte_orig":"I[SP]understand[SP]how[SP]you[SP]feel,[SP][1113],[SP]but\nwe're[SP]fugitives[SP]now.[SP]We[SP]shouldn't[SP]stay[SP]in\none[SP]place[SP]too[SP]long.",
+      "nom_fr":"Yukino",
+      "texte_fr":"Je comprends, [1113], mais nous sommes fugitifs.\nNe restons pas trop longtemps au même endroit."
+   },
+   {
+      "id":278,
+      "offset":346948,
+      "data_size":118,
+      "slot_size":122,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Eikichi",
+      "texte_orig":"There's[SP]no[SP]point[SP]being[SP]here[SP]anymore.\nLet's[SP]go.",
+      "nom_fr":"Michel",
+      "texte_fr":"Cela ne sert plus à rien d'être ici.\nAllons-y."
+   },
+   {
+      "id":279,
+      "offset":347070,
+      "data_size":168,
+      "slot_size":172,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Maya",
+      "texte_orig":"We've[SP]already[SP]got[SP]the[SP]crystal[SP]skull[SP]here.\nLet's[SP]hurry[SP]and[SP]find[SP]the[SP]others.",
+      "nom_fr":"Maya",
+      "texte_fr":"Nous avons déjà le crâne de cristal.\nTrouvons les autres."
+   },
+   {
+      "id":280,
+      "offset":347242,
+      "data_size":214,
+      "slot_size":218,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Maya",
+      "texte_orig":"I[SP]can[SP]hear[SP]voices...[SP]The[SP]fighting's[SP]still\ngoing[SP]on[SP]inside.[SP]We[SP]need[SP]to[SP]hurry[SP]and[SP]put\na[SP]stop[SP]to[SP]it.",
+      "nom_fr":"Maya",
+      "texte_fr":"J'entends des voix. Le combat continue.\nIl faut y mettre fin."
+   },
+   {
+      "id":281,
+      "offset":347460,
+      "data_size":212,
+      "slot_size":216,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Ginko",
+      "texte_orig":"[1113],[SP]now's[SP]not[SP]the[SP]time[SP]for[SP]detours.\nEveryone's[SP]waiting...[SP]We[SP]have[SP]to[SP]go[SP]to[SP]the\ndetective[SP]agency.",
+      "nom_fr":"Ginko",
+      "texte_fr":"[1113], pas de détours.\nTout le monde attend. Allons à l'agence."
+   },
+   {
+      "id":282,
+      "offset":347676,
+      "data_size":170,
+      "slot_size":174,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Ginko",
+      "texte_orig":"Huh?[SP]It's[SP]closed.[SP]I[SP]wonder[SP]what's[SP]up...\nOh[SP]well,[SP]let's[SP]go[SP]somewhere[SP]else.",
+      "nom_fr":"Ginko",
+      "texte_fr":"C'est fermé. Je me demande pourquoi…\nBon, allons ailleurs."
+   },
+   {
+      "id":283,
+      "offset":347850,
+      "data_size":232,
+      "slot_size":236,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Ginko",
+      "texte_orig":"[1113],[SP]I[SP]kinda[SP]feel[SP]bad[SP]making[SP]everyone\nwait[SP]while[SP]we[SP]wander[SP]around.[SP]We[SP]should[SP]hurry\nto[SP]the[SP]detective[SP]agency.",
+      "nom_fr":"Ginko",
+      "texte_fr":"[1113], je me sens mal de faire attendre tout le monde.\nDépêchons-nous d'aller à l'agence."
+   },
+   {
+      "id":284,
+      "offset":348086,
+      "data_size":220,
+      "slot_size":224,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Ginko",
+      "texte_orig":"Wait[SP]a[SP]sec,[SP]Chinyan![SP]We[SP]don't[SP]have[SP]the[SP]skull\nfrom[SP]Taurus[SP]Temple[SP]yet.[SP]We[SP]should[SP]stop[SP]by\nthere[SP]first.",
+      "nom_fr":"Ginko",
+      "texte_fr":"Attends, Chinyan ! On n'a pas encore le crâne\ndu temple du Taureau. Allons-y d'abord."
+   },
+   {
+      "id":285,
+      "offset":348310,
+      "data_size":246,
+      "slot_size":250,
+      "_term":[
+         4358,
+         4354,
+         4355,
+         5169
+      ],
+      "nom_orig":"Eikichi",
+      "texte_orig":"H-Hold[SP]the[SP]phone,[SP]man.[1205][U+000F][SP]We're[SP]still[SP]not[SP]done\nwith[SP]Scorpio[SP]Temple.[1205][U+000F][SP]Let's[SP]go[SP]grab[SP]the[SP]skull\nfrom[SP]there[SP]first.",
+      "nom_fr":"Michel",
+      "texte_fr":"A-Attends, mec.[1205][U+000F] On n'a pas fini avec\ntemple du Scorpion.[1205][U+000F] Prenons ce crâne d'abord."
+   },
+   {
+      "id":286,
+      "offset":348560,
+      "data_size":144,
+      "slot_size":148,
+      "_term":[
+         4358,
+         4354,
+         5169
+      ],
+      "nom_orig":"Jun",
+      "texte_orig":"Hold[SP]on[SP]a[SP]moment.[SP]We're[SP]still[SP]not[SP]done[SP]with\nthe[SP]Aquarius[SP]Temple.",
+      "nom_fr":"Jun",
+      "texte_fr":"Attends. On n'a pas fini avec\nle temple du Verseau."
+   }
 ]

--- a/traduction/MMAP04.json
+++ b/traduction/MMAP04.json
@@ -12,7 +12,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "Heh...[SP]There's[SP]a[SP]nice[SP]breeze[SP]today,[SP]too...[1205][U+000F]\nAll[SP]men[SP]are[SP]on[SP]a[SP]journey,[SP]somewhere[SP]in[SP]their\nhearts.",
     "nom_fr": "Gars cool",
-    "texte_fr": "Aujourd'hui aussi, la brise est douce...[1205][U+000F]\nChacun vit son voyage, quelque part dans son\ncoeur."
+    "texte_fr": "Aujourd'hui aussi, la brise est douce...[1205][U+000F]\nChacun vit son voyage, quelque part dans\nson coeur."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "Just[SP]when[SP]they[SP]finally[SP]make[SP]it[SP]to[SP]shore[SP]and\nought[SP]to[SP]think[SP]about[SP]settling[SP]down,[SP]they[SP]row\nout[SP]again[SP]into[SP]the[SP]sea.",
     "nom_fr": "Gars cool",
-    "texte_fr": "Au moment où ils atteignent la\ncôte et envisagent de s'installer,\nils repartent voguer en mer."
+    "texte_fr": "Au moment où ils atteignent la côte et\nenvisagent de s'installer, ils repartent voguer\nen mer."
   },
   {
     "id": 2,
@@ -73,7 +73,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "I[SP]think[SP]you[SP]get[SP]the[SP]picture[SP]already[SP]that[SP]this\nis[SP]a[SP]city[SP]for[SP]the[SP]hardboiled.[SP]For[SP]adults.[1205][U+000F][SP]But\nlook[SP]at[SP]that[SP]building[SP]with[SP]the[SP]blimp[SP]on[SP]top...",
     "nom_fr": "Gars cool",
-    "texte_fr": "T'as dû piger que c'était une ville taillée\npour les durs à cuire, les adultes.[1205][U+000F] Mais\nregarde ce bâtiment avec le dirigeable au\nsommet..."
+    "texte_fr": "T'as dû piger que c'était une ville taillée\npour les durs à cuire, les adultes.[1205][U+000F] Mais regarde\nce bâtiment avec le dirigeable au sommet..."
   },
   {
     "id": 5,
@@ -88,7 +88,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "The[SP]goddamn[SP]Aerospace[SP]Museum.[1205][U+000F][SP]Ever[SP]since[SP]they\nbuilt[SP]that[SP]thing,[SP]packs[SP]of[SP]wild[SP]kids[SP]swarm[SP]here\non[SP]class[SP]trips[SP]and[SP]such.",
     "nom_fr": "Gars cool",
-    "texte_fr": "Ce fichu Musée Aéronautique.[1205][U+000F] Depuis sa\nconstruction, y'a foule de gosses qui\nviennent en voyage scolaire ou autre."
+    "texte_fr": "Ce fichu Musée Aéronautique.[1205][U+000F] Depuis sa construction,\ny'a foule de gosses qui viennent en voyage\nscolaire ou autre."
   },
   {
     "id": 6,
@@ -104,7 +104,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "I[SP]hate[SP]rugrats.[SP]This[SP]city[SP]ain't[SP]so[SP]much[SP]for[SP]me\nanymore.[1205][U+000F][SP]Guess[SP]the[SP]day[SP]is[SP]coming[SP]when[SP]I'll[SP]be\ngoing[SP]back[SP]to[SP]the[SP]sea.",
     "nom_fr": "Gars cool",
-    "texte_fr": "Je hais les mômes. Cette ville me\ncorrespond plus du tout.[1205][U+000F] Il doit être\ntemps pour moi de retourner en mer."
+    "texte_fr": "Je hais les mômes. Cette ville me correspond\nplus du tout.[1205][U+000F] Il doit être temps pour moi\nde retourner en mer."
   },
   {
     "id": 7,
@@ -150,7 +150,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "Some[SP]kids[SP]were[SP]just[SP]here[SP]and[SP]told[SP]me[SP]the[SP]group\nof[SP]five[SP]in[SP]the[SP]news[SP]are[SP]actually[SP]heroes[SP]fighting\nthe[SP]Masked[SP]Circle.[SP]Then[SP]they[SP]took[SP]off.",
     "nom_fr": "Gars cool",
-    "texte_fr": "Des gamins sont venus me dire que les cinq\nqu'on voit aux infos étaient des héros\ncombattant le Cercle Masqué. Puis ils sont\npartis."
+    "texte_fr": "Des gamins sont venus me dire que les cinq\nqu'on voit aux infos étaient des héros combattant\nle Cercle Masqué. Puis ils sont partis."
   },
   {
     "id": 10,
@@ -181,7 +181,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "So[SP]those[SP]five[SP]saved[SP]some[SP]kids,[SP]did[SP]they?[1205][U+000F]\n...Don't[SP]seem[SP]like[SP]such[SP]a[SP]bad[SP]bunch[SP]to[SP]me.",
     "nom_fr": "Gars cool",
-    "texte_fr": "Ces cinq-là ont sauvés des gamins, hein?[1205][U+000F]\n... Ils ont pas l'air de mauvais bougres."
+    "texte_fr": "Ces cinq-là ont sauvés des gamins, hein?[1205][U+000F]\n...Ils ont pas l'air de mauvais bougres."
   },
   {
     "id": 12,
@@ -196,7 +196,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "The[SP]In[SP]Lak'ech,[SP]huh...?[SP]If[SP]the[SP]stuff[SP]written[SP]in\nthat[SP]is[SP]true,[SP]the[SP]world's[SP]gonna[SP]end[SP]once[SP]the\nGrand[SP]Cross[SP]is[SP]finished.",
     "nom_fr": "Gars cool",
-    "texte_fr": "L'In Lak'ech, hein...? Si ce qui y est\nécrit est vrai, la Croix Cosmique causera\nla fin du monde une fois réalisée."
+    "texte_fr": "L'In Lak'ech, hein...? Si ce qui y est écrit\nest vrai, la Croix Cosmique causera la fin du\nmonde une fois réalisée."
   },
   {
     "id": 13,
@@ -212,7 +212,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "This[SP]city[SP]and[SP]this[SP]sea[SP]could[SP]disappear.[1205][U+000F]\nAnd[SP]my[SP]journey[SP]might[SP]end[SP]along[SP]with[SP]them.[1205][U+000F]\nA[SP]sad[SP]ending[SP]to[SP]the[SP]hard[SP]life[SP]I've[SP]led...",
     "nom_fr": "Gars cool",
-    "texte_fr": "Cette ville et cette mer pourraient\ndisparaître.[1205][U+000F] Mon voyage pourrait cesser\navec elles.[1205][U+000F] Une triste fin à ma rude vie..."
+    "texte_fr": "Cette ville et cette mer pourraient disparaître.[1205][U+000F]\nMon voyage pourrait cesser avec elles.[1205][U+000F]\nUne triste fin à ma rude vie..."
   },
   {
     "id": 14,
@@ -243,7 +243,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "You[SP]see[SP]those[SP]meteors,[SP]kid?[1205][U+000F][SP]The[SP]Masked[SP]Circle\nguys[SP]say[SP]that's[SP]the[SP][1432][NULL][NULL][0014]lion's[SP]roar[1432][NULL][NULL][0014][SP]part[SP]of\ntheir[SP]Oracle.",
     "nom_fr": "Gars cool",
-    "texte_fr": "Tu vois ces météores?[1205][U+000F] D'après ceux\ndu Cercle Masqué c'est le\n[1432][NULL][NULL][0014]rugissement du lion[1432][NULL][NULL][0014] de leur oracle."
+    "texte_fr": "Tu vois ces météores?[1205][U+000F] D'après ceux du Cercle\nMasqué c'est le [1432][NULL][NULL][0014]rugissement du lion[1432][NULL][NULL][0014] de\nleur oracle."
   },
   {
     "id": 16,
@@ -259,7 +259,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "Heh,[SP]I[SP]should've[SP]at[SP]least[SP]made[SP]a[SP]wish[SP]on[SP]'em.\nWith[SP]that[SP]many[SP]of[SP]'em[SP]shooting[SP]down,[SP]I[SP]bet\nI[SP]could've[SP]had[SP]lots[SP]of[SP]wishes[SP]come[SP]true.",
     "nom_fr": "Gars cool",
-    "texte_fr": "Hah, j'aurais du en profiter pour faire\nun voeu. Vu leur nombre, je parie que\nbeaucoup de mes voeux se réaliseraient."
+    "texte_fr": "Hah, j'aurais du en profiter pour faire un voeu.\nVu leur nombre, je parie que beaucoup de mes\nvoeux se réaliseraient."
   },
   {
     "id": 17,
@@ -274,7 +274,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "What[SP]the[SP]hell[SP]is[SP]that?[1205][U+000A][SP]It's[SP]blown[SP]the[SP]hard-\nboiled[SP]atmosphere[SP]to[SP]hell[SP]and[SP]gone![1205][U+000F][SP]Just[SP]when\nthe[SP]Aerospace[SP]Museum[SP]was[SP]kaput,[SP]too...",
     "nom_fr": "Gars cool",
-    "texte_fr": "C'était quoi ça, bordel?[1205][U+000A] Ça a totalement\npulvérisé l'atmosphère![1205][U+000A] Comme quand le\nMusée Aéronautique était kaput..."
+    "texte_fr": "C'était quoi ça, bordel?[1205][U+000A] Ça a totalement pulvérisé\nl'atmosphère![1205][U+000A] Comme quand le Musée\nAéronautique était kaput..."
   },
   {
     "id": 18,
@@ -290,7 +290,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "I[SP]can't[SP]take[SP]it[SP]anymore![1205][U+000A][SP]I'm[SP]going[SP]on[SP]another\njourney![1205][U+000A][SP]I'll[SP]take[SP]a[SP]ship,[SP]set[SP]sail,[SP]and...[1205][U+000F]\nWell,[SP]I'll[SP]probably[SP]fall[SP]off[SP]the[SP]edge,[SP]huh...",
     "nom_fr": "Gars cool",
-    "texte_fr": "J'en peux plus![1205][U+000A] Je repars en voyage![1205][U+000A] Je vais\nprendre un bateau, larguer les amarres et...[1205][U+000A]\nBen... sûrement tomber du rebord, hum..."
+    "texte_fr": "J'en peux plus![1205][U+000A] Je repars en voyage![1205][U+000A]\nJe vais prendre un bateau, larguer les amarres\net...[1205][U+000A] Ben... sûrement tomber du rebord, hum..."
   },
   {
     "id": 19,
@@ -305,7 +305,7 @@
     "nom_orig": "Sad[SP]woman",
     "texte_orig": "That's[SP]Ebisu[SP]Beach.[1205][U+000F][SP]It[SP]got[SP]its[SP]name[SP]because\npeople[SP]called[SP]the[SP]corpses[SP]that[SP]used[SP]to[SP]drift\nashore[SP][1432][NULL][NULL][0014]Ebisu-sama[1432][NULL][NULL][0014]...",
     "nom_fr": "Femme triste",
-    "texte_fr": "C'est la plage d'Ebisu.[1205][U+000A] Son nom\nvient des gens qui nommaient les\ncorps ramenés par la houle [1432][NULL][NULL][0014]Ebisu[1432][NULL][NULL][0014]..."
+    "texte_fr": "C'est la plage d'Ebisu.[1205][U+000A] Son nom vient des\ngens qui nommaient les corps ramenés par la\nhoule [1432][NULL][NULL][0014]Ebisu[1432][NULL][NULL][0014]..."
   },
   {
     "id": 20,
@@ -367,7 +367,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "I[SP]wonder[SP]what[SP]that[SP]police[SP]detective's[SP]name[SP]is...[1205][U+000F]\nTh-Those[SP]glasses[SP]really[SP]suit[SP]him...[1205][U+000F][SP]Such[SP]a\nsharp[SP]look...",
     "nom_fr": "Femme éprise",
-    "texte_fr": "Je me demande comment s'appelle ce\npolicier...[1205][U+000F] C-ces lunettes lui vont\nvraiment bien...[1205][U+000F] Quelle classe..."
+    "texte_fr": "Je me demande comment s'appelle ce policier...[1205][U+000F]\nC-ces lunettes lui vont vraiment bien...[1205][U+000F]\nQuelle classe..."
   },
   {
     "id": 24,
@@ -398,7 +398,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "I[SP]wonder[SP]what's[SP]wrong...[1205][U+000F][SP]They[SP]posted[SP]composite\nsketches[SP]of[SP]the[SP]suspects,[SP]but[SP]that[SP]police\ndetective[SP]looks[SP]so[SP]sad[SP]about[SP]it...",
     "nom_fr": "Femme éprise",
-    "texte_fr": "Qu'est ce qui ne va pas...[1205][U+000F] Les portraits-robot\ndes suspects sont sortis, mais ça semble\nattrister ce détective de police..."
+    "texte_fr": "Qu'est ce qui ne va pas...[1205][U+000F] Les\nportraits-robot des suspects sont sortis, mais ça\nsemble attrister ce détective de police..."
   },
   {
     "id": 26,
@@ -413,7 +413,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "If[SP]I[SP]was[SP]his[SP]lover,[SP]it[SP]would[SP]be[SP]up[SP]to[SP]me[SP]to\ntalk[SP]to[SP]him[SP]about[SP]it...[SP]But[SP]it's[SP]not[SP]my[SP]place.\nI[SP]can[SP]only[SP]watch[SP]him[SP]from[SP]afar[SP]like[SP]this.",
     "nom_fr": "Femme éprise",
-    "texte_fr": "Si j'étais son amante, ce serait à moi de\nlui parler... Mais ce n'est pas ma place.\nJe peux seulement l'observer de loin."
+    "texte_fr": "Si j'étais son amante, ce serait à moi de lui\nparler... Mais ce n'est pas ma place.\nJe peux seulement l'observer de loin."
   },
   {
     "id": 27,
@@ -429,7 +429,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "Oh,[SP]I[SP]nearly[SP]forgot.[SP]I[SP]bought[SP]the[SP]same[SP]style\nof[SP]glasses[SP]he[SP]wears.[SP]What[SP]do[SP]you[SP]think?[SP]Do[SP]they\nlook[SP]good[SP]on[SP]me?",
     "nom_fr": "Femme éprise",
-    "texte_fr": "Oh, j'oubliais. J'ai acheté des lunettes\nau style similaire aux siennes. Qu'en\npenses-tu? Elles me vont bien?"
+    "texte_fr": "Oh, j'oubliais. J'ai acheté des lunettes au style\nsimilaire aux siennes. Qu'en penses-tu? Elles\nme vont bien?"
   },
   {
     "id": 28,
@@ -445,7 +445,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "That[SP]police[SP]detective[SP]seems[SP]happy[SP]for[SP]some\nreason[SP]after[SP]hearing[SP]the[SP]news.[1205][U+000F][SP]It's[SP]the[SP]first\ntime[SP]I've[SP]seen[SP]him[SP]smile.",
     "nom_fr": "Femme éprise",
-    "texte_fr": "Ce détective de police semblait heureux\nen entendant les informations.[1205][U+000F] C'est la\npremière fois que je l'ai vu sourire."
+    "texte_fr": "Ce détective de police semblait heureux en\nentendant les informations.[1205][U+000F] C'est la première fois\nque je l'ai vu sourire."
   },
   {
     "id": 29,
@@ -461,7 +461,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "I-I[SP]was[SP]almost[SP]attacked[SP]by[SP]those[SP]soldiers...[1205][U+000F]\nBut[SP]that[SP]police[SP]detective[SP]saved[SP]me![1205][U+000F][SP]Ahhh,[SP]I\ncould[SP]die[SP]happy[SP]now!",
     "nom_fr": "Femme éprise",
-    "texte_fr": "C-ces soldats m'ont presque agressée...[1205][U+000F]\nMais ce policier m'a sauvée![1205][U+000F] Ahhh, je\npeux mourir heureuse désormais!"
+    "texte_fr": "C-ces soldats m'ont presque agressée...[1205][U+000F]\nMais ce policier m'a sauvée![1205][U+000F] Ahhh,\nje peux mourir heureuse désormais!"
   },
   {
     "id": 30,
@@ -477,7 +477,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "Hm?[1205][U+000A][SP]That[SP]blonde[SP]girl[SP]with[SP]you...[1205][U+000A][SP]Didn't[SP]she[SP]go\ninto[SP]that[SP]temple[SP]a[SP]second[SP]ago?[1205][U+000F][SP]Was[SP]I[SP]just\nseeing[SP]things...?",
     "nom_fr": "Femme éprise",
-    "texte_fr": "Hm?[1205][U+000F] Cette fille blonde avec toi...[1205][U+000F]\nElle n'est pas entrée dans ce temple\nà l'instant?[1205][U+000F] Ou j'ai halluciné...?"
+    "texte_fr": "Hm?[1205][U+000F] Cette fille blonde avec toi...[1205][U+000F] Elle\nn'est pas entrée dans ce temple à l'instant?[1205][U+000F]\nOu j'ai halluciné...?"
   },
   {
     "id": 31,
@@ -492,7 +492,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "That[SP]producer,[SP]Ginji[SP]Sasaki...[1205][U+000F][SP]Looks[SP]like[SP]he's\ngot[SP]a[SP]new[SP]idol[SP]group[SP]lined[SP]up.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ce producteur, Ginji Sasaki...[1205][U+000F] Il\naurait formé un nouveau groupe d'idols."
+    "texte_fr": "Ce producteur, Ginji Sasaki...[1205][U+000F] Il aurait formé\nun nouveau groupe d'idols."
   },
   {
     "id": 32,
@@ -508,7 +508,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Songs[SP]slake[SP]my[SP]heart's[SP]thirst...[1205][U+000F][SP]What[SP]sort[SP]of\nmessage[SP]will[SP]Muses[SP]inscribe[SP]into[SP]my[SP]heart?[1205][U+000F]\nThe[SP]suspense[SP]is[SP]delectable...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "La musique étanche la soif de mon\ncoeur...[1205][U+000F] Quel message Muses gravera dans\nmon coeur?[1205][U+000F] Ce suspense est délicieux..."
+    "texte_fr": "La musique étanche la soif de mon coeur...[1205][U+000F]\nQuel message Muses gravera dans mon coeur?[1205][U+000F]\nCe suspense est délicieux..."
   },
   {
     "id": 33,
@@ -523,7 +523,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "From[SP]what[SP]I've[SP]heard...[1205][U+000F][SP]The[SP]veil[SP]of[SP]mystery\nsurrounding[SP]the[SP]third[SP]member[SP]will[SP]be[SP]torn[SP]off\nduring[SP]the[SP]live[SP]recording[SP]at[SP]Giga[SP]Macho...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "De ce que je sais...[1205][U+000F] Le voile mystèrieux\nenveloppant le troisième membre sera levé\ndurant la diffusion en direct au Giga Macho..."
+    "texte_fr": "De ce que je sais...[1205][U+000F] Le voile mystèrieux\nenveloppant le troisième membre sera levé durant la\ndiffusion en direct au Giga Macho..."
   },
   {
     "id": 34,
@@ -570,7 +570,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "A[SP]ticket?[1205][U+000F][SP]Ha![SP]I[SP]need[SP]no[SP]ticket.[SP]I[SP]shall[SP]listen\nto[SP]them[SP]from[SP]beyond[SP]the[SP]wall.[SP]There[SP]are[SP]more\nways[SP]to[SP]show[SP]one's[SP]support[SP]than[SP]making[SP]a[SP]fuss.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Un ticket?[1205][U+000F] Ha! Pas besoin de ticket.\nJ'écouterais par-delà le mur. S'agiter\nbêtement n'est pas la seule façon de témoigner\nson soutien."
+    "texte_fr": "Un ticket?[1205][U+000F] Ha! Pas besoin de ticket. J'écouterais\npar-delà le mur. S'agiter bêtement n'est pas\nla seule façon de témoigner son soutien."
   },
   {
     "id": 37,
@@ -585,7 +585,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Ha.[SP]So[SP]the[SP]concert[SP]hall[SP]has[SP]burned[SP]to[SP]ash...[1205][U+000F]\nThe[SP]building[SP]itself[SP]couldn't[SP]contain[SP]its\nexcitement[SP]for[SP]the[SP]Muses'[SP]song.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ha. La salle de concert a brûlée...[1205][U+000F] Le\nbâtiment lui-même n'a pu contenir\nl'excitation issue des chansons de Muses."
+    "texte_fr": "Ha. La salle de concert a brûlée...[1205][U+000F]\nLe bâtiment lui-même n'a pu contenir l'excitation\nissue des chansons de Muses."
   },
   {
     "id": 38,
@@ -616,7 +616,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Apparently[SP]the[SP]terrorists[SP]behind[SP]these[SP]attacks\nare[SP]a[SP]mysterious[SP]organization[SP]called[SP]the[SP]Last\nBattalion.[1205][U+000F][SP]I've[SP]heard[SP]people[SP]talk[SP]about[SP]them.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Apparemment les terroristes derrière ces\nattaques sont une organisation mystérieuse\nnommée Bataillon.[1205][U+000F] J'ai entendu des gens en\nparler."
+    "texte_fr": "Apparemment les terroristes derrière ces attaques\nsont une organisation mystérieuse nommée Bataillon.[1205][U+000F]\nJ'ai entendu des gens en parler."
   },
   {
     "id": 40,
@@ -631,7 +631,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "If[SP]that's[SP]what[SP]they[SP]were[SP]up[SP]against,[SP]then[SP]even\nif[SP]the[SP]police[SP]weren't[SP]handicapped,[SP]they[SP]would\nhave[SP]had[SP]little[SP]success.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Si ils doivent affronter ça, même si\nla police n'était pas incapacitée,\nils n'auraient presque aucune chance."
+    "texte_fr": "Si ils doivent affronter ça, même si la\npolice n'était pas incapacitée, ils n'auraient\npresque aucune chance."
   },
   {
     "id": 41,
@@ -647,7 +647,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "At[SP]least[SP]now[SP]they[SP]have[SP]a[SP]good[SP]excuse[SP]for[SP]their\nfailure[SP]to[SP]protect[SP]the[SP]city--they[SP]were[SP]victims\nof[SP]the[SP]same[SP]arson.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Au moins maintenant ils ont une\nbonne raison d'échouer à protéger la\nville--ils sont victimes eux aussi."
+    "texte_fr": "Au moins maintenant ils ont une bonne raison\nd'échouer à protéger la ville--ils sont\nvictimes eux aussi."
   },
   {
     "id": 42,
@@ -662,7 +662,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "The[SP]men[SP]at[SP]Sumaru[SP]TV[SP]are[SP]frantically[SP]gathering\nmaterial.[1205][U+000F][SP]I[SP]presume[SP]they're[SP]putting[SP]together[SP]a\nspecial[SP]on[SP]the[SP]terror[SP]wave.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ceux de Sumaru TV rassemblent hâtivement\ndu matériel.[1205][U+000F] Ils préparent une émission\nspéciale sur les drames, je présume."
+    "texte_fr": "Ceux de Sumaru TV rassemblent hâtivement du\nmatériel.[1205][U+000F] Ils préparent une émission spéciale sur\nles drames, je présume."
   },
   {
     "id": 43,
@@ -678,7 +678,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Ha![SP]If[SP]only[SP]they[SP]had[SP]talked[SP]to[SP]me,[SP]I[SP]could[SP]have\nrecounted[SP]the[SP]smallest[SP]details[SP]of[SP]how[SP]the[SP]blimp\ntook[SP]off.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ha! Si seulement ils m'avaient\nparlé, j'aurais reconté chaque petit\ndétail de l'envol du dirigeable."
+    "texte_fr": "Ha! Si seulement ils m'avaient parlé, j'aurais\nreconté chaque petit détail de l'envol du\ndirigeable."
   },
   {
     "id": 44,
@@ -693,7 +693,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Hmph...[SP]The[SP]In[SP]Lak'ech[SP]says[SP]we'll[SP]evolve[SP]into\na[SP]higher[SP]form,[SP]called[SP]Idealians,[SP]upon[SP]the\ncompletion[SP]of[SP]the[SP]Grand[SP]Cross.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Hm... Selon l'In Lak'ech nous évoluerons\nen Idéaliens, une forme supérieure,\nquand la Croix Cosmique sera complète."
+    "texte_fr": "Hm... Selon l'In Lak'ech nous évoluerons en\nIdéaliens, une forme supérieure, quand la Croix\nCosmique sera complète."
   },
   {
     "id": 45,
@@ -708,7 +708,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "A[SP]juicy[SP]story,[SP]no?[1205][U+000F][SP]I[SP]choose[SP]to[SP]believe[SP]it.[1205][U+000F]\nMy[SP]life[SP]would[SP]never[SP]end[SP]this[SP]way.[SP]There[SP]has[SP]to\nbe[SP]a[SP]more[SP]stimulating[SP]future[SP]in[SP]store[SP]for[SP]me.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Une histoire intéressante, non?[1205][U+000F] J'ai décidé\nd'y croire.[1205][U+000F] Ma vie ne saurait s'achever ainsi.\nUn futur plus stimulant doit m'attendre."
+    "texte_fr": "Une histoire intéressante, non?[1205][U+000F] J'ai décidé d'y\ncroire.[1205][U+000F] Ma vie ne saurait s'achever ainsi.\nUn futur plus stimulant doit m'attendre."
   },
   {
     "id": 46,
@@ -724,7 +724,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Hohoho,[SP]I[SP]can[SP]scarcely[SP]wait[SP]for[SP]the[SP]moment[SP]of\nour[SP]transfiguration.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Hohoho, je ne puis attendre\nl'instant de notre transfiguration."
+    "texte_fr": "Hohoho, je ne puis attendre l'instant de notre\ntransfiguration."
   },
   {
     "id": 47,
@@ -756,7 +756,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "I[SP]pity[SP]the[SP]poor[SP]souls[SP]below[SP]us...[SP]But[SP]at[SP]least\nour[SP]evolution[SP]will[SP]go[SP]unimpeded.[1205][U+000F][SP]Still,[SP]just\nhow[SP]will[SP]the[SP]world[SP]end?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ah, ces pauvres âmes là-dessous... Au\nmoins rien ne gênera notre évolution.[1205][U+000F]\nMais comment le monde sera anéanti?"
+    "texte_fr": "Ah, ces pauvres âmes là-dessous... Au moins\nrien ne gênera notre évolution.[1205][U+000F] Mais comment le\nmonde sera anéanti?"
   },
   {
     "id": 49,
@@ -787,7 +787,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "An[SP]acquaintance[SP]of[SP]mine[SP]told[SP]me[SP]that[SP]when[SP]the\nGrand[SP]Cross[SP]is[SP]complete,[SP]electrified[SP]rain[SP]will\npour[SP]down[SP]upon[SP]the[SP]Earth.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "D'après une connaissance, lorsque la\nCroix Cosmique sera complète, une\npluie électrifiée s'abattra sur Terre."
+    "texte_fr": "D'après une connaissance, lorsque la Croix\nCosmique sera complète, une pluie électrifiée\ns'abattra sur Terre."
   },
   {
     "id": 51,
@@ -803,7 +803,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "That[SP]is[SP]supposedly[SP]the[SP]manner[SP]of[SP]its[SP]demise.[1205][U+000F]\nNothing[SP]for[SP]us[SP]to[SP]worry[SP]about,[SP]up[SP]here[SP]in[SP]the\nheavens.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Bah, sûrement une divagation issue\nde sa terreur.[1205][U+000F] Dans ce paradis\nnous ne sommes pas inquiétés."
+    "texte_fr": "Bah, sûrement une divagation issue de sa terreur.[1205][U+000F]\nDans ce paradis nous ne sommes pas inquiétés."
   },
   {
     "id": 52,
@@ -818,7 +818,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Things[SP]are[SP]becoming[SP]interesting[SP]indeed.[1205][U+000A][SP]I[SP]hear\nnow[SP]that[SP]the[SP]Grand[SP]Cross[SP]will[SP]halt[SP]the[SP]Earth's\nrotation[SP]entirely.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Les choses deviennent intéressantes.[1205][U+000F]\nJ'entend dire que la Croix Cosmique\nva stopper la rotation terrestre."
+    "texte_fr": "Les choses deviennent intéressantes.[1205][U+000F] J'entend\ndire que la Croix Cosmique va stopper la\nrotation terrestre."
   },
   {
     "id": 53,
@@ -881,7 +881,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "*sigh*[SP]Surely[SP]there[SP]must[SP]be[SP]one[SP]foolproof[SP]way\nof[SP]getting[SP]rich[SP]quickly.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "*soupir* Un moyen sûr de s'enrichir\nrapidement doit bien exister."
+    "texte_fr": "*soupir* Un moyen sûr de s'enrichir rapidement\ndoit bien exister."
   },
   {
     "id": 57,
@@ -897,7 +897,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "The[SP]ghost[SP]of[SP]an[SP]idol[SP]singer[SP]who[SP]died[SP]young\nhas[SP]been[SP]appearing[SP]at[SP]Aoba[SP]Park.[1205][U+000F][SP]Can[SP]she\nstill[SP]not[SP]forget[SP]me,[SP]even[SP]in[SP]death?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Le fantôme d'une idol, morte jeune,\napparaîtrait au Parc d'Aoba.[1205][U+000F] Faillirait-elle\nà m'oublier, même dans la mort?"
+    "texte_fr": "Le fantôme d'une idol, morte jeune, apparaîtrait\nau Parc d'Aoba.[1205][U+000F] Faillirait-elle à\nm'oublier, même dans la mort?"
   },
   {
     "id": 58,
@@ -912,7 +912,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "There's[SP]something[SP]called[SP]a[SP]Cursed[SP]Taxi[SP]parked\nat[SP]the[SP]abandoned[SP]factory.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Un dénommé Taxi Maudit serait\ngaré à l'usine abandonnée."
+    "texte_fr": "Un dénommé Taxi Maudit serait garé à\nl'usine abandonnée."
   },
   {
     "id": 59,
@@ -959,7 +959,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Apparently[SP]the[SP]Cursed[SP]Taxi[SP]at[SP]the[SP]abandoned\nfactory[SP]was[SP]actually[SP]a[SP]Cursed[SP]Escort.[SP]Not[SP]that\nI[SP]care[SP]one[SP]whit.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Apparemment le Taxi Maudit de\nl'usine abandonnée était en fait une\nEscorte Maudite. Bah, je m'en fiche."
+    "texte_fr": "Apparemment le Taxi Maudit de l'usine abandonnée\nétait en fait une Escorte Maudite. Bah,\nje m'en fiche."
   },
   {
     "id": 62,
@@ -974,7 +974,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Kuchisake-onna,[SP]hmm...?[SP]That[SP]story[SP]gave[SP]me\nquite[SP]a[SP]fright[SP]as[SP]a[SP]child.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Kuchisake-onna, hein...? Enfant,\ncette histoire me terrorisait."
+    "texte_fr": "Kuchisake-onna, hein...? Enfant, cette histoire\nme terrorisait."
   },
   {
     "id": 63,
@@ -989,7 +989,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Ah,[SP]the[SP]memories...[1205][U+000F][SP]I[SP]doubt[SP]children[SP]your[SP]age\nwould[SP]know[SP]who[SP]she[SP]is.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Que de souvenirs...[1205][U+000F] Je doute qu'à\nvotre âge vous la connaissiez."
+    "texte_fr": "Que de souvenirs...[1205][U+000F] Je doute qu'à votre âge\nvous la connaissiez."
   },
   {
     "id": 64,
@@ -1005,7 +1005,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Then[SP]here's[SP]a[SP]social[SP]studies[SP]assignment[SP]for\nyou:[SP]Go[SP]to[SP]this[SP]Mt.[SP]Iwato[SP]place.[1205][U+000F][SP]Apparently\nyou[SP]can[SP]see[SP]her[SP]for[SP]yourself[SP]there.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Tenez, voici un devoir de sciences\nsociales: allez à ce Mont Iwato, là.[1205][U+000F]\nVous pourriez la voir vous-même là-bas."
+    "texte_fr": "Tenez, voici un devoir de sciences sociales:\nallez à ce Mont Iwato, là.[1205][U+000F] Vous pourriez\nla voir vous-même là-bas."
   },
   {
     "id": 65,
@@ -1035,7 +1035,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "He[SP]was[SP]much[SP]faster[SP]than[SP]me,[SP]though.[1205][U+000F][SP]He[SP]jumped\nright[SP]over[SP]my[SP]GT8.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Mais il était plus rapide.[1205][U+000F] Il\nsautais au dessus de ma GT8."
+    "texte_fr": "Mais il était plus rapide.[1205][U+000F] Il sautais\nau dessus de ma GT8."
   },
   {
     "id": 67,
@@ -1051,7 +1051,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "If[SP]you[SP]care[SP]to[SP]challenge[SP]him,[SP]go[SP]to[SP]Mt.\nKatatsumuri.[SP]The[SP]cursed[SP]six[SP]hairpin[SP]curves...[1205][U+000F]\nHe'll[SP]be[SP]waiting[SP]there[SP]for[SP]you.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Si vous voulez l'affronter, allez au\nMont Katatsumuri. Les six virages en\népingle maudits...[1205][U+000F] Il vous y attendra."
+    "texte_fr": "Si vous voulez l'affronter, allez au Mont\nKatatsumuri. Les six virages en épingle maudits...[1205][U+000F]\nIl vous y attendra."
   },
   {
     "id": 68,
@@ -1067,7 +1067,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Harumph...[1205][U+000F][SP]I[SP]can't[SP]believe[SP]I'm[SP]letting[SP]this\nridiculous[SP]story[SP]affect[SP]me...[1205][U+000F][SP]Kudan,[SP]hmm?[1205][U+000F]\nAt[SP]that[SP]abandoned[SP]factory...[1205][U+000F][SP]No![SP]No[SP]more!",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Grumpf...[1205][U+000F] Il est impensable que cette\nridicule histoire puisse m'affecter...[1205][U+000F] Kudan,\nhmm?[1205][U+000F] À l'usine abandonnée...[1205][U+000F] Non! Assez!"
+    "texte_fr": "Grumpf...[1205][U+000F] Il est impensable que cette ridicule\nhistoire puisse m'affecter...[1205][U+000F]Kudan, hmm?[1205][U+000F]\nÀ l'usine abandonnée...[1205][U+000F] Non! Assez!"
   },
   {
     "id": 69,
@@ -1083,7 +1083,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Hmm...[SP]It[SP]appears[SP]the[SP]rumor[SP]was[SP]true[SP]about[SP]the\nsecret[SP]CD[SP]at[SP]Giga[SP]Macho.[1205][U+000F][SP]Time[SP]for[SP]me[SP]to[SP]go[SP]pick\nit[SP]up...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Hmm... Il semble que la rumeur du CD\nsecret du Giga Macho était fondée.[1205][U+000F]\nJe dois aller le chercher..."
+    "texte_fr": "Hmm... Il semble que la rumeur du CD secret\ndu Giga Macho était fondée.[1205][U+000F] Je dois aller\nle chercher..."
   },
   {
     "id": 70,
@@ -1098,7 +1098,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Have[SP]you[SP]heard?[1205][U+000F][SP]There's[SP]a[SP]creature[SP]called\na[SP]Dresser[SP]Hag[SP]at[SP]the[SP]abandoned[SP]factory.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Une dénommée Sorcière\nde la Commode est à l'usine abandonnée."
+    "texte_fr": "Es-tu au courant? Une dénommée Sorcière de\nla Commode est à l'usine abandonnée."
   },
   {
     "id": 71,
@@ -1114,7 +1114,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "By[SP]all[SP]accounts,[SP]it[SP]shoves[SP]passersby[SP]into[SP]its\ndresser.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Elle encastrerait les\npassants dans sa commode."
+    "texte_fr": "Elle encastrerait les passants dans sa\ncommode."
   },
   {
     "id": 72,
@@ -1145,7 +1145,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "You[SP]see...[1205][U+000F][SP]A[SP]store[SP]called[SP]Time[SP]Castle[SP]in\nRengedai[SP]sells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]quality\nand[SP]price[SP]are[SP]average.[SP]Shocking,[SP]no?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Tu vois...[1205][U+000F] Time Castle à Rengedai\nvendrait de vraies armes.[1205][U+000F] Le prix et la\nqualité y sont standards. Dingue, non?"
+    "texte_fr": "Tu vois...[1205][U+000F] Time Castle à Rengedai vendrait\nde vraies armes.[1205][U+000F] Le prix et la qualité y\nsont standards. Dingue, non?"
   },
   {
     "id": 74,
@@ -1176,7 +1176,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "You[SP]see...[1205][U+000F][SP]A[SP]store[SP]called[SP]Time[SP]Castle[SP]in\nRengedai[SP]sells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]quality\nis[SP]good,[SP]but[SP]they're[SP]expensive.[SP]Shocking,[SP]no?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Tu vois...[1205][U+000F] Time Castle à Rengedai\nvendrait de vraies armes.[1205][U+000F] La sélection y\nest bonne, mais coûteuse. Dingue, non?"
+    "texte_fr": "Tu vois...[1205][U+000F] Time Castle à Rengedai vendrait\nde vraies armes.[1205][U+000F] La sélection y est\nbonne, mais coûteuse. Dingue, non?"
   },
   {
     "id": 76,
@@ -1207,7 +1207,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "You[SP]see...[1205][U+000F][SP]A[SP]store[SP]called[SP]Time[SP]Castle[SP]in\nRengedai[SP]sells[SP]real[SP]weapons.[1205][U+000F][SP]They're[SP]cheap,\nbut[SP]low[SP]quality.[SP]Shocking,[SP]no?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Tu vois...[1205][U+000F] Time Castle à Rengedai\nvendrait de vraies armes.[1205][U+000F] C'est pas cher,\nmais de basse qualité. Dingue, non?"
+    "texte_fr": "Tu vois...[1205][U+000F] Time Castle à Rengedai vendrait\nde vraies armes.[1205][U+000F] C'est pas cher, mais de\nbasse qualité. Dingue, non?"
   },
   {
     "id": 78,
@@ -1223,7 +1223,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Great[SP]selection,[SP]but[SP]low[SP]resale[SP]value?[SP]Hmph,\neven[SP]that[SP]Tony[SP]has[SP]a[SP]hand[SP]in[SP]illicit[SP]weapon\nsales...[1205][U+000F][SP]The[SP]bastard's[SP]good.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Bonne sélection, mais bas prix de\nrevente? Hmph, même ce Tony traîne dans\nle trafic d'armes...[1205][U+000F] Doué, cet enfoiré."
+    "texte_fr": "Bonne sélection, mais bas prix de revente?\nHmph, même ce Tony traîne dans le trafic\nd'armes...[1205][U+000F] Doué, cet enfoiré."
   },
   {
     "id": 79,
@@ -1239,7 +1239,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Poor[SP]quality,[SP]but[SP]decent[SP]prices?[SP]Hmph,\neven[SP]that[SP]Tony[SP]has[SP]a[SP]hand[SP]in[SP]illicit[SP]weapon\nsales...[1205][U+000F][SP]The[SP]bastard's[SP]good.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Basse qualité, mais prix décents?\nHmph, même ce Tony traîne dans le\ntrafic d'armes...[1205][U+000F] Doué, cet enfoiré."
+    "texte_fr": "Basse qualité, mais prix décents? Hmph,\nmême ce Tony traîne dans le trafic\nd'armes...[1205][U+000F] Doué, cet enfoiré."
   },
   {
     "id": 80,
@@ -1255,7 +1255,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Satisfaction[SP]guaranteed[SP]through[SP]average[SP]prices\nand[SP]quality?[SP]Hmph,[SP]even[SP]that[SP]Tony[SP]has[SP]a[SP]hand\nin[SP]illicit[SP]weapon[SP]sales...[1205][U+000F][SP]The[SP]bastard's[SP]good.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Prix et qualité standardisés pour une\nsatisfaction assurée? Hmph, même ce Tony\ntraîne dans le trafic d'armes...[1205][U+000F] Doué, cet\nenfoiré."
+    "texte_fr": "Prix et qualité standardisés pour une\nsatisfaction assurée? Hmph, même ce Tony traîne\ndans le trafic d'armes...[1205][U+000F] Doué, cet enfoiré."
   },
   {
     "id": 81,
@@ -1271,7 +1271,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Expensive[SP]stock,[SP]but[SP]the[SP]highest[SP]quality...\nHmph,[SP]even[SP]that[SP]Tony[SP]has[SP]a[SP]hand[SP]in[SP]illicit\nweapon[SP]sales...[1205][U+000F][SP]The[SP]bastard's[SP]good.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Des produits coûteux, mais de haute\nqualité... Hmph, même ce Tony traîne dans\nle trafic d'armes...[1205][U+000F] Doué, cet enfoiré."
+    "texte_fr": "Des produits coûteux, mais de haute qualité...\nHmph, même ce Tony traîne dans le trafic\nd'armes...[1205][U+000F] Doué, cet enfoiré."
   },
   {
     "id": 82,
@@ -1287,7 +1287,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its\nrepertoire[SP]to[SP]include[SP]weapons.[SP]Their[SP]selection\nisn't[SP]the[SP]best,[SP]but[SP]their[SP]resale[SP]value[SP]is[SP]high.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Clair de Lune semble avoir inclu des armes à\nson répertoire. L'offre n'y est pas la\nmeilleure, mais la valeur de revente est\nhaute."
+    "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. L'offre n'y est pas la meilleure,\nmais la valeur de revente est haute."
   },
   {
     "id": 83,
@@ -1303,7 +1303,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its\nrepertoire[SP]to[SP]include[SP]weapons.[SP]They're[SP]cheap,\nbut[SP]dismal[SP]quality.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Clair de Lune semble avoir inclu\ndes armes à son répertoire. Elles\nsont bon marché, mais médiocres."
+    "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. Elles sont bon marché,\nmais médiocres."
   },
   {
     "id": 84,
@@ -1319,7 +1319,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its\nrepertoire[SP]to[SP]include[SP]weapons.[SP]The[SP]quality[SP]is\nexcellent,[SP]but[SP]the[SP]prices[SP]are[SP]high.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Clair de Lune semble avoir inclu des\narmes à son répertoire. C'est\nd'excellente facture, mais vraiment cher."
+    "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. C'est d'excellente facture,\nmais vraiment cher."
   },
   {
     "id": 85,
@@ -1335,7 +1335,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its\nrepertoire[SP]to[SP]include[SP]weapons.[SP]Their[SP]selection\nis[SP]great,[SP]but[SP]their[SP]resale[SP]prices[SP]aren't.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Clair de Lune semble avoir inclu des\narmes à son répertoire. La sélection y\nest bonne, mais pas les prix de revente."
+    "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. La sélection y est bonne,\nmais pas les prix de revente."
   },
   {
     "id": 86,
@@ -1351,7 +1351,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its\nrepertoire[SP]to[SP]include[SP]weapons.[SP]Their[SP]quality\nand[SP]prices[SP]are[SP]merely[SP]ordinary.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Clair de Lune semble avoir inclu\ndes armes à son répertoire. Le prix\net la qualité y sont ordinaires."
+    "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. Le prix et la qualité\ny sont ordinaires."
   },
   {
     "id": 87,
@@ -1367,7 +1367,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "I[SP]never[SP]noticed[SP]that[SP]the[SP]local[SP]cafe[SP]sold\nweapons[SP]before.[SP]Scuttlebutt[SP]is[SP]that[SP]their\nquality[SP]and[SP]prices[SP]are[SP]average.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Je n'avais jamais remarqué que le café\ndu coin vendait des armes. Le prix et\nla qualité y seraient corrects."
+    "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Le prix et la\nqualité y seraient corrects."
   },
   {
     "id": 88,
@@ -1383,7 +1383,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "I[SP]never[SP]noticed[SP]that[SP]the[SP]local[SP]cafe[SP]sold\nweapons[SP]before.[SP]Scuttlebutt[SP]is[SP]that[SP]their\nprices[SP]are[SP]low,[SP]but[SP]so[SP]is[SP]the[SP]quality.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Je n'avais jamais remarqué que le café\ndu coin vendait des armes. Le prix et\nla qualité des produits y seraient bas."
+    "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Le prix et la\nqualité des produits y seraient bas."
   },
   {
     "id": 89,
@@ -1431,7 +1431,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "I[SP]never[SP]noticed[SP]that[SP]the[SP]local[SP]cafe[SP]sold\nweapons[SP]before.[SP]Scuttlebutt[SP]is[SP]that[SP]their\nquality's[SP]great,[SP]but[SP]it's[SP]quite[SP]pricey.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Je n'avais jamais remarqué que le café\ndu coin vendait des armes. Les produits\ny seraient de qualité, mais assez chers."
+    "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Les produits y seraient\nde qualité, mais assez chers."
   },
   {
     "id": 92,
@@ -1446,7 +1446,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "It[SP]appears[SP]that[SP]the[SP]boutique[SP]in[SP]Rengedai\nsells[SP]armor.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "La boutique de Rengedai vendrait des armures."
+    "texte_fr": "La boutique de Rengedai vendrait des\narmures."
   },
   {
     "id": 93,
@@ -1477,7 +1477,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "It[SP]appears[SP]that[SP]the[SP]boutique[SP]in[SP]Rengedai\nsells[SP]armor.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "La boutique de Rengedai vendrait des armures."
+    "texte_fr": "La boutique de Rengedai vendrait des\narmures."
   },
   {
     "id": 95,
@@ -1508,7 +1508,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "It[SP]appears[SP]that[SP]the[SP]boutique[SP]in[SP]Rengedai\nsells[SP]armor.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "La boutique à Rengedai vendrait des armures."
+    "texte_fr": "La boutique à Rengedai vendrait des\narmures."
   },
   {
     "id": 97,
@@ -1540,7 +1540,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Is[SP]armor[SP]the[SP]latest[SP]fashion[SP]trend?[SP]Judging[SP]by\nAnima[SP]Mundi,[SP]apparently[SP]so.[SP]Their[SP]quality[SP]and\nprices[SP]are[SP]average[SP]at[SP]best.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Les armures sont à la mode? Apparemment\noui, si on regarde Anima Mundi. Leurs\nprix et qualité sont standards."
+    "texte_fr": "Les armures sont à la mode? Apparemment oui,\nsi on regarde Anima Mundi. Leurs prix et\nqualité sont standards."
   },
   {
     "id": 99,
@@ -1556,7 +1556,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Is[SP]armor[SP]the[SP]latest[SP]fashion[SP]trend?[SP]Judging[SP]by\nAnima[SP]Mundi,[SP]apparently[SP]so.[SP]Their[SP]stock[SP]is\ncheap,[SP]but[SP]low[SP]in[SP]quality.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Les armures sont à la mode? Apparemment\noui, si on regarde Anima Mundi. C'est\nbon marché, mais de basse qualité."
+    "texte_fr": "Les armures sont à la mode? Apparemment oui,\nsi on regarde Anima Mundi. C'est bon marché,\nmais de basse qualité."
   },
   {
     "id": 100,
@@ -1588,7 +1588,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Is[SP]armor[SP]the[SP]latest[SP]fashion[SP]trend?[SP]Judging[SP]by\nAnima[SP]Mundi,[SP]apparently[SP]so.[SP]The[SP]quality[SP]is\nhigh,[SP]but[SP]the[SP]prices[SP]are[SP]equally[SP]so.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Les armures sont à la mode? Apparemment\noui, si on regarde Anima Mundi. La qualité\ny est élevée, mais les prix aussi."
+    "texte_fr": "Les armures sont à la mode? Apparemment oui,\nsi on regarde Anima Mundi. La qualité y\nest élevée, mais les prix aussi."
   },
   {
     "id": 102,
@@ -1604,7 +1604,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling\nreal[SP]armor.[SP]They[SP]say[SP]the[SP]selection[SP]is[SP]poor,\nbut[SP]the[SP]resale[SP]value[SP]is[SP]high.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba\nvend de vraies armures. L'offre serait\nmauvaise, mais la revente paierait bien."
+    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. L'offre serait mauvaise,\nmais la revente paierait bien."
   },
   {
     "id": 103,
@@ -1620,7 +1620,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling\nreal[SP]armor.[SP]They[SP]say[SP]their[SP]quality[SP]and[SP]prices\nare[SP]average.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Rosa Candida à\nAoba vend de vraies armures. Prix\net qualité y seraient standards."
+    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. Prix et qualité y seraient\nstandards."
   },
   {
     "id": 104,
@@ -1652,7 +1652,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling\nreal[SP]armor.[SP]They[SP]say[SP]their[SP]goods[SP]are[SP]cheap,\nbut[SP]lacking[SP]in[SP]quality.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba\nvend de vraies armures. On dit que\nc'est pas cher, mais de basse qualité."
+    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. On dit que c'est pas\ncher, mais de basse qualité."
   },
   {
     "id": 106,
@@ -1668,7 +1668,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling\nreal[SP]armor.[SP]They[SP]say[SP]the[SP]selection[SP]is[SP]good,\nbut[SP]the[SP]resale[SP]value[SP]is[SP]low.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba\nvend de vraies armures. L'offre y serait\nbonne, mais pas la valeur de revente."
+    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. L'offre y serait bonne,\nmais pas la valeur de revente."
   },
   {
     "id": 107,
@@ -1699,7 +1699,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Seems[SP]their[SP]selection's[SP]impressive,[SP]but[SP]their\nresale[SP]value[SP]is[SP]fairly[SP]low.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Leur sélection semble géniale, mais\nla valeur de revente y est basse."
+    "texte_fr": "Leur sélection semble géniale, mais la valeur\nde revente y est basse."
   },
   {
     "id": 109,
@@ -1730,7 +1730,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Seems[SP]their[SP]stock[SP]is[SP]cheap,[SP]but[SP]not[SP]the\nhighest[SP]quality.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ça semble être bon marché,\nmais de médiocre qualité."
+    "texte_fr": "Ça semble être bon marché, mais de médiocre\nqualité."
   },
   {
     "id": 111,
@@ -1761,7 +1761,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Their[SP]quality[SP]is[SP]unimpeachable,[SP]but[SP]the[SP]prices\nare[SP]quite[SP]steep.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "La qualité y est sans égale,\nmais les prix suivent avec."
+    "texte_fr": "La qualité y est sans égale, mais les\nprix suivent avec."
   },
   {
     "id": 113,
@@ -1792,7 +1792,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Seems[SP]the[SP]quality[SP]and[SP]price[SP]of[SP]their[SP]goods\nis[SP]fairly[SP]standard.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "La qualité et le prix de leurs\nproduits semblent standards."
+    "texte_fr": "La qualité et le prix de leurs produits\nsemblent standards."
   },
   {
     "id": 115,
@@ -1823,7 +1823,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Seems[SP]their[SP]selection[SP]is[SP]less[SP]than[SP]impressive,\nbut[SP]the[SP]resale[SP]value[SP]is[SP]high.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Leur sélection semble quelconque, mais\nla valeur de revente y est élevée."
+    "texte_fr": "Leur sélection semble quelconque, mais la\nvaleur de revente y est élevée."
   },
   {
     "id": 117,
@@ -1853,7 +1853,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "I've[SP]heard[SP]that[SP]winners[SP]receive[SP]real[SP]weapons\nand[SP]items.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Les gagnants pourraient y\nobtenir armes et objets."
+    "texte_fr": "Les gagnants pourraient y obtenir armes\net objets."
   },
   {
     "id": 119,
@@ -1869,7 +1869,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "They're[SP]allegedly[SP]not[SP]easy[SP]to[SP]win,[SP]but[SP]the\nprizes[SP]are[SP]fairly[SP]nice.[1205][U+000F][SP]I[SP]suppose[SP]I'll[SP]keep\ntrying...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Il est difficile de gagner, mais les prix sont\nassez bons.[1205][U+000F] Je vais réessayer, j'imagine..."
+    "texte_fr": "Il est difficile de gagner, mais les\nprix sont assez bons.[1205][U+000F] Je vais réessayer,\nj'imagine..."
   },
   {
     "id": 120,
@@ -1899,7 +1899,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "I've[SP]heard[SP]that[SP]winners[SP]receive[SP]real[SP]weapons\nand[SP]items.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Les gagnants pourraient y\nobtenir armes et objets."
+    "texte_fr": "Les gagnants pourraient y obtenir armes\net objets."
   },
   {
     "id": 122,
@@ -1915,7 +1915,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "They're[SP]allegedly[SP]very[SP]difficult[SP]to[SP]win,[SP]but[SP]the\nprizes[SP]are[SP]quite[SP]rare.[1205][U+000F][SP]I[SP]suppose[SP]I'll[SP]keep\ntrying...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Gagner serait difficile, mais les prix sont\nvraiment rares.[1205][U+000F] Je vais réessayer,\nj'imagine..."
+    "texte_fr": "Gagner serait difficile, mais les prix\nsont vraiment rares.[1205][U+000F] Je vais réessayer,\nj'imagine..."
   },
   {
     "id": 123,
@@ -1945,7 +1945,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "I've[SP]heard[SP]that[SP]winners[SP]receive[SP]real[SP]weapons\nand[SP]items.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Les gagnants pourraient y\nobtenir armes et objets."
+    "texte_fr": "Les gagnants pourraient y obtenir armes\net objets."
   },
   {
     "id": 125,
@@ -1961,7 +1961,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "They're[SP]allegedly[SP]easy[SP]to[SP]win,[SP]but[SP]the[SP]prizes\nare[SP]no[SP]great[SP]shakes.[1205][U+000F][SP]Perhaps[SP]now's[SP]the\ntime[SP]to[SP]quit...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Gagner serait facile, mais les\nprix ne sont pas mirobolants.[1205][U+000F] Il\nest peut-être temps d'arrêter..."
+    "texte_fr": "Gagner serait facile, mais les prix ne\nsont pas mirobolants.[1205][U+000F] Il est peut-être\ntemps d'arrêter..."
   },
   {
     "id": 126,
@@ -2023,7 +2023,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "I[SP]hadn't[SP]realized[SP]Mu[SP]was[SP]one[SP]such[SP]place.\nTime[SP]to[SP]show[SP]my[SP]luck[SP]that[SP]made[SP]Las[SP]Vegas[1205][U+000F]\ntremble...[SP]Slots[SP]are[SP]my[SP]specialty,[SP]after[SP]all!",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Mu étais donc aussi ce genre de lieu. La\nchance qui ébranla Las Vegas va sévir...\nCar les machines à sous sont ma spécialité!"
+    "texte_fr": "Mu étais donc aussi ce genre de lieu.\nLa chance qui ébranla Las Vegas va sévir...\nCar les machines à sous sont ma spécialité!"
   },
   {
     "id": 130,
@@ -2054,7 +2054,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "I[SP]hadn't[SP]realized[SP]Mu[SP]was[SP]one[SP]such[SP]place.\nTime[SP]to[SP]show[SP]my[SP]unbeatable[SP]tactics[SP]once[SP]again.[1205][U+000F]\nBlackjack's[SP]my[SP]specialty,[SP]after[SP]all!",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Je n'imaginais pas Mu être ce genre de lieu.\nMes tactiques imparables vont sévir...[1205][U+000F] Car\nle blackjack est ma spécialité!"
+    "texte_fr": "Je n'imaginais pas Mu être ce genre de\nlieu. Mes tactiques imparables vont sévir...[1205][U+000F]\nCar le blackjack est ma spécialité!"
   },
   {
     "id": 132,
@@ -2070,7 +2070,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Hmm,[SP]so[SP]there's[SP]some[SP]sort[SP]of[SP]legendary[SP]weapon\nfor[SP]sale[SP]at[SP]that[SP]ramen[SP]shop...[SP]I'm[SP]glad[SP]someone\ntold[SP]me.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Hmm, ce restaurant de ramen vend\nune sorte d'arme légendaire...\nHeureusement qu'on m'a mis au jus."
+    "texte_fr": "Hmm, ce restaurant de ramen vend une sorte\nd'arme légendaire... Heureusement qu'on m'a mis\nau jus."
   },
   {
     "id": 133,
@@ -2102,7 +2102,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle[SP]is[SP]claiming[SP]he[SP]has[SP]no\nlegendary[SP]weapon,[SP]just[SP]to[SP]drive[SP]up[SP]its[SP]price.[1205][U+000F]\nHah![SP]I'm[SP]not[SP]fooled,[SP]believe[SP]you[SP]me!",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Le gérant du Time Castle nie posséder une\narme légendaire, juste pour faire monter\nses prix.[1205][U+000F] Hah! Je suis pas dupe, crois-moi!"
+    "texte_fr": "Le gérant du Time Castle nie posséder une\narme légendaire, juste pour faire monter ses prix.[1205][U+000F]\nHah! Je suis pas dupe, crois-moi!"
   },
   {
     "id": 135,
@@ -2117,7 +2117,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Apparently,[SP]Time[SP]Castle's[SP]legendary[SP]weapon[SP]is\nheld[SP]up[SP]in[SP]transit.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "L'arme légendaire du Time Castle\nne serait pas encore arrivée."
+    "texte_fr": "L'arme légendaire du Time Castle ne serait\npas encore arrivée."
   },
   {
     "id": 136,
@@ -2133,7 +2133,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "The[SP]seller[SP]is[SP]still[SP]at[SP]the[SP]abandoned[SP]factory.[1205][U+000F]\nI[SP]suppose[SP]someone[SP]could[SP]try[SP]to[SP]get[SP]there[SP]first\nand[SP]buy[SP]it[SP]directly[SP]from[SP]him...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Le vendeur est encore à l'usine abandonnée.[1205][U+000F]\nJ'imagine que quelqu'un devrait directement\ny aller pour la lui acheter..."
+    "texte_fr": "Le vendeur est encore à l'usine abandonnée.[1205][U+000F]\nJ'imagine que quelqu'un devrait directement y\naller pour la lui acheter..."
   },
   {
     "id": 137,
@@ -2148,7 +2148,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Demon,[SP]eh...?[1205][U+000F][SP]Well,[SP]the[SP]fantastical[SP]Last\nBattalion[SP]actually[SP]existed.[SP]Who's[SP]to[SP]say\ndemons[SP]don't[SP]as[SP]well?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Un démon, hein...?[1205][U+000F] Eh bien, le\nBataillon existait vraiment. Donc\npourquoi pas les démons aussi?"
+    "texte_fr": "Un démon, hein...?[1205][U+000F] Eh bien, le Bataillon\nexistait vraiment. Donc pourquoi pas les\ndémons aussi?"
   },
   {
     "id": 138,
@@ -2164,7 +2164,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "The[SP]rumor[SP]about[SP]Time[SP]Castle's[SP]legendary[SP]weapon\nbeing[SP]stolen[SP]by[SP]demons[SP]may[SP]also[SP]be[SP]true.[1205][U+000F][SP]Not\nthat[SP]I[SP]care.[SP]The[SP]time[SP]of[SP]Idealian[SP]is[SP]coming!",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "La rumeur des démons ayant volée l'arme\nlégendaire du Time Castle peut aussi être\nvraie.[1205][U+000F] Mais qu'importe. L'ère des Idéaliens\narrive!"
+    "texte_fr": "La rumeur des démons ayant volée l'arme\nlégendaire du Time Castle peut aussi être\nvraie.[1205][U+000F] Mais qu'importe. L'ère des Idéaliens arrive!"
   },
   {
     "id": 139,
@@ -2195,7 +2195,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "I[SP]expect[SP]I'll[SP]be[SP]fine[SP]without[SP]it,[SP]as[SP]I[SP]was\nnaturally[SP]strong[SP]to[SP]begin[SP]with.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Je m'en sortirais sans j'imagine,\ncomme je suis naturellement fort."
+    "texte_fr": "Je m'en sortirais sans j'imagine, comme\nje suis naturellement fort."
   },
   {
     "id": 141,
@@ -2210,7 +2210,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "It[SP]seems[SP]the[SP]owner[SP]of[SP]Time[SP]Castle[SP]made[SP]a\npresent[SP]of[SP]his[SP]legendary[SP]weapon[SP]to[SP]a[SP]girl\nwith[SP]short[SP]hair.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Le propriétaire du Time Castle\naurait offert son arme légendaire\nà une fille aux cheveux courts."
+    "texte_fr": "Le propriétaire du Time Castle aurait\noffert son arme légendaire à une fille\naux cheveux courts."
   },
   {
     "id": 142,
@@ -2226,7 +2226,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "What[SP]a[SP]smooth[SP]operator...[SP]Nowhere[SP]near[SP]as\nsmooth[SP]as[SP]myself,[SP]though.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Quel sacré manipulateur... Pas\naussi doué que moi, ceci dit."
+    "texte_fr": "Quel sacré manipulateur... Pas aussi doué\nque moi, ceci dit."
   },
   {
     "id": 143,
@@ -2489,7 +2489,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]museum[SP]was[SP]built[SP]pretty[SP]recently.[SP]I[SP]hear\nthey[SP]have[SP]lots[SP]of[SP]different[SP]kinds[SP]of[SP]planes\non[SP]display...[1205][U+000A][SP]We[SP]should[SP]check[SP]it[SP]out[SP]sometime!",
     "nom_fr": "Maya",
-    "texte_fr": "Ce musée a été bâti assez récemment.\nApparemment ils exposent de nombreux types\nd'avions...[1205][U+000F] On pourrais y faire un tour, un\njour!"
+    "texte_fr": "Ce musée a été bâti assez récemment. Apparemment\nils exposent de nombreux types d'avions...[1205][U+000F]\nOn pourrais y faire un tour, un jour!"
   },
   {
     "id": 160,
@@ -2505,7 +2505,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I'm[SP]surprised[SP]we[SP]made[SP]it[SP]out[SP]alive...[1205][U+000F][SP]I[SP]mean\nout[SP]of[SP]the[SP]blimp,[SP]not[SP]the[SP]museum...",
     "nom_fr": "Ginko",
-    "texte_fr": "Je pensais pas qu'on sortirais vivants...[1205][U+000F]\nDu dirigeable, hein, pas du musée..."
+    "texte_fr": "Je pensais pas qu'on sortirais vivants...[1205][U+000F] Du\ndirigeable, hein, pas du musée..."
   },
   {
     "id": 161,
@@ -2569,7 +2569,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Whoa,[SP]isn't[SP]it[SP]a[SP]little[SP]early[SP]in[SP]the[SP]year[SP]to\ntake[SP]a[SP]swim[SP]in[SP]the[SP]ocean?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Wouah, on fait pas trempette dans\nla mer aussi tôt dans l'année, si?"
+    "texte_fr": "Wouah, on fait pas trempette dans la mer\naussi tôt dans l'année, si?"
   },
   {
     "id": 165,
@@ -2585,7 +2585,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We've[SP]got[SP]the[SP]crystal[SP]skull[SP]from[SP]this[SP]place.\nWhere[SP]to[SP]next?",
     "nom_fr": "Ginko",
-    "texte_fr": "On a le crâne de crystal de\ncet endroit. On va où ensuite?"
+    "texte_fr": "On a le crâne de crystal de cet endroit.\nOn va où ensuite?"
   },
   {
     "id": 166,
@@ -2601,7 +2601,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "There's[SP]still[SP]people[SP]fighting[SP]in[SP]there!?[1205][U+000F]\nBut[SP]there's[SP]no[SP]crystal[SP]skull[SP]anymore!\nThere's[SP]nothing[SP]for[SP]them[SP]to[SP]fight[SP]over!",
     "nom_fr": "Ginko",
-    "texte_fr": "Il y a encore des gens qui se battent\nlà-dedans!?[1205][U+000F] Mais il n'y a plus de\ncrâne de crytal pour lequel se battre!"
+    "texte_fr": "Il y a encore des gens qui se battent\nlà-dedans!?[1205][U+000F] Mais il n'y a plus de crâne\nde crytal pour lequel se battre!"
   },
   {
     "id": 167,
@@ -2617,7 +2617,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "[1113],[SP]everyone's[SP]waiting[SP]at[SP]the[SP]detective\nagency.[SP]We[SP]should[SP]go.",
     "nom_fr": "Ginko",
-    "texte_fr": "[1113], les autres attendent à\nl'agence de détectives. Allons-y."
+    "texte_fr": "[1113], les autres attendent à l'agence de\ndétectives. Allons-y."
   },
   {
     "id": 168,
@@ -2633,7 +2633,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What[SP]the[SP]hell,[SP]man!?[SP]They[SP]burned[SP]down[SP]the\npolice[SP]headquarters!",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est quoi ce bordel!? Ils\nont brûlé le QG de la police!"
+    "texte_fr": "C'est quoi ce bordel!? Ils ont brûlé le\nQG de la police!"
   },
   {
     "id": 169,
@@ -2665,7 +2665,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It[SP]was[SP]probably[SP]to[SP]prevent[SP]the[SP]police[SP]from\ninterfering...[1205][U+000F][SP]We're[SP]the[SP]only[SP]ones[SP]left[SP]who\ncan[SP]stop[SP]him[SP]now.",
     "nom_fr": "Maya",
-    "texte_fr": "C'était sûrement pour empêcher la\npolice d'interférer...[1205][U+000F] Il ne reste\nque nous pour l'arrêter désormais."
+    "texte_fr": "C'était sûrement pour empêcher la police\nd'interférer...[1205][U+000F] Il ne reste que nous pour\nl'arrêter désormais."
   },
   {
     "id": 171,
@@ -2681,7 +2681,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We[SP]can't[SP]go[SP]in[SP]at[SP]this[SP]rate...[1205][U+000F][SP]The[SP]nerve[SP]of\nthat[SP]asshole!",
     "nom_fr": "Eikichi",
-    "texte_fr": "On peut pas continuer comme\nça...[1205][U+000F] Ce connard est gonflé!"
+    "texte_fr": "On peut pas continuer comme ça...[1205][U+000F] Ce\nconnard est gonflé!"
   },
   {
     "id": 172,
@@ -2697,7 +2697,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Let's[SP]get[SP]out[SP]of[SP]here,[SP][1113].[SP]They're[SP]gonna\narrest[SP]us[SP]if[SP]we[SP]stand[SP]around[SP]like[SP]this.",
     "nom_fr": "Ginko",
-    "texte_fr": "Sortons de là, [1113]. Ils vont\nnous arrêter si on reste plantés là."
+    "texte_fr": "Sortons de là, [1113]. Ils vont nous\narrêter si on reste plantés là."
   },
   {
     "id": 173,
@@ -2713,7 +2713,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "If[SP]the[SP]police[SP]are[SP]this[SP]bad[SP]off,[SP]the[SP]city's\ncompletely[SP]defenseless.[SP]King[SP]Leo[SP]only[SP]ended\nup[SP]helping[SP]those[SP]bastards!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Si la police est à ce point dans la\nmouise, la ville est sans-défense. Le\nRoi Lion a vraiment aidé ces enfoirés!"
+    "texte_fr": "Si la police est à ce point dans la\nmouise, la ville est sans-défense. Le Roi\nLion a vraiment aidé ces enfoirés!"
   },
   {
     "id": 174,
@@ -2729,7 +2729,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Looks[SP]like[SP]there's[SP]no[SP]one[SP]here.[SP]Let's[SP]go\nsomewhere[SP]else,[SP][1113].",
     "nom_fr": "Ginko",
-    "texte_fr": "Il n'y a personne ici, on dirait.\nAllons ailleurs, [1113]."
+    "texte_fr": "Il n'y a personne ici, on dirait. Allons\nailleurs, [1113]."
   },
   {
     "id": 175,
@@ -2745,7 +2745,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We[SP]shouldn't[SP]go[SP]in[SP]without[SP]Maya-san.[SP]Let's\ncome[SP]back[SP]after[SP]we've[SP]met[SP]up[SP]with[SP]the[SP]others\nback[SP]at[SP]the[SP]detective[SP]agency.",
     "nom_fr": "Ginko",
-    "texte_fr": "On devrais éviter d'avancer sans\nMaya. Revenons après avoir rejoint\nles autres à l'agence de détectives."
+    "texte_fr": "On devrais éviter d'avancer sans Maya.\nRevenons après avoir rejoint les autres\nà l'agence de détectives."
   },
   {
     "id": 176,
@@ -2761,7 +2761,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]don't[SP]have[SP]the[SP]key[SP]to[SP]my[SP]room[SP]on[SP]me[SP]now.\nLet's[SP]come[SP]back[SP]some[SP]other[SP]time.",
     "nom_fr": "Maya",
-    "texte_fr": "Je n'ai pas la clé de ma chambre sur\nmoi, là. Revenons une autre fois."
+    "texte_fr": "Je n'ai pas la clé de ma chambre sur moi,\nlà. Revenons une autre fois."
   },
   {
     "id": 177,
@@ -2793,7 +2793,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "H-Hold[SP]the[SP]phone,[SP]man.[1205][U+000F][SP]We're[SP]still[SP]not[SP]done\nwith[SP]Scorpio[SP]Temple.[1205][U+000F][SP]Let's[SP]go[SP]grab[SP]the[SP]skull\nfrom[SP]there[SP]first.",
     "nom_fr": "Eikichi",
-    "texte_fr": "M-minute papillon![1205][U+000F] On en a pas encore\nfini avec le Temple de Scorpio.[1205][U+000F]\nRécupérons le crâne là-bas d'abord."
+    "texte_fr": "M-minute papillon![1205][U+000F] On en a pas encore\nfini avec le Temple de Scorpio.[1205][U+000F] Récupérons\nle crâne là-bas d'abord."
   },
   {
     "id": 179,
@@ -2808,6 +2808,6 @@
     "nom_orig": "Jun",
     "texte_orig": "Hold[SP]on[SP]a[SP]moment.[SP]We're[SP]still[SP]not[SP]done[SP]with\nthe[SP]Aquarius[SP]Temple.",
     "nom_fr": "Jun",
-    "texte_fr": "Un instant. Nous n'avons pas\nterminé le Temple d'Aquarius."
+    "texte_fr": "Un instant. Nous n'avons pas terminé le\nTemple d'Aquarius."
   }
 ]

--- a/traduction/MMAP05.json
+++ b/traduction/MMAP05.json
@@ -12,7 +12,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Is[SP]the[SP]Exalted[SP]One[SP]up[SP]there?[1205][U+000F][SP]I[SP]hear[SP]gunshots\nand[SP]yells[SP]from[SP]the[SP]summit...[1205][0014][SP]The[SP]battle[SP]must\nbe[SP]raging[SP]on.",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "L'Exalté est là-haut?[1205][U+000F] J'entends des coups\nde feu du sommet...[1205][0014] La bataille fait rage."
+    "texte_fr": "L'Exalté est là-haut ?[1205][U+000F] J'entends\ndes coups de feu du sommet...[1205][0014]\nLa bataille fait rage."
   },
   {
     "id": 1,
@@ -28,7 +28,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "But[SP]those[SP]soldiers[SP]are[SP]guarding[SP]the[SP]mountain\npath[SP]and[SP]no[SP]one[SP]can[SP]get[SP]through.[1205][U+000F][SP]They've[SP]even\ntaken[SP]over[SP]the[SP]cable[SP]car![1205][U+000A][SP]What[SP]should[SP]we[SP]do!?",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Ces soldats gardent le chemin de montagne[1205][U+000F] et\npersonne ne peut passer.[1205][U+000A] Ils ont même pris\nle téléphérique![1205][U+000A] Qu'est-ce qu'on fait!?"
+    "texte_fr": "Ces soldats gardent le chemin de montagne[1205][U+000F]\net personne ne peut passer.[1205][U+000A] Ils ont même\npris le téléphérique ![1205][U+000A] Qu'est-ce qu'on fait !?"
   },
   {
     "id": 2,
@@ -43,7 +43,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Hey![SP]Did[SP]you[SP]see[SP]those[SP]meteors?[1205][U+000F][SP]Those[SP]were[SP]the\nLeonids...[1205][U+000A][SP]The[SP]lion's[SP]roar![1205][U+000A][SP]Hahaha,[SP]another\nstep[SP]in[SP]the[SP]Oracle[SP]fulfilled!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Hé! Ces météores?[1205][U+000F] C'était les\nLéonides...[1205][U+000A] Rugissement du lion!\n[1205][U+000A]Hahaha, encore une étape de l'Oracle!"
+    "texte_fr": "Hé ! Ces météores ?[1205][U+000F] C'était\nles Léonides...[1205][U+000A] Rugissement du lion !\n[1205][U+000A]Hahaha, encore une étape de l'Oracle !"
   },
   {
     "id": 3,
@@ -59,7 +59,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "The[SP]Exalted[SP]One[SP]still[SP]lives![1205][U+000A][SP]We[SP]will[SP]evolve\ninto[SP]Idealians,[SP]just[SP]as[SP]the[SP]In[SP]Lak'ech[SP]has\nforetold!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "L'Exalté vit encore![1205][U+000A] Nous évoluerons en\nIdéaliens, comme l'In Lak'ech l'a prédit!"
+    "texte_fr": "L'Exalté vit encore ![1205][U+000A] Nous évoluerons\nen Idéaliens, comme l'In Lak'ech\nl'a prédit !"
   },
   {
     "id": 4,
@@ -74,7 +74,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Walking[SP]along,[SP]checking[SP]out[SP]the[SP]scenery...[1205][U+000F]\nMountain[SP]climbing[SP]like[SP]usual,[SP]heigh-ho...\nHm?[SP]Aaaaaaaaaaaah!",
     "nom_fr": "Randonneur",
-    "texte_fr": "Je me promenais admirant le\npaysage...[1205][U+000F] Je grimpais comme d'hab,\ntra-la-la... Hm? Aaaaaaaaaaaah!"
+    "texte_fr": "Je me promenais admirant le paysage...[1205][U+000F]\nJe grimpais comme d'hab, tra-la-la...\nHm ? Aaaaaaaaaaaah !"
   },
   {
     "id": 5,
@@ -89,7 +89,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "...Bam,[SP]just[SP]like[SP]that.[SP]Suddenly[SP]these[SP]soldiers\nwith[SP]scary[SP]weapons[SP]came[SP]up[SP]the[SP]mountain[SP]and[SP]I\nbarely[SP]got[SP]back[SP]down[SP]here[SP]with[SP]my[SP]life.",
     "nom_fr": "Randonneur",
-    "texte_fr": "... Et d'un coup. Des soldats armés\njusqu'aux dents ont grimpé la montagne\net je me suis à peine sorti vivant."
+    "texte_fr": "...Et d'un coup. Des soldats armés jusqu'aux\ndents ont grimpé la montagne et je me\nsuis à peine sorti vivant."
   },
   {
     "id": 6,
@@ -105,7 +105,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Geez,[SP]and[SP]I[SP]was[SP]having[SP]a[SP]nice[SP]hike[SP]before[SP]those\nguys[SP]showed[SP]up![SP]What's[SP]their[SP]problem!?",
     "nom_fr": "Randonneur",
-    "texte_fr": "Pfff, j'avais une belle rando avant\nça! C'est quoi leur problème!?"
+    "texte_fr": "Pfff, j'avais une belle rando avant ça !\nC'est quoi leur problème !?"
   },
   {
     "id": 7,
@@ -120,7 +120,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Oh![1205][U+0008][SP]I[SP]almost[SP]forgot[SP]the[SP]important[SP]part.[1205][U+000A][SP]The\nwhole[SP]reason[SP]I[SP]was[SP]hiking[SP]on[SP]Mt.[SP]Katatsumuri!",
     "nom_fr": "Randonneur",
-    "texte_fr": "Oh![1205][U+0008] J'avais presque oublié l'essentiel.[1205][U+000A]\nMon vrai but sur le Mont Katatsumuri!"
+    "texte_fr": "Oh ![1205][U+0008] J'avais presque oublié l'essentiel.[1205][U+000A]\nMon vrai but sur le Mont Katatsumuri !"
   },
   {
     "id": 8,
@@ -135,7 +135,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Huh?[1205][U+000A][SP]You[SP]really[SP]want[SP]to[SP]know?",
     "nom_fr": "Randonneur",
-    "texte_fr": "Hein?[1205][U+000A] Vraiment?"
+    "texte_fr": "Hein ?[1205][U+000A] Vraiment ?"
   },
   {
     "id": 9,
@@ -150,7 +150,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "The[SP][E4][NULL][NULL][U+0006]Jumping[SP]Geezer[E4][NULL][NULL][0002],[SP]man![1205][U+000A][SP]The[SP]Jumping[SP]Geezer![1205][U+000A]\nI[SP]saw[SP]an[SP]old[SP]man[SP]hopping[SP]from[SP]branch[SP]to[SP]branch\nlast[SP]time[SP]I[SP]was[SP]here.[1205][U+000A][SP]No[SP]kidding![1205][U+000A]",
     "nom_fr": "Randonneur",
-    "texte_fr": "Le [E4][NULL][NULL][U+0006]Vieux Sauteur[E4][NULL][NULL][0002], c'est lui![1205][U+000A] Le Vieux\nSauteur![1205][U+000A] J'ai vu un vieux sauter de\nbranche en branche l'autre fois. Sérieux![1205][U+000A]"
+    "texte_fr": "Le [E4][NULL][NULL][U+0006]Vieux Sauteur[E4][NULL][NULL][0002], c'est lui ![1205][U+000A]\nLe Vieux Sauteur ![1205][U+000A] J'ai vu un vieux sauter\nde branche en branche l'autre fois. Sérieux ![1205][U+000A]"
   },
   {
     "id": 10,
@@ -165,7 +165,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "The[SP]only[SP]guy[SP]that[SP]old[SP]who[SP]could[SP]do[SP]that[SP]would\nbe[SP]the[SP]real[SP]Jumping[SP]Geezer,[SP]right?[1205][U+000F][SP]I[SP]couldn't\nbelieve[SP]my[SP]luck,[SP]seeing[SP]him[SP]in[SP]person.",
     "nom_fr": "Randonneur",
-    "texte_fr": "Un gars aussi vieux qui fait ça,\nseul le vrai Vieux Sauteur le peut![1205][U+000F]\nJ'arrive pas à croire ma chance!"
+    "texte_fr": "Un gars aussi vieux qui fait ça, seul\nle vrai Vieux Sauteur le peut ![1205][U+000F]\nJ'arrive pas à croire ma chance !"
   },
   {
     "id": 11,
@@ -180,7 +180,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "That's[SP]why[SP]I[SP]wanted[SP]to[SP]get[SP]some[SP]photographic\nevidence,[SP]and[SP]maybe[SP]a[SP]commemorative[SP]picture\nfor[SP]myself.",
     "nom_fr": "Randonneur",
-    "texte_fr": "Voilà pourquoi je voulais une preuve\nphotographique, et peut-être une photo pour\nmoi."
+    "texte_fr": "Voilà pourquoi je voulais une preuve\nphotographique, et peut-être une photo\npour moi."
   },
   {
     "id": 12,
@@ -211,7 +211,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Hey,[SP]could[SP]you[SP]get[SP]some[SP]kind[SP]of[SP]evidence[SP]or\nproof[SP]for[SP]me[SP]that[SP]Jumping[SP]Geezer[SP]exists?[1205][U+000F][SP]I'll\ngive[SP]you[SP]a[SP]proper[SP]reward![1205][U+000F][SP]Pleeeeeease!",
     "nom_fr": "Randonneur",
-    "texte_fr": "Hé, vous pourriez me rapporter une preuve[1205][U+000F]\nque le Vieux Sauteur existe?[1205][U+000F] Je vous\ndonne une récompense! S'il vous plaîîît!"
+    "texte_fr": "Hé, vous pourriez me rapporter une preuve[1205][U+000F]\nque le Vieux Sauteur existe ?[1205][U+000F]\nJe vous donne une récompense ! S'il vous plaîîît !"
   },
   {
     "id": 14,
@@ -227,7 +227,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Jumping[SP]Geezer[SP]is[SP]somewhere[SP]in[SP]Mt.[SP]Katatsumuri.[1205][U+000F]\nBring[SP]back[SP]some[SP]proof[SP]he[SP]exists![1205][U+000F][SP]I'll[SP]give[SP]you\na[SP]proper[SP]reward,[SP]so[SP]pleeeeeease!",
     "nom_fr": "Randonneur",
-    "texte_fr": "Le Vieux Sauteur est sur le Mont\nKatatsumuri.[1205][U+000F] Ramenez-moi une preuve![1205][U+000F]\nJe vous récompense, s'il vous plaîîît!"
+    "texte_fr": "Le Vieux Sauteur est sur le Mont\nKatatsumuri.[1205][U+000F] Ramenez-moi une preuve ![1205][U+000F]\nJe vous récompense, s'il vous plaîîît !"
   },
   {
     "id": 15,
@@ -242,7 +242,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Wait[SP]a[SP]second...[1205][U+000F][SP]Are[SP]those[SP]the[SP][E4][NULL][NULL][U+0006]Jumping[SP]Geta[E4][NULL][NULL][0002]\nthat[SP]the[SP]Jumping[SP]Geezer[SP]wore?",
     "nom_fr": "Randonneur",
-    "texte_fr": "Attendez...[1205][U+000F] Ce sont les [E4][NULL][NULL][U+0006]Geta\nSauteurs[E4][NULL][NULL][0002] du Vieux Sauteur?"
+    "texte_fr": "Attendez...[1205][U+000F] Ce sont les [E4][NULL][NULL][U+0006]Geta Sauteurs[E4][NULL][NULL][0002]\ndu Vieux Sauteur ?"
   },
   {
     "id": 16,
@@ -257,7 +257,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Ooooooh![1205][U+000F][SP]You[SP]really[SP]got[SP]them[SP]for[SP]me!?[1205][U+000F][SP]Ahhhh,\nthis[SP]is[SP]even[SP]better[SP]than[SP]a[SP]photo![1205][U+000F][SP]Thank[SP]you!\nOh,[SP]this[SP]is[SP]so[SP]great!",
     "nom_fr": "Randonneur",
-    "texte_fr": "Ooooooh![1205][U+000F] Vous les avez eus!?[1205][U+000F]\nAhhhh, c'est encore mieux qu'une\nphoto![1205][U+000F] Merci! Oh, c'est trop bien!"
+    "texte_fr": "Ooooooh ![1205][U+000F] Vous les avez eus !?[1205][U+000F]\nAhhhh, c'est encore mieux qu'une photo ![1205][U+000F]\nMerci ! Oh, c'est trop bien !"
   },
   {
     "id": 17,
@@ -273,7 +273,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Here,[SP]have[SP]a[SP]little[SP]something[SP]for[SP]your[SP]trouble.\nIt's[SP]a[SP][E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Holylight[SP]Card[E4][NULL][NULL][0002].[SP]I[SP]want[SP]you[SP]to[SP]have[SP]it!",
     "nom_fr": "Randonneur",
-    "texte_fr": "Tenez, voici quelque chose pour vous.\nC'est une [E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Carte Lumière[E4][NULL][NULL][0002]. Je vous l'offre!"
+    "texte_fr": "Tenez, voici quelque chose pour vous.\nC'est une [E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Carte Lumière[E4][NULL][NULL][0002]. Je vous l'offre !"
   },
   {
     "id": 18,
@@ -289,7 +289,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Heheheh,[SP]so[SP]these[SP]are[SP]the[SP]Jumping[SP]Geta...[1205][U+000F]\nCan[SP]I[SP]move[SP]as[SP]fast[SP]as[SP]that[SP]old[SP]man[SP]with[SP]these\non?[1205][U+000F][SP]Maybe[SP]I[SP]should[SP]give[SP]'em[SP]a[SP]try.",
     "nom_fr": "Randonneur",
-    "texte_fr": "Héhéhé, ce sont les Geta Sauteurs...[1205][U+000F]\nJe peux bouger aussi vite que ce vieux\navec eux?[1205][U+000F] Je devrais les essayer."
+    "texte_fr": "Héhéhé, ce sont les Geta Sauteurs...[1205][U+000F]\nJe peux bouger aussi vite que ce vieux\navec eux ?[1205][U+000F] Je devrais les essayer."
   },
   {
     "id": 19,
@@ -305,7 +305,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yeesh,[SP]the[SP]Last[SP]Battalion's[SP]here[SP]too.[SP]If[SP]we\ntook[SP]the[SP]cable[SP]car,[SP]it'd[SP]be[SP]a[SP]quick[SP]trip[SP]up\nto[SP]the[SP]summit...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Punaise, le Bataillon est là aussi.\nSi on prenait le téléphérique, on\nserait vite au sommet..."
+    "texte_fr": "Punaise, le Bataillon est là aussi. Si on\nprenait le téléphérique, on serait\nvite au sommet..."
   },
   {
     "id": 20,
@@ -321,7 +321,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP][1113],[SP]it[SP]looks[SP]like[SP]we[SP]can[SP]use[SP]this\ncable[SP]car.",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, [U+1113], on peut utiliser ce téléphérique!"
+    "texte_fr": "Hé, [U+1113], on peut utiliser\nce téléphérique !"
   },
   {
     "id": 21,
@@ -337,6 +337,6 @@
     "nom_orig": "Ginko",
     "texte_orig": "Should[SP]we[SP]ride[SP]it?\n[1208][0002]Yes\nNo",
     "nom_fr": "Ginko",
-    "texte_fr": "On le prend?\n[1208][0002]Oui\nNon"
+    "texte_fr": "On le prend ?\n[1208][0002]Oui\nNon"
   }
 ]

--- a/traduction/MMAP06.json
+++ b/traduction/MMAP06.json
@@ -12,7 +12,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "Guess[SP]what?[SP]You've[SP]noticed[SP]how[SP]this[SP]place[SP]is[SP]an\nisland[SP]surrounded[SP]by[SP]the[SP]Tanabata[SP]River,[SP]right?",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Cet endroit est une île dans la Tanabata, non?"
+    "texte_fr": "Cet endroit est une île\n dans la Tanabata, non ?"
   },
   {
     "id": 1,
@@ -28,7 +28,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "I[SP]was[SP]told[SP]it[SP]got[SP]its[SP]name[SP]because[SP]Rengedai\nmeans[SP][1432][NULL][NULL][0014]lotus[SP]flower.[1432][NULL][NULL][0014][SP]In[SP]the[SP]spring,[SP]it[SP]looks\nlike[SP]a[SP]lotus[SP]floating[SP]on[SP]the[SP]water[SP]from[SP]above.",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Rengedai veut dire [1432][NULL][NULL][0014]fleur de lotus.[1432][NULL][NULL][0014] Au\nprintemps, vue d'en haut, on dirait un lotus\nflottant."
+    "texte_fr": "Rengedai veut dire [1432][NULL][NULL][0014]fleur de lotus.[1432][NULL][NULL][0014] Au printemps, vue d'en haut,\n on dirait un lotus flottant."
   },
   {
     "id": 2,
@@ -44,7 +44,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "Have[SP]you[SP]been[SP]to[SP]Honmaru[SP]Park?[SP]It's[SP]very\nbeautiful.[SP]The[SP]perfect[SP]place[SP]for[SP]taking[SP]a[SP]walk.\nI[SP]hear[SP]some[SP]strange[SP]rumors[SP]about[SP]it,[SP]though...",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Tu connais le parc Honmaru? Très\nbeau pour s'y promener. Mais\nd'étranges rumeurs circulent..."
+    "texte_fr": "Tu connais le parc Honmaru ? Très beau pour s'y promener.\n Mais d'étranges rumeurs circulent..."
   },
   {
     "id": 3,
@@ -60,7 +60,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "Do[SP]you[SP]know[SP]the[SP]homeless[SP]man[SP]in[SP]Honmaru[SP]Park?\nI[SP]hear[SP]he[SP]used[SP]to[SP]be[SP]a[SP]college[SP]professor.[1205][U+000F]\nI[SP]wonder[SP]how[SP]he[SP]became[SP]homeless...",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Tu connais le SDF du parc Honmaru? Ancien\nprof. Comment en est-il arrivé là?[1205][U+000F]"
+    "texte_fr": "Tu connais le SDF du parc Honmaru ? Ancien prof.\n Comment en est-il arrivé là ?[1205][U+000F]"
   },
   {
     "id": 4,
@@ -76,7 +76,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "Huh?[1205][U+000A][SP]The[SP]Masked[SP]Circle?[1205][U+000F][SP]Can't[SP]say[SP]I've[SP]ever\nheard[SP]of[SP]them,[SP]no.[SP]Is[SP]there[SP]an[SP]organization[SP]in\nSumaru[SP]by[SP]that[SP]name?",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Hein? Le Cercle Masqué?[1205][U+000A] Jamais entendu parler.\nUne organisation à Sumaru porte ce nom?[1205][U+000F]"
+    "texte_fr": "Hein ? Le Cercle Masqué ?[1205][U+000A] Jamais entendu parler.\n Une organisation à Sumaru porte ce nom ?[1205][U+000F]"
   },
   {
     "id": 5,
@@ -92,7 +92,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "I[SP]haven't[SP]seen[SP]any[SP]Kasugayama[SP]High[SP]students\naround[SP]lately.[1205][U+000F][SP]I[SP]wonder[SP]if[SP]they[SP]all[SP]went[SP]on\na[SP]school[SP]trip...",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Je n'ai vu aucun élève de Kasugayama\nces temps-ci.[1205][U+000F] En voyage scolaire?"
+    "texte_fr": "Je n'ai vu aucun élève de Kasugayama ces temps-ci.[1205][U+000F]\n En voyage scolaire ?"
   },
   {
     "id": 6,
@@ -123,7 +123,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "I[SP]guess[SP]they're[SP]already[SP]having[SP]a[SP]concert[SP]at\nthe[SP]outdoor[SP]concert[SP]hall.",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Elles donnent déjà un concert\nà la salle en plein air."
+    "texte_fr": "Elles donnent déjà un concert\n à la salle en plein air."
   },
   {
     "id": 8,
@@ -139,7 +139,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "I[SP]bet[SP]the[SP]Masked[SP]Circle[SP]are[SP]the[SP]terrorists\nhere.[1205][U+000F][SP]No[SP]sane[SP]man[SP]would[SP]do[SP]these[SP]things...\nSo[SP]the[SP]Masked[SP]Circle[SP]was[SP]sinister[SP]after[SP]all.",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "C'est sûrement le Cercle Masqué les\nterroristes.[1205][U+000F] Aucun sain d'esprit ne\nferait ça... Donc ils étaient sinistres."
+    "texte_fr": "C'est sûrement le Cercle Masqué les terroristes.[1205][U+000F]\n Aucun sain d'esprit ne ferait ça...\n Donc ils étaient sinistres."
   },
   {
     "id": 9,
@@ -155,7 +155,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "They[SP]posted[SP]the[SP]composite[SP]sketches[SP]of[SP]those\nterrorists,[SP]so[SP]I[SP]went[SP]to[SP]see[SP]for[SP]myself.[1205][U+000F][SP]All[SP]five\nof[SP]them[SP]were[SP]the[SP]scariest-looking[SP]people...",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Les portraits-robots des terroristes\nsont affichés, je suis allée voir.[1205][U+000F]\nLes cinq avaient l'air terrifiant..."
+    "texte_fr": "Les portraits-robots des terroristes sont affichés, je suis allée voir.[1205][U+000F]\n Les cinq avaient l'air terrifiant..."
   },
   {
     "id": 10,
@@ -170,7 +170,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "I[SP]spoke[SP]with[SP]the[SP]woman[SP]next[SP]door,[SP]and[SP]we[SP]think\nthe[SP]things[SP]in[SP]that[SP]In[SP]Lak'ech[SP]are[SP]all[SP]true.",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Avec la voisine, on pense que\ntout l'In Lak'ech est vrai."
+    "texte_fr": "Avec la voisine, on pense que tout l'In Lak'ech est vrai."
   },
   {
     "id": 11,
@@ -186,7 +186,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "I[SP]mean,[SP]everything[SP]that's[SP]happened[SP]up[SP]to[SP]now\nwas[SP]foretold[SP]in[SP]it,[SP]right?[1205][U+000F][SP]They[SP]said[SP]so[SP]on[SP]the\nnews.[SP]That[SP]can't[SP]be[SP]coincidence.",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Tout ce qui est arrivé était prédit, non?[1205][U+000F] Ils\nl'ont dit aux infos. Pas une coïncidence."
+    "texte_fr": "Tout ce qui est arrivé était prédit, non ?[1205][U+000F]\n Ils l'ont dit aux infos. Pas une coïncidence."
   },
   {
     "id": 12,
@@ -201,7 +201,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "I-I[SP]almost[SP]got[SP]attacked[SP]by[SP]those[SP]soldiers[SP]just\nnow...[1205][U+000F][SP]It[SP]was[SP]terrifying...[1205][U+000F]",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "J'ai failli me faire attaquer\npar ces soldats...[1205][U+000F] Terrible..."
+    "texte_fr": "J'ai failli me faire attaquer par ces soldats...[1205][U+000F]\n Terrible..."
   },
   {
     "id": 13,
@@ -216,7 +216,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "B-But[SP]then[SP]one[SP]of[SP]the[SP]Masked[SP]Circle[SP]saved[SP]me![1205][U+000F]\nWhat's[SP]going[SP]on[SP]here?",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Un membre du Cercle Masqué m'a\nsauvée![1205][U+000F] Que se passe-t-il?"
+    "texte_fr": "Un membre du Cercle Masqué m'a sauvée ![1205][U+000F]\n Que se passe-t-il ?"
   },
   {
     "id": 14,
@@ -247,7 +247,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "Hey![1205][U+000F][SP]S-Some[SP]of[SP]those[SP]Masked[SP]Circle[SP]people\nsaw[SP]the[SP]shooting[SP]stars[SP]and[SP]said,[SP][1432][NULL][NULL][0014]It's[SP]the\nlion's[SP]roar![1432][NULL][NULL][0014][1205][U+000F]",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Hé! Des gens du Cercle Masqué ont\ndit: [1432][NULL][NULL][0014]C'est le rugissement du lion![1432][NULL][NULL][0014][1205][U+000F]"
+    "texte_fr": "Hé ! Des gens du Cercle Masqué ont dit : [1432][NULL][NULL][0014]C'est le rugissement du lion ![1432][NULL][NULL][0014][1205][U+000F]"
   },
   {
     "id": 16,
@@ -263,7 +263,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "That's[SP]another[SP]line[SP]from[SP]that[SP]Oracle,[SP]right?\nI[SP]knew[SP]it...[SP]The[SP]In[SP]Lak'ech[SP]is[SP]true[SP]after[SP]all!",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "C'est encore une phrase de l'Oracle,\nnon? L'In Lak'ech est donc vrai!"
+    "texte_fr": "C'est encore une phrase de l'Oracle, non ?\n L'In Lak'ech est donc vrai !"
   },
   {
     "id": 17,
@@ -279,7 +279,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "Have[SP]you[SP]been[SP]to[SP]Honmaru[SP]Park[SP]already?[1205][U+000A][SP]They're\nhaving[SP]a[SP]gathering[SP]to[SP]evolve[SP]into[SP]Idealians\nright[SP]now!",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Tu es allé au parc Honmaru?[1205][U+000A] Ils se rassemblent\npour devenir Idéaliens là maintenant!"
+    "texte_fr": "Tu es allé au parc Honmaru ?[1205][U+000A] Ils se rassemblent\n pour devenir Idéaliens là maintenant !"
   },
   {
     "id": 18,
@@ -294,7 +294,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "H-Hey![1205][U+000A][SP]You're[SP]a[SP]Sevens[SP]student,[SP]right?[1205][U+000A][SP]What's\nthat[SP]light[SP]coming[SP]out[SP]from[SP]your[SP]school?",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Hé! Tu es de Seven?[1205][U+000A] C'est quoi cette\nlumière qui sort de ton école?"
+    "texte_fr": "Hé ! Tu es de Seven ?[1205][U+000A] C'est quoi cette lumière\n qui sort de ton école ?"
   },
   {
     "id": 19,
@@ -310,7 +310,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "Is[SP]the[SP]evolution[SP]starting[SP]already?[1205][U+000A][SP]Oh,[SP]no!\nI'm[SP]not[SP]ready[SP]for[SP]it[SP]yet!",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "L'évolution a déjà commencé?[1205][U+000A]\nOh non, je ne suis pas prête!"
+    "texte_fr": "L'évolution a déjà commencé ?[1205][U+000A] Oh non,\n je ne suis pas prête !"
   },
   {
     "id": 20,
@@ -326,7 +326,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "*sigh*[1205][U+0008][SP]I[SP]wish[SP]they'd[SP]get[SP]this[SP]evolution[SP]thing\nover[SP]with...[1205][U+000A][SP]I[SP]feel[SP]like[SP]the[SP]excitement[SP]has\npassed[SP]and[SP]I'm[SP]losing[SP]interest.",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "*soupir*[1205][U+0008] J'aimerais en finir avec\ncette évolution...[1205][U+000A] L'excitation est\nretombée, ça ne m'intéresse plus."
+    "texte_fr": "*soupir*[1205][U+0008] J'aimerais en finir avec cette évolution...[1205][U+000A]\n L'excitation est retombée, ça ne m'intéresse plus."
   },
   {
     "id": 21,
@@ -342,7 +342,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Oh,[SP]don't[SP]you[SP]go[SP]to[SP]Sevens?[SP]Did[SP]something\nhappen[SP]at[SP]your[SP]school?[SP]It[SP]sounded[SP]like[SP]there\nwas[SP]some[SP]commotion[SP]on[SP]the[SP]school[SP]grounds.",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Oh, tu vas à Seven? Il s'est passé\nquelque chose dans ton école? On a\nentendu du bruit dans la cour."
+    "texte_fr": "Oh, tu vas à Seven ? Il s'est passé quelque chose dans ton école ?\n On a entendu du bruit dans la cour."
   },
   {
     "id": 22,
@@ -358,7 +358,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "My[SP]colleagues[SP]have[SP]been[SP]pretty[SP]distant[SP]lately.\nThey[SP]keep[SP]leaving[SP]before[SP]me[SP]because[SP]they[SP]have\nsome[SP]meeting[SP]to[SP]attend.[1205][U+000F][SP]Are[SP]they[SP]in[SP]some[SP]union?",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Mes collègues sont distants. Ils partent avant\nmoi pour une réunion.[1205][U+000F] Sont-ils syndiqués?"
+    "texte_fr": "Mes collègues sont distants. Ils partent avant moi pour une réunion.[1205][U+000F]\n Sont-ils syndiqués ?"
   },
   {
     "id": 23,
@@ -373,7 +373,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Wow,[SP]Kasugayama[SP]High's[SP]festival[SP]is[SP]the[SP]talk[SP]of\nthe[SP]town[SP]over[SP]in[SP]Hirasaka.",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "La fête de Kasugayama fait\njaser dans tout Hirasaka."
+    "texte_fr": "La fête de Kasugayama fait jaser\n dans tout Hirasaka."
   },
   {
     "id": 24,
@@ -389,7 +389,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "I'm[SP]sure[SP]the[SP]people[SP]who[SP]live[SP]there[SP]must[SP]be[SP]glad\nthe[SP]local[SP]school's[SP]on[SP]the[SP]rise[SP]in[SP]popularity.",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Les habitants sont contents que\nl'école du coin gagne en popularité."
+    "texte_fr": "Les habitants sont contents que l'école du coin\n gagne en popularité."
   },
   {
     "id": 25,
@@ -405,7 +405,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Do[SP]you[SP]know[SP]who[SP]the[SP]third[SP]member[SP]of[SP]Muses[SP]is?[1205][U+000F]\nShe's[SP]apparently[SP]a[SP]Sevens[SP]student[SP]like[SP]you.[SP]If\nyou[SP]know[SP]her,[SP]would[SP]you[SP]mind[SP]introducing[SP]me?",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Tu sais qui est le troisième membre\nde Muses?[1205][U+000F] Une élève de Seven comme\ntoi. Tu pourrais me la présenter?"
+    "texte_fr": "Tu sais qui est le troisième membre de Muses ?[1205][U+000F]\n Une élève de Seven comme toi. Tu pourrais me la présenter ?"
   },
   {
     "id": 26,
@@ -421,7 +421,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "They're[SP]going[SP]to[SP]announce[SP]the[SP]third[SP]member[SP]of\nMuses[SP]at[SP]the[SP]live[SP]recording[SP]at[SP]Giga[SP]Macho.[1205][U+000F]\nI[SP]wonder[SP]what[SP]she's[SP]like.[SP]I[SP]can't[SP]wait!",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Ils annoncent le 3e membre de Muses\nau live de Giga Macho.[1205][U+000F] J'ai hâte de\nvoir à quoi elle ressemble!"
+    "texte_fr": "Ils annoncent le 3e membre de Muses au live de Giga Macho.[1205][U+000F]\n J'ai hâte de voir à quoi elle ressemble !"
   },
   {
     "id": 27,
@@ -436,7 +436,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "So[SP]the[SP]third[SP]member's[SP]fluent[SP]in[SP]English...[1205][U+000F]\nI[SP]see...",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "La 3e parle anglais couramment...[1205][U+000F] Je vois..."
+    "texte_fr": "La 3e parle anglais couramment...[1205][U+000F]\n Je vois..."
   },
   {
     "id": 28,
@@ -452,7 +452,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "A[SP]bilingual[SP]idol,[SP]eh?[1205][U+000F][SP]I[SP]like[SP]that.[SP]It[SP]has\na[SP]nice[SP]intellectual[SP]air[SP]to[SP]it.[SP]I'm[SP]looking\nforward[SP]to[SP]hearing[SP]her[SP]solo.",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Une idole bilingue?[1205][U+000F] J'aime ça. Ça fait\nintellectuel. J'ai hâte d'entendre son solo."
+    "texte_fr": "Une idole bilingue ?[1205][U+000F] J'aime ça. Ça fait intellectuel.\n J'ai hâte d'entendre son solo."
   },
   {
     "id": 29,
@@ -468,7 +468,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Fortunately,[SP]there[SP]were[SP]no[SP]casualties[SP]in[SP]the\nconcert[SP]hall[SP]fire.[1205][U+000F][SP]But[SP]whose[SP]concert[SP]was\nit?[SP]I[SP]can't[SP]really[SP]remember...",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Heureusement, pas de victimes dans\nl'incendie.[1205][U+000F] C'était le concert de\nqui? Je ne me souviens pas."
+    "texte_fr": "Heureusement, pas de victimes dans l'incendie.[1205][U+000F]\n C'était le concert de qui ? Je ne me souviens pas."
   },
   {
     "id": 30,
@@ -484,7 +484,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Wasn't[SP]that[SP]one[SP]of[SP]the[SP]teachers[SP]at[SP]Sevens...?[1205][U+000F]\nShe[SP]had[SP]this[SP]crazy[SP]expression[SP]and[SP]told[SP]me[SP]that\nthe[SP]terrorists[SP]were[SP]this[SP]Last...[SP]something.",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "C'était une prof de Seven?[1205][U+000F] Elle avait\nl'air folle et m'a dit que les terroristes\nétaient ce... Dernier quelque chose."
+    "texte_fr": "C'était une prof de Seven ?[1205][U+000F] Elle avait l'air folle\n et m'a dit que les terroristes étaient ce... Dernier quelque chose."
   },
   {
     "id": 31,
@@ -500,7 +500,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Some[SP]kids[SP]just[SP]now[SP]said[SP]that[SP]the[SP]five[SP]people[SP]in\nthose[SP]composite[SP]sketches[SP]are[SP]heroes[SP]fighting[SP]the\nMasked[SP]Circle.[1205][U+000F][SP]Now[SP]how[SP]would[SP]they[SP]know[SP]that?",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Des gamins disent que les 5 personnes\ndes portraits sont des héros.[1205][U+000F] Comment\npourraient-ils savoir ça?"
+    "texte_fr": "Des gamins disent que les 5 personnes des portraits sont des héros.[1205][U+000F]\n Comment pourraient-ils savoir ça ?"
   },
   {
     "id": 32,
@@ -516,7 +516,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "The[SP]Last[SP]Battalion[SP]and[SP]the[SP]Masked[SP]Circle[SP]are\nfighting[SP]over[SP]the[SP]secret[SP]treasure[SP]of[SP]Sumaru\nCity.[SP]It's[SP]all[SP]in[SP]the[SP]In[SP]Lak'ech.",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Le Dernier Bataillon et le Cercle\nMasqué se battent pour le trésor secret\nde Sumaru. Tout est dans l'In Lak'ech."
+    "texte_fr": "Le Dernier Bataillon et le Cercle Masqué se battent\n pour le trésor secret de Sumaru. Tout est dans l'In Lak'ech."
   },
   {
     "id": 33,
@@ -532,7 +532,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "D-Did[SP]you[SP]see[SP]the[SP]size[SP]of[SP]that[SP]air[SP]fleet?\nThere[SP]were[SP]20[SP]of[SP]them,[SP]easy![1205][U+000F][SP]Th-They've[SP]come\nto[SP]steal[SP]Sumaru's[SP]hidden[SP]treasure!",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "T'as vu cette flotte aérienne? 20\nappareils, facile![1205][U+000F] Ils sont venus\nvoler le trésor caché de Sumaru!"
+    "texte_fr": "T'as vu cette flotte aérienne ? 20 appareils, facile ![1205][U+000F]\n Ils sont venus voler le trésor caché de Sumaru !"
   },
   {
     "id": 34,
@@ -547,7 +547,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "These[SP]weird[SP]temples[SP]showed[SP]up[SP]in[SP]the[SP]other\nwards,[SP]right?[1205][U+000A][SP]The[SP]Masked[SP]Circle[SP]and[SP]Last\nBattalion[SP]were[SP]going[SP]in[SP]to[SP]fight[SP]each[SP]other!",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Ces étranges temples sont apparus ailleurs,\nnon?[1205][U+000A] Le Cercle Masqué et le Dernier\nBataillon y entraient pour se battre!"
+    "texte_fr": "Ces étranges temples sont apparus ailleurs, non ?[1205][U+000A]\n Le Cercle Masqué et le Dernier Bataillon y entraient pour se battre !"
   },
   {
     "id": 35,
@@ -563,7 +563,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "But...[SP]why[SP]didn't[SP]one[SP]of[SP]those[SP]temples[SP]appear\nhere,[SP]too?[1205][U+000F][SP]It[SP]makes[SP]me[SP]sort[SP]of[SP]nervous...",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Mais pourquoi aucun temple n'est\napparu ici?[1205][U+000F] Ça m'inquiète..."
+    "texte_fr": "Mais pourquoi aucun temple n'est apparu ici ?[1205][U+000F]\n Ça m'inquiète..."
   },
   {
     "id": 36,
@@ -579,7 +579,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "You're[SP]safe?[1205][U+000A][SP]I'd[SP]heard[SP]the[SP]Last[SP]Battalion\ncaptured[SP]all[SP]the[SP]Sevens[SP]students.[1205][U+000F][SP]Did[SP]you\nmanage[SP]to[SP]escape?",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Tu es sain et sauf?[1205][U+000A] Les élèves de Seven\nont été capturés.[1205][U+000F] Tu t'es échappé?"
+    "texte_fr": "Tu es sain et sauf ?[1205][U+000A] Les élèves de Seven ont été capturés.[1205][U+000F]\n Tu t'es échappé ?"
   },
   {
     "id": 37,
@@ -595,7 +595,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "I[SP]hear[SP]the[SP]students[SP]at[SP]Sevens[SP]got[SP]rescued.[1205][U+000A]\nI[SP]don't[SP]know[SP]who[SP]pulled[SP]that[SP]off,[SP]but[SP]they're\nsome[SP]damn[SP]brave[SP]people,[SP]whoever[SP]they[SP]are.",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "J'entends que les élèves de Seven ont\nété secourus.[1205][U+000A] Je ne sais pas qui a fait\nça, mais ce sont des gens courageux."
+    "texte_fr": "J'entends que les élèves de Seven ont été secourus.[1205][U+000A]\n Je ne sais pas qui a fait ça, mais ce sont des gens courageux."
   },
   {
     "id": 38,
@@ -611,7 +611,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Um,[SP]I[SP]hear[SP]a[SP]ramen[SP]shop[SP]sells[SP]guns[SP]and[SP]swords\nand[SP]stuff.[SP]I[SP]wonder[SP]if[SP]they[SP]have[SP]a[SP]really\ncool[SP]sword.[E1][E2]\n[E3][E4][NULL][NULL]\"Boy\nDid[SP]the[SP]boys[SP]at[SP]Cuss[SP]High[SP]get[SP]cooler?[1205][U+000F][SP]That's\nwhat[SP]my[SP]sister[SP]said.[SP]How[SP]do[SP]they[SP]do[SP]that?\nDo[SP]they[SP]transform?",
     "nom_fr": "Garçon",
-    "texte_fr": "Un resto de ramen vend des flingues et\ndes épées. Ils ont une épée super cool?[E1][E2]\n[E3][E4][NULL][NULL]\"Garçon Les garçons du lycée Cuss sont\nplus cools?[1205][U+000F] C'est ce que ma sœur a dit.\nComment ils font? Ils se transforment?"
+    "texte_fr": "Un resto de ramen vend des flingues et des épées.\n Ils ont une épée super cool ?[E1][E2]\n[E3][E4][NULL][NULL]\"Garçon\nLes garçons du lycée Cuss sont plus cools ?[1205][U+000F]\n C'est ce que ma sœur a dit. Comment ils font ?\n Ils se transforment ?"
   },
   {
     "id": 39,
@@ -627,7 +627,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Waaaaah![1205][U+000F][SP]I[SP]wanted[SP]to[SP]go[SP]to[SP]Kasuga[SP]Festival!\nMy[SP]sister[SP]said[SP]kids[SP]can't[SP]go.[1205][U+000F][SP]It's[SP]not[SP]faaaair!",
     "nom_fr": "Garçon",
-    "texte_fr": "Waaaaah![1205][U+000F] Je voulais aller au festival Kasuga!\nLes enfants ne peuvent pas.[1205][U+000F] Pas juste!"
+    "texte_fr": "Waaaaah ![1205][U+000F] Je voulais aller au festival Kasuga !\n Les enfants ne peuvent pas.[1205][U+000F] Pas juste !"
   },
   {
     "id": 40,
@@ -658,7 +658,7 @@
     "nom_orig": "Boy",
     "texte_orig": "My[SP]sister[SP]didn't[SP]come[SP]home[SP]after[SP]the[SP]Kasuga\nFestival...[SP]What's[SP]wrong[SP]with[SP]her?",
     "nom_fr": "Garçon",
-    "texte_fr": "Ma sœur n'est pas rentrée après le\nfestival... Qu'est-ce qu'elle a?"
+    "texte_fr": "Ma sœur n'est pas rentrée après le festival...\n Qu'est-ce qu'elle a ?"
   },
   {
     "id": 42,
@@ -674,7 +674,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Oh[SP]well.[SP]I[SP]wonder[SP]what's[SP]for[SP]dinner.",
     "nom_fr": "Garçon",
-    "texte_fr": "Tant pis. Quoi manger?"
+    "texte_fr": "Tant pis. Quoi manger ?"
   },
   {
     "id": 43,
@@ -689,7 +689,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Mommy[SP]said[SP]I[SP]shouldn't[SP]go[SP]outside.[SP]She[SP]says\nit's[SP]dangerous.",
     "nom_fr": "Garçon",
-    "texte_fr": "Maman dit de ne pas sortir. C'est dangereux."
+    "texte_fr": "Maman dit de ne pas sortir.\n C'est dangereux."
   },
   {
     "id": 44,
@@ -705,7 +705,7 @@
     "nom_orig": "Boy",
     "texte_orig": "But[SP]I[SP]think[SP]I[SP]was[SP]waiting[SP]for[SP]someone[SP]here.[1205][U+000F]\nI[SP]can't[SP]remember[SP]who[SP]though.",
     "nom_fr": "Garçon",
-    "texte_fr": "Je crois que j'attendais quelqu'un\nici.[1205][U+000F] Je ne me souviens plus qui."
+    "texte_fr": "Je crois que j'attendais quelqu'un ici.[1205][U+000F]\n Je ne me souviens plus qui."
   },
   {
     "id": 45,
@@ -721,7 +721,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Hey[SP]Mister?[SP]What's[SP]a[SP]Last[SP]Battalion?[SP]Are[SP]they\nbad[SP]guys[SP]like[SP]the[SP]Masked[SP]Circle?",
     "nom_fr": "Garçon",
-    "texte_fr": "C'est quoi le Dernier Bataillon? Des\nméchants comme le Cercle Masqué?"
+    "texte_fr": "C'est quoi le Dernier Bataillon ?\n Des méchants comme le Cercle Masqué ?"
   },
   {
     "id": 46,
@@ -737,7 +737,7 @@
     "nom_orig": "Boy",
     "texte_orig": "The[SP]people[SP]in[SP]the[SP]drawings[SP]are[SP]heroes[SP]and\nthey[SP]fight[SP]the[SP]Masked[SP]Circle.[1205][U+000F][SP]My[SP]friend\ntold[SP]me.",
     "nom_fr": "Garçon",
-    "texte_fr": "Les dessins montrent des héros combattant\nle Cercle Masqué.[1205][U+000F] Mon ami l'a dit."
+    "texte_fr": "Les dessins montrent des héros combattant le Cercle Masqué.[1205][U+000F]\n Mon ami l'a dit."
   },
   {
     "id": 47,
@@ -753,7 +753,7 @@
     "nom_orig": "Boy",
     "texte_orig": "What's[SP]Xibalba[SP]like?[1205][U+000F][SP]Does[SP]it[SP]combine[SP]with\nstuff[SP]and[SP]transform?",
     "nom_fr": "Garçon",
-    "texte_fr": "C'est quoi Xibalba?[1205][U+000F] Ça se\ncombine et ça se transforme?"
+    "texte_fr": "C'est quoi Xibalba ?[1205][U+000F]\n Ça se combine et ça se transforme ?"
   },
   {
     "id": 48,
@@ -769,7 +769,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Waaaaaah![SP]Waaaaaah![1205][U+000F][SP]I'm[SP]scaaaared![SP]Mommy!\nSister!",
     "nom_fr": "Garçon",
-    "texte_fr": "Waaaaaah! J'ai peur! Maman! Ma sœur!"
+    "texte_fr": "Waaaaaah ! J'ai peur !\n Maman ! Ma sœur !"
   },
   {
     "id": 49,
@@ -784,7 +784,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Woooow...[SP]The[SP]city's[SP]flying![1205][U+000A][SP]But[SP]the[SP]Earth[SP]is\ngonna[SP]get[SP]uh-nye-a-lated[SP]after[SP]the[SP]Grand[SP]Cross.",
     "nom_fr": "Garçon",
-    "texte_fr": "Woooow... La ville vole![1205][U+000A] Mais la Terre\nva être anéantie après la Grande Croix."
+    "texte_fr": "Woooow... La ville vole ![1205][U+000A] Mais la Terre va être anéantie\n après la Grande Croix."
   },
   {
     "id": 50,
@@ -815,7 +815,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Um,[SP]so,[SP]I[SP]heard[SP]the[SP]Earth's[SP]gonna[SP]split[SP]open\nafter[SP]the[SP]Grand[SP]Cross.[1205][U+000A][SP]That's[SP]how[SP]it[SP]gets\nuh-nye-a-lated.",
     "nom_fr": "Garçon",
-    "texte_fr": "J'ai entendu que la Terre va se\nfendre après la Grande Croix.[1205][U+000A] C'est\ncomme ça qu'elle est anéantie."
+    "texte_fr": "J'ai entendu que la Terre va se fendre après la Grande Croix.[1205][U+000A]\n C'est comme ça qu'elle est anéantie."
   },
   {
     "id": 52,
@@ -846,7 +846,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Mommy[SP]says[SP]after[SP]the[SP]Grand[SP]Cross,[SP]there's[SP]gonna\nbe[SP]a[SP]huge[SP]earthquake[SP]and[SP]the[SP]Earth[SP]down[SP]there\nis[SP]gonna[SP]get[SP]uh-nye-a-lated.",
     "nom_fr": "Garçon",
-    "texte_fr": "Maman dit qu'après la Grande Croix,\nil y aura un grand tremblement de\nterre et que la Terre sera anéantie."
+    "texte_fr": "Maman dit qu'après la Grande Croix, il y aura un grand tremblement de terre\n et que la Terre sera anéantie."
   },
   {
     "id": 54,
@@ -877,7 +877,7 @@
     "nom_orig": "Boy",
     "texte_orig": "After[SP]the[SP]Grand[SP]Cross,[SP]the[SP]Earth's[SP]gonna[SP]stop\nspinning.[1205][U+000A][SP]That's[SP]what[SP]my[SP]daddy[SP]said.",
     "nom_fr": "Garçon",
-    "texte_fr": "Après la Grande Croix, la Terre\nva s'arrêter.[1205][U+000A] C'est mon papa."
+    "texte_fr": "Après la Grande Croix, la Terre va s'arrêter.[1205][U+000A]\n C'est mon papa."
   },
   {
     "id": 56,
@@ -893,7 +893,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Is[SP]that[SP]what[SP]uh-nye-a-lated[SP]means?[SP]The[SP]Earth\nstops[SP]spinning?[1205][U+000F][SP]I[SP]don't[SP]get[SP]it.",
     "nom_fr": "Garçon",
-    "texte_fr": "C'est ça, anéanti? La Terre\ns'arrête?[1205][U+000F] Je ne comprends pas."
+    "texte_fr": "C'est ça, anéanti ? La Terre s'arrête ?[1205][U+000F]\n Je ne comprends pas."
   },
   {
     "id": 57,
@@ -908,7 +908,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Um,[SP]someone[SP]told[SP]me[SP]there[SP]are[SP]flowers[SP]in[SP]Aoba\nPark[SP]that[SP]talk.[SP]But[SP]that[SP]sounds[SP]dumb.",
     "nom_fr": "Garçon",
-    "texte_fr": "Des fleurs qui parlent au parc\nd'Aoba? Ça me paraît idiot."
+    "texte_fr": "Des fleurs qui parlent au parc d'Aoba ?\n Ça me paraît idiot."
   },
   {
     "id": 58,
@@ -924,7 +924,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Flowers[SP]don't[SP]have[SP]mouths,[SP]silly![SP]Can[SP]they\ntalk[SP]with[SP]their[SP]petals?",
     "nom_fr": "Garçon",
-    "texte_fr": "Les fleurs n'ont pas de bouche!\nElles parlent par pétales?"
+    "texte_fr": "Les fleurs n'ont pas de bouche !\n Elles parlent par pétales ?"
   },
   {
     "id": 59,
@@ -939,7 +939,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Hey,[SP]what's[SP]Zodiac[SP]like?[SP]'Cause[SP]my[SP]friend[SP]said\nthe[SP]second[SP]floor[SP]is[SP]this[SP]big[SP]dungeon[SP]with[SP]a\nlot[SP]of[SP]cool[SP]stuff.",
     "nom_fr": "Garçon",
-    "texte_fr": "C'est quoi Zodiac? Mon pote dit que le 2e\nétage est un grand donjon avec des trucs\ncools."
+    "texte_fr": "C'est quoi Zodiac ? Mon pote dit que le 2e étage\n est un grand donjon avec des trucs cools."
   },
   {
     "id": 60,
@@ -955,7 +955,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]bet[SP]there's[SP]an[SP]archfiend[SP]in[SP]there.[SP]He's[SP]just\nwaiting[SP]for[SP]the[SP]heroes[SP]to[SP]show[SP]up.",
     "nom_fr": "Garçon",
-    "texte_fr": "Il y a un archidémon là-dedans.\nIl attend que les héros viennent."
+    "texte_fr": "Il y a un archidémon là-dedans.\n Il attend que les héros viennent."
   },
   {
     "id": 61,
@@ -1002,7 +1002,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Hey,[SP]is[SP]Bukimi[SP]really[SP]at[SP]Cuss[SP]High?[SP]She's[SP]even\nscarier[SP]than[SP]Hanako.[SP]You're[SP]a[SP]goner[SP]if[SP]she\nsees[SP]you,[SP]Mister.",
     "nom_fr": "Garçon",
-    "texte_fr": "Bukimi est vraiment au lycée Cuss?\nElle fait plus peur qu'Hanako.\nVous êtes mort si elle vous voit."
+    "texte_fr": "Bukimi est vraiment au lycée Cuss ?\n Elle fait plus peur qu'Hanako.\n Vous êtes mort si elle vous voit."
   },
   {
     "id": 64,
@@ -1018,7 +1018,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Is[SP]there[SP]really[SP]a[SP]ghost[SP]in[SP]the[SP]park[SP]by[SP]the\nconcert[SP]hall?[SP]Um,[SP]I[SP]heard[SP]it's[SP]an[SP]idol's[SP]ghost.[1205][U+000F]\nWhat[SP]do[SP]I[SP]do?[SP]My[SP]treasure's[SP]buried[SP]there...",
     "nom_fr": "Garçon",
-    "texte_fr": "Il y a vraiment un fantôme dans le parc\nprès de la salle? C'est le fantôme d'une\nidole.[1205][U+000F] Mon trésor est enterré là..."
+    "texte_fr": "Il y a vraiment un fantôme dans le parc près de la salle ?\n C'est le fantôme d'une idole.[1205][U+000F] Mon trésor est enterré là..."
   },
   {
     "id": 65,
@@ -1034,7 +1034,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Guess[SP]what?[SP]There's[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the\nabandoned[SP]factory.[SP]I[SP]bet[SP]you'll[SP]get[SP]cursed\nif[SP]you[SP]equip[SP]it.",
     "nom_fr": "Garçon",
-    "texte_fr": "Devine quoi? Il y a un Taxi Maudit à l'usine\nabandonnée. Tu seras maudit si tu l'équipes."
+    "texte_fr": "Devine quoi ? Il y a un Taxi Maudit à l'usine abandonnée.\n Tu seras maudit si tu l'équipes."
   },
   {
     "id": 66,
@@ -1050,7 +1050,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Hey,[SP]you[SP]know[SP]what?[SP]There's[SP]a[SP]Cursed[SP]Escort[SP]at\nthe[SP]abandoned[SP]factory.[SP]I[SP]bet[SP]your[SP]HP[SP]drops[SP]if\nyou[SP]equip[SP]it.",
     "nom_fr": "Garçon",
-    "texte_fr": "Il y a une Escorte Maudite à l'usine\nabandonnée. Tes PV baissent si tu l'équipes."
+    "texte_fr": "Il y a une Escorte Maudite à l'usine abandonnée.\n Tes PV baissent si tu l'équipes."
   },
   {
     "id": 67,
@@ -1065,7 +1065,7 @@
     "nom_orig": "Boy",
     "texte_orig": "What[SP]do[SP]I[SP]do...?[SP]I[SP]heard[SP]Kuchisake-onna[SP]is\nat[SP]Mt.[SP]Iwato.",
     "nom_fr": "Garçon",
-    "texte_fr": "Je fais quoi? Kuchisake-onna\nest au mont Iwato."
+    "texte_fr": "Je fais quoi ? Kuchisake-onna est au mont Iwato."
   },
   {
     "id": 68,
@@ -1081,7 +1081,7 @@
     "nom_orig": "Boy",
     "texte_orig": "And[SP]my[SP]teacher[SP]says[SP]it[SP]chases[SP]kids[SP]who[SP]don't\ngo[SP]straight[SP]home[SP]after[SP]school.",
     "nom_fr": "Garçon",
-    "texte_fr": "Mon prof dit qu'elle poursuit\nceux qui ne rentrent pas."
+    "texte_fr": "Mon prof dit qu'elle poursuit ceux qui ne rentrent pas."
   },
   {
     "id": 69,
@@ -1112,7 +1112,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Jumping[SP]Geezer's[SP]this[SP]guy[SP]who[SP]chases[SP]after[SP]you\nand[SP]stomps[SP]on[SP]your[SP]head.",
     "nom_fr": "Garçon",
-    "texte_fr": "Le Sauteur Vieux, un type qui te\ncourt après et te piétine la tête."
+    "texte_fr": "Le Sauteur Vieux, un type qui te court après\n et te piétine la tête."
   },
   {
     "id": 71,
@@ -1128,7 +1128,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Waaaaaah![SP]Waaaaah![SP]I'm[SP]scaaaared!\nU-Um,[SP]Kudan's[SP]at[SP]the[SP]abandoned[SP]factory...\nWaaaaaah![SP]Waaaaah!",
     "nom_fr": "Garçon",
-    "texte_fr": "Waaaaah! J'ai peur! Kudan est à\nl'usine abandonnée... Waaaaah!"
+    "texte_fr": "Waaaaah ! J'ai peur !\n Kudan est à l'usine abandonnée...\n Waaaaah !"
   },
   {
     "id": 72,
@@ -1159,7 +1159,7 @@
     "nom_orig": "Boy",
     "texte_orig": "It's[SP]like[SP]a[SP]secret[SP]item[SP]in[SP]a[SP]game,[SP]huh?\nThat's[SP]so[SP]weird.",
     "nom_fr": "Garçon",
-    "texte_fr": "C'est comme un objet secret\nde jeu, non? Bizarre."
+    "texte_fr": "C'est comme un objet secret de jeu, non ?\n Bizarre."
   },
   {
     "id": 74,
@@ -1174,7 +1174,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]wonder[SP]if[SP]Dresser[SP]Hag[SP]is[SP]the[SP]monster[SP]my\nfriend[SP]Chii[SP]was[SP]talking[SP]about.",
     "nom_fr": "Garçon",
-    "texte_fr": "La Sorcière du Buffet, c'est le\nmonstre dont mon pote Chii parlait?"
+    "texte_fr": "La Sorcière du Buffet, c'est le monstre\n dont mon pote Chii parlait ?"
   },
   {
     "id": 75,
@@ -1190,7 +1190,7 @@
     "nom_orig": "Boy",
     "texte_orig": "So[SP]he[SP]wasn't[SP]lying[SP]when[SP]he[SP]said[SP]he[SP]saw[SP]it[SP]at\nthe[SP]abandoned[SP]factory!",
     "nom_fr": "Garçon",
-    "texte_fr": "Donc il ne mentait pas en\ndisant l'avoir vue à l'usine!"
+    "texte_fr": "Donc il ne mentait pas en disant l'avoir vue à l'usine !"
   },
   {
     "id": 76,
@@ -1205,7 +1205,7 @@
     "nom_orig": "Boy",
     "texte_orig": "If[SP]you[SP]go[SP]to[SP]Time[SP]Castle,[SP]you[SP]can[SP]buy\nreal[SP]weapons!",
     "nom_fr": "Garçon",
-    "texte_fr": "Au Château du Temps, de vraies armes!"
+    "texte_fr": "Au Château du Temps, de vraies armes !"
   },
   {
     "id": 77,
@@ -1236,7 +1236,7 @@
     "nom_orig": "Boy",
     "texte_orig": "If[SP]you[SP]go[SP]to[SP]Time[SP]Castle,[SP]you[SP]can[SP]buy\nreal[SP]weapons!",
     "nom_fr": "Garçon",
-    "texte_fr": "Au Château du Temps, de vraies armes!"
+    "texte_fr": "Au Château du Temps, de vraies armes !"
   },
   {
     "id": 79,
@@ -1267,7 +1267,7 @@
     "nom_orig": "Boy",
     "texte_orig": "If[SP]you[SP]go[SP]to[SP]Time[SP]Castle,[SP]you[SP]can[SP]buy\nreal[SP]weapons!",
     "nom_fr": "Garçon",
-    "texte_fr": "Au Château du Temps, de vraies armes!"
+    "texte_fr": "Au Château du Temps, de vraies armes !"
   },
   {
     "id": 81,
@@ -1298,7 +1298,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]about[SP]a[SP]weapon[SP]store[SP]in[SP]Yumezaki\ncalled[SP]Tony's[SP]Shop.",
     "nom_fr": "Garçon",
-    "texte_fr": "Il y a un magasin d'armes\nà Yumezaki: Tony's Shop."
+    "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop."
   },
   {
     "id": 83,
@@ -1314,7 +1314,7 @@
     "nom_orig": "Boy",
     "texte_orig": "They[SP]sell[SP]a[SP]bunch[SP]of[SP]stuff,[SP]but[SP]they[SP]don't\npay[SP]you[SP]much[SP]for[SP]sales.",
     "nom_fr": "Garçon",
-    "texte_fr": "Ils vendent plein de trucs,\nmais reprennent pas cher."
+    "texte_fr": "Ils vendent plein de trucs, mais reprennent pas cher."
   },
   {
     "id": 84,
@@ -1329,7 +1329,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]about[SP]a[SP]weapon[SP]store[SP]in[SP]Yumezaki\ncalled[SP]Tony's[SP]Shop.",
     "nom_fr": "Garçon",
-    "texte_fr": "Il y a un magasin d'armes\nà Yumezaki: Tony's Shop."
+    "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop."
   },
   {
     "id": 85,
@@ -1360,7 +1360,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]about[SP]a[SP]weapon[SP]store[SP]in[SP]Yumezaki\ncalled[SP]Tony's[SP]Shop.",
     "nom_fr": "Garçon",
-    "texte_fr": "Il y a un magasin d'armes\nà Yumezaki: Tony's Shop."
+    "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop."
   },
   {
     "id": 87,
@@ -1391,7 +1391,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]about[SP]a[SP]weapon[SP]store[SP]in[SP]Yumezaki\ncalled[SP]Tony's[SP]Shop.",
     "nom_fr": "Garçon",
-    "texte_fr": "Il y a un magasin d'armes\nà Yumezaki: Tony's Shop."
+    "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop."
   },
   {
     "id": 89,
@@ -1422,7 +1422,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?",
     "nom_fr": "Garçon",
-    "texte_fr": "Un resto à Aoba vend des armes, vrai?"
+    "texte_fr": "Un resto à Aoba vend des armes, vrai ?"
   },
   {
     "id": 91,
@@ -1438,7 +1438,7 @@
     "nom_orig": "Boy",
     "texte_orig": "This[SP]lady[SP]said[SP]they[SP]don't[SP]have[SP]a[SP]lot[SP]of[SP]stuff,\nbut[SP]their[SP]trade-ins[SP]are[SP]good.",
     "nom_fr": "Garçon",
-    "texte_fr": "Cette dame a dit qu'ils ont peu\nde choix, mais reprennent bien."
+    "texte_fr": "Cette dame a dit qu'ils ont peu de choix,\n mais reprennent bien."
   },
   {
     "id": 92,
@@ -1453,7 +1453,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?",
     "nom_fr": "Garçon",
-    "texte_fr": "Un resto à Aoba vend des armes, vrai?"
+    "texte_fr": "Un resto à Aoba vend des armes, vrai ?"
   },
   {
     "id": 93,
@@ -1469,7 +1469,7 @@
     "nom_orig": "Boy",
     "texte_orig": "This[SP]lady[SP]said[SP]they're[SP]cheap,[SP]but[SP]they[SP]don't\nhave[SP]great[SP]stuff.",
     "nom_fr": "Garçon",
-    "texte_fr": "Bon marché, mais pas de\nsuper trucs, dit cette dame."
+    "texte_fr": "Bon marché, mais pas de super trucs,\n dit cette dame."
   },
   {
     "id": 94,
@@ -1484,7 +1484,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?",
     "nom_fr": "Garçon",
-    "texte_fr": "Un resto à Aoba vend des armes, vrai?"
+    "texte_fr": "Un resto à Aoba vend des armes, vrai ?"
   },
   {
     "id": 95,
@@ -1515,7 +1515,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?",
     "nom_fr": "Garçon",
-    "texte_fr": "Un resto à Aoba vend des armes, vrai?"
+    "texte_fr": "Un resto à Aoba vend des armes, vrai ?"
   },
   {
     "id": 97,
@@ -1531,7 +1531,7 @@
     "nom_orig": "Boy",
     "texte_orig": "This[SP]lady[SP]said[SP]they[SP]have[SP]a[SP]lot[SP]of[SP]stuff,\nbut[SP]their[SP]trade-ins[SP]are[SP]cheap.",
     "nom_fr": "Garçon",
-    "texte_fr": "Cette dame a dit beaucoup de\nchoix, mais reprises bas prix."
+    "texte_fr": "Cette dame a dit beaucoup de choix,\n mais reprises bas prix."
   },
   {
     "id": 98,
@@ -1546,7 +1546,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?",
     "nom_fr": "Garçon",
-    "texte_fr": "Un resto à Aoba vend des armes, vrai?"
+    "texte_fr": "Un resto à Aoba vend des armes, vrai ?"
   },
   {
     "id": 99,
@@ -1562,7 +1562,7 @@
     "nom_orig": "Boy",
     "texte_orig": "This[SP]cool[SP]lady[SP]said[SP]their[SP]stuff[SP]is[SP]okay[SP]and\ntheir[SP]prices[SP]were[SP]normal.",
     "nom_fr": "Garçon",
-    "texte_fr": "Cette dame sympa a dit: trucs\ncorrects, prix normaux."
+    "texte_fr": "Cette dame sympa a dit : trucs corrects,\n prix normaux."
   },
   {
     "id": 100,
@@ -1577,7 +1577,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a\nboat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.",
     "nom_fr": "Garçon",
-    "texte_fr": "Devine: au magasin avec un bateau,\non achète de vraies armes."
+    "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes."
   },
   {
     "id": 101,
@@ -1593,7 +1593,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]their[SP]stuff[SP]is[SP]okay.[SP]And[SP]their[SP]prices\nare[SP]normal.",
     "nom_fr": "Garçon",
-    "texte_fr": "Leurs trucs sont corrects, prix normaux."
+    "texte_fr": "Leurs trucs sont corrects,\n prix normaux."
   },
   {
     "id": 102,
@@ -1608,7 +1608,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a\nboat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.",
     "nom_fr": "Garçon",
-    "texte_fr": "Devine: au magasin avec un bateau,\non achète de vraies armes."
+    "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes."
   },
   {
     "id": 103,
@@ -1639,7 +1639,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a\nboat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.",
     "nom_fr": "Garçon",
-    "texte_fr": "Devine: au magasin avec un bateau,\non achète de vraies armes."
+    "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes."
   },
   {
     "id": 105,
@@ -1655,7 +1655,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]they[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]they\ndon't[SP]pay[SP]you[SP]much[SP]for[SP]yours.",
     "nom_fr": "Garçon",
-    "texte_fr": "Beaucoup de choix, mais tes\nreprises sont mal payées."
+    "texte_fr": "Beaucoup de choix, mais tes reprises\n sont mal payées."
   },
   {
     "id": 106,
@@ -1670,7 +1670,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a\nboat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.",
     "nom_fr": "Garçon",
-    "texte_fr": "Devine: au magasin avec un bateau,\non achète de vraies armes."
+    "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes."
   },
   {
     "id": 107,
@@ -1701,7 +1701,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a\nboat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.",
     "nom_fr": "Garçon",
-    "texte_fr": "Devine: au magasin avec un bateau,\non achète de vraies armes."
+    "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes."
   },
   {
     "id": 109,
@@ -1733,7 +1733,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]didn't[SP]know[SP]Rosa[SP]Candida[SP]was[SP]an[SP]armor[SP]store.\nI[SP]wonder[SP]if[SP]they[SP]sell[SP]Orichalcum[SP]shields...\nTheir[SP]defense[SP]and[SP]price[SP]is[SP]normal,[SP]right?",
     "nom_fr": "Garçon",
-    "texte_fr": "Je ne savais pas que Rosa Candida vendait\ndes armures. Des boucliers en orichalque?\nDéfense et prix normaux, non?"
+    "texte_fr": "Je ne savais pas que Rosa Candida vendait des armures.\n Des boucliers en orichalque ? Défense et prix normaux, non ?"
   },
   {
     "id": 111,
@@ -1749,7 +1749,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]didn't[SP]know[SP]Rosa[SP]Candida[SP]was[SP]an[SP]armor[SP]store.\nI[SP]wonder[SP]if[SP]they[SP]sell[SP]Orichalcum[SP]shields...\nThey're[SP]not[SP]great,[SP]but[SP]cheap,[SP]right?",
     "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida vend des armures? Des boucliers\nen orichalque? Pas géniaux mais bon marché?"
+    "texte_fr": "Rosa Candida vend des armures ? Des boucliers en orichalque ?\n Pas géniaux mais bon marché ?"
   },
   {
     "id": 112,
@@ -1765,7 +1765,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]didn't[SP]know[SP]Rosa[SP]Candida[SP]was[SP]an[SP]armor[SP]store.\nI[SP]wonder[SP]if[SP]they[SP]sell[SP]Orichalcum[SP]shields...\nThey[SP]sell[SP]good[SP]stuff,[SP]but[SP]it's[SP]expensive,[SP]huh?",
     "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida est un magasin d'armures?\nDes boucliers en orichalque? Bonne\nqualité mais cher, hein?"
+    "texte_fr": "Rosa Candida est un magasin d'armures ? Des boucliers en orichalque ?\n Bonne qualité mais cher, hein ?"
   },
   {
     "id": 113,
@@ -1796,7 +1796,7 @@
     "nom_orig": "Boy",
     "texte_orig": "A[SP]lady[SP]said[SP]their[SP]stuff[SP]is[SP]okay[SP]and[SP]the[SP]prices\nwere[SP]normal.",
     "nom_fr": "Garçon",
-    "texte_fr": "Une dame a dit: trucs corrects, prix normaux."
+    "texte_fr": "Une dame a dit : trucs corrects,\n prix normaux."
   },
   {
     "id": 115,
@@ -1858,7 +1858,7 @@
     "nom_orig": "Boy",
     "texte_orig": "A[SP]lady[SP]said[SP]they[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]the\ntrade-ins[SP]are[SP]cheap.",
     "nom_fr": "Garçon",
-    "texte_fr": "Une dame a dit beaucoup de\nchoix, mais reprises bon marché."
+    "texte_fr": "Une dame a dit beaucoup de choix,\n mais reprises bon marché."
   },
   {
     "id": 119,
@@ -1889,7 +1889,7 @@
     "nom_orig": "Boy",
     "texte_orig": "A[SP]lady[SP]said[SP]they[SP]had[SP]good[SP]stuff,[SP]but[SP]it\ncost[SP]a[SP]lot.",
     "nom_fr": "Garçon",
-    "texte_fr": "Une dame a dit de bonnes choses, mais cher."
+    "texte_fr": "Une dame a dit de bonnes choses,\n mais cher."
   },
   {
     "id": 121,
@@ -1904,7 +1904,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?",
     "nom_fr": "Garçon",
-    "texte_fr": "Il y a aussi un Rosa Candida à Aoba.\nC'est un magasin d'armures, non?"
+    "texte_fr": "Il y a aussi un Rosa Candida à Aoba.\n C'est un magasin d'armures, non ?"
   },
   {
     "id": 122,
@@ -1920,7 +1920,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Someone[SP]said[SP]they[SP]don't[SP]have[SP]a[SP]lot,[SP]but\ntheir[SP]trade-ins[SP]are[SP]good.",
     "nom_fr": "Garçon",
-    "texte_fr": "Quelqu'un a dit peu de\nchoix, mais bonnes reprises."
+    "texte_fr": "Quelqu'un a dit peu de choix,\n mais bonnes reprises."
   },
   {
     "id": 123,
@@ -1936,7 +1936,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][U+000F][SP]Someone[SP]said\ntheir[SP]stuff's[SP]okay[SP]and[SP]their[SP]prices[SP]are[SP]normal.",
     "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida à Aoba, c'est aussi\nun magasin d'armures?[1205][U+000F] Quelqu'un a\ndit trucs corrects, prix normaux."
+    "texte_fr": "Rosa Candida à Aoba, c'est aussi un magasin d'armures ?[1205][U+000F]\n Quelqu'un a dit trucs corrects, prix normaux."
   },
   {
     "id": 124,
@@ -1952,7 +1952,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][U+000F][SP]Someone[SP]said\ntheir[SP]stuff's[SP]great,[SP]but[SP]it[SP]costs[SP]a[SP]lot.",
     "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida à Aoba, armurerie?[1205][U+000F] Quelqu'un\na dit trucs géniaux, mais cher."
+    "texte_fr": "Rosa Candida à Aoba, armurerie ?[1205][U+000F]\n Quelqu'un a dit trucs géniaux, mais cher."
   },
   {
     "id": 125,
@@ -1968,7 +1968,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][U+000F][SP]Someone[SP]said\nthey're[SP]cheap,[SP]but[SP]their[SP]stuff's[SP]kinda[SP]bad.",
     "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida à Aoba, magasin d'armures?[1205][U+000F]\nQuelqu'un a dit bon marché, mais qualité bof."
+    "texte_fr": "Rosa Candida à Aoba, magasin d'armures ?[1205][U+000F]\n Quelqu'un a dit bon marché, mais qualité bof."
   },
   {
     "id": 126,
@@ -1984,7 +1984,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][U+000F][SP]They[SP]have[SP]a\nlot[SP]of[SP]stuff,[SP]but[SP]trade-ins[SP]are[SP]cheap.",
     "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida à Aoba, armures?[1205][U+000F] Beaucoup\nde choix, mais reprises bon marché."
+    "texte_fr": "Rosa Candida à Aoba, armures ?[1205][U+000F]\n Beaucoup de choix, mais reprises bon marché."
   },
   {
     "id": 127,
@@ -2000,7 +2000,7 @@
     "nom_orig": "Boy",
     "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady\nsaid[SP]they[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]trade-ins\nare[SP]cheap.",
     "nom_fr": "Garçon",
-    "texte_fr": "London Clothier fait aussi des armures?[1205][U+000F]\nBeaucoup de choix, reprises pas chères."
+    "texte_fr": "London Clothier fait aussi des armures ?[1205][U+000F]\n Beaucoup de choix, reprises pas chères."
   },
   {
     "id": 128,
@@ -2016,7 +2016,7 @@
     "nom_orig": "Boy",
     "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady\nsaid[SP]they're[SP]cheap,[SP]but[SP]their[SP]stuff[SP]isn't\nthat[SP]great.",
     "nom_fr": "Garçon",
-    "texte_fr": "London Clothier, armures?[1205][U+000F]\nBon marché, qualité moyenne."
+    "texte_fr": "London Clothier, armures ?[1205][U+000F]\n Bon marché, qualité moyenne."
   },
   {
     "id": 129,
@@ -2032,7 +2032,7 @@
     "nom_orig": "Boy",
     "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady\nsaid[SP]their[SP]stuff[SP]is[SP]nice,[SP]but[SP]it's[SP]expensive.",
     "nom_fr": "Garçon",
-    "texte_fr": "London Clothier vend des\narmures?[1205][U+000F] Joli mais cher."
+    "texte_fr": "London Clothier vend des armures ?[1205][U+000F]\n Joli mais cher."
   },
   {
     "id": 130,
@@ -2048,7 +2048,7 @@
     "nom_orig": "Boy",
     "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady\nsaid[SP]their[SP]stuff[SP]is[SP]okay.[SP]And[SP]she[SP]said[SP]their\nprices[SP]are[SP]normal[SP]too.",
     "nom_fr": "Garçon",
-    "texte_fr": "London Clothier, armures?[1205][U+000F]\nTrucs corrects, prix normaux."
+    "texte_fr": "London Clothier, armures ?[1205][U+000F]\n Trucs corrects, prix normaux."
   },
   {
     "id": 131,
@@ -2064,7 +2064,7 @@
     "nom_orig": "Boy",
     "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady\nsaid[SP]they[SP]don't[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]their\ntrade-ins[SP]are[SP]good.",
     "nom_fr": "Garçon",
-    "texte_fr": "London Clothier fait des armures?[1205][U+000F]\nPeu de choix, mais bonnes reprises."
+    "texte_fr": "London Clothier fait des armures ?[1205][U+000F]\n Peu de choix, mais bonnes reprises."
   },
   {
     "id": 132,
@@ -2079,7 +2079,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]magazine[SP]contests?[1205][U+000F][SP]I[SP]heard[SP]if\nyou[SP]win[SP]one,[SP]you[SP]get[SP]real[SP]weapons[SP]and[SP]stuff.",
     "nom_fr": "Garçon",
-    "texte_fr": "Tu connais les concours de magazines?\nSi on gagne, on a des vraies armes."
+    "texte_fr": "Tu connais les concours de magazines ?\n Si on gagne, on a des vraies armes."
   },
   {
     "id": 133,
@@ -2110,7 +2110,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]magazine[SP]contests?[1205][U+000F][SP]I[SP]heard[SP]if\nyou[SP]win[SP]one,[SP]you[SP]get[SP]real[SP]weapons[SP]and[SP]stuff.",
     "nom_fr": "Garçon",
-    "texte_fr": "Tu connais les concours de magazines?\nSi on gagne, on a des vraies armes."
+    "texte_fr": "Tu connais les concours de magazines ?\n Si on gagne, on a des vraies armes."
   },
   {
     "id": 135,
@@ -2126,7 +2126,7 @@
     "nom_orig": "Boy",
     "texte_orig": "You[SP]hardly[SP]ever[SP]win,[SP]but[SP]when[SP]you[SP]do,[SP]the\nprizes[SP]are[SP]really[SP]rare[SP]stuff.",
     "nom_fr": "Garçon",
-    "texte_fr": "On gagne rarement, mais\nles lots sont très rares."
+    "texte_fr": "On gagne rarement, mais les lots sont très rares."
   },
   {
     "id": 136,
@@ -2141,7 +2141,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]magazine[SP]contests?[1205][U+000F][SP]I[SP]heard[SP]if\nyou[SP]win[SP]one,[SP]you[SP]get[SP]real[SP]weapons[SP]and[SP]stuff.",
     "nom_fr": "Garçon",
-    "texte_fr": "Tu connais les concours de magazines?\nSi on gagne, on a des vraies armes."
+    "texte_fr": "Tu connais les concours de magazines ?\n Si on gagne, on a des vraies armes."
   },
   {
     "id": 137,
@@ -2172,7 +2172,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]know[SP]what[SP]a[SP]casino[SP]is![SP]They[SP]have[SP]stuff[SP]like\nslots[SP]and[SP]races.[SP]Mu[SP]has[SP]one,[SP]right?",
     "nom_fr": "Garçon",
-    "texte_fr": "Je sais ce qu'est un casino! Machines\nà sous, courses. Mu en a un, non?"
+    "texte_fr": "Je sais ce qu'est un casino !\n Machines à sous, courses. Mu en a un, non ?"
   },
   {
     "id": 139,
@@ -2188,7 +2188,7 @@
     "nom_orig": "Boy",
     "texte_orig": "They[SP]say[SP]poker's[SP]the[SP]best[SP]game[SP]there.[SP]I[SP]dunno\nhow[SP]to[SP]play[SP]that[SP]one,[SP]though.",
     "nom_fr": "Garçon",
-    "texte_fr": "Le poker est le meilleur jeu là-bas,\nmais je ne sais pas y jouer."
+    "texte_fr": "Le poker est le meilleur jeu là-bas,\n mais je ne sais pas y jouer."
   },
   {
     "id": 140,
@@ -2203,7 +2203,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]know[SP]what[SP]a[SP]casino[SP]is![SP]They[SP]have[SP]stuff[SP]like\nslots[SP]and[SP]races.[SP]Mu[SP]has[SP]one,[SP]right?",
     "nom_fr": "Garçon",
-    "texte_fr": "Je sais ce qu'est un casino! Machines\nà sous, courses. Mu en a un, non?"
+    "texte_fr": "Je sais ce qu'est un casino !\n Machines à sous, courses. Mu en a un, non ?"
   },
   {
     "id": 141,
@@ -2219,7 +2219,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Slots[SP]are[SP]the[SP]best.[SP]I[SP]know[SP]how[SP]to[SP]play[SP]those!\nUm,[SP]I[SP]heard[SP]you[SP]can[SP]win[SP]a[SP]lot[SP]on[SP]machine[SP]#1.",
     "nom_fr": "Garçon",
-    "texte_fr": "Machines à sous: le top. Je sais\ny jouer! Grosse gagne sur la n°1."
+    "texte_fr": "Machines à sous : le top. Je sais y jouer !\n Grosse gagne sur la n°1."
   },
   {
     "id": 142,
@@ -2234,7 +2234,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]know[SP]what[SP]a[SP]casino[SP]is![SP]They[SP]have[SP]stuff[SP]like\nslots[SP]and[SP]races.[SP]Mu[SP]has[SP]one,[SP]right?",
     "nom_fr": "Garçon",
-    "texte_fr": "Je sais ce qu'est un casino! Machines\nà sous, courses. Mu en a un, non?"
+    "texte_fr": "Je sais ce qu'est un casino !\n Machines à sous, courses. Mu en a un, non ?"
   },
   {
     "id": 143,
@@ -2250,7 +2250,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Um,[SP]I[SP]heard[SP]it's[SP]good[SP]to[SP]play[SP]blackjack[SP]there,\nbut[SP]I[SP]dunno[SP]how[SP]to[SP]play[SP]that.[SP]Do[SP]you,[SP]Mister?",
     "nom_fr": "Garçon",
-    "texte_fr": "Blackjack est bon là-bas, mais je\nne sais pas. Vous savez, monsieur?"
+    "texte_fr": "Blackjack est bon là-bas, mais je ne sais pas.\n Vous savez, monsieur ?"
   },
   {
     "id": 144,
@@ -2266,7 +2266,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Is[SP]there[SP]really[SP]a[SP]legendary[SP]weapon[SP]at[SP]the[SP]ramen\nshop?[1205][U+000F][SP]Some[SP]lady[SP]said[SP]so[SP]a[SP]minute[SP]ago.[SP]Wow,[SP]I\ndidn't[SP]know[SP]those[SP]really[SP]existed!",
     "nom_fr": "Garçon",
-    "texte_fr": "Une arme légendaire au resto de\nramen? Une dame vient de le dire.\nJe ne savais pas que ça existait!"
+    "texte_fr": "Une arme légendaire au resto de ramen ?\n Une dame vient de le dire. Je ne savais pas que ça existait !"
   },
   {
     "id": 145,
@@ -2282,7 +2282,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Is[SP]it[SP]true[SP]there's[SP]a[SP]legendary[SP]weapon[SP]at[SP]the\nrestaurant[SP]in[SP]Aoba?[1205][U+000F][SP]Would[SP]it[SP]be[SP]in[SP]a[SP]dresser?",
     "nom_fr": "Garçon",
-    "texte_fr": "Une arme légendaire dans le\nresto d'Aoba? Dans un buffet?"
+    "texte_fr": "Une arme légendaire dans le resto d'Aoba ?\n Dans un buffet ?"
   },
   {
     "id": 146,
@@ -2298,7 +2298,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Why[SP]would[SP]the[SP]man[SP]at[SP]Time[SP]Castle[SP]lie[SP]about\nhaving[SP]a[SP]legendary[SP]weapon?[1205][U+000F][SP]I[SP]heard[SP]it's[SP]'cause\nhe's[SP]trying[SP]to[SP]charge[SP]a[SP]lot...",
     "nom_fr": "Garçon",
-    "texte_fr": "Pourquoi le gars du Château du Temps\nmentirait sur une arme légendaire?[1205][U+000F]\nPour faire monter les prix..."
+    "texte_fr": "Pourquoi le gars du Château du Temps mentirait\n sur une arme légendaire ?[1205][U+000F] Pour faire monter les prix..."
   },
   {
     "id": 147,
@@ -2313,7 +2313,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]wonder[SP]why[SP]the[SP]man[SP]at[SP]Time[SP]Castle[SP]won't[SP]go\nget[SP]his[SP]legendary[SP]weapon.",
     "nom_fr": "Garçon",
-    "texte_fr": "Pourquoi ne pas chercher son arme légendaire?"
+    "texte_fr": "Pourquoi ne pas chercher son arme légendaire ?"
   },
   {
     "id": 148,
@@ -2329,7 +2329,7 @@
     "nom_orig": "Boy",
     "texte_orig": "He[SP]should[SP]just[SP]beat[SP]up[SP]those[SP]monsters[SP]at[SP]the\nabandoned[SP]factory.",
     "nom_fr": "Garçon",
-    "texte_fr": "Il n'a qu'à battre les\nmonstres à l'usine abandonnée."
+    "texte_fr": "Il n'a qu'à battre les monstres\n à l'usine abandonnée."
   },
   {
     "id": 149,
@@ -2345,7 +2345,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]the[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle\ngot[SP]stolen.[SP]I[SP]bet[SP]it[SP]was[SP]the[SP]minions[SP]of[SP]the\narchfiend.",
     "nom_fr": "Garçon",
-    "texte_fr": "L'arme légendaire du Château du Temps a été\nvolée. Ce sont les sbires de l'archidémon."
+    "texte_fr": "L'arme légendaire du Château du Temps a été volée.\n Ce sont les sbires de l'archidémon."
   },
   {
     "id": 150,
@@ -2376,7 +2376,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]bet[SP]her[SP]kid's[SP]all[SP]grown[SP]up[SP]now[SP]and[SP]going[SP]on\na[SP]journey,[SP]so[SP]she's[SP]gonna[SP]give[SP]it[SP]to[SP]him[SP]as[SP]a\npresent.[SP]That's[SP]how[SP]it[SP]always[SP]is.",
     "nom_fr": "Garçon",
-    "texte_fr": "Son fils a grandi et part en\nvoyage, alors elle va la lui donner\nen cadeau. C'est toujours comme ça."
+    "texte_fr": "Son fils a grandi et part en voyage,\n alors elle va la lui donner en cadeau.\n C'est toujours comme ça."
   },
   {
     "id": 152,
@@ -2391,7 +2391,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Um,[SP]I[SP]heard[SP]the[SP]man[SP]at[SP]Time[SP]Castle[SP]gave[SP]his\nlegendary[SP]weapon[SP]to[SP]a[SP]lady[SP]with[SP]short[SP]hair.",
     "nom_fr": "Garçon",
-    "texte_fr": "Le gars du Château du Temps a donné son\narme à une dame aux cheveux courts."
+    "texte_fr": "Le gars du Château du Temps a donné son arme\n à une dame aux cheveux courts."
   },
   {
     "id": 153,
@@ -2407,7 +2407,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]bet...[SP]she's[SP]actually[SP]a[SP]princess,[SP]and[SP]she's\ngonna[SP]hold[SP]onto[SP]it[SP]until[SP]the[SP]hero[SP]comes.\nRight,[SP]Mister?",
     "nom_fr": "Garçon",
-    "texte_fr": "Je parie que c'est une princesse, elle garde\nl'arme pour le héros. C'est ça, monsieur?"
+    "texte_fr": "Je parie que c'est une princesse, elle garde l'arme\n pour le héros. C'est ça, monsieur ?"
   },
   {
     "id": 154,
@@ -2423,7 +2423,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "The[SP]principal's[SP]statue[SP]at[SP]Sevens[SP]doesn't[SP]like\nto[SP]be[SP]seen[SP]walking[SP]around...[1205][U+000F][SP]But[SP]there[SP]aren't\nmany[SP]foxes[SP]around[SP]these[SP]days.[SP]Is[SP]it[SP]possible?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "La statue du proviseur à Seven n'aime pas\nqu'on la voie se promener...[1205][U+000F] Mais il n'y a\nplus beaucoup de renards. Est-ce possible?"
+    "texte_fr": "La statue du proviseur à Seven n'aime pas qu'on la voie se promener...[1205][U+000F]\n Mais il n'y a plus beaucoup de renards. Est-ce possible ?"
   },
   {
     "id": 155,
@@ -2439,7 +2439,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I've[SP]stopped[SP]seeing[SP]young[SP]girls[SP]around[SP]here\nlately.[1205][U+000F][SP]Is[SP]the[SP]bloom[SP]off[SP]the[SP]rose[SP]for[SP]Sevens\nbecause[SP]of[SP]that[SP]disease?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Je ne vois plus de jeunes filles\npar ici.[1205][U+000F] Seven a-t-il perdu son\nattrait à cause de cette maladie?"
+    "texte_fr": "Je ne vois plus de jeunes filles par ici.[1205][U+000F]\n Seven a-t-il perdu son attrait à cause de cette maladie ?"
   },
   {
     "id": 156,
@@ -2455,7 +2455,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "It[SP]seems[SP]Kasugayama[SP]High's[SP]holding[SP]a[SP]masquerade\nas[SP]part[SP]of[SP]their[SP]school[SP]festival.[SP]Is[SP]that[SP]some\nkind[SP]of[SP]grape?[SP]It's[SP]all[SP]Greek[SP]to[SP]me.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Kasugayama organise un bal masqué\npour sa fête. Une sorte de raisin?\nC'est du chinois pour moi."
+    "texte_fr": "Kasugayama organise un bal masqué pour sa fête.\n Une sorte de raisin ? C'est du chinois pour moi."
   },
   {
     "id": 157,
@@ -2470,7 +2470,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I[SP]heard[SP]at[SP]Honmaru[SP]Park[SP]that[SP]a[SP]store[SP]in[SP]Yumezaki\nsells[SP]real[SP]armor[SP]alongside[SP]regular[SP]clothes.\nWhat[SP]a[SP]dangerous[SP]place[SP]this[SP]world's[SP]become...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "J'ai entendu au parc Honmaru qu'un magasin à\nYumezaki vend des armures avec des vêtements.\nDans quel monde dangereux on vit..."
+    "texte_fr": "J'ai entendu au parc Honmaru qu'un magasin à Yumezaki\n vend des armures avec des vêtements. Dans quel monde dangereux on vit..."
   },
   {
     "id": 158,
@@ -2485,7 +2485,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "If[SP]you[SP]want[SP]to[SP]know[SP]more[SP]about[SP]it,[SP]I'd[SP]say[SP]you\nshould[SP]start[SP]by[SP]visiting[SP]Honmaru[SP]Park.[1205][U+000F]",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Si tu veux en savoir plus, commence\npar visiter le parc Honmaru."
+    "texte_fr": "Si tu veux en savoir plus, commence par visiter le parc Honmaru."
   },
   {
     "id": 159,
@@ -2517,7 +2517,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Do[SP]you[SP]know[SP]the[SP]Masked[SP]Circle?[SP]There's[SP]some\ngroup[SP]by[SP]that[SP]name,[SP]apparently.[SP]It[SP]reminds[SP]me\nof[SP]those[SP]bandits[SP]you[SP]see[SP]in[SP]period[SP]films.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Tu connais le Cercle Masqué? Il paraît\nqu'il y a un groupe de ce nom. Ça me\nrappelle les bandits des films d'époque."
+    "texte_fr": "Tu connais le Cercle Masqué ? Il paraît qu'il y a un groupe de ce nom.\n Ça me rappelle les bandits des films d'époque."
   },
   {
     "id": 161,
@@ -2532,7 +2532,7 @@
     "nom_orig": "Old[SP]man[121D][U+0001]",
     "texte_orig": "Well,[SP]it[SP]appears[SP]this[SP]Masked[SP]Circle[SP]is[SP]quite\nthe[SP]frightening[SP]group.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Eh bien, ce Cercle Masqué est\nun groupe assez effrayant."
+    "texte_fr": "Eh bien, ce Cercle Masqué est un groupe assez effrayant."
   },
   {
     "id": 162,
@@ -2548,7 +2548,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I'd[SP]rather[SP]steer[SP]clear[SP]of[SP]such[SP]folk[SP]at[SP]my[SP]age.[1205][U+000F]\nFingers[SP]crossed...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "À mon âge, je préfère éviter ces\ngens. Croisons les doigts..."
+    "texte_fr": "À mon âge, je préfère éviter ces gens.\n Croisons les doigts..."
   },
   {
     "id": 163,
@@ -2564,7 +2564,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Sounds[SP]like[SP]it[SP]was[SP]the[SP]Masked[SP]Circle[SP]who[SP]burned\ndown[SP]the[SP]outdoor[SP]concert[SP]hall.[1205][U+000F][SP]What's[SP]this[SP]world\ncoming[SP]to[SP]if[SP]such[SP]people[SP]really[SP]exist...?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "On dirait que c'est le Cercle Masqué qui a\nbrûlé la salle de concert.[1205][U+000F] Où va le monde\nsi de telles personnes existent vraiment?"
+    "texte_fr": "On dirait que c'est le Cercle Masqué qui a brûlé la salle de concert.[1205][U+000F]\n Où va le monde si de telles personnes existent vraiment ?"
   },
   {
     "id": 164,
@@ -2580,7 +2580,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Turns[SP]out[SP]the[SP]real[SP]culprit[SP]was[SP]a[SP]gang[SP]of[SP]five\nterrorists.[1205][U+000F][SP]That's[SP]more[SP]plausible[SP]than[SP]the\nMasked[SP]Circle,[SP]I'd[SP]say...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Le vrai coupable était une bande de\ncinq terroristes.[1205][U+000F] Plus plausible\nque le Cercle Masqué, je dirais..."
+    "texte_fr": "Le vrai coupable était une bande de cinq terroristes.[1205][U+000F]\n Plus plausible que le Cercle Masqué, je dirais..."
   },
   {
     "id": 165,
@@ -2596,7 +2596,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "There[SP]was[SP]a[SP]fella[SP]I[SP]used[SP]to[SP]play[SP]Go[SP]with...[1205][U+000F]\nHaven't[SP]seen[SP]him[SP]around[SP]lately.[1205][U+000F][SP]He[SP]seemed\nawful[SP]depressed,[SP]so[SP]I[SP]worry[SP]about[SP]him.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Il y avait un type avec qui je jouais au\ngo...[1205][U+000F] Je ne l'ai pas vu récemment.[1205][U+000F] Il\navait l'air très déprimé, je m'inquiète."
+    "texte_fr": "Il y avait un type avec qui je jouais au go...[1205][U+000F]\n Je ne l'ai pas vu récemment.[1205][U+000F] Il avait l'air très déprimé,\n je m'inquiète."
   },
   {
     "id": 166,
@@ -2611,7 +2611,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "If[SP]folks[SP]like[SP]that[SP]are[SP]really[SP]here,[SP]does[SP]that\nmean[SP]there[SP]is[SP]such[SP]a[SP]thing[SP]as[SP]Xibalba[SP]under\nthis[SP]city?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Si des gens comme ça sont ici, cela\nsignifie-t-il qu'il existe un Xibalba sous\ncette ville?"
+    "texte_fr": "Si des gens comme ça sont ici, cela signifie-t-il\n qu'il existe un Xibalba sous cette ville ?"
   },
   {
     "id": 167,
@@ -2642,7 +2642,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I'm[SP]too[SP]old[SP]to[SP]evolve![1205][U+000A][SP]I'm[SP]more[SP]worried[SP]about\nwhat's[SP]happening[SP]down[SP]there.[1205][U+000A][SP]It'll[SP]all[SP]be\ndestroyed[SP]when[SP]the[SP]stars[SP]align,[SP]no?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Je suis trop vieux pour évoluer![1205][U+000A] Je\nm'inquiète pour en bas.[1205][U+000A] Destruction\nquand les étoiles s'alignent, non?"
+    "texte_fr": "Je suis trop vieux pour évoluer ![1205][U+000A]\n Je m'inquiète pour en bas.[1205][U+000A] Destruction quand les étoiles s'alignent, non ?"
   },
   {
     "id": 169,
@@ -2658,7 +2658,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I[SP]have[SP]friends[SP]down[SP]there...[1205][U+000F][SP]Isn't[SP]there\nanything[SP]I[SP]can[SP]do[SP]for[SP]them...?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "J'ai des amis en bas...[1205][U+000F] Rien\nque je puisse faire pour eux?"
+    "texte_fr": "J'ai des amis en bas...[1205][U+000F]\n Rien que je puisse faire pour eux ?"
   },
   {
     "id": 170,
@@ -2673,7 +2673,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "The[SP]people[SP]in[SP]this[SP]city[SP]are[SP]appalling.[1205][U+000A][SP]They\nknow[SP]they're[SP]safe,[SP]so[SP]they're[SP]imagining[SP]what\nmight[SP]destroy[SP]the[SP]Earth[SP]below.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Les gens sont épouvantables.[1205][U+000A] En sécurité,\nils imaginent la destruction de la Terre."
+    "texte_fr": "Les gens sont épouvantables.[1205][U+000A]\n En sécurité, ils imaginent la destruction de la Terre."
   },
   {
     "id": 171,
@@ -2689,7 +2689,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "What[SP]good[SP]will[SP]it[SP]do[SP]mankind[SP]if[SP]folks[SP]like\nthem[SP]evolve...?[1205][U+000F][SP]I[SP]don't[SP]hold[SP]out[SP]much[SP]hope...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "À quoi bon si des gens comme eux évoluent?[1205][U+000F]\nJe n'ai pas beaucoup d'espoir..."
+    "texte_fr": "À quoi bon si des gens comme eux évoluent ?[1205][U+000F]\n Je n'ai pas beaucoup d'espoir..."
   },
   {
     "id": 172,
@@ -2705,7 +2705,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Sounds[SP]like[SP]the[SP]Earth's[SP]air[SP]will[SP]evaporate[SP]when\nthe[SP]stars[SP]align.[1205][U+000F][SP]Criminy...[SP]The[SP]things[SP]those\nkids[SP]think[SP]up[SP]lately[SP]scares[SP]the[SP]life[SP]out[SP]of[SP]me.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "L'air de la Terre va s'évaporer quand les\nétoiles s'aligneront.[1205][U+000F] Bon sang... Ce que ces\ngosses inventent me fait une peur bleue."
+    "texte_fr": "L'air de la Terre va s'évaporer quand les étoiles s'aligneront.[1205][U+000F]\n Bon sang... Ce que ces gosses inventent me fait une peur bleue."
   },
   {
     "id": 173,
@@ -2720,7 +2720,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Sounds[SP]like[SP]the[SP]Earth's[SP]rotation[SP]will[SP]stop[SP]when\nthe[SP]stars[SP]align...[1205][U+000A][SP]Everything[SP]on[SP]Earth[SP]will[SP]get\nblasted[SP]away...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "La Terre va s'arrêter quand les étoiles\ns'aligneront...[1205][U+000A] Tout sera pulvérisé..."
+    "texte_fr": "La Terre va s'arrêter quand les étoiles s'aligneront...[1205][U+000A]\n Tout sera pulvérisé..."
   },
   {
     "id": 174,
@@ -2736,7 +2736,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Why[SP]is[SP]God[SP]doing[SP]such[SP]horrible[SP]things[SP]to[SP]us?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Pourquoi Dieu nous fait-il ça?"
+    "texte_fr": "Pourquoi Dieu nous fait-il ça ?"
   },
   {
     "id": 175,
@@ -2751,7 +2751,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Sounds[SP]like[SP]the[SP]Earth's[SP]rotation[SP]will[SP]stop[SP]when\nthe[SP]stars[SP]align...[1205][U+000A][SP]Everything[SP]on[SP]Earth[SP]will[SP]get\nblasted[SP]away...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "La Terre va s'arrêter quand les étoiles\ns'aligneront...[1205][U+000A] Tout sera pulvérisé..."
+    "texte_fr": "La Terre va s'arrêter quand les étoiles s'aligneront...[1205][U+000A]\n Tout sera pulvérisé..."
   },
   {
     "id": 176,
@@ -2767,7 +2767,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Why[SP]is[SP]God[SP]doing[SP]such[SP]horrible[SP]things[SP]to[SP]us?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Pourquoi Dieu nous fait-il ça?"
+    "texte_fr": "Pourquoi Dieu nous fait-il ça ?"
   },
   {
     "id": 177,
@@ -2783,7 +2783,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I[SP]heard[SP]there's[SP]talking[SP]flowers[SP]in[SP]Aoba[SP]Park.\nI'd[SP]have[SP]dismissed[SP]it[SP]when[SP]I[SP]was[SP]young,[SP]but\nwho[SP]can[SP]say[SP]in[SP]today's[SP]world?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Des fleurs qui parlent au parc\nd'Aoba? Je l'aurais rejeté avant,\nmais de nos jours, qui sait?"
+    "texte_fr": "Des fleurs qui parlent au parc d'Aoba ?\n Je l'aurais rejeté avant, mais de nos jours, qui sait ?"
   },
   {
     "id": 178,
@@ -2798,7 +2798,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "It[SP]seems[SP]that[SP]club[SP]called[SP]Zodiac[SP]is[SP]one[SP]big\nmonster's[SP]den[SP]now.[SP]Some[SP]young'uns[SP]were[SP]getting\nexcited[SP]to[SP]venture[SP]in[SP]there.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Le club Zodiac est devenu un antre\nde monstres. Des jeunes étaient\ntout excités à l'idée d'y aller."
+    "texte_fr": "Le club Zodiac est devenu un antre de monstres.\n Des jeunes étaient tout excités à l'idée d'y aller."
   },
   {
     "id": 179,
@@ -2814,7 +2814,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "They[SP]talked[SP]about[SP]some[SP]treasure...[1205][U+000F][SP]But[SP]the\nmore[SP]you[SP]find,[SP]the[SP]greater[SP]the[SP]danger.\nI[SP]wouldn't[SP]go[SP]in[SP]carelessly[SP]if[SP]I[SP]were[SP]you.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Un trésor...[1205][U+000F] Plus on en trouve, plus\ngrand danger. N'y va pas imprudemment."
+    "texte_fr": "Un trésor...[1205][U+000F] Plus on en trouve, plus grand danger.\n N'y va pas imprudemment."
   },
   {
     "id": 180,
@@ -2845,7 +2845,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "First[SP]that[SP]strange[SP]disease,[SP]then[SP]the[SP]principal's\nstatue[SP]gets[SP]up[SP]and[SP]walks,[SP]and[SP]now[SP]this?\nIt's[SP]the[SP]damnedest[SP]school.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Maladie étrange, statue qui marche,\net ça? C'est la pire école."
+    "texte_fr": "Maladie étrange, statue qui marche, et ça ?\n C'est la pire école."
   },
   {
     "id": 182,
@@ -2861,7 +2861,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Did[SP]you[SP]hear?[SP]There's[SP]a[SP]ghost[SP]by[SP]the[SP]name[SP]of\nBukimi[SP]hanging[SP]around[SP]Kasugayama[SP]High.[SP]Wonder\nif[SP]that[SP]school's[SP]been[SP]cursed[SP]now...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Tu as entendu? Un fantôme nommé Bukimi\ntraîne au lycée Kasugayama. Je me\ndemande si cette école a été maudite..."
+    "texte_fr": "Tu as entendu ? Un fantôme nommé Bukimi traîne au lycée Kasugayama.\n Je me demande si cette école a été maudite..."
   },
   {
     "id": 183,
@@ -2876,7 +2876,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "People[SP]who[SP]die[SP]with[SP]attachments[SP]to[SP]this[SP]world\ncan't[SP]find[SP]peace[SP]and[SP]end[SP]up[SP]wandering[SP]the[SP]Earth.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Ceux qui meurent avec des attaches\nn'ont pas la paix et errent."
+    "texte_fr": "Ceux qui meurent avec des attaches n'ont pas la paix\n et errent."
   },
   {
     "id": 184,
@@ -2892,7 +2892,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "That's[SP]probably[SP]what[SP]happened[SP]to[SP]the[SP]idol[SP]whose\nghost[SP]is[SP]at[SP]Aoba[SP]Park.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "L'idole dont le fantôme est\nau parc d'Aoba, c'est ça."
+    "texte_fr": "L'idole dont le fantôme est au parc d'Aoba, c'est ça."
   },
   {
     "id": 185,
@@ -2907,7 +2907,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I[SP]wouldn't[SP]go[SP]near[SP]the[SP]abandoned[SP]factory[SP]if\nI[SP]was[SP]you,[SP]boy.[SP]There's[SP]a[SP]Cursed[SP]Taxi[SP]parked\nthere.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "N'approche pas l'usine abandonnée.\nUn Taxi Maudit y est garé."
+    "texte_fr": "N'approche pas l'usine abandonnée.\n Un Taxi Maudit y est garé."
   },
   {
     "id": 186,
@@ -2923,7 +2923,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "They[SP]say[SP]to[SP]let[SP]sleeping[SP]dogs[SP]lie...\nYou[SP]should[SP]be[SP]careful.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Ne réveille pas le chat\nqui dort... Sois prudent."
+    "texte_fr": "Ne réveille pas le chat qui dort...\n Sois prudent."
   },
   {
     "id": 187,
@@ -2938,7 +2938,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Sounds[SP]like[SP]there's[SP]a[SP]monster[SP]called[SP]a[SP]Cursed\nEscort[SP]at[SP]the[SP]abandoned[SP]factory.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Il y a un monstre appelé Escorte\nMaudite à l'usine abandonnée."
+    "texte_fr": "Il y a un monstre appelé Escorte Maudite\n à l'usine abandonnée."
   },
   {
     "id": 188,
@@ -2954,7 +2954,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "The[SP]rumor[SP]goes[SP]that[SP]it[SP]runs[SP]over[SP]people[SP]night\nafter[SP]night...[SP]Terrible,[SP]just[SP]terrible...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "On dit qu'elle renverse les gens\nnuit après nuit... Terrible."
+    "texte_fr": "On dit qu'elle renverse les gens nuit après nuit...\n Terrible."
   },
   {
     "id": 189,
@@ -2970,7 +2970,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Hohoho,[SP]I[SP]used[SP]to[SP]be[SP]scared[SP]that[SP]Kuchisake-onna\nwould[SP]come[SP]after[SP]me[SP]when[SP]I[SP]was[SP]a[SP]kid.[SP]I[SP]didn't\nknow[SP]she[SP]lives[SP]at[SP]Mt.[SP]Iwato.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Hohoho, j'avais peur de Kuchisake-onna\nenfant. Elle vit au mont Iwato."
+    "texte_fr": "Hohoho, j'avais peur de Kuchisake-onna enfant.\n Elle vit au mont Iwato."
   },
   {
     "id": 190,
@@ -2986,7 +2986,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Just[SP]because[SP]there's[SP]a[SP]spy[SP]old[SP]man[SP]at[SP]Mt.\nKatatsumuri[SP]is[SP]no[SP]reason[SP]to[SP]think[SP]he's[SP]the\nJumping[SP]Geezer![SP]Don't[SP]mock[SP]the[SP]elderly!",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Un vieil homme espion au mont\nKatatsumuri n'est pas le Sauteur Vieux!\nNe moquez pas les personnes âgées!"
+    "texte_fr": "Un vieil homme espion au mont Katatsumuri n'est pas le Sauteur Vieux !\n Ne moquez pas les personnes âgées !"
   },
   {
     "id": 191,
@@ -3002,7 +3002,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I-I[SP]can't[SP]believe[SP]it...[SP]My[SP]heart[SP]almost[SP]gave\nout[SP]when[SP]I[SP]heard...[1205][U+000F][SP]Kudan[SP]is...[1205][U+000F][SP]Kid,[SP]you[SP]must\nnever[SP]go[SP]near[SP]a[SP]Kudan!",
     "nom_fr": "Vieil homme",
-    "texte_fr": "J'y crois pas... Crise cardiaque...[1205][U+000F] Kudan...[1205][U+000F]\nNe t'approche jamais d'un Kudan, gamin!"
+    "texte_fr": "J'y crois pas... Crise cardiaque...[1205][U+000F] Kudan...[1205][U+000F]\n Ne t'approche jamais d'un Kudan, gamin !"
   },
   {
     "id": 192,
@@ -3018,7 +3018,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I[SP]like[SP]the[SP]sound[SP]of[SP]albums[SP]from[SP]back[SP]in[SP]the[SP]day.\nSomething[SP]about[SP]these[SP]CDs[SP]and[SP]their[SP]glitz...\nThere's[SP]even[SP]a[SP]secret[SP]CD[SP]out[SP]there[SP]somewhere.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "J'aime le son des albums d'autrefois. Quelque\nchose à propos des CD et de leur clinquant...\nIl y a même un CD secret quelque part."
+    "texte_fr": "J'aime le son des albums d'autrefois.\n Quelque chose à propos des CD et de leur clinquant...\n Il y a même un CD secret quelque part."
   },
   {
     "id": 193,
@@ -3034,7 +3034,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "There's[SP]no[SP]call[SP]to[SP]pick[SP]on[SP]the[SP]elderly[SP]like\nthis![SP]Just[SP]'cause[SP]an[SP]old[SP]lady[SP]has[SP]a[SP]dresser,\nthey[SP]call[SP]her[SP]the[SP]Dresser[SP]Hag!?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Pourquoi s'en prendre aux vieux? Une dame\navec un buffet, la Sorcière du Buffet!?"
+    "texte_fr": "Pourquoi s'en prendre aux vieux ?\n Une dame avec un buffet, la Sorcière du Buffet !?"
   },
   {
     "id": 194,
@@ -3050,7 +3050,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Time[SP]Castle[SP]sells[SP]weapons[SP]too?[SP]I[SP]always[SP]thought\nthey[SP]seemed[SP]crooked.[SP]Sounds[SP]like[SP]their[SP]quality\nand[SP]prices[SP]are[SP]average.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Château du Temps vend des armes?\nLouche. Qualité et prix moyens."
+    "texte_fr": "Château du Temps vend des armes ? Louche.\n Qualité et prix moyens."
   },
   {
     "id": 195,
@@ -3066,7 +3066,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Time[SP]Castle[SP]sells[SP]weapons[SP]too?[SP]I[SP]always[SP]thought\nthey[SP]seemed[SP]crooked.[SP]Sounds[SP]like[SP]their[SP]quality\nis[SP]good,[SP]but[SP]it's[SP]expensive.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Le Château du Temps vend des armes?\nLouche, mais qualité bonne et cher."
+    "texte_fr": "Le Château du Temps vend des armes ? Louche,\n mais qualité bonne et cher."
   },
   {
     "id": 196,
@@ -3082,7 +3082,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Time[SP]Castle[SP]sells[SP]weapons[SP]too?[SP]I[SP]always[SP]thought\nthey[SP]seemed[SP]crooked.[SP]Sounds[SP]like[SP]they're[SP]cheap,\nbut[SP]bad[SP]quality.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Le Château du Temps vend des armes?\nLouche, bon marché mais mauvaise qualité."
+    "texte_fr": "Le Château du Temps vend des armes ? Louche,\n bon marché mais mauvaise qualité."
   },
   {
     "id": 197,
@@ -3097,7 +3097,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "That[SP]young'un[SP]Tony[SP]was[SP]selling[SP]weapons\nafter[SP]all!",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Ce jeune Tony vendait donc des armes!"
+    "texte_fr": "Ce jeune Tony vendait donc des armes !"
   },
   {
     "id": 198,
@@ -3113,7 +3113,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "People[SP]like[SP]him[SP]are[SP]good[SP]for[SP]nothing.[SP]He[SP]has\na[SP]good[SP]selection,[SP]but[SP]his[SP]resale[SP]prices\nare[SP]low.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Les gens comme lui ne valent\nrien. Bon choix, reprises basses."
+    "texte_fr": "Les gens comme lui ne valent rien.\n Bon choix, reprises basses."
   },
   {
     "id": 199,
@@ -3128,7 +3128,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "That[SP]young'un[SP]Tony[SP]was[SP]selling[SP]weapons\nafter[SP]all!",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Ce jeune Tony vendait donc des armes!"
+    "texte_fr": "Ce jeune Tony vendait donc des armes !"
   },
   {
     "id": 200,
@@ -3144,7 +3144,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "People[SP]like[SP]him[SP]are[SP]good[SP]for[SP]nothing.[SP]He[SP]has\nlow[SP]prices,[SP]but[SP]his[SP]stuff[SP]is[SP]junk.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Les gens comme lui ne valent\nrien. Prix bas, camelote."
+    "texte_fr": "Les gens comme lui ne valent rien.\n Prix bas, camelote."
   },
   {
     "id": 201,
@@ -3159,7 +3159,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "That[SP]young'un[SP]Tony[SP]was[SP]selling[SP]weapons\nafter[SP]all!",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Ce jeune Tony vendait donc des armes!"
+    "texte_fr": "Ce jeune Tony vendait donc des armes !"
   },
   {
     "id": 202,
@@ -3175,7 +3175,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "People[SP]like[SP]him[SP]are[SP]good[SP]for[SP]nothing.[SP]He[SP]has\naverage[SP]quality[SP]and[SP]prices.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Les gens comme lui ne valent\nrien. Qualité et prix moyens."
+    "texte_fr": "Les gens comme lui ne valent rien.\n Qualité et prix moyens."
   },
   {
     "id": 203,
@@ -3190,7 +3190,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "That[SP]young'un[SP]Tony[SP]was[SP]selling[SP]weapons\nafter[SP]all!",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Ce jeune Tony vendait donc des armes!"
+    "texte_fr": "Ce jeune Tony vendait donc des armes !"
   },
   {
     "id": 204,
@@ -3206,7 +3206,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "People[SP]like[SP]him[SP]are[SP]good[SP]for[SP]nothing.[SP]He[SP]has\nquality[SP]stuff,[SP]but[SP]it's[SP]expensive.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Les gens comme lui ne valent\nrien. Qualité mais cher."
+    "texte_fr": "Les gens comme lui ne valent rien.\n Qualité mais cher."
   },
   {
     "id": 205,
@@ -3222,7 +3222,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?\nI've[SP]heard[SP]their[SP]selection[SP]is[SP]bad,[SP]but[SP]the\nresale[SP]prices[SP]are[SP]good.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Ma parole, même les restos d'Aoba vendent des\narmes? Peu de choix, mais bonnes reprises."
+    "texte_fr": "Ma parole, même les restos d'Aoba vendent des armes ?\n Peu de choix, mais bonnes reprises."
   },
   {
     "id": 206,
@@ -3238,7 +3238,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?\nI've[SP]heard[SP]they're[SP]cheap,[SP]but[SP]the[SP]quality[SP]is\nnot[SP]so[SP]hot.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Les restos d'Aoba vendent des\narmes? Bon marché, qualité bof."
+    "texte_fr": "Les restos d'Aoba vendent des armes ?\n Bon marché, qualité bof."
   },
   {
     "id": 207,
@@ -3254,7 +3254,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?\nI've[SP]heard[SP]their[SP]quality[SP]is[SP]top-notch,[SP]but[SP]it's\nexpensive[SP]stuff.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Les restos d'Aoba vendent des armes?\nQualité excellente, mais cher."
+    "texte_fr": "Les restos d'Aoba vendent des armes ?\n Qualité excellente, mais cher."
   },
   {
     "id": 208,
@@ -3270,7 +3270,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?\nI've[SP]heard[SP]their[SP]selection[SP]is[SP]great,[SP]but[SP]the\nresale[SP]prices[SP]are[SP]low.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Restos d'Aoba vendent des armes?\nExcellent choix, reprises basses."
+    "texte_fr": "Restos d'Aoba vendent des armes ?\n Excellent choix, reprises basses."
   },
   {
     "id": 209,
@@ -3286,7 +3286,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?\nI've[SP]heard[SP]the[SP]quality[SP]and[SP]prices[SP]are[SP]both\nfairly[SP]standard.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Restos d'Aoba vendent des armes?\nQualité et prix standards."
+    "texte_fr": "Restos d'Aoba vendent des armes ?\n Qualité et prix standards."
   },
   {
     "id": 210,
@@ -3301,7 +3301,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit\nJolly[SP]Roger[SP]in[SP]Kounan.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Au Jolly Roger à Kounan, on\npeut acheter de vraies armes."
+    "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes."
   },
   {
     "id": 211,
@@ -3317,7 +3317,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I[SP]hear[SP]the[SP]quality[SP]and[SP]prices[SP]are[SP]ordinary,\nbut[SP]if[SP]you[SP]ask[SP]me,[SP]there's[SP]nothing[SP]ordinary\nabout[SP]selling[SP]weapons.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Qualité et prix ordinaires, mais\nvendre des armes n'a rien d'ordinaire."
+    "texte_fr": "Qualité et prix ordinaires, mais vendre des armes\n n'a rien d'ordinaire."
   },
   {
     "id": 212,
@@ -3332,7 +3332,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit\nJolly[SP]Roger[SP]in[SP]Kounan.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Au Jolly Roger à Kounan, on\npeut acheter de vraies armes."
+    "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes."
   },
   {
     "id": 213,
@@ -3363,7 +3363,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit\nJolly[SP]Roger[SP]in[SP]Kounan.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Au Jolly Roger à Kounan, on\npeut acheter de vraies armes."
+    "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes."
   },
   {
     "id": 215,
@@ -3394,7 +3394,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit\nJolly[SP]Roger[SP]in[SP]Kounan.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Au Jolly Roger à Kounan, on\npeut acheter de vraies armes."
+    "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes."
   },
   {
     "id": 217,
@@ -3425,7 +3425,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit\nJolly[SP]Roger[SP]in[SP]Kounan.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Au Jolly Roger à Kounan, on\npeut acheter de vraies armes."
+    "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes."
   },
   {
     "id": 219,
@@ -3472,7 +3472,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "That[SP]means[SP]things[SP]like[SP]helmets[SP]and[SP]chestplates\nand[SP]such,[SP]right?[SP]I[SP]hear[SP]their[SP]quality[SP]and\nprices[SP]are[SP]average.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Des casques, plastrons, etc.\nQualité et prix moyens."
+    "texte_fr": "Des casques, plastrons, etc.\n Qualité et prix moyens."
   },
   {
     "id": 222,
@@ -3503,7 +3503,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "That[SP]means[SP]things[SP]like[SP]helmets[SP]and[SP]chestplates\nand[SP]such,[SP]right?[SP]I[SP]hear[SP]their[SP]prices[SP]are\ngreat,[SP]but[SP]the[SP]quality's[SP]lacking.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Des casques, plastrons... Prix\nsuper, qualité manquante."
+    "texte_fr": "Des casques, plastrons... Prix super,\n qualité manquante."
   },
   {
     "id": 224,
@@ -3534,7 +3534,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "That[SP]means[SP]things[SP]like[SP]helmets[SP]and[SP]chestplates\nand[SP]such,[SP]right?[SP]I[SP]hear[SP]their[SP]quality[SP]is\ngreat,[SP]but[SP]the[SP]prices[SP]are[SP]sky-high.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Casques, plastrons... Qualité\nexcellente, prix exorbitants."
+    "texte_fr": "Casques, plastrons... Qualité excellente,\n prix exorbitants."
   },
   {
     "id": 226,
@@ -3549,7 +3549,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I've[SP]heard[SP]you[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima\nMundi[SP]in[SP]Yumezaki.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "On peut acheter des armures\nà Anima Mundi, Yumezaki."
+    "texte_fr": "On peut acheter des armures à Anima Mundi, Yumezaki."
   },
   {
     "id": 227,
@@ -3565,7 +3565,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Their[SP]quality[SP]and[SP]prices[SP]are[SP]normal...[SP]But[SP]just\nwhat's[SP]normal[SP]about[SP]wearing[SP]armor[SP]around[SP]town?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Qualité et prix normaux... Mais porter\nune armure en ville, rien de normal."
+    "texte_fr": "Qualité et prix normaux... Mais porter une armure en ville,\n rien de normal."
   },
   {
     "id": 228,
@@ -3581,7 +3581,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I've[SP]heard[SP]you[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima\nMundi[SP]in[SP]Yumezaki.[SP]It[SP]seems[SP]cheap,[SP]but[SP]pretty\nlow[SP]quality.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Anima Mundi vend des armures.\nBon marché mais basse qualité."
+    "texte_fr": "Anima Mundi vend des armures.\n Bon marché mais basse qualité."
   },
   {
     "id": 229,
@@ -3597,7 +3597,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I've[SP]heard[SP]you[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima\nMundi[SP]in[SP]Yumezaki.[SP]The[SP]selection[SP]seems[SP]great,\nbut[SP]the[SP]resale[SP]prices[SP]are[SP]cheap.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Anima Mundi à Yumezaki: excellent\nchoix, reprises basses."
+    "texte_fr": "Anima Mundi à Yumezaki : excellent choix,\n reprises basses."
   },
   {
     "id": 230,
@@ -3613,7 +3613,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I've[SP]heard[SP]you[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima\nMundi[SP]in[SP]Yumezaki.[SP]It[SP]seems[SP]high[SP]quality,\nbut[SP]you'll[SP]pay[SP]a[SP]pretty[SP]penny.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Anima Mundi: haute qualité,\nmais ça coûte un bras."
+    "texte_fr": "Anima Mundi : haute qualité,\n mais ça coûte un bras."
   },
   {
     "id": 231,
@@ -3629,7 +3629,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they\nsell[SP]real[SP]armor.[SP]Their[SP]selection[SP]isn't[SP]great,\nbut[SP]their[SP]resale[SP]prices[SP]are[SP]nice.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures.\nPeu de choix, mais bonnes reprises."
+    "texte_fr": "Rosa Candida à Aoba vend des armures.\n Peu de choix, mais bonnes reprises."
   },
   {
     "id": 232,
@@ -3645,7 +3645,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they\nsell[SP]real[SP]armor.[SP]The[SP]quality[SP]and[SP]prices[SP]of\ntheir[SP]stuff[SP]are[SP]average.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Rosa Candida à Aoba: armures,\nqualité et prix moyens."
+    "texte_fr": "Rosa Candida à Aoba : armures,\n qualité et prix moyens."
   },
   {
     "id": 233,
@@ -3661,7 +3661,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they\nsell[SP]real[SP]armor.[SP]The[SP]quality[SP]of[SP]their[SP]stock\nis[SP]great,[SP]but[SP]it's[SP]pricey.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Rosa Candida à Aoba:\nexcellente qualité, mais cher."
+    "texte_fr": "Rosa Candida à Aoba : excellente qualité,\n mais cher."
   },
   {
     "id": 234,
@@ -3677,7 +3677,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they\nsell[SP]real[SP]armor.[SP]The[SP]prices[SP]are[SP]right,[SP]but[SP]you\nget[SP]what[SP]you[SP]pay[SP]for.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Rosa Candida à Aoba: prix corrects,\nmais tu en as pour ton argent."
+    "texte_fr": "Rosa Candida à Aoba : prix corrects,\n mais tu en as pour ton argent."
   },
   {
     "id": 235,
@@ -3693,7 +3693,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they\nsell[SP]real[SP]armor.[SP]Their[SP]selection[SP]is[SP]great,\nbut[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Rosa Candida à Aoba: excellent\nchoix, reprises basses."
+    "texte_fr": "Rosa Candida à Aoba : excellent choix,\n reprises basses."
   },
   {
     "id": 236,
@@ -3709,7 +3709,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the\nscamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]selection\nis[SP]great,[SP]but[SP]his[SP]resale[SP]prices[SP]are[SP]cheap.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Hoho, le gars chez London Clothier\nest un sacré coquin. Il fait des\narmures! Beau choix, reprises basses."
+    "texte_fr": "Hoho, le gars chez London Clothier est un sacré coquin.\n Il fait des armures ! Beau choix, reprises basses."
   },
   {
     "id": 237,
@@ -3725,7 +3725,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the\nscamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]stuff\nis[SP]cheap,[SP]but[SP]low[SP]quality.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "London Clothier: ce coquin vend des\narmures. Bon marché, mauvaise qualité."
+    "texte_fr": "London Clothier : ce coquin vend des armures.\n Bon marché, mauvaise qualité."
   },
   {
     "id": 238,
@@ -3741,7 +3741,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the\nscamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]stuff\nis[SP]great,[SP]but[SP]very[SP]expensive.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "London Clothier: ce coquin vend des\narmures. Excellente qualité, très cher."
+    "texte_fr": "London Clothier : ce coquin vend des armures.\n Excellente qualité, très cher."
   },
   {
     "id": 239,
@@ -3757,7 +3757,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the\nscamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]prices\nand[SP]quality[SP]are[SP]average,[SP]I[SP]hear.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "London Clothier: ce coquin fait des\narmures. Prix et qualité moyens, parait-il."
+    "texte_fr": "London Clothier : ce coquin fait des armures.\n Prix et qualité moyens, parait-il."
   },
   {
     "id": 240,
@@ -3773,7 +3773,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the\nscamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]selection\nis[SP]limited,[SP]but[SP]his[SP]resale[SP]prices[SP]are[SP]high.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "London Clothier: ce coquin vend des\narmures. Choix limité, reprises élevées."
+    "texte_fr": "London Clothier : ce coquin vend des armures.\n Choix limité, reprises élevées."
   },
   {
     "id": 241,
@@ -3789,7 +3789,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Lately,[SP]the[SP]magazines[SP]have[SP]been[SP]giving[SP]out\nreal[SP]weapons[SP]and[SP]items[SP]in[SP]contests.[SP]They're\nhard[SP]to[SP]win,[SP]but[SP]you[SP]can[SP]get[SP]nice[SP]stuff.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Les magazines offrent des armes et objets dans\ndes concours. Durs à gagner, mais beaux lots."
+    "texte_fr": "Les magazines offrent des armes et objets dans des concours.\n Durs à gagner, mais beaux lots."
   },
   {
     "id": 242,
@@ -3805,7 +3805,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Lately,[SP]the[SP]magazines[SP]have[SP]been[SP]giving[SP]out\nreal[SP]weapons[SP]and[SP]items[SP]in[SP]contests.[SP]They're\nnearly[SP]impossible[SP]to[SP]win,[SP]but[SP]those[SP]prizes...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Magazines donnent des armes dans\ndes concours. Presque impossibles\nà gagner, mais ces lots..."
+    "texte_fr": "Magazines donnent des armes dans des concours.\n Presque impossibles à gagner, mais ces lots..."
   },
   {
     "id": 243,
@@ -3821,7 +3821,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Lately,[SP]the[SP]magazines[SP]have[SP]been[SP]giving[SP]out\nreal[SP]weapons[SP]and[SP]items[SP]in[SP]contests.[SP]They're\neasy[SP]to[SP]win,[SP]but[SP]why[SP]would[SP]you[SP]want[SP]to?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Concours de magazines faciles à\ngagner, mais pourquoi voudrais-tu?"
+    "texte_fr": "Concours de magazines faciles à gagner,\n mais pourquoi voudrais-tu ?"
   },
   {
     "id": 244,
@@ -3837,7 +3837,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "A[SP]casino...[SP]like[SP]a[SP]gambling[SP]parlor,[SP]right?\nAnd[SP]Mu[SP]has[SP]one[SP]now?[SP]I[SP]hear[SP]a[SP]certain[SP]poker\nmachine[SP]is[SP]your[SP]best[SP]bet.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Un casino, une salle de jeu? Mu en a un? Une\nmachine de poker est ton meilleur choix."
+    "texte_fr": "Un casino, une salle de jeu ? Mu en a un ?\n Une machine de poker est ton meilleur choix."
   },
   {
     "id": 245,
@@ -3853,7 +3853,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "A[SP]casino...[SP]like[SP]a[SP]gambling[SP]parlor,[SP]right?\nAnd[SP]Mu[SP]has[SP]one[SP]now?[SP]I[SP]hear[SP]a[SP]certain[SP]slot\nmachine[SP]is[SP]your[SP]best[SP]bet.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Un casino? Mu en a un? Une machine\nà sous est ton meilleur choix."
+    "texte_fr": "Un casino ? Mu en a un ?\n Une machine à sous est ton meilleur choix."
   },
   {
     "id": 246,
@@ -3869,7 +3869,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "A[SP]casino...[SP]like[SP]a[SP]gambling[SP]parlor,[SP]right?\nAnd[SP]Mu[SP]has[SP]one[SP]now?[SP]I[SP]hear[SP]it's[SP]easiest[SP]to\nwin[SP]at[SP]blackjack.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Un casino? Mu en a un? Le plus facile\npour gagner, c'est le blackjack."
+    "texte_fr": "Un casino ? Mu en a un ?\n Le plus facile pour gagner, c'est le blackjack."
   },
   {
     "id": 247,
@@ -3885,7 +3885,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Does[SP]Shiraishi[SP]Ramen[SP]in[SP]Hirasaka[SP]really[SP]have\na[SP]legendary[SP]weapon?[SP]The[SP]things[SP]they[SP]say[SP]about\nthat[SP]place...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Le Shiraishi Ramen à Hirasaka a\nvraiment une arme légendaire? Ce\nqu'on raconte sur cet endroit..."
+    "texte_fr": "Le Shiraishi Ramen à Hirasaka a vraiment une arme légendaire ?\n Ce qu'on raconte sur cet endroit..."
   },
   {
     "id": 248,
@@ -3901,7 +3901,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Are[SP]you[SP]searching[SP]for[SP]a[SP]legendary[SP]weapon?\nThen[SP]try[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I've[SP]heard\nrumors[SP]that[SP]they[SP]have[SP]one.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Tu cherches une arme légendaire?\nEssaye Clair de Lune à Aoba.\nJ'ai entendu qu'ils en ont une."
+    "texte_fr": "Tu cherches une arme légendaire ?\n Essaye Clair de Lune à Aoba. J'ai entendu qu'ils en ont une."
   },
   {
     "id": 249,
@@ -3917,7 +3917,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Lying[SP]about[SP]your[SP]store[SP]to[SP]drive[SP]up[SP]the[SP]price!\nThe[SP]very[SP]idea![SP]It[SP]seems[SP]you[SP]can't[SP]put[SP]that\npast[SP]the[SP]owner[SP]of[SP]Time[SP]Castle.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Mentir sur son magasin pour faire\nmonter les prix! L'idée! C'est le\nproprio du Château du Temps."
+    "texte_fr": "Mentir sur son magasin pour faire monter les prix !\n L'idée ! C'est le proprio du Château du Temps."
   },
   {
     "id": 250,
@@ -3933,7 +3933,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I[SP]hear[SP]Time[SP]Castle's[SP]legendary[SP]weapons[SP]is[SP]still\nwith[SP]the[SP]seller[SP]at[SP]the[SP]abandoned[SP]factory.[SP]He's\nstill[SP]waiting[SP]for[SP]the[SP]owner[SP]to[SP]come[SP]claim[SP]it.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "L'arme légendaire du Château du Temps est\ntoujours chez le vendeur à l'usine abandonnée.\nIl attend que le proprio vienne la réclamer."
+    "texte_fr": "L'arme légendaire du Château du Temps est toujours chez le vendeur\n à l'usine abandonnée. Il attend que le proprio vienne la réclamer."
   },
   {
     "id": 251,
@@ -3949,7 +3949,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "It[SP]seems[SP]demons[SP]have[SP]stolen[SP]the[SP]legendary\nweapon[SP]from[SP]Time[SP]Castle.[SP]How[SP]is[SP]that[SP]even\npossible?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Des démons ont volé l'arme légendaire du\nChâteau du Temps. Comment est-ce possible?"
+    "texte_fr": "Des démons ont volé l'arme légendaire du Château du Temps.\n Comment est-ce possible ?"
   },
   {
     "id": 252,
@@ -3965,7 +3965,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "The[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle[SP]got[SP]sold.\nRumor[SP]has[SP]it[SP]an[SP]unlucky[SP]woman[SP]bought[SP]it,[SP]but\nwho[SP]knows[SP]what[SP]she'll[SP]use[SP]it[SP]for...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "L'arme légendaire a été vendue. Une\nfemme malchanceuse l'aurait achetée.\nQui sait ce qu'elle en fera..."
+    "texte_fr": "L'arme légendaire a été vendue.\n Une femme malchanceuse l'aurait achetée.\n Qui sait ce qu'elle en fera..."
   },
   {
     "id": 253,
@@ -3981,7 +3981,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle[SP]gave[SP]his[SP]legendary\nweapon[SP]away[SP]to[SP]a[SP]girl[SP]with[SP]short[SP]hair.[SP]Now\nwhat[SP]would[SP]she[SP]want[SP]with[SP]such[SP]a[SP]thing?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Le proprio du Château du Temps a donné\nson arme légendaire à une fille aux\ncheveux courts. Que veut-elle en faire?"
+    "texte_fr": "Le proprio du Château du Temps a donné son arme légendaire\n à une fille aux cheveux courts. Que veut-elle en faire ?"
   },
   {
     "id": 254,
@@ -3997,7 +3997,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "J-Joker[SP]told[SP]us[SP]to[SP]protect[SP]the[SP]city,[SP]but\nthere's[SP]no[SP]way[SP]we[SP]can[SP]beat[SP]guys[SP]like[SP]that![1205][U+000F]\nThis[SP]wasn't[SP]part[SP]of[SP]the[SP]deal!",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Joker nous a dit de protéger la ville,\nmais pas possible![1205][U+000F] Pas dans le contrat!"
+    "texte_fr": "Joker nous a dit de protéger la ville,\n mais pas possible ![1205][U+000F] Pas dans le contrat !"
   },
   {
     "id": 255,
@@ -4013,7 +4013,7 @@
     "nom_orig": "Last[SP]Battalion",
     "texte_orig": "Mt.[SP]Katatsumuri[SP]is[SP]already[SP]ours.[1205][U+000F][SP]To[SP]resist\nis[SP]futile.[1205][U+000F][SP]Those[SP]who[SP]do[SP]will[SP]be[SP]killed.",
     "nom_fr": "Dernier Bataillon",
-    "texte_fr": "Le mont Katatsumuri est à nous.[1205][U+000F] Résister\nest futile.[1205][U+000F] Les résistants tués."
+    "texte_fr": "Le mont Katatsumuri est à nous.[1205][U+000F]\n Résister est futile.[1205][U+000F] Les résistants tués."
   },
   {
     "id": 256,
@@ -4029,7 +4029,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]wonder[SP]if[SP]Kozy's[SP]got[SP]some[SP]info[SP]for[SP]us.\nHey,[SP][1113],[SP]let's[SP]head[SP]to[SP]Peace[SP]Diner\nin[SP]Yumezaki.",
     "nom_fr": "Ginko",
-    "texte_fr": "Kozy a des infos pour nous? Hé, [1113],\nallons au Peace Diner à Yumezaki."
+    "texte_fr": "Kozy a des infos pour nous ?\n Hé, [1113], allons au Peace Diner à Yumezaki."
   },
   {
     "id": 257,
@@ -4045,7 +4045,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Looks[SP]like[SP]the[SP]curse[SP]has[SP]been[SP]lifted,[SP]so[SP]things\nshould[SP]be[SP]fine[SP]at[SP]Sevens[SP]now.",
     "nom_fr": "Ginko",
-    "texte_fr": "La malédiction est levée, tout devrait\naller bien à Seven maintenant."
+    "texte_fr": "La malédiction est levée,\n tout devrait aller bien à Seven maintenant."
   },
   {
     "id": 258,
@@ -4061,7 +4061,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]feel[SP]bad[SP]for[SP]what[SP]I[SP]did[SP]to[SP]the[SP]guys[SP]here...\nYo[SP][1113],[SP]let's[SP]go[SP]to[SP]Kasugayama[SP]High.[SP]I'll\nmake[SP]that[SP]president[SP]pay!",
     "nom_fr": "Michel",
-    "texte_fr": "Je me sens mal... Yo [1113], allons\nà Kasugayama. Ce président va payer!"
+    "texte_fr": "Je me sens mal... Yo [1113], allons à Kasugayama.\n Ce président va payer !"
   },
   {
     "id": 259,
@@ -4093,7 +4093,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]know[SP]you're[SP]worried[SP]about[SP]your[SP]school,[SP]but[SP]I\ndon't[SP]think[SP]they'll[SP]strike[SP]here.[SP]We[SP]don't[SP]have\nmuch[SP]time,[SP]man.[SP]Let's[SP]go.",
     "nom_fr": "Michel",
-    "texte_fr": "Je sais que tu t'inquiètes, mais pas\nici. On a peu de temps. Allons-y."
+    "texte_fr": "Je sais que tu t'inquiètes, mais pas ici.\n On a peu de temps. Allons-y."
   },
   {
     "id": 261,
@@ -4109,7 +4109,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]already[SP]miss[SP]the[SP]regular[SP]school[SP]days...\nHey,[SP][1113],[SP]will[SP]things[SP]ever[SP]go[SP]back[SP]to\nnormal?[SP]Will[SP]Sheba[SP]and[SP]Mee-ho[SP]come[SP]back...?",
     "nom_fr": "Ginko",
-    "texte_fr": "Les jours normaux me manquent... Hé, [1113],\ntout redeviendra normal? Sheba et Mee-ho?"
+    "texte_fr": "Les jours normaux me manquent...\n Hé, [1113], tout redeviendra normal ?\n Sheba et Mee-ho ?"
   },
   {
     "id": 262,
@@ -4125,7 +4125,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Looks[SP]like[SP]those[SP]soldiers[SP]haven't[SP]made[SP]it[SP]this\nfar[SP]yet...[SP]Are[SP]the[SP]students[SP]still[SP]inside?",
     "nom_fr": "Maya",
-    "texte_fr": "Ces soldats ne sont pas allés aussi loin...\nLes élèves sont-ils encore à l'intérieur?"
+    "texte_fr": "Ces soldats ne sont pas allés aussi loin...\n Les élèves sont-ils encore à l'intérieur ?"
   },
   {
     "id": 263,
@@ -4141,7 +4141,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Mt.[SP]Iwato...[SP]That's[SP]weird...[SP]I've[SP]seen[SP]it[SP]in\nmy[SP]dreams...[SP]Is[SP]this[SP]deja[SP]vu[SP]or[SP]something?\nWe[SP]don't[SP]have[SP]any[SP]business[SP]here,[SP]right?",
     "nom_fr": "Michel",
-    "texte_fr": "Mont Iwato... C'est bizarre... Je\nl'ai vu dans mes rêves... Du déjà-vu?\nOn n'a rien à faire ici, non?"
+    "texte_fr": "Mont Iwato... C'est bizarre... Je l'ai vu dans mes rêves...\n Du déjà-vu ? On n'a rien à faire ici, non ?"
   },
   {
     "id": 264,
@@ -4173,7 +4173,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "H-Hey,[SP][1113]?[SP]I[SP]don't[SP]like[SP]it[SP]here...[1205][U+000F]\nCan[SP]we[SP]go[SP]somewhere[SP]else?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, [1113]? J'aime pas ici...[1205][U+000F] Ailleurs?"
+    "texte_fr": "Hé, [1113] ? J'aime pas ici...[1205][U+000F]\n Ailleurs ?"
   },
   {
     "id": 266,
@@ -4189,7 +4189,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Mt.[SP]Iwato?[SP]What's[SP]this[SP]feeling...?[SP]Like...\nNostalgia,[SP]but[SP]bittersweet...[SP]I[SP]guess[SP]now\nisn't[SP]the[SP]time.",
     "nom_fr": "Maya",
-    "texte_fr": "Mont Iwato? Quel est ce sentiment...? De la\nnostalgie, mais douce-amère... Pas le moment."
+    "texte_fr": "Mont Iwato ? Quel est ce sentiment... ?\n De la nostalgie, mais douce-amère...\n Pas le moment."
   },
   {
     "id": 267,
@@ -4205,7 +4205,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "It's[SP]been[SP]ten[SP]years...[SP]Why[SP]now...?[SP]Let's[SP]stay\naway[SP]from[SP]here[SP]for[SP]now,[SP][1113].[SP]There's\nsomething[SP]I[SP]need[SP]to[SP]be[SP]sure[SP]of[SP]first...",
     "nom_fr": "Ginko",
-    "texte_fr": "Dix ans... Pourquoi maintenant? Restons\nloin, [1113]. Je dois d'abord vérifier."
+    "texte_fr": "Dix ans... Pourquoi maintenant ?\n Restons loin, [1113]. Je dois d'abord vérifier."
   },
   {
     "id": 268,
@@ -4221,7 +4221,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]was[SP]scared[SP]of[SP]this[SP]place[SP]for[SP]a[SP]long[SP]time.\nBut[SP]I'm[SP]okay[SP]now.[SP]I[SP]won't[SP]run[SP]anymore,\nfrom[SP]anything...",
     "nom_fr": "Ginko",
-    "texte_fr": "Peur longtemps. Maintenant\nça va. Je ne fuirai plus."
+    "texte_fr": "Peur longtemps. Maintenant ça va.\n Je ne fuirai plus."
   },
   {
     "id": 269,
@@ -4237,7 +4237,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Our[SP]secret[SP]hideout...[SP]It[SP]feels[SP]a[SP]little[SP]odd\nto[SP]be[SP]able[SP]to[SP]come[SP]here[SP]with[SP][1113][SP]again...",
     "nom_fr": "Jun",
-    "texte_fr": "Notre cachette secrète... Ça fait étrange de\npouvoir venir ici avec [1113] à nouveau..."
+    "texte_fr": "Notre cachette secrète...\n Ça fait étrange de pouvoir venir ici avec [1113] à nouveau..."
   },
   {
     "id": 270,
@@ -4252,7 +4252,7 @@
     "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
     "texte_orig": "I[SP]saw[SP]her[SP]at[SP]Mt.[SP]Iwato.[1205][U+000F][SP]You[SP]know[SP]who[SP]I[SP]mean...\nThat[SP][E4][NULL][NULL][U+0006]urban[SP]legend,[SP]Kuchisake-onna[E4][NULL][NULL][0002].[SP]I[SP]saw[SP]a\nwoman[SP]wearing[SP]a[SP]mask[SP]out[SP]there.",
     "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Je l'ai vue au mont Iwato.[1205][U+000F] Cette [E4][NULL][NULL][U+0006]légende\nurbaine, Kuchisake-onna[E4][NULL][NULL][0002]. J'ai vu une femme\nmasquée."
+    "texte_fr": "Je l'ai vue au mont Iwato.[1205][U+000F]\n Cette [E4][NULL][NULL][U+0006]légende urbaine, Kuchisake-onna[E4][NULL][NULL][0002].\n J'ai vu une femme masquée."
   },
   {
     "id": 271,
@@ -4267,7 +4267,7 @@
     "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
     "texte_orig": "Dollars[SP]to[SP]donuts[SP]there's[SP]a[SP]huge[SP]mouth,[SP]split\nfrom[SP]ear[SP]to[SP]ear,[SP]under[SP]that[SP]mask.",
     "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Sous ce masque, une bouche\nfendue d'une oreille à l'autre."
+    "texte_fr": "Sous ce masque, une bouche fendue d'une oreille à l'autre."
   },
   {
     "id": 272,
@@ -4282,7 +4282,7 @@
     "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
     "texte_orig": "But[SP]my[SP]wife[SP]tells[SP]me[SP]not[SP]to[SP]be[SP]such[SP]a[SP]baby\nand[SP]refuses[SP]to[SP]take[SP]me[SP]seriously.",
     "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Ma femme dit que j'en fais\ntrop, elle ne me croit pas."
+    "texte_fr": "Ma femme dit que j'en fais trop, elle ne me croit pas."
   },
   {
     "id": 273,
@@ -4313,7 +4313,7 @@
     "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
     "texte_orig": "Don't[SP]worry,[SP]I'll[SP]be[SP]sure[SP]to[SP]repay[SP]the[SP]favor.\nI'm[SP]counting[SP]on[SP]you!",
     "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Je te revaudrai ça. Compte sur toi!"
+    "texte_fr": "Je te revaudrai ça. Compte sur toi !"
   },
   {
     "id": 275,
@@ -4329,7 +4329,7 @@
     "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
     "texte_orig": "Kuchisake-onna[SP]should[SP]still[SP]be[SP]somewhere[SP]on\nMt.[SP]Iwato.[1205][U+000F][SP]I'm[SP]begging[SP]you,[SP]bring[SP]back[SP]proof\nshe's[SP]really[SP]there!",
     "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Kuchisake-onna est au mont\nIwato.[1205][U+000F] Prouve qu'elle est là!"
+    "texte_fr": "Kuchisake-onna est au mont Iwato.[1205][U+000F]\n Prouve qu'elle est là !"
   },
   {
     "id": 276,
@@ -4344,7 +4344,7 @@
     "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
     "texte_orig": "Hm?[1205][U+000A][SP]Ohhhhh![1205][U+000F][SP]That's[SP]it![SP][E4][NULL][NULL][U+0006]Kuchisake-onna's[SP]mask[E4][NULL][NULL][0002]![1205][U+000F]\nKid,[SP]I[SP]gotta[SP]thank[SP]you[SP]for[SP]bringing[SP]it[SP]to[SP]me!",
     "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Ohhhhh![1205][U+000F] C'est ça! [E4][NULL][NULL][U+0006]Le masque de\nKuchisake-onna[E4][NULL][NULL][0002]![1205][U+000F] Merci de me l'avoir apporté!"
+    "texte_fr": "Ohhhhh ![1205][U+000F] C'est ça !\n [E4][NULL][NULL][U+0006]Le masque de Kuchisake-onna[E4][NULL][NULL][0002] ![1205][U+000F]\n Merci de me l'avoir apporté !"
   },
   {
     "id": 277,
@@ -4360,7 +4360,7 @@
     "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
     "texte_orig": "L-Like[SP]I[SP]said,[SP]I'll[SP]repay[SP]you[SP]for[SP]the[SP]favor.\nHere's[SP]a[SP][E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Megido[SP]Card[E4][NULL][NULL][0002].[SP]Go[SP]on,[SP]it's[SP]yours!",
     "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Comme je l'ai dit, je te revaudrai ça.\nTiens, une [E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Carte Megido[E4][NULL][NULL][0002]. Elle est à toi!"
+    "texte_fr": "Comme je l'ai dit, je te revaudrai ça.\n Tiens, une [E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Carte Megido[E4][NULL][NULL][0002].\n Elle est à toi !"
   },
   {
     "id": 278,
@@ -4390,7 +4390,7 @@
     "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
     "texte_orig": "...You[SP]know,[SP]though,[SP]that[SP]Kuchisake-onna[SP]did\na[SP]lot[SP]of[SP]mumbling[SP]to[SP]herself.",
     "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "... Cette Kuchisake-onna se\nparlait tout le temps toute seule."
+    "texte_fr": "... Cette Kuchisake-onna se parlait tout le temps toute seule."
   },
   {
     "id": 280,
@@ -4406,6 +4406,6 @@
     "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
     "texte_orig": "Like,[SP][1432][NULL][NULL][0014]I[SP]wonder[SP]if[SP]this[SP]costume's[SP]too[SP]obvious...[1432][NULL][NULL][0014]\nOr[SP][1432][NULL][NULL][0014]Has[SP][1113]-kun[SP]reached[SP]the[SP]detective\nagency[SP]yet?[1432][NULL][NULL][0014][1205][U+000F][SP]What[SP]a[SP]strange[SP]monster...",
     "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "[1432][NULL][NULL][0014]Déguisement trop voyant?[1432][NULL][NULL][0014] Ou [1432][NULL][NULL][0014][1113]-kun\nà l'agence?[1432][NULL][NULL][0014][1205][U+000F] Drôle de monstre..."
+    "texte_fr": "[1432][NULL][NULL][0014]Déguisement trop voyant ?[1432][NULL][NULL][0014]\n Ou [1432][NULL][NULL][0014][1113]-kun à l'agence ?[1432][NULL][NULL][0014][1205][U+000F]\n Drôle de monstre..."
   }
 ]

--- a/traduction/event_scripts/script_254.json
+++ b/traduction/event_scripts/script_254.json
@@ -93,7 +93,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What're[SP]you[SP]mumbling[SP]about,[SP]Undie[SP]Boss!?\nHurry[SP]up[SP]and[SP]find[SP]that[SP]emblem!",
     "nom_fr": "Ginko",
-    "texte_fr": "Que marmonnes-tu, Boss en slip!?\nVite, trouve cet insigne!"
+    "texte_fr": "Que marmonnes-tu, Boss des calbutes!?\nVite, trouve cet insigne!"
   },
   {
     "id": 6,
@@ -125,7 +125,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP]Undie[SP]Boss![SP]Don't[SP]treat[SP]us[SP]the[SP]same[SP]as\nthese[SP]idiots![SP]It's[SP]not[SP]like[SP][1113]'s[SP]the\nBoss[SP]of[SP]Sevens[SP]or[SP]anything!",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, Boss en slip! Ne nous traite pas comme ces\nidiots! [1113] n'est pas le Boss de Seven!"
+    "texte_fr": "Hé, Boss des calbutes! Ne nous traite pas comme ces\nidiots! [1113] n'est pas le Boss de Seven!"
   },
   {
     "id": 8,
@@ -141,7 +141,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP][1113]?[SP]You[SP]think[SP]the[SP]Undie[SP]Boss[SP]is\nsincere[SP]about[SP]being[SP]a[SP]leader?[1205][001E][SP]Guys[SP]like[SP]him\nare[SP]pretty[SP]rare[SP]these[SP]days.",
     "nom_fr": "Ginko",
-    "texte_fr": "[1113]? Le Boss en slip est un vrai leader?[1205][001E]\nLes mecs comme lui sont rares de nos jours."
+    "texte_fr": "[1113]? Le Boss des calbutes est un vrai leader?[1205][001E]\nLes mecs comme lui sont rares de nos jours."
   },
   {
     "id": 9,
@@ -461,7 +461,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "Huh!?[SP]Isn't[SP]that[SP]Undie[SP]Boss?[SP]What's[SP]he[SP]doing\nwith[SP]you,[SP]Senpai?",
     "nom_fr": "Lycéen bandé",
-    "texte_fr": "Hein!? C'est le Boss en slip?\nQue fait-il avec vous, Senpai?"
+    "texte_fr": "Hein!? C'est le Boss des calbutes?\nQue fait-il avec vous, Senpai?"
   },
   {
     "id": 29,

--- a/traduction/event_scripts/script_275.json
+++ b/traduction/event_scripts/script_275.json
@@ -13,7 +13,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "You[SP]know[SP]that[SP]Joker[SP]Game[SP]thing?[SP]I[SP]wonder[SP]if\nit's[SP]real...[1205][001E][SP]Oh,[SP]I[SP]just[SP]heard[SP]a[SP]rumor,[SP]is[SP]all.\nYour[SP]dreams[SP]come[SP]true,[SP]eh?[SP]Has[SP]that[SP]happened?",
     "nom_fr": "Lycéen",
-    "texte_fr": "T'as entendu parler du Joker Game? C'est\nvrai tout ça...[1205][001E] Bah, j'ai juste entendu\nune rumeur. Tes rêves se [1205][U+000F] réalisent, non?"
+    "texte_fr": "T'as entendu parler du Jeu du Joker? C'est\nvrai tout ça...[1205][001E] Bah, j'ai juste entendu\nune rumeur. Tes rêves se [1205][U+000F] réalisent, non?"
   },
   {
     "id": 1,

--- a/traduction/event_scripts/script_296.json
+++ b/traduction/event_scripts/script_296.json
@@ -503,7 +503,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Maya-san[SP]says[SP]otherwise,[SP]but[SP]there's[SP]no[SP]way\nUndie[SP]Boss[SP]is[SP]that[SP]sensitive.[1205][U+000F][SP]She's[SP]just\noverthinking[SP]things.",
     "nom_fr": "Ginko",
-    "texte_fr": "Maya dit l'inverse, mais Undie Boss n'est\npas si sensible.[1205][U+000F] Elle se prend trop la tête."
+    "texte_fr": "Maya dit l'inverse, mais Boss des calbutes n'est\npas si sensible.[1205][U+000F] Elle se prend trop la tête."
   },
   {
     "id": 31,

--- a/traduction/event_scripts/script_299.json
+++ b/traduction/event_scripts/script_299.json
@@ -205,7 +205,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Awww...[SP]He[SP]did[SP]the[SP]Joker[SP]Game[SP]too.[SP]I[SP]guess[SP]if\nit[SP]can[SP]fulfill[SP]any[SP]ideal,[SP]I[SP]may[SP]as[SP]well[SP]give[SP]it\na[SP]try.[SP]But[SP]what[SP]should[SP]I[SP]ask[SP]for?",
     "nom_fr": "Élève",
-    "texte_fr": "Ah bon... Lui aussi a fait le Joker Game.\nBon, si ça peut exaucer n'importe quel\nidéal, autant essayer. Mais quoi demander?"
+    "texte_fr": "Ah bon... Lui aussi a fait le Jeu du Joker.\nBon, si ça peut exaucer n'importe quel\nidéal, autant essayer. Mais quoi demander?"
   },
   {
     "id": 13,

--- a/traduction/event_scripts/script_319.json
+++ b/traduction/event_scripts/script_319.json
@@ -253,7 +253,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Should[SP]we[SP]try[SP]the[SP]Undie[SP]Boss'[SP]plan?[1205][001E][SP]Hey,[SP]maybe\nif[SP]we[SP]spread[SP]the[SP]rumor[SP]that[SP]Joker[SP]is[SP]really\nweak,[SP]it[SP]might[SP]come[SP]true[SP]and[SP]help[SP]us[SP]win...",
     "nom_fr": "Ginko",
-    "texte_fr": "On tente le plan d'Undie Boss?[1205][001E] Si\non dit partout que le Joker est\nfaible, on pourrait gagner..."
+    "texte_fr": "On tente le plan d'Boss des calbutes?[1205][001E] Si\non dit partout que le Joker est\nfaible, on pourrait gagner..."
   },
   {
     "id": 16,

--- a/traduction/event_scripts/script_325.json
+++ b/traduction/event_scripts/script_325.json
@@ -625,7 +625,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh?[SP]Cuss[SP]High's[SP]Undie[SP]Boss[SP]isn't[SP]the[SP]Boss\nanymore?[SP]Huh...[SP]I[SP]guess[SP]that's[SP]big[SP]news[SP]for\nhis[SP]schoolmates.[SP]Okay,[SP]here's[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hein? Undie Boss n'est plus chef\ndu Lycée Kasu? C'est une grande\nnouvelle. Voici[1205][U+000F] ce que je sais."
+    "texte_fr": "Hein? Boss des calbutes n'est plus chef\ndu Lycée Kasu? C'est une grande\nnouvelle. Voici[1205][U+000F] ce que je sais."
   },
   {
     "id": 37,
@@ -753,7 +753,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh,[SP]so[SP]the[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High[SP]used[SP]to\nbe[SP]the[SP]Undie[SP]Boss'[SP]flunky.[SP]The[SP]world[SP]of[SP]high\nschool[SP]sounds[SP]rough...[SP]Here's[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Le nouveau chef du Lycée Kasu était le larbin\nd'Undie Boss. Dur dur... Voici pour toi."
+    "texte_fr": "Le nouveau chef du Lycée Kasu était le larbin\nd'Boss des calbutes. Dur dur... Voici pour toi."
   },
   {
     "id": 45,

--- a/traduction/event_scripts/script_332.json
+++ b/traduction/event_scripts/script_332.json
@@ -219,7 +219,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]wonder[SP]if[SP]it's[SP]true[SP]that[SP]Undie[SP]Boss[SP]was[SP]going\nout[SP]with[SP]Kozy...",
     "nom_fr": "Ginko",
-    "texte_fr": "Je me demande si Undie Boss\nsortait vraiment avec Kozy..."
+    "texte_fr": "Je me demande si Boss des calbutes\nsortait vraiment avec Kozy..."
   },
   {
     "id": 14,

--- a/traduction/event_scripts/script_334.json
+++ b/traduction/event_scripts/script_334.json
@@ -221,7 +221,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Ugh,[SP]Undie[SP]Boss[SP]is[SP]such[SP]an[SP]idiot![1205][U+000F][SP]Look[SP]at[SP]all\nthe[SP]trouble[SP]he[SP]caused[SP]us,[SP]taking[SP]off[SP]like[SP]that!",
     "nom_fr": "Ginko",
-    "texte_fr": "Argh, Undie Boss est idiot![1205][U+000F] Regarde tous les\nennuis qu'il nous cause en fuyant ainsi!"
+    "texte_fr": "Argh, Boss des calbutes est idiot![1205][U+000F] Regarde tous les\nennuis qu'il nous cause en fuyant ainsi!"
   },
   {
     "id": 14,

--- a/traduction/event_scripts/script_338.json
+++ b/traduction/event_scripts/script_338.json
@@ -173,7 +173,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Oh,[SP]crap![SP]That[SP]reminds[SP]me,[SP]Undie[SP]Boss[SP]took[SP]off\nwithout[SP]knowing[SP]Kozy[SP]is[SP]Miyabi...[1205][U+000F][SP]Should[SP]we\nhave[SP]mentioned[SP]that?",
     "nom_fr": "Ginko",
-    "texte_fr": "Oh, mince! Undie Boss est parti sans savoir\nque Kozy est Miyabi...[1205][U+000F] Aurait-on dû lui dire?"
+    "texte_fr": "Oh, mince! Boss des calbutes est parti sans savoir\nque Kozy est Miyabi...[1205][U+000F] Aurait-on dû lui dire?"
   },
   {
     "id": 11,

--- a/traduction/event_scripts/script_396.json
+++ b/traduction/event_scripts/script_396.json
@@ -269,7 +269,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "H-Hey,[SP]Undie[SP]Boss![1205][001E][SP]I[SP]know[SP]Miyabi[SP]really[SP]well...[1205][001E]\nWhat[SP]was[SP]your[SP]relationship[SP]with[SP]her?",
     "nom_fr": "Lisa",
-    "texte_fr": "H-Hey, Undie Boss![1205][001E] Je connais bien Miyabi...[1205][001E]\nC'était quoi ta relation avec elle?"
+    "texte_fr": "H-Hey, Boss des calbutes![1205][001E] Je connais bien Miyabi...[1205][001E]\nC'était quoi ta relation avec elle?"
   },
   {
     "id": 17,
@@ -301,7 +301,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "H-Hey,[SP]Undie[SP]Boss![1205][001E][SP]I[SP]know[SP]Miyabi[SP]really[SP]well...[1205][001E]\nWhat[SP]was[SP]your[SP]relationship[SP]with[SP]her?",
     "nom_fr": "Ginko",
-    "texte_fr": "H-Hey, Undie Boss![1205][001E] Je connais bien Miyabi...[1205][001E]\nC'était quoi ta relation avec elle?"
+    "texte_fr": "H-Hey, Boss des calbutes![1205][001E] Je connais bien Miyabi...[1205][001E]\nC'était quoi ta relation avec elle?"
   },
   {
     "id": 19,
@@ -877,7 +877,7 @@
     "nom_orig": "School[SP]paper[SP]writer",
     "texte_orig": "I[SP]never[SP]knew[SP]our[SP]editor[SP]and[SP]the[SP]Undie[SP]Boss[SP]used\nto[SP]be[SP]lovers...[SP]How[SP]strange[SP]fate[SP]can[SP]be.\nThis[SP]is[SP]a[SP]huge[SP]scoop![SP]Hmmm...",
     "nom_fr": "Rédacteur du journal scolaire",
-    "texte_fr": "J'ignorais que notre rédactrice et\nUndie Boss étaient ensemble... Quel\ndestin! Un scoop énorme! Hmmm..."
+    "texte_fr": "J'ignorais que notre rédactrice et\nBoss des calbutes étaient ensemble... Quel\ndestin! Un scoop énorme! Hmmm..."
   },
   {
     "id": 55,


### PR DESCRIPTION
Cette Pull Request corrige les traductions des termes 'Undie Boss' en 'Boss des calbutes' et 'Joker Game' en 'Jeu du Joker' dans tous les fichiers de scripts et de la map. Le Dictionnaire a été mis à jour en conséquence.

Cela inclut aussi le patch pour l'encodeur MMAP afin d'utiliser des balises de fin de script [E3] au lieu d'espaces transparents, ce qui évite les crashs (chargements infinis) sur les bulles de dialogue dynamiques.