### PR TITLE
fix: applique 240 corrections de relecture de Seb sur les scripts FR

### DIFF
--- a/traduction/event_scripts/script_000.json
+++ b/traduction/event_scripts/script_000.json
@@ -253,7 +253,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Why[SP]won't[SP]you[SP]obey[SP]me!?\nThis[SP]is[SP]unacceptable!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Pourquoi tu n'obéis pas!? C'est inadmissible!"
+    "texte_fr": "Pourquoi tu n'obéis pas!?\nC'est inadmissible!"
   },
   {
     "id": 16,
@@ -301,7 +301,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "If[SP]that[SP]nasty[SP]resonance[SP]I[SP]sensed[SP]from[SP]the\nhall[SP]was[SP]you,[SP]it[SP]makes[SP]sense...[SP][1205][001E]Looks[SP]like\nyou're[SP]as[SP]much[SP]trouble[SP]as[SP]the[SP]rumors[SP]say.",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Si tu es à l'origine de ces bruits agaçants\nque j'entends depuis le hall, c'est\nlogique...[1205][U+000F] Tu es aussi gênant qu'on le dit."
+    "texte_fr": "Si tu es à l'origine de ces bruits\nagaçants que j'entends depuis le hall,\nc'est logique...[1205][U+000F] Tu es aussi gênant qu'on le dit."
   },
   {
     "id": 19,
@@ -365,7 +365,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "You've[SP]been[SP]dodging[SP]guidance[SP]counseling,\neh?[SP]She[SP]looked[SP]ready[SP]to[SP]chase[SP]you[SP]all[SP]the\nway[SP]to[SP]your[SP]house.[SP]Better[SP]go[SP]see[SP]her.",
     "nom_fr": "Lycéen",
-    "texte_fr": "T'as séché l'orientation, hein? Elle avait\nl'air prête à te courser jusque chez toi.[1205][U+000F]\nJ'irais vite la voir à ta place."
+    "texte_fr": "T'as séché l'orientation, hein? Elle avait\nl'air prête à te courser jusque chez toi.\nJ'irais vite la voir à ta place."
   },
   {
     "id": 23,
@@ -381,7 +381,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "*sigh*[SP]I've[SP]taken[SP]ill[SP]myself.[SP]I[SP]woke[SP]up\nthis[SP]morning[SP]with[SP]a[SP]swollen[SP]face[SP]and[SP]a\nbald[SP]spot.[SP]Laugh[SP]if[SP]you[SP]want...",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "*soupir* Je suis malade. Je me suis\nréveillé le visage enflé et le crâne\nun peu[1205][U+000F] dégarni. Tu peux rire, ouais..."
+    "texte_fr": "*soupir* Je suis malade. Je me suis\nréveillé le visage enflé et le crâne\nun peu dégarni. Tu peux rire, ouais..."
   },
   {
     "id": 24,
@@ -397,7 +397,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "I[SP]don't[SP]envy[SP]your[SP]long[SP]hair[SP]at[SP]all.[SP]In[SP]the\nyears[SP]to[SP]come,[SP]everyone[SP]will[SP]go[SP]bald\nanyway.[1205][001E][SP]Heh...[1205][001E][SP]I'll[SP]be[SP]waiting,[SP][1113].",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "J'envie pas du tout tes cheveux longs. Tout\nle monde finira par être chauve de toute\nfaçon.[1205][U+000F] [1205][001E] Héhé...[1205][001E] t'es le prochain, [1113]."
+    "texte_fr": "J'envie pas du tout tes cheveux longs.\nTout le monde finira par être chauve de\ntoute façon.[1205][001E] Héhé...[1205][001E] t'es le prochain, [1113]."
   },
   {
     "id": 25,
@@ -413,7 +413,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "Bad[SP]luck,[SP][1113]-senpai.[SP]I'm[SP]surprised\nat[SP]how[SP]popular[SP]Principal[SP]Hanya[SP]is.[1205][001E][SP]He's\nawful,[SP]but[SP]I[SP]like[SP]him...[SP]Why[SP]is[SP]that?",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Pas de bol, [1113]-senpai. Je suis étonnée\nqu'Hanya soit si populaire.[1205][001E] Il est\ndétestable, mais je l'aime bien...[1205][U+000F] Pourquoi?"
+    "texte_fr": "Pas de bol, [1113]-senpai. Je suis étonnée\nqu'Hanya soit si populaire.[1205][001E] Il est détestable, mais je l'aime bien...\nPourquoi?"
   },
   {
     "id": 26,

--- a/traduction/event_scripts/script_001.json
+++ b/traduction/event_scripts/script_001.json
@@ -29,7 +29,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Don't[SP]worry,[SP]guidance[SP]counseling[SP]is[SP]a\npretty[SP]informal[SP]process.",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "T'inquiète pas, l'entretien\nd'orientation c'est pas formel."
+    "texte_fr": "T'inquiète pas, l'entretien\nd'orientation n'est pas formel."
   },
   {
     "id": 2,
@@ -103,7 +103,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Will[SP]you[SP]apply[SP]to[SP]college[SP]or[SP]go\njob[SP]hunting?\n[1208][0002][1432][NULL][NULL][0014]I[SP]want[SP]to[SP]go[SP]to[SP]college.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]I'd[SP]like[SP]a[SP]job.[1432][NULL][NULL][0014]",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Tu tentes l'université\nou chercher du boulot?\n[1208][0002][1432][NULL][NULL][0014]Je veux aller à la fac.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Je veux un job.[1432][NULL][NULL][0014]",
+    "texte_fr": "Tu tentes la fac \nou de chercher du boulot?\n[1208][0002][1432][NULL][NULL][0014]Je veux aller à la fac.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Je veux un job.[1432][NULL][NULL][0014]",
     "question_orig": "Will[SP]you[SP]apply[SP]to[SP]college[SP]or[SP]go\njob[SP]hunting?",
     "choix_orig": [
       "I[SP]want[SP]to[SP]go[SP]to[SP]college.",
@@ -145,7 +145,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Do[SP]you[SP]really[SP]want[SP]to[SP]go[SP]to[SP]college?\n[1208][0002][1432][NULL][NULL][0014]I[SP]seriously[SP]do.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Honestly,[SP]I[SP]don't[SP]know.[1432][NULL][NULL][0014]",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "T'as vraiment envie de l'université?\n[1208][0002][1432][NULL][NULL][0014]Oui, vraiment. [1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]aucune idée.           [1432][NULL][NULL][0014]",
+    "texte_fr": "T'as vraiment envie de l'université?\n[1208][0002][1432][NULL][NULL][0014]Oui, vraiment. [1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Aucune idée.           [1432][NULL][NULL][0014]",
     "question_orig": "Do[SP]you[SP]really[SP]want[SP]to[SP]go[SP]to[SP]college?",
     "choix_orig": [
       "I[SP]seriously[SP]do.",
@@ -171,7 +171,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "If[SP]you're[SP]just[SP]saying[SP]what[SP]you[SP]think\nI[SP]want[SP]to[SP]hear,[SP]think[SP]harder.[SP]Do[SP]you\nreally[SP]want[SP]a[SP]job?",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Si tu dis ce que tu crois que je veux\nentendre, réfléchis. T'as vraiment envie de\nbosser?"
+    "texte_fr": "Si tu dis ce que tu crois que je\nveux entendre, réfléchis. T'as vraiment\nenvie de bosser?"
   },
   {
     "id": 9,
@@ -229,7 +229,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Is[SP]there[SP]anything[SP]you[SP]want[SP]to[SP]do?\n[1208][0002][1432][NULL][NULL][0014]Actually,[SP]there[SP]is.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]No,[SP]not[SP]yet.[1432][NULL][NULL][0014]",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Y a un truc que tu veux faire?  \n[1208][0002][1432][NULL][NULL][0014]En vrai, ouais.    [1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Pas encore. [1432][NULL][NULL][0014]",
+    "texte_fr": "Y a un truc que tu veux faire?   \n[1208][0002][1432][NULL][NULL][0014]En vrai, ouais.    [1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Pas encore. [1432][NULL][NULL][0014]",
     "question_orig": "Is[SP]there[SP]anything[SP]you[SP]want[SP]to[SP]do?",
     "choix_orig": [
       "Actually,[SP]there[SP]is.",
@@ -271,7 +271,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "What[SP]do[SP]you[SP]think?\n[1208][0002][1432][NULL][NULL][0014]I'll[SP]balance[SP]dreams[SP]and[SP]life.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]I[SP]don't[SP]think[SP]about[SP]it[SP]much.[1432][NULL][NULL][0014]",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "T'en penses quoi?\n[1208][0002][1432][NULL][NULL][0014]Je mêlerai rêve et réalité.  [1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]J'y pense pas trop.         [1432][NULL][NULL][0014]",
+    "texte_fr": "T'en penses quoi? \n[1208][0002][1432][NULL][NULL][0014]Je mêlerai rêve et réalité.  [1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]J'y pense pas trop.         [1432][NULL][NULL][0014]",
     "question_orig": "What[SP]do[SP]you[SP]think?",
     "choix_orig": [
       "I'll[SP]balance[SP]dreams[SP]and[SP]life.",
@@ -371,7 +371,7 @@
     "nom_orig": "???",
     "texte_orig": "Wait...[SP]Aiyah!",
     "nom_fr": "???",
-    "texte_fr": "Attends... Wow!"
+    "texte_fr": "Hey... Aiyah!"
   },
   {
     "id": 19,
@@ -403,7 +403,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Sorry-ia,[SP]Ms.[SP]Saeko![SP]I[SP]have[SP]important\nbusiness[SP]with[SP][1113][SP]here![SP]Can[SP]I\nborrow[SP]him?",
     "nom_fr": "Lisa",
-    "texte_fr": "Pardon, Madame! J'ai d'importantes affaires\navec [1113]! Je peux vous l'emprunter?"
+    "texte_fr": "Pardon, Madame! J'ai d'importantes\naffaires avec [1113]! Je peux vous l'emprunter?"
   },
   {
     "id": 21,
@@ -451,7 +451,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Wait[SP]a[SP]sec...[SP]Aiyah!",
     "nom_fr": "Lisa",
-    "texte_fr": "Deux secondes... Wow!"
+    "texte_fr": "Attends... Aiyah!"
   },
   {
     "id": 24,
@@ -467,7 +467,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "I[SP]don't[SP]believe[SP]this![1205][001E][SP]Why[SP]are[SP]you[SP]still\nwearing[SP]your[SP]emblem!?[SP]You[SP]DO[SP]know[SP]about\nthe[SP]emblem[SP]curse,[SP]right?",
     "nom_fr": "Lisa",
-    "texte_fr": "J'y crois pas![1205][001E] Pourquoi tu portes encore ton\nemblème!? Tu sais bien qu'il est maudit, non?"
+    "texte_fr": "J'y crois pas![1205][001E] Pourquoi tu portes encore ton\nemblème!? Tu sais bien qu'il\nest maudit, non?"
   },
   {
     "id": 25,
@@ -515,7 +515,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Says[SP]here...\n[1432][NULL][NULL][0014][1113][SP][1112]:[SP]We're[SP]holding\na[SP]girl[SP]from[SP]your[SP]school[SP]hostage.[1432][NULL][NULL][0014]",
     "nom_fr": "Lisa",
-    "texte_fr": "C'est écrit... [1432][NULL][NULL][0014][1113] [1112]: On tient\nune fille de votre lycée en otage.[1432][NULL][NULL][0014]"
+    "texte_fr": "C'est écrit...\n[1432][NULL][NULL][0014][1113] [1112]: On tient une fille de\nvotre lycée en otage.[1432][NULL][NULL][0014]"
   },
   {
     "id": 28,
@@ -531,7 +531,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "[1432][NULL][NULL][0014]If[SP]you[SP]value[SP]her[SP]life,[SP]come[SP]to[SP]Sumaru\nPrison[SP]alone.[SP]-Kasugayama[SP]High[SP]Boss,\n[SP][SP][SP][SP][SP][SP][SP][SP][SP][SP][SP][SP]Michel[SP]Eikichi[1432][NULL][NULL][0014]...!?",
     "nom_fr": "Lisa",
-    "texte_fr": "[1432][NULL][NULL][0014]tu veux la sauver? Viens seul à la prison\nSumaru.-Le boss de Kasugayama, Michel\nEikichi[1432][NULL][NULL][0014]...!?"
+    "texte_fr": "[1432][NULL][NULL][0014]Tu veux la sauver? Viens seul à la prison\nde Sumaru. -Le boss de Kasugayama,\nMichel Eikichi[1432][NULL][NULL][0014]...!?"
   },
   {
     "id": 29,
@@ -547,7 +547,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Haime![SP]Seriously!?[SP]Now[SP]that's[SP]old-\nschool...[1205][001E][SP]I[SP]dunno,[SP]though,[SP]rumor[SP]has\nit[SP]this[SP]guy's[SP]really[SP]strong!",
     "nom_fr": "Lisa",
-    "texte_fr": "Sérieux!? C'est trop veillot...[1205][001E]\nJ'sais pas, mais les rumeurs disent\nque ce mec est vraiment balèze!"
+    "texte_fr": "Sérieux!? C'est trop vieillot...[1205][001E]\nJ'sais pas, mais les rumeurs disent\nque ce mec est vraiment balèze!"
   },
   {
     "id": 30,
@@ -563,7 +563,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "I[SP]also[SP]heard[SP]a[SP]rumor[SP]that[SP]it[SP]was[SP]a[SP]Cuss\nHigh[SP]jerk[SP]who[SP]cursed[SP]our[SP]emblem...[1205][001E]\nI[SP]bet[SP]it[SP]was[SP]this[SP]same[SP]guy!",
     "nom_fr": "Lisa",
-    "texte_fr": "J'ai aussi entendu qu'un con du\nLycée Kasu aurait maudit notre\nemblème...[1205][001E] Pari que c'est le même!"
+    "texte_fr": "J'ai aussi entendu qu'un con du\nLycée Kasu aurait maudit notre\nemblème...[1205][001E] Je parie que c'est le même!"
   },
   {
     "id": 31,
@@ -611,7 +611,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "I[SP]can[SP]at[SP]least[SP]show[SP]you[SP]the[SP]way![SP]I[SP]don't\nwant[SP]to[SP]sit[SP]around[SP]until[SP]the[SP]curse[SP]gets\nme[SP]too.[SP]Please,[SP]take[SP]me[SP]along!",
     "nom_fr": "Lisa",
-    "texte_fr": "Je peux te montrer le chemin! J'veux pas\nrester là pendant que la malédiction[1205][U+000F]\nm'emporte. Emmène-moi avec toi!"
+    "texte_fr": "Je peux te montrer le chemin! J'veux pas\nrester là pendant que la malédiction\nm'emporte. Emmène-moi avec toi!"
   },
   {
     "id": 34,
@@ -627,7 +627,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Is[SP]that[SP]so![SP]You[SP]seemed[SP]indecisive\nfor[SP]long[SP]enough,[SP]but[SP]I'm[SP]glad[SP]you[SP]did\ngive[SP]it[SP]some[SP]thought.",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Ah bon! Tu avais l'air indécis mais je suis\ncontente que t'y aies quand même réfléchi."
+    "texte_fr": "Ah bon! Tu avais l'air indécis mais\nje suis contente que t'y aies\nquand même réfléchi."
   },
   {
     "id": 35,
@@ -706,7 +706,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "I[SP]see...[1205][001E][SP]Well,[SP]there's[SP]no[SP]reason[SP]to\nrush[SP]this.[SP]Give[SP]your[SP]future[SP]the[SP]long,\ncareful[SP]consideration[SP]it[SP]deserves.",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Je vois...[1205][001E] Pas besoin de se presser. Prends\nle temps qu'il faut pour penser à ton avenir."
+    "texte_fr": "Je vois...[1205][001E] Pas besoin de se presser. Prends\nle temps qu'il faut pour\npenser à ton avenir."
   },
   {
     "id": 40,
@@ -785,7 +785,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Still...[SP]You[SP]can't[SP]live[SP]on[SP]dreams[SP]alone.\nDon't[SP]forget[SP]that.",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Même ainsi... On vit pas que\nde rêves. Ne l'oublie pas."
+    "texte_fr": "Même ainsi... On ne vit pas que\nde rêves. Ne l'oublie pas."
   },
   {
     "id": 45,
@@ -817,7 +817,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "So...[1205][001E][SP]You[SP]have[SP]no[SP]idea[SP]what[SP]to[SP]do[SP]after\ngraduation,[SP]and[SP]there's[SP]nothing[SP]you[SP]want\nto[SP]do[SP]either...",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Du coup...[1205][001E] T'as aucune idée de ce que tu veux\nfaire, et rien qui te donne envie non plus..."
+    "texte_fr": "Du coup...[1205][001E] T'as aucune idée de ce que tu veux\nfaire, et rien qui te donne\nenvie non plus..."
   },
   {
     "id": 47,

--- a/traduction/event_scripts/script_002.json
+++ b/traduction/event_scripts/script_002.json
@@ -29,7 +29,7 @@
     "nom_orig": "???",
     "texte_orig": "...[1205][U+000A]...[1205][U+000A]...[1205][U+000A]Gah!",
     "nom_fr": "???",
-    "texte_fr": "...[1205][U+000A]...[1205][U+000A]...[1205][U+000A] Gah!"
+    "texte_fr": "...[1205][U+000A]...[1205][U+000A]...[1205][U+000A]Gah!"
   },
   {
     "id": 2,
@@ -204,7 +204,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "What...[1205][001E][SP]are[SP]you[SP]smoking?",
     "nom_fr": "Lisa",
-    "texte_fr": "Tu fumes...[1205][001E] quoi?"
+    "texte_fr": "T'as fumé...[1205][001E] quoi?"
   },
   {
     "id": 13,
@@ -300,7 +300,7 @@
     "nom_orig": "Shogo,[SP]Ken[SP]&[SP]Takeshi",
     "texte_orig": "Yes,[SP]sir![SP][1432][NULL][NULL][0014]Cowardice[SP]is[SP]unbefitting[SP]of[SP]a\nreal[SP]man![1432][NULL][NULL][0014][SP]We'll[SP]take[SP]whatever[SP]punishment\nyou[SP]have[SP]in[SP]store!",
     "nom_fr": "Shogo, Ken & Takeshi",
-    "texte_fr": "Oui, chef! [1432][NULL][NULL][0014]La lâcheté est indigne d'un vrai\nhomme![1432][NULL][NULL][0014] On acceptera n'importe quelle punition!"
+    "texte_fr": "Oui, chef! [1432][NULL][NULL][0014]La lâcheté est indigne d'un\nvrai homme![1432][NULL][NULL][0014] On acceptera n'importe quelle\npunition!"
   },
   {
     "id": 19,

--- a/traduction/event_scripts/script_003.json
+++ b/traduction/event_scripts/script_003.json
@@ -29,7 +29,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Phile...mon...?",
     "nom_fr": "Lisa",
-    "texte_fr": "Phile... mon...?"
+    "texte_fr": "Philé...mon...?"
   },
   {
     "id": 2,
@@ -125,6 +125,6 @@
     "nom_orig": "Philemon",
     "texte_orig": "From[SP]time[SP]out[SP]of[SP]mind,[SP]beyond[SP]oblivion...\nThe[SP]land[SP]of[SP]Sumaru[SP]is[SP]now[SP]a[SP]netherworld[SP]where\nrumors[SP]are[SP]reality.[1205][001E][SP]The[SP]battle[SP]is[SP]begun...",
     "nom_fr": "Philémon",
-    "texte_fr": "Depuis la nuit des temps, par-delà l'oubli...\nSumaru est devenu un monde où les[1205][U+000F] rumeurs\nsont réalité.[1205][001E] La bataille commence..."
+    "texte_fr": "Depuis la nuit des temps, par-delà \nl'oubli... Sumaru est devenu une terre \noù les[1205][U+000F] rumeurs sont réalité.[1205][001E] La bataille commence..."
   }
 ]

--- a/traduction/event_scripts/script_004.json
+++ b/traduction/event_scripts/script_004.json
@@ -45,7 +45,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "I[SP]knew[SP]it...![1205][001E][SP]I[SP]saw[SP]it,[SP]too.[SP]It[SP]called\nthose[SP]things[SP]Personas...?",
     "nom_fr": "Lisa",
-    "texte_fr": "Je le savais![1205][001E] J'ai vu aussi. Ça\nappelait ça des Personae...?"
+    "texte_fr": "Je le savais![1205][001E] Je l'ai vu aussi. Il\nappelait ça des Personae...?"
   },
   {
     "id": 3,
@@ -61,7 +61,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Even[SP]the[SP]part[SP]about[SP]rumors[SP]coming[SP]true,\nand[SP]the[SP]stuff[SP]about[SP]the[SP]future...?[1205][001E][SP]That's\ntoo[SP]much[SP]for[SP]it[SP]to[SP]be[SP]a[SP]coincidence.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Même les rumeurs qui deviennent\nréalité, et les trucs sur l'avenir...?[1205][001E]\nTrop pour que ce soit une coïncidence."
+    "texte_fr": "Même les rumeurs qui deviennent\nréalité, et les trucs sur l'avenir...?[1205][001E]\nC'est trop pour que ça soit\nune coïncidence."
   },
   {
     "id": 4,
@@ -93,7 +93,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]thing[SP]where[SP]you[SP]call[SP]your[SP]own[SP]cell\nand[SP]it[SP]shows[SP]up?[1205][001E][SP]Why[SP]would[SP]I[SP]want[SP]to\ntry[SP]that?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le truc où t'appelles ton portable et il se\npointe?[1205][001E] Pourquoi je voudrais essayer ça?"
+    "texte_fr": "Le truc où t'appelles ton portable et\nil se pointe?[1205][001E] Pourquoi je voudrais essayer ça?"
   },
   {
     "id": 6,
@@ -157,7 +157,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "If[SP]you[SP]say[SP]so...[1205][001E][SP]It[SP]does[SP]feel[SP]like[SP]we\nshould[SP]be[SP]doing[SP]something[SP]after[SP]a[SP]dream\nlike[SP]that.[SP]Let's[SP]see[SP]if[SP]this[SP]is[SP]for[SP]real.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Si tu le dis...[1205][001E] C'est vrai qu'on devrait\nfaire quelque chose après un rêve\npareil. Voyons si c'est pour de vrai."
+    "texte_fr": "Si tu le dis...[1205][001E] C'est vrai qu'on devrait\nfaire quelque chose après un rêve\npareil. Voyons voir si c'est vrai."
   },
   {
     "id": 10,
@@ -269,7 +269,7 @@
     "nom_orig": "Joker",
     "texte_orig": "I[SP]am[SP]Joker...[1205][001E][SP]The[SP]final[SP]trump[SP]card[SP]drawn\nby[SP]those[SP]anguished[SP]over[SP]their[SP]dreams...",
     "nom_fr": "Joker",
-    "texte_fr": "Je suis le Joker...[1205][001E] L'atout final tiré\npar ceux que leurs rêves tourmentent..."
+    "texte_fr": "Je suis le Joker...[1205][001E] L'atout final tiré\npar ceux tourmentés par leurs rêves..."
   },
   {
     "id": 17,
@@ -284,7 +284,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Tell[SP]me[SP]your[SP]ideal...",
     "nom_fr": "",
-    "texte_fr": "Dites-moi votre idéal..."
+    "texte_fr": "Votre idéal est...?"
   },
   {
     "id": 18,
@@ -332,7 +332,7 @@
     "nom_orig": "Joker",
     "texte_orig": "The[SP]bet[SP]on[SP]the[SP]table[SP]was[SP]your[SP]inner,\ndreaming[SP]heart...[1205][001E][SP]In[SP]accordance[SP]with[SP]the\nritual,[SP]I[SP]will[SP]now[SP]claim[SP]the[SP]pot.",
     "nom_fr": "Joker",
-    "texte_fr": "La mise était votre cœur rêveur...[1205][001E]\nConformément au rituel, je vais réclamer le\ngain."
+    "texte_fr": "La mise était votre cœur rêveur...[1205][001E]\nConformément au rituel, je vais \nréclamer le gain."
   },
   {
     "id": 21,
@@ -412,7 +412,7 @@
     "nom_orig": "Joker",
     "texte_orig": "They[SP]are[SP]lifeless[SP]shells[SP]of[SP]dreams...[1205][001E]\nThey[SP]can[SP]be[SP]seen,[SP]but[SP]are[SP]not.[SP]They[SP]will\nbe[SP]forgotten[SP]and[SP]become[SP]true[SP]shadows.",
     "nom_fr": "Joker",
-    "texte_fr": "Ces coquilles vides de rêves...[1205][001E] Sont\nvisibles mais ne sont plus. Oubliés,\nils deviendront de vraies ombres."
+    "texte_fr": "Ces coquilles vides de rêves...[1205][001E] Ils sont\nvisibles mais ne sont plus. Oubliés,\nils deviendront de vraies ombres."
   },
   {
     "id": 26,

--- a/traduction/event_scripts/script_005.json
+++ b/traduction/event_scripts/script_005.json
@@ -125,7 +125,7 @@
     "nom_orig": "Joker",
     "texte_orig": "The[SP]poker[SP]face[SP]doesn't[SP]fool[SP]me.[SP]I[SP]know.\nYou[SP]wanted[SP]to[SP]follow[SP]your[SP]dream...\nIsn't[SP]that[SP]so?",
     "nom_fr": "Joker",
-    "texte_fr": "Ton masque ne me trompe pas. Je sais. Tu\nvoulais poursuivre ton rêve... N'est-ce pas?"
+    "texte_fr": "Ton masque ne me trompe pas. Je sais. Tu\nvoulais poursuivre ton rêve...\nN'est-ce pas?"
   },
   {
     "id": 8,
@@ -173,7 +173,7 @@
     "nom_orig": "Joker",
     "texte_orig": "The[SP]poker[SP]face[SP]doesn't[SP]fool[SP]me.[SP]I[SP]know.\nYou're[SP]a[SP]dunce[SP]who[SP]doesn't[SP]even[SP]know[SP]what\nhe[SP]wants[SP]to[SP]do.",
     "nom_fr": "Joker",
-    "texte_fr": "Ton masque ne trompe pas. T'es un cancre qui\nsait même pas ce qu'il veut faire de sa vie."
+    "texte_fr": "Ton masque ne me trompe pas. T'es un \ncancre qui sait même pas ce\nqu'il veut faire de sa vie."
   },
   {
     "id": 11,
@@ -301,7 +301,7 @@
     "nom_orig": "Joker",
     "texte_orig": "No...[1205][001E][SP]Do[SP]you[SP]not[SP]remember!?",
     "nom_fr": "Joker",
-    "texte_fr": "Non...[1205][001E] Z'avez oublié!?"
+    "texte_fr": "Non...[1205][001E] Vous avez oublié!?"
   },
   {
     "id": 19,
@@ -557,7 +557,7 @@
     "nom_orig": "Takeshi",
     "texte_orig": "I[SP]wanted...[SP]to[SP]be[SP]a[SP]doctor...[1205][001E][SP]But[SP]that'll\nnever[SP]happen...[1205][001E][SP]I[SP]don't[SP]want[SP]to[SP]think\nanymore...",
     "nom_fr": "Takeshi",
-    "texte_fr": "Je voulais... devenir médecin...[1205][001E] Mais ça\nn'arrivera jamais...[1205][001E] Je ne veux plus penser..."
+    "texte_fr": "Je voulais... devenir médecin...[1205][001E] Mais ça\nn'arrivera jamais...[1205][001E] Je ne veux plus y penser..."
   },
   {
     "id": 35,
@@ -605,7 +605,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Whoa[SP]there,[SP]both[SP]of[SP]you![1205][001E][SP]You're[SP]up[SP]against\na[SP]real[SP]monster[SP]here![SP]If[SP]we[SP]don't[SP]stick\ntogether,[SP]you'll[SP]die!",
     "nom_fr": "Lisa",
-    "texte_fr": "Doucement, vous deux![1205][001E] C'est un vrai monstre!\nSi on reste pas ensemble, vous allez crever!"
+    "texte_fr": "Doucement, vous deux![1205][001E] C'est un vrai monstre!\nSi on reste pas ensemble, vous allez\ncrever!"
   },
   {
     "id": 38,
@@ -637,7 +637,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Who'd[SP]believe[SP]us!?[1205][001E][SP]We[SP]gotta[SP]arm[SP]up[SP]and\nkill[SP]that[SP]guy,[SP]or[SP]we're[SP]all[SP]screwed.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Qui nous croirait!?[1205][001E] Faut s'armer et\ntuer ce type, ou on est tous foutus."
+    "texte_fr": "Qui nous croirait!?[1205][001E] Faut s'armer et\ntuer ce type sinon on est tous foutus."
   },
   {
     "id": 40,
@@ -669,7 +669,7 @@
     "nom_orig": "Kozy",
     "texte_orig": "While[SP]I[SP]do[SP]that,[SP]you[SP]should[SP]prepare[SP]to\ndefend[SP]yourselves...",
     "nom_fr": "Kozy",
-    "texte_fr": "En attendant, préparez-vous à vous défendre..."
+    "texte_fr": "En attendant, préparez-vous à\nvous défendre..."
   },
   {
     "id": 42,

--- a/traduction/event_scripts/script_007.json
+++ b/traduction/event_scripts/script_007.json
@@ -77,7 +77,7 @@
     "nom_orig": "Janitor",
     "texte_orig": "No![SP]Something[SP]awful[SP]will[SP]happen![SP]Before\nhe[SP]died,[SP]that[SP]teacher[SP]said,[SP][1432][NULL][NULL][0014]The[SP]world\nwill[SP]end[SP]if[SP]time[SP]is[SP]not[SP]stopped.[1432][NULL][NULL][0014]",
     "nom_fr": "Concierge",
-    "texte_fr": "Non! Un malheur va arriver! Avant\nsa mort, le prof a dit: [1432][NULL][NULL][0014]Le monde\nfinira si on n'arrête pas le temps.[1432][NULL][NULL][0014]"
+    "texte_fr": "Non! Un malheur va arriver! Avant\nsa mort, le prof a dit: [1432][NULL][NULL][0014]Le monde\ns'éteindra si on n'arrête pas le temps.[1432][NULL][NULL][0014]"
   },
   {
     "id": 5,
@@ -141,7 +141,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "What's[SP]gotten[SP]into[SP]Ms.[SP]Ideal?[SP]Can[SP]this\nday[SP]get[SP]any[SP]crazier!?",
     "nom_fr": "Lycéen",
-    "texte_fr": "Qu'est-ce qui prend à Mme Ideal?\nCette journée peut être pire!?"
+    "texte_fr": "Qu'est-ce qui prend à Mme Ideal?\nCette journée s'empire!"
   },
   {
     "id": 9,
@@ -157,7 +157,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "The[SP]big[SP]clock's[SP]started[SP]again,[SP]so...\nI'd[SP]say[SP]yes!",
     "nom_fr": "Lycéen",
-    "texte_fr": "La grande horloge a redémarré,\nalors... je dirais oui!"
+    "texte_fr": "La grande horloge a redémarré,\nalors... je pense, oui!"
   },
   {
     "id": 10,
@@ -205,7 +205,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Oh[SP]god![SP]Y-Your[SP]face...!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Oh dieu! T-Ton visage...!"
+    "texte_fr": "Mon Dieu! T-Ton visage...!"
   },
   {
     "id": 13,
@@ -253,6 +253,6 @@
     "nom_orig": "Lisa",
     "texte_orig": "Kehhei!?[SP]What's[SP]going[SP]on!?[SP]Does[SP]this[SP]mean\nit[SP]isn't[SP]enough[SP]to[SP]take[SP]the[SP]emblems[SP]off\nour[SP]uniforms!?",
     "nom_fr": "Lisa",
-    "texte_fr": "Quoi!? Qu'est-ce qui se passe!?\nEnlever les emblèmes de nos\nuniformes n'est donc pas suffisant!?"
+    "texte_fr": "Quoi!? Qu'est-ce qui se passe!?\nEnlever les emblèmes de nos\nuniformes n'était pas suffisant!?"
   }
 ]

--- a/traduction/event_scripts/script_008.json
+++ b/traduction/event_scripts/script_008.json
@@ -301,7 +301,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Fanna![SP]No[SP]you[SP]don't![SP]You're[SP]not[SP]saddling\nme[SP]with[SP]a[SP]lame[SP]nickname[SP]like[SP]that!",
     "nom_fr": "Ginko",
-    "texte_fr": "N'importe quoi! Pas question! Tu\nvas pas me coller un surnom naze!"
+    "texte_fr": "Fanna! Pas question! Tu\nvas pas me coller un surnom aussi naze!"
   },
   {
     "id": 19,
@@ -413,7 +413,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Me,[SP]I'm[SP]Yukino[SP]Mayuzumi.[SP]I'm[SP]a[SP]freelance\nphotographer...[1205][001E][SP]An[SP]apprentice[SP]one,[SP]anyway.",
     "nom_fr": "Yukino",
-    "texte_fr": "Moi, c'est Yukino Mayuzumi. Photographe\nindépendante...[1205][001E] apprentie, en tout cas."
+    "texte_fr": "Moi, c'est Yukino Mayuzumi. Photographe\nindépendante...[1205][001E] Apprentie, en tout cas."
   },
   {
     "id": 26,
@@ -429,7 +429,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Really!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Vrai!?"
+    "texte_fr": "Quoi!?"
   },
   {
     "id": 27,
@@ -493,7 +493,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP][1432][NULL][NULL][0014]emblem[SP]curse[1432][NULL][NULL][0014][SP]here[SP]at[SP]Sevens[SP]is[SP]the\nbest[SP]known[SP]one[SP]after[SP]the[SP][1432][NULL][NULL][0014]Joker[SP]Game,[1432][NULL][NULL][0014]\nyou[SP]know.",
     "nom_fr": "Maya",
-    "texte_fr": "La [1432][NULL][NULL][0014]malédiction de l'emblème[1432][NULL][NULL][0014] de Seven\nest plus connue que le [1432][NULL][NULL][0014]Jeu du Joker[1432][NULL][NULL][0014]"
+    "texte_fr": "La [1432][NULL][NULL][0014]malédiction de l'emblème[1432][NULL][NULL][0014] de Seven\nest quasiment aussi connue que le\n[1432][NULL][NULL][0014]Jeu du Joker[1432][NULL][NULL][0014]"
   },
   {
     "id": 31,
@@ -509,7 +509,7 @@
     "nom_orig": "Maya",
     "texte_orig": "But[SP]it's[SP]been[SP]chaos[SP]since[SP]just[SP]after[SP]we\ngot[SP]here.[SP]No[SP]one's[SP]been[SP]willing[SP]to[SP]give\nus[SP]an[SP]interview!",
     "nom_fr": "Maya",
-    "texte_fr": "Mais c'est le chaos depuis qu'on est arrivées.\nPersonne ne veut nous accorder d'interview!"
+    "texte_fr": "Mais c'est le chaos depuis qu'on est\narrivées. Personne ne veut nous\naccorder d'interview!"
   },
   {
     "id": 32,
@@ -557,7 +557,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Right,[SP][1113]?",
     "nom_fr": "Ginko",
-    "texte_fr": "Vrai, [1113]?"
+    "texte_fr": "Hein, [1113]?"
   },
   {
     "id": 35,
@@ -589,7 +589,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "True[SP]stories,[SP]babes![SP]We're[SP]not[SP]looking\nfor[SP]Sevens'[SP]principal[SP]and[SP]we[SP]certainly\nnever[SP]got[SP]stomped[SP]by[SP]any[SP]Joker!",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est vrai! On cherche pas le proviseur et\non s'est jamais fait rétamer par Joker!"
+    "texte_fr": "C'est vrai! On cherche pas du tout le\nproviseur et on s'est certainement\npas fait rétamer par le Joker!"
   },
   {
     "id": 37,

--- a/traduction/event_scripts/script_009.json
+++ b/traduction/event_scripts/script_009.json
@@ -45,7 +45,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh...?[1205][0014][SP]Why[SP]am[SP]I[SP]crying?[SP]It's[SP]so[SP]strange,\nbut...[SP]*sniff*[1205][0014][SP]I[SP]can't[SP]stop...",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein?[1205][0014] Pourquoi je pleure? C'est\nétrange. *sniff*[1205][0014] J'peux pas m'arrêter."
+    "texte_fr": "Hein?[1205][0014] Pourquoi je pleure? C'est\nétrange. *pleurs*[1205][0014] J'peux pas m'arrêter."
   },
   {
     "id": 3,
@@ -61,7 +61,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's...[1205][001E][SP]like[SP]a[SP]nice[SP]memory...[SP]Warmer[SP]than\nwhat[SP]I[SP]felt[SP]with[SP][1113][SP]and[SP]Ginko...[1205][001E]\nLike[SP]a[SP]hug[SP]from[SP]my[SP]mom...",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est..[1205][001E] si chaleureux.. Plus que ce que je\nressens avec [1113] et Ginko..[1205][001E] Comme un\ncâlin.."
+    "texte_fr": "C'est...[1205][001E] si chaleureux... Plus que ce que j'ai\nressenti avec [1113] et Ginko...[1205][001E] Comme un\ncâlin..."
   },
   {
     "id": 4,
@@ -77,7 +77,7 @@
     "nom_orig": "Maya",
     "texte_orig": "How[SP]weird...[1205][0014][SP]I[SP]felt[SP]it,[SP]too.[SP]What[SP]was\nthat[SP]wave[SP]of[SP]nostalgia...?",
     "nom_fr": "Maya",
-    "texte_fr": "Bizarre..[1205][0014] Moi aussi. C'était\nquoi cette nostalgie..?"
+    "texte_fr": "Bizarre...[1205][0014] Je l'ai aussi senti. Était-ce de\nla nostalgie..?"
   },
   {
     "id": 5,
@@ -93,7 +93,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Could[SP]you[SP]elaborate?[SP]I[SP]know[SP]more[SP]than\nyou'd[SP]think[SP]about[SP]demons.[SP]Maybe[SP]I[SP]could\nhelp[SP]you[SP]kids[SP]out[SP]a[SP]bit.",
     "nom_fr": "Yukino",
-    "texte_fr": "Développez. Je m'y connais en démons.\nJe peux peut-être vous aider."
+    "texte_fr": "Vous pouvez développer ? Je m'y connais\nen démons. Je peux peut-être vous aider."
   },
   {
     "id": 6,
@@ -109,7 +109,7 @@
     "nom_orig": "Maya",
     "texte_orig": "You[SP]mean[SP]you[SP]three[SP]have[SP]the[SP]same[SP]powers\nI[SP]do?[SP]Persona,[SP]huh...[SP]So[SP]it's[SP]not[SP]just\nmy[SP]guardian[SP]angel...",
     "nom_fr": "Maya",
-    "texte_fr": "Vous avez les mêmes pouvoirs? Persona, hein..\nCe n'est donc pas que mon ange gardien.."
+    "texte_fr": "Vous avez les mêmes pouvoirs? Une Persona,\nhein... Ce n'est donc pas que \nmon ange gardien..."
   },
   {
     "id": 7,
@@ -141,7 +141,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I've[SP]been[SP]a[SP]Persona-user[SP]since[SP]I[SP]played\nthe[SP][1432][NULL][NULL][0014]Persona[SP]Game[1432][NULL][NULL][0014][SP]back[SP]in[SP]high[SP]school...[1205][0014]\nThat[SP]was[SP]three[SP]years[SP]ago.",
     "nom_fr": "Yukino",
-    "texte_fr": "J'utilise le Persona depuis que\nj'ai fait le [1432][NULL][NULL][0014]Jeu de la Persona[1432][NULL][NULL][0014]\nau lycée...[1205][0014] Y'a trois ans de ça."
+    "texte_fr": "J'ai une Persona depuis que\nj'ai fait le [1432][NULL][NULL][0014]Jeu de la Persona[1432][NULL][NULL][0014]\nau lycée...[1205][0014] Y'a trois ans de ça."
   },
   {
     "id": 9,
@@ -205,7 +205,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "A[SP]dream...!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Un rêve!?"
+    "texte_fr": "En rêve!?"
   },
   {
     "id": 13,
@@ -269,7 +269,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Haime!?[SP]Seriously!?[SP]You're[SP]gonna[SP]come\nalong[SP]with[SP]us?",
     "nom_fr": "Ginko",
-    "texte_fr": "Quoi!? Sérieusement!? Tu vas venir avec nous?"
+    "texte_fr": "Quoi!? Sérieusement!?\nTu vas venir avec nous?"
   },
   {
     "id": 17,
@@ -285,7 +285,7 @@
     "nom_orig": "Maya",
     "texte_orig": "You[SP]three[SP]are[SP]chasing[SP]Joker[SP]himself,\nright?[SP]If[SP]we[SP]could[SP]catch[SP]him,[SP]that[SP]would\nbe[SP]one[SP]hell[SP]of[SP]a[SP]scoop!",
     "nom_fr": "Maya",
-    "texte_fr": "Vous trois, vous courez après Joker, c'est ça?\nSi on l'attrape, ça ferait un sacré scoop!"
+    "texte_fr": "Vous trois, vous courez après Joker,\nc'est ça? Si on l'attrape, ça ferait un\nsacré scoop!"
   },
   {
     "id": 18,
@@ -301,7 +301,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Plus,[SP]if[SP]we[SP]go[SP]with[SP]you,[SP]maybe[SP]I[SP]can[SP]find\nout[SP]how[SP]I[SP]became[SP]a[SP]Persona-user.",
     "nom_fr": "Maya",
-    "texte_fr": "En venant, je saurai peut-être\ncomment j'ai eu mon Persona."
+    "texte_fr": "En venant, je trouverai peut-être\ncomment j'ai eu ma Persona."
   },
   {
     "id": 19,
@@ -317,7 +317,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I'll[SP]tag[SP]along.[SP]Now[SP]that[SP]I[SP]know[SP]this[SP]guy's\nin[SP]cahoots[SP]with[SP]demons,[SP]I[SP]can't[SP]sit[SP]back\nand[SP]do[SP]nothing.",
     "nom_fr": "Yukino",
-    "texte_fr": "Je viens. Ce type est de mèche avec les\ndémons, je ne peux pas rester sans rien faire."
+    "texte_fr": "Je viens. Ce type est de mèche avec les\ndémons, je ne peux pas là rester sans \nrien faire."
   },
   {
     "id": 20,
@@ -349,7 +349,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Then[SP]let's[SP]start[SP]by[SP]putting[SP]an[SP]end[SP]to\nthis[SP]madness!",
     "nom_fr": "Maya",
-    "texte_fr": "Alors on commence par\nmettre fin à cette folie!"
+    "texte_fr": "Alors commençons par\nmettre fin à cette folie!"
   },
   {
     "id": 22,
@@ -365,7 +365,7 @@
     "nom_orig": "Maya",
     "texte_orig": "If[SP]the[SP]principal[SP]is[SP]behind[SP]the[SP]chaos[SP]like\nyou[SP]think[SP]he[SP]is,[SP]won't[SP]that[SP]draw[SP]him[SP]out\nof[SP]hiding?",
     "nom_fr": "Maya",
-    "texte_fr": "Si Hanya est derrière tout ça, ça\nle fera sortir de sa cachette, non?"
+    "texte_fr": "Si Hanya est derrière tout ce bazar, ça\nle fera sortir de sa cachette, non?"
   },
   {
     "id": 23,
@@ -397,7 +397,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]know![SP]Let's[SP]destroy[SP]all[SP]the[SP]emblems[SP]in\nthe[SP]school.[SP]Getting[SP]rid[SP]of[SP]the[SP]cause[SP]of\nthe[SP]problem[SP]should[SP]help,[SP]right?",
     "nom_fr": "Maya",
-    "texte_fr": "J'ai une idée! On détruit tous les\nemblèmes du lycée. Éliminer la source\ndu problème,[1205][U+000F] ça devrait aider, non?"
+    "texte_fr": "J'ai une idée! Détruisons tous les\nemblèmes du lycée. Éliminer la source\ndu problème,[1205][U+000F] ça devrait aider, non?"
   },
   {
     "id": 25,
@@ -413,7 +413,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "If[SP]rumors[SP]ARE[SP]coming[SP]true,[SP]the[SP]curse'll\nbe[SP]lifted[SP]once[SP]the[SP]emblems[SP]are[SP]gone.\nBut[SP]could[SP]that[SP]really[SP]be[SP]happening?",
     "nom_fr": "Yukino",
-    "texte_fr": "Si les rumeurs sont vraies, briser les\nemblèmes lèvera le sort. Mais est-ce possible?"
+    "texte_fr": "Si les rumeurs sont vraies, briser les\nemblèmes lèvera le sort. Mais est-ce \npossible?"
   },
   {
     "id": 26,
@@ -461,7 +461,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]design[SP]must[SP]show[SP]up[SP]somewhere[SP]else\nbesides[SP]the[SP]emblems[SP]on[SP]the[SP]uniforms.\nLet's[SP]look[SP]for[SP]it!",
     "nom_fr": "Maya",
-    "texte_fr": "Ce motif doit apparaître ailleurs que sur\nles emblèmes des uniformes. On le cherche!"
+    "texte_fr": "Ce motif doit apparaître ailleurs que sur\nles emblèmes des uniformes.\nAllons vérifier ça!"
   },
   {
     "id": 29,
@@ -525,7 +525,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]memories[SP]evoked[SP]by[SP]the[SP]lady[SP]Maya-san...[1205][001E]\nThey[SP]were[SP]warm,[SP]sad,[SP]and[SP]painful,[SP]all[SP]at\nonce...[1205][001E][SP]Like[SP]the[SP]wringing[SP]of[SP]my[SP]heart...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Les souvenirs que la belle Maya-san a\néveillés...[1205][001E] Chauds, tristes et douloureux à\nla fois...[1205][001E][1205][U+000F] Comme si mon cœur se tordait..."
+    "texte_fr": "Les souvenirs que Maya-san a\néveillé...[1205][001E] Chauds, tristes et douloureux à\nla fois...[1205][001E][1205][U+000F] Comme si mon cœur se tordait..."
   },
   {
     "id": 33,
@@ -541,7 +541,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]felt[SP]it[SP]too,[SP]right,[SP][1113]?[SP]And[SP]yet,\nthis[SP]is[SP]our[SP]first[SP]meeting...[1205][001E][SP]Is[SP]this[SP]a\nlove[SP]that's[SP]destined[SP]to[SP]be?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tu l'as senti, [1113]? Pourtant on\nvient de se voir..[1205][001E] Serait-ce le destin?"
+    "texte_fr": "Tu l'as resenti aussi, hein, [1113]? Pourtant on\nvient de se rencontrer...[1205][001E] Serait-ce le destin?"
   },
   {
     "id": 34,
@@ -557,7 +557,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]get[SP]this[SP]weird,[SP]nostalgic[SP]feeling\nfrom[SP]her...",
     "nom_fr": "Ginko",
-    "texte_fr": "Elle me donne un sentiment de nostalgie.."
+    "texte_fr": "Étrange, sa présence me rend\nnostalgique..."
   },
   {
     "id": 35,
@@ -589,7 +589,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]were[SP]actually[SP]looking[SP]for[SP]you[SP]earlier.[1205][001E]\nI[SP]mean,[SP]there's[SP]no[SP]way[SP]we'd[SP]leave[SP]without\ninterviewing[SP]the[SP]famous[SP][1113]-kun!",
     "nom_fr": "Maya",
-    "texte_fr": "En fait on te cherchait tout à l'heure.[1205][001E]\nHors de question qu'on reparte sans\ninterviewer[1205][U+000F] le célèbre [1113]-kun!"
+    "texte_fr": "En fait, on te cherchait tout à l'heure.[1205][001E]\nHors de question qu'on reparte sans\ninterviewer[1205][U+000F] le célèbre [1113]-kun!"
   },
   {
     "id": 37,
@@ -653,7 +653,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "You've[SP]heard[SP]of[SP]it,[SP]right?[1205][001E][SP]The[SP]SEBEC\nScandal[SP]three[SP]years[SP]ago.[SP]Mikage-cho[SP]got\ncompletely[SP]walled[SP]off...",
     "nom_fr": "Yukino",
-    "texte_fr": "Vous connaissez le scandale SEBEC d'il\ny a 3 ans? Mikage-cho était bouclé.."
+    "texte_fr": "Vous connaissez le scandale de la SEBEC \nd'il y a 3 ans? Mikage-cho était \nbouclé.."
   },
   {
     "id": 41,
@@ -669,7 +669,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "It's[SP]a[SP]long[SP]story,[SP]but...[1205][001E][SP]That's[SP]when[SP]I\nawoke[SP]to[SP]my[SP]Persona.[1205][001E][SP]There[SP]was[SP]me[SP]and\neight[SP]other[SP]guys...",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est long, mais..[1205][001E] j'ai éveillé mon\nPersona là-bas.[1205][001E] On était neuf en tout.."
+    "texte_fr": "C'est long, mais..[1205][001E] j'ai éveillé ma\nPersona là-bas.[1205][001E] On était neuf en tout.."
   },
   {
     "id": 42,
@@ -701,7 +701,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "The[SP]news[SP]called[SP]it[SP]an[SP]accident,[SP]but[SP]that\nwasn't[SP]it[SP]at[SP]all.[1205][001E][SP]SEBEC's[SP]Kandori...[1205][001E]\nHaha,[SP]never[SP]mind.[SP]Water[SP]under[SP]the[SP]bridge.",
     "nom_fr": "Yukino",
-    "texte_fr": "Ce n'était pas un accident.[1205][001E] Kandori\nde SEBEC..[1205][001E] Bref, c'est du passé."
+    "texte_fr": "Ce n'était pas un accident.[1205][001E] Kandori\nde la SEBEC...[1205][001E] Bref, c'est du passé."
   },
   {
     "id": 44,
@@ -781,7 +781,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Sorry...[1205][001E][SP]But[SP]I'm[SP]already[SP]carrying[SP]my\nfavorite[SP]weapon!",
     "nom_fr": "Yukino",
-    "texte_fr": "Désolée...[1205][001E] Mais j'ai déjà mon arme préférée!"
+    "texte_fr": "Désolée...[1205][001E] Mais j'ai déjà mon arme fétiche!"
   },
   {
     "id": 49,

--- a/traduction/event_scripts/script_010.json
+++ b/traduction/event_scripts/script_010.json
@@ -45,7 +45,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Ms.[SP]Saeko!?[SP]What[SP]are[SP]you...",
     "nom_fr": "Yukino",
-    "texte_fr": "Mme Saeko!? Mais que..."
+    "texte_fr": "Mme Saeko!? Mais qu'est..."
   },
   {
     "id": 3,
@@ -77,7 +77,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "I[SP]transferred[SP]here[SP]last[SP]year.[SP]But[SP]never\nmind[SP]me--what[SP]are[SP]YOU[SP]doing[SP]here?[SP]Don't\ntell[SP]me[SP]you're[SP]redoing[SP]high[SP]school...?",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Je suis ici depuis un an. Mais\nTOI, que fais-tu là? Ne me dis pas\nque tu redoubles ton lycée...?"
+    "texte_fr": "Je suis ici depuis un an. Mais\nTOI, que fais-tu là? Ne me dis pas\nque tu as redoublé ton lycée...?"
   },
   {
     "id": 5,
@@ -93,7 +93,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Oh,[SP]no,[SP]I'm[SP]on[SP]assignment![SP]I[SP]have[SP]a[SP]part-\ntime[SP]job[SP]as[SP]an[SP]assistant[SP]photographer,[SP]so[SP]I\ncame[SP]to[SP]cover[SP]a[SP]story.",
     "nom_fr": "Yukino",
-    "texte_fr": "Non, je bosse comme assistante photographe,\nje suis là pour couvrir un article."
+    "texte_fr": "Non, je bosse comme assistante\nphotographe, je suis là pour couvrir un \narticle."
   },
   {
     "id": 6,
@@ -109,7 +109,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah![SP]Ms.[SP]Saeko[SP]and[SP]Yukino-san[SP]know\neach[SP]other?",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiya! Mme Saeko et Yukino-san se connaissent?"
+    "texte_fr": "Aiya! Mme Saeko et Yukino-san se\nconnaissent?"
   },
   {
     "id": 7,
@@ -141,7 +141,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Your[SP]timing[SP]in[SP]coming[SP]here[SP]wasn't[SP]very\ngood,[SP]I'm[SP]afraid.[SP]As[SP]you[SP]can[SP]see,[SP]we're\nin[SP]a[SP]bit[SP]of[SP]a[SP]crisis...",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Tu es arrivée au mauvais moment, j'en ai peur.\nComme tu vois, on est en pleine crise..."
+    "texte_fr": "Tu es arrivée au mauvais moment, j'en ai\npeur. Comme tu vois, on est en pleine\ncrise..."
   },
   {
     "id": 9,
@@ -189,7 +189,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "[1113]![SP]I[SP]take[SP]full[SP]responsibility[SP]here.\nYou[SP]have[SP]my[SP]blessing[SP]to[SP]go[SP]and[SP]destroy\nall[SP]the[SP]emblems!",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "[1113]! J'assume tout. Allez-y,\ndétruisez tous les emblèmes!"
+    "texte_fr": "[1113]! J'assumerai les conséquences.\nAllez-y, détruisez tous les emblèmes!"
   },
   {
     "id": 12,
@@ -268,7 +268,7 @@
     "nom_orig": "Principal[SP]Hanya's[SP]voice",
     "texte_orig": "Ahem![SP]Attention[SP]all[SP]students![SP]You[SP]will\nimmediately[SP]cease[SP]all[SP]destructive\nactivity[SP]within[SP]school[SP]grounds!",
     "nom_fr": "Voix du directeur Hanya",
-    "texte_fr": "Hum! Attention tous les élèves!\nCessez immédiatement toute activité\ndestructrice dans le lycée!"
+    "texte_fr": "Hum! À l'attention des élèves!\nCessez immédiatement toute activité\nde destruction dans le lycée!"
   },
   {
     "id": 17,
@@ -284,7 +284,7 @@
     "nom_orig": "Principal[SP]Hanya's[SP]voice",
     "texte_orig": "As[SP]principal,[SP]everyone[SP]must[SP]obey[SP]my\norders.[SP]Do[SP]you[SP]hear[SP]me?[1205][001E][SP]You[SP]will[SP]treat\nMY[SP]Seven[SP]Sisters[SP]High[SP]with[SP]respect![E1][E2]\n[E3][E4][NULL][NULL]\"Ms.[SP]Saeko\nI[SP]suppose[SP]we[SP]have[SP]no[SP]choice,[SP]if[SP]the\nprincipal[SP]says[SP]so...",
     "nom_fr": "Voix du directeur Hanya",
-    "texte_fr": "Tout le monde doit obéir à mes ordres.\nVous m'entendez?[1205][001E] Vous respectez MON lycée\ndes Sept Sœurs![E1][E2]\n[E3][E4][NULL][NULL]\"Mme Saeko\nSi le directeur\nl'ordonne, on n'a pas le choix..."
+    "texte_fr": "Tout le monde doit obéir à mes ordres.\nVous m'entendez?[1205][001E] Vous allez respectez MON lycée\nSeven Sisters![E1][E2]\n[E3][E4][NULL][NULL]\"Mme Saeko\nSi le directeur\nl'ordonne, on n'a pas le choix..."
   },
   {
     "id": 18,
@@ -332,7 +332,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Anyway,[SP]don't[SP]we[SP]have[SP]a[SP]big[SP]clock[SP]to\ngo[SP]break?",
     "nom_fr": "Yukino",
-    "texte_fr": "Bref, faut pas casser une horloge?"
+    "texte_fr": "Bref, on devait pas péter une grosse\nhorloge?"
   },
   {
     "id": 21,
@@ -364,7 +364,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "It's[SP]probably[SP]in[SP]the[SP]teacher's[SP]lounge\nsomewhere.[SP]Let's[SP]try[SP]asking[SP]the[SP]teachers\nabout[SP]it.",
     "nom_fr": "Ginko",
-    "texte_fr": "Elle est sûrement dans la salle des profs.\nOn essaie de leur demander où elle est."
+    "texte_fr": "Elle est sûrement dans la salle des profs.\nOn peut tenter de leur demander où\nelle est."
   },
   {
     "id": 23,
@@ -412,7 +412,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Is[SP]this[SP]really[SP]going[SP]to[SP]work,[SP]Chinyan?\nYou[SP]think[SP]Maya-san's[SP]right[SP]and[SP]the[SP]curse\nwill[SP]be[SP]lifted[SP]once[SP]the[SP]emblems[SP]are[SP]gone?",
     "nom_fr": "Ginko",
-    "texte_fr": "Ça va vraiment marcher, Chinyan? Tu crois\nque Maya-san a raison et que la\nmalédiction se lèvera sans les emblèmes[1205][U+000F] ?"
+    "texte_fr": "Ça va vraiment marcher, Chinyan? Tu crois\nque Maya-san a raison? La malédiction se\nlèvera quand on cassera l'horloge[1205][U+000F]?"
   },
   {
     "id": 26,
@@ -460,7 +460,7 @@
     "nom_orig": "Maya",
     "texte_orig": "These[SP]emblems[SP]here[SP]are[SP]the[SP]last[SP]of[SP]them.\nI[SP]hope[SP]the[SP]curse[SP]gets[SP]lifted[SP]after[SP]this...",
     "nom_fr": "Maya",
-    "texte_fr": "C'est fini pour les emblèmes.\nJ'espère que le sort sera levé..."
+    "texte_fr": "C'est le dernier emblème.\nJ'espère que le sort sera levé après ça..."
   },
   {
     "id": 29,
@@ -476,7 +476,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Looks[SP]like[SP]the[SP]principal's[SP]making[SP]his\nmove,[SP]right[SP]on[SP]cue![1205][001E][SP]Let's[SP]hurry[SP]and[SP]find\nthe[SP]key[SP]to[SP]the[SP]clock[SP]tower!",
     "nom_fr": "Maya",
-    "texte_fr": "Le directeur passe à l'action,\njuste au bon moment![1205][001E] On se dépêche\nde trouver la clé de la tour!"
+    "texte_fr": "Le directeur passe à l'action,\npile au bon moment![1205][001E] Dépéchons-nous\nde trouver la clé de la tour!"
   },
   {
     "id": 30,
@@ -524,7 +524,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Ms.[SP]Saeko[SP]would[SP]never[SP]blindly[SP]obey[SP]like\nthis.[1205][001E][SP]She's[SP]the[SP]kind[SP]of[SP]lady[SP]who'd[SP]punch\na[SP]minister[SP]if[SP]she[SP]thought[SP]she[SP]had[SP]to.",
     "nom_fr": "Yukino",
-    "texte_fr": "Mme Saeko obéirait jamais aveuglément\ncomme ça.[1205][001E] C'est le genre de femme à coller\nune beigne à un ministre si besoin."
+    "texte_fr": "Mme Saeko lui aurait jamais obéit \naveuglément.[1205][U+000F] C'est le genre de femme à coller\nune beigne à un ministre si besoin."
   },
   {
     "id": 33,
@@ -620,7 +620,7 @@
     "nom_orig": "Mr.[SP]Aishi",
     "texte_orig": "The[SP]principal[SP]took[SP]the[SP]key[SP]that[SP]was[SP]here\nin[SP]the[SP]lounge.[SP]The[SP]janitor[SP]should[SP]have[SP]the\nother[SP]one![SP]Hahaha![SP]I[SP]see![SP]How[SP]marvelous!",
     "nom_fr": "M. Aishi",
-    "texte_fr": "Le directeur a pris la clé ici. Le\nconcierge a l'autre! Hahaha! Formidable!"
+    "texte_fr": "Le directeur a pris la clé de la\nsalle des profs. Le concierge doit\navoir l'autre! Hahaha! Formidable!"
   },
   {
     "id": 39,
@@ -652,7 +652,7 @@
     "nom_orig": "Mr.[SP]Oriri",
     "texte_orig": "Oh,[SP]and[SP]since[SP]Lisa's[SP]with[SP]you...[SP]Her\ngrades[SP]in[SP]English[SP]are[SP]horrible![SP]Tell[SP]her\nshe[SP]needs[SP]to[SP]take[SP]it[SP]more[SP]seriously!",
     "nom_fr": "M. Oriri",
-    "texte_fr": "Puisque Ginko est là... Ses notes en anglais\nsont atroces! Dites-lui de travailler plus!"
+    "texte_fr": "Puisque Ginko est là... Ses notes en\nanglais sont atroces! Dites-lui de\ntravailler plus assidûment!"
   },
   {
     "id": 41,
@@ -668,7 +668,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "It's[SP]tough[SP]finding[SP]EVERY[SP]emblem...[SP]Not\neven[SP]I[SP]can[SP]predict[SP]where[SP]they'll[SP]all[SP]be!\nBut[SP]I'm[SP]sure[SP]the[SP]curse[SP]will[SP]be[SP]lifted.",
     "nom_fr": "Élève bandagé",
-    "texte_fr": "Dur de trouver TOUT... Je ne peux pas\nprédire où ils sont, mais le sort sera levé."
+    "texte_fr": "Dur de trouver TOUS les emblèmes... Je ne\npeux pas deviner où ils sont,\nmais le sort sera levé."
   },
   {
     "id": 42,
@@ -700,7 +700,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "See?[SP]It's[SP]just[SP]like[SP]we[SP]said.[SP]We[SP]should've\ndestroyed[SP]those[SP]emblems[SP]a[SP]long[SP]time[SP]ago!\nAlright,[SP][1113],[SP]go[SP]crush[SP]'em!",
     "nom_fr": "Élève bandagé",
-    "texte_fr": "Tu vois? On aurait dû les détruire\nplus tôt! Allez, [1113], écrase-les!"
+    "texte_fr": "Tu vois? On aurait dû les détruire\nplus tôt! Allez, [1113], explose-les!"
   },
   {
     "id": 44,
@@ -716,7 +716,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "Tch...[SP]If[SP]the[SP]principal[SP]commands[SP]it,\nwe've[SP]got[SP]no[SP]choice.[SP]You'd[SP]better[SP]help\nclean[SP]up,[SP]too.",
     "nom_fr": "Élève bandagé",
-    "texte_fr": "Tch... Si Hanya l'ordonne, on n'a pas\nle choix. Aide aussi au nettoyage."
+    "texte_fr": "Tch... Si Hanya l'ordonne, on n'a pas\nle choix. Aide-nous à nettoyer."
   },
   {
     "id": 45,
@@ -732,7 +732,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "What!?[SP]I'm[SP]a[SP]little[SP]busy[SP]here![SP]I[SP]need[SP]to\ndestroy[SP]those[SP]emblems[SP]quick[SP]and[SP]get[SP]my\nface[SP]back[SP]to[SP]normal!",
     "nom_fr": "Élève bandagée",
-    "texte_fr": "Quoi!? Je suis occupée là! Faut que\nje détruise ces emblèmes vite fait\npour retrouver mon visage normal!"
+    "texte_fr": "Quoi!? Je suis occupée là! Faut que\nje détruise ces rapidement emblèmes\npour retrouver mon visage normal!"
   },
   {
     "id": 46,

--- a/traduction/event_scripts/script_011.json
+++ b/traduction/event_scripts/script_011.json
@@ -93,7 +93,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Alright,[SP]gramps![SP]Breathe[SP]deep[SP]and[SP]try\nto[SP]remember[SP]with[SP]me[SP]where[SP]you[SP]put[SP]it.",
     "nom_fr": "Michel",
-    "texte_fr": "Bon, Papy! Respire un coup\net essaye de te rappeler où."
+    "texte_fr": "Bon, Papy! Respire un coup et essaye\nde te rappeler où tu l'as rangée."
   },
   {
     "id": 6,
@@ -109,7 +109,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Who[SP]knows[SP]when[SP]this[SP]guy'll[SP]remember...\nIt'd[SP]be[SP]faster[SP]to[SP]look[SP]ourselves.",
     "nom_fr": "Yukino",
-    "texte_fr": "Qui sait quand il s'en\nsouviendra... Cherchons nous-mêmes."
+    "texte_fr": "Qui sait quand il s'en souviendra...\n Cherchons par nous-mêmes."
   },
   {
     "id": 7,
@@ -157,7 +157,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "By[SP]the[SP]way,[SP]gramps.[SP]I[SP]keep[SP]wondering...\nWhat's[SP]that?",
     "nom_fr": "Michel",
-    "texte_fr": "Au fait, papy. Je me demande... C'est quoi?"
+    "texte_fr": "Au fait, papy. Je me demandais... C'est\nquoi ça?"
   },
   {
     "id": 10,
@@ -205,7 +205,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hot[SP]diggity![SP]I[SP]found[SP]us[SP]the[SP]key.\nNow[SP]let's[SP]get[SP]to[SP]that[SP]clock[SP]tower!",
     "nom_fr": "Michel",
-    "texte_fr": "Génial! J'ai la clé. En route vers cette tour!"
+    "texte_fr": "Génial! J'ai la clé. En route vers cette\ntour!"
   },
   {
     "id": 13,
@@ -237,7 +237,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah![SP]So[SP]musty!",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiya! Ça pue!"
+    "texte_fr": "Aiyah! Ça pue!"
   },
   {
     "id": 15,
@@ -253,7 +253,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Geez![SP]Have[SP]these[SP]futons[SP]been[SP]aired[SP]out\nthis[SP]decade!?[SP]I[SP]don't[SP]see[SP]any[SP]key[SP]here.",
     "nom_fr": "Ginko",
-    "texte_fr": "Purée! On a aéré ces futons\ncette décennie? Pas de clé."
+    "texte_fr": "Purée! Ces futons ont pas été lavé depuis\ncombien d'années? Aucune clé ici."
   },
   {
     "id": 16,
@@ -301,7 +301,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "No[SP]key[SP]here,[SP]but[SP]plenty[SP]of[SP]side[SP]dishes.[1205][001E]\nWhatever[SP]she[SP]says,[SP]that[SP]lady[SP]seems[SP]to[SP]be\ntaking[SP]good[SP]care[SP]of[SP]gramps.",
     "nom_fr": "Yukino",
-    "texte_fr": "Pas de clé, mais des plats.[1205][001E]\nElle s'occupe bien du papy."
+    "texte_fr": "Aucune clé ici, il y a que des plats.[1205][001E]\nQu'importe ce qu'elle dit, cette femme\ns'occupe bien de papy."
   },
   {
     "id": 19,
@@ -317,7 +317,7 @@
     "nom_orig": "Caretaker",
     "texte_orig": "Hohoho![SP]This[SP]man[SP]loses[SP]things[SP]so\neasily.[SP]It's[SP]not[SP]easy,[SP]getting[SP]old.",
     "nom_fr": "Gardienne",
-    "texte_fr": "Hohoho! Il s'égare si vite.\nPas facile de vieillir."
+    "texte_fr": "Hohoho! Il s'égare si vite.\nC'est pas facile de vieillir."
   },
   {
     "id": 20,

--- a/traduction/event_scripts/script_012.json
+++ b/traduction/event_scripts/script_012.json
@@ -29,7 +29,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Looks[SP]like[SP]Mr.[SP]Hanya's[SP]not[SP]here,[SP]either.\nLet's[SP]hurry[SP]and[SP]break[SP]the[SP]big[SP]clock[SP]so\nwe[SP]can[SP]get[SP]outta[SP]here.",
     "nom_fr": "Eikichi",
-    "texte_fr": "M. Hanya est pas là non plus. On casse vite\ncette grande horloge et on se casse d'ici."
+    "texte_fr": "M. Hanya est pas là non plus. On casse \nvite la grande horloge et on se casse\nd'ici."
   },
   {
     "id": 2,
@@ -77,7 +77,7 @@
     "nom_orig": "Teacher's[SP]ghost",
     "texte_orig": "...not[SP]be...",
     "nom_fr": "Prof fantôme",
-    "texte_fr": "... pas être..."
+    "texte_fr": "...pas être..."
   },
   {
     "id": 5,
@@ -109,7 +109,7 @@
     "nom_orig": "Teacher's[SP]ghost",
     "texte_orig": "I[SP]said...[1205][001E][SP]that[SP]time...[1205][001E][SP]must[SP]not[SP]be[SP]set\nfree...[1205][001E][SP]I[SP]said[SP]it...[1205][001E][SP]so[SP]often...\n[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nHe[SP]disappeared![1205][001E][SP]But...[SP]I[SP]feel[SP]like[SP]I've...",
     "nom_fr": "Fantôme du prof",
-    "texte_fr": "J'ai dit...[1205][001E] le temps...[1205][001E] pas libéré...[1205][001E]\nJe l'ai dit...[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nDisparu![1205][001E]\nMais... j'ai l'impression..."
+    "texte_fr": "J'ai dit...[1205][001E] que le temps...[1205][001E] doit rester figé...[1205][001E]\nJe le disais... [E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nIl a disparu![1205][001E]\nJ'ai l'impression... que je l'ai..."
   },
   {
     "id": 7,
@@ -205,7 +205,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Principal[SP]Hanya![SP]So[SP]you[SP]were[SP]mixed[SP]up\nwith[SP]Joker!",
     "nom_fr": "Ginko",
-    "texte_fr": "Proviseur Hanya! Donc vous étiez mêlé à Joker!"
+    "texte_fr": "Proviseur Hanya! Vous aviez un lien\navec Joker!"
   },
   {
     "id": 13,
@@ -221,7 +221,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "The[SP]emblem[SP]curse[SP]and[SP]everyone[SP]acting[SP]weird\nis[SP]all[SP]because[SP]you[SP]teamed[SP]up[SP]with[SP]Joker,\nisn't[SP]it!?[SP]Fess[SP]up!",
     "nom_fr": "Ginko",
-    "texte_fr": "La malédiction et les gens bizarres, c'est\ncar vous êtes allié à Joker, non!? Parlez!"
+    "texte_fr": "La malédiction et les gens bizarres,\nc'est car vous vous êtes alliés à Joker,\nnon!? Parlez!"
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Foolish[SP]girl![SP]How[SP]dare[SP]you?[SP]The[SP][1432][NULL][NULL][0014]emblem\ncurse[1432][NULL][NULL][0014][SP]is[SP]a[SP]divine[SP]punishment[SP]brought[SP]on\nby[SP]the[SP]students'[SP]poor[SP]conduct!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Sotte! Osez-vous? La [1432][NULL][NULL][0014]malédiction[1432][NULL][NULL][0014] est un\nchâtiment divin dû à la conduite des élèves!"
+    "texte_fr": "Sotte! Osez-vous? La [1432][NULL][NULL][0014]malédiction[1432][NULL][NULL][0014] est un\nchâtiment divin dû à la conduite\ndes élèves!"
   },
   {
     "id": 15,
@@ -253,7 +253,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "You[SP]fools[SP]forget[SP]that[SP]you're[SP]students[SP]and\nwaste[SP]your[SP]lives[SP]worrying[SP]about[SP]dating\nand[SP]fashion!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Vous oubliez être des élèves et gâchez\nvotre vie pour la mode et les sorties!"
+    "texte_fr": "Vous oubliez que vous êtes des élèves\net gâchez votre vie pour la mode et\nles amourettes!"
   },
   {
     "id": 16,
@@ -269,7 +269,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "You[SP]brought[SP]this[SP]curse[SP]on[SP]yourselves!\nThough[SP]I[SP]didn't[SP]think[SP]the[SP]rumor[SP]Cuss[SP]High\nstarted[SP]would[SP]come[SP]true...",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Vous l'avez provoquée! Même si je pensais\npas que la rumeur de Kasu serait vraie..."
+    "texte_fr": "Vous l'avez provoquée! Même si je ne\npensais pas que la rumeur de Kasu\nserait vraie..."
   },
   {
     "id": 17,
@@ -285,7 +285,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "But[SP]if[SP]they'd[SP]make[SP]a[SP]wish[SP]to[SP]Master[SP]Joker,\nthe[SP]students'[SP]faces[SP]would[SP]return[SP]to[SP]normal\nin[SP]no[SP]time.",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Mais un vœu au Joker et les visages\ndes élèves seront normaux illico."
+    "texte_fr": "Mais un vœu au Joker et les visages\ndes élèves redeviendront normaux\nillico presto."
   },
   {
     "id": 18,
@@ -301,7 +301,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Not[SP]only[SP]that,[SP]but[SP]following[SP]Master[SP]Joker\nis[SP]the[SP]essence[SP]of[SP]having[SP]a[SP]chance[SP]at[SP]a\nfulfilling[SP]life!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Et pas seulement ça! Suivre le Maître\nJoker, c'est la clé d'une vie épanouie!"
+    "texte_fr": "Et pas seulement ça! Suivre Maître\nJoker, c'est la clé d'une vie épanouie!"
   },
   {
     "id": 19,
@@ -317,7 +317,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "So[SP]what[SP]did[SP]he[SP]give[SP]you!?",
     "nom_fr": "Yukino",
-    "texte_fr": "Il a donné quoi?"
+    "texte_fr": "Il vous a donné quoi?"
   },
   {
     "id": 20,
@@ -333,7 +333,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Hahaha![SP]Me,[SP]you[SP]ask?[SP]My[SP]wish[SP]was[SP]to[SP]become\na[SP]principal[SP]beloved[SP]by[SP]his[SP]students...[1205][001E]\nAs[SP]well[SP]as[SP]this[SP]fine[SP]mane[SP]you[SP]now[SP]see!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Hahaha! Moi? Mon vœu était de devenir\nun directeur aimé de ses élèves...[1205][001E]\nAinsi que cette magnifique chevelure!"
+    "texte_fr": "Hahaha! Moi? Mon vœu était de devenir\nun directeur aimé de ses élèves...[1205][001E]Ainsi que d'avoir cette magnifique\nchevelure!"
   },
   {
     "id": 21,
@@ -365,7 +365,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What's[SP]the[SP]point[SP]in[SP]granting[SP]a[SP]stupid\ngeezer's[SP]wish!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ça sert à quoi d'exaucer\nle vœu d'un vieux con!?"
+    "texte_fr": "Ça sert à quoi d'exaucer\nles vœux d'un vieux con!?"
   },
   {
     "id": 23,
@@ -413,7 +413,7 @@
     "nom_orig": "Joker",
     "texte_orig": "I'll[SP]never[SP]let[SP]you[SP]destroy[SP]my[SP]dream\nagain...[1205][001E][SP]I[SP]won't[SP]make[SP]the[SP]same\nmistake[SP]twice!",
     "nom_fr": "Joker",
-    "texte_fr": "Je te laisserai plus détruire mon\nrêve...[1205][001E] Je ne ferai plus cette erreur!"
+    "texte_fr": "Je te laisserai plus détruire mon\nrêve...[1205][001E] Je ne referai pas cette erreur!"
   },
   {
     "id": 26,
@@ -445,7 +445,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Time[SP]is[SP]free[SP]again...[1205][001E][SP]Heed[SP]the[SP]sound[SP]of[SP]the\nbells[SP]that[SP]toll[SP]for[SP]your[SP]dreams!",
     "nom_fr": "Joker",
-    "texte_fr": "Temps libre...[1205][001E] Écoutez les cloches\nsonner le glas de vos rêves!"
+    "texte_fr": "Le temps a repris...[1205][001E] Écoutez les cloches\nsonner le glas de vos rêves!"
   },
   {
     "id": 28,
@@ -461,7 +461,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Dammit![SP]You're[SP]not[SP]going[SP]anywhere!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Merde! Tu vas nulle part!"
+    "texte_fr": "Merde! Tu vas aller nulle part!"
   },
   {
     "id": 29,

--- a/traduction/event_scripts/script_013.json
+++ b/traduction/event_scripts/script_013.json
@@ -93,7 +93,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Guidance[SP]sessions[SP]are[SP]over[SP]for[SP]today!\nSo[SP]long[SP]as[SP]you[SP]defy[SP]Master[SP]Joker,[SP]you\nwill[SP]never[SP]find[SP]peace!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Orientation finie pour aujourd'hui! Défié\nMaître Joker et vous n'aurez jamais la paix!"
+    "texte_fr": "Orientation du jour terminée!\nArrêtez de défier Maître Joker ou vous\nn'aurez jamais la paix!"
   },
   {
     "id": 6,
@@ -125,7 +125,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Isn't[SP]this[SP]the[SP]fourth[SP]floor!?[SP]Eh...[1205][001E]\nI[SP]doubt[SP]even[SP]that[SP]would[SP]kill[SP]him.",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est pas le 4e étage!? Bah...[1205][001E]\nÇa suffirait même pas à le tuer."
+    "texte_fr": "On est pas au 4e étage!? Bah...[1205][001E]\nÇa suffirait même pas à le tuer."
   },
   {
     "id": 8,
@@ -141,7 +141,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Joker...[SP]He's[SP]so[SP]alone.[1205][001E][SP]He's[SP]struggling\nwith[SP]a[SP]sin[SP]in[SP]the[SP]depths[SP]of[SP]his[SP]heart...",
     "nom_fr": "Maya",
-    "texte_fr": "Joker... Il est tellement seul.[1205][001E] Il se bat\ncontre un péché au fond de son cœur..."
+    "texte_fr": "Joker... Il est tellement seul.[1205][001E] Il combat\nun péché caché au fond de son cœur..."
   },
   {
     "id": 9,
@@ -173,7 +173,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1432][NULL][NULL][0014]I[SP]shudder[SP]when[SP]I[SP]behold[SP]his[SP]face.\nThe[SP]moon[SP]reveals[SP]to[SP]me[SP]my[SP]own[SP]likeness.\nYou[SP]Doppelganger,[SP]you[SP]pale[SP]companion!",
     "nom_fr": "Maya",
-    "texte_fr": "[1432][NULL][NULL][0014]Je frémis devant son visage. La\nlune révèle ma ressemblance. Toi\nDoppelganger, mon pâle compagnon!"
+    "texte_fr": "[1432][NULL][NULL][0014]Je frémis devant son visage.\nLa Lune révèle ma ressemblance.\nToi Doppelganger, mon pâle compagnon!"
   },
   {
     "id": 11,
@@ -189,7 +189,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1432][NULL][NULL][0014]Why[SP]do[SP]you[SP]mimic[SP]my[SP]lovesickness,\nThat[SP]tormented[SP]me[SP]at[SP]this[SP]place\nFor[SP]so[SP]many[SP]nights[SP]in[SP]the[SP]past?[1432][NULL][NULL][0014]",
     "nom_fr": "Maya",
-    "texte_fr": "[1432][NULL][NULL][0014]Pourquoi imites-tu mon mal d'amour, Qui me\ntorturait en ce lieu Tant de nuits passées?[1432][NULL][NULL][0014]"
+    "texte_fr": "[1432][NULL][NULL][0014]Pourquoi imites-tu mon mal d'amour,\nQui me torturait en ce lieu\nTant de nuits passées?[1432][NULL][NULL][0014]"
   },
   {
     "id": 12,
@@ -221,7 +221,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Uh,[SP]Maya-san...[1205][001E][SP]You're[SP]not[SP]suggesting\nthat[SP]Joker[SP]is[SP][1113]'s[SP]doppelganger,\nare[SP]you?",
     "nom_fr": "Yukino",
-    "texte_fr": "Euh, Maya...[1205][001E] Vous insinuez pas que\nJoker est le doppelganger de [1113]?"
+    "texte_fr": "Euh, Maya...[1205][001E] T'insinues quand même pas que\nJoker est le doppelganger de [1113]?"
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Oh,[SP]no![SP]I[SP]just[SP]thought[SP]there[SP]were\nsome[SP]similarities.[SP]Ah,[SP]ignore[SP]me,\n[1113]-kun.",
     "nom_fr": "Maya",
-    "texte_fr": "Oh non! Je voyais juste des points\ncommuns. Oublie, [1113]-kun."
+    "texte_fr": "Oh, non! Je voyais juste des points\ncommuns. Oublie ça, [1113]-kun."
   },
   {
     "id": 15,
@@ -253,7 +253,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Wai![SP]What[SP]should[SP]we[SP]do[SP]now?[SP]Hanya[SP]got\naway[SP]and[SP]took[SP]our[SP]only[SP]lead[SP]to[SP]Joker\nwith[SP]him.",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé! On fait quoi? Hanya s'est tiré et a\npris notre seule piste vers Joker avec lui."
+    "texte_fr": "Hé! On fait quoi? Hanya s'est tiré et a\npris notre seule piste vers Joker avec\nlui."
   },
   {
     "id": 16,
@@ -285,7 +285,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Let's[SP]chase[SP]the[SP]rumors![SP]They'll[SP]surely\nlead[SP]us[SP]straight[SP]to[SP]Joker.",
     "nom_fr": "Maya",
-    "texte_fr": "On suit les rumeurs! Elles nous\nmèneront sûrement droit à Joker."
+    "texte_fr": "Suivons les rumeurs! Elles nous\nmèneront sûrement droit à Joker."
   },
   {
     "id": 18,
@@ -317,7 +317,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Whoa[SP]there![SP]There's[SP]no[SP]one[SP]at[SP]Kasugayama\nHigh[SP]whom[SP]the[SP]great[SP]Michel[SP]knows[SP]of[SP]that\nwould[SP]start[SP]such[SP]a[SP]rumor.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Doucement! Personne au lycée\nKasugayama que le grand Michel connaît\nn'aurait lancé une telle rumeur."
+    "texte_fr": "Doucement! Aucun élève de Kasugayama connu\ndu grand Michel n'aurait pu lancé une\ntelle rumeur."
   },
   {
     "id": 20,
@@ -333,7 +333,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We'd[SP]be[SP]wasting[SP]our[SP]time[SP]checking[SP]it[SP]out.\nIf[SP]we're[SP]gonna[SP]search,[SP]let's[SP]start\nsomewhere[SP]else.",
     "nom_fr": "Eikichi",
-    "texte_fr": "On perdrait notre temps à vérifier. Si\non cherche, autant commencer ailleurs."
+    "texte_fr": "On perdrait notre temps à vérifier. Si\non doit enquêter, autant commencer\nailleurs."
   },
   {
     "id": 21,
@@ -381,7 +381,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "Omigosh![SP]I[SP]heard[SP]the[SP]principal[SP]went[SP]to\nthe[SP]clock[SP]tower[SP]to[SP]lift[SP]the[SP]emblem\ncurse...[SP]Did[SP]you[SP]see[SP]him!?",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Mon dieu! Le directeur est allé à la tour\nlever la malédiction... L'avez-vous vu!?"
+    "texte_fr": "Mon dieu! Le directeur est allé à la tour\npour lever la malédiction... L'avez-vous\nvu!?"
   },
   {
     "id": 24,
@@ -413,7 +413,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "He's[SP]not[SP]dead,[SP]is[SP]he!?\n[1208][0002][1432][NULL][NULL][0014]He's[SP]dead.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]No,[SP]he[SP]made[SP]it.[1432][NULL][NULL][0014]",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Il est pas mort!?\n[1208][0002][1432][NULL][NULL][0014]Il est mort.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Il s'en est sorti.[1432][NULL][NULL][0014]",
+    "texte_fr": "Il est pas mort, hein!?\n[1208][0002][1432][NULL][NULL][0014]Il est mort.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Il s'en est sorti.[1432][NULL][NULL][0014]",
     "question_orig": "He's[SP]not[SP]dead,[SP]is[SP]he!?",
     "choix_orig": [
       "He's[SP]dead.",
@@ -455,6 +455,6 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "I[SP]knew[SP]it![SP]Our[SP]dear[SP]principal[SP]is\ninvincible![SP]I[SP]bet[SP]he'll[SP]show[SP]up[SP]again\nin[SP]our[SP]hour[SP]of[SP]greatest[SP]need!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Je le savais! Notre directeur est invincible!\nIl reviendra quand on aura besoin de lui!"
+    "texte_fr": "Je le savais! Notre directeur est \ninvincible! Il reviendra quand on aura\nbesoin de lui!"
   }
 ]

--- a/traduction/event_scripts/script_014.json
+++ b/traduction/event_scripts/script_014.json
@@ -29,7 +29,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah![SP]Noriko's[SP]here[SP]too!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiya! Noriko est là!?"
+    "texte_fr": "Aiyah! Noriko est là!?"
   },
   {
     "id": 2,
@@ -61,7 +61,7 @@
     "nom_orig": "Noriko",
     "texte_orig": "Sister,[SP]no![SP]You[SP]can't[SP]keep[SP]that[SP]up[SP]or\nit'll[SP]ruin[SP]your[SP]health[SP]even[SP]worse!\nThen[SP]you'll[SP]never[SP]run[SP]again...",
     "nom_fr": "Noriko",
-    "texte_fr": "Grande sœur, non! Arrête ça ou ta santé va\nempirer! Tu ne pourras plus jamais courir..."
+    "texte_fr": "Grande sœur, non! Arrête ça ou ta santé va\nempirer! Et tu ne pourras plus jamais \ncourir..."
   },
   {
     "id": 4,
@@ -237,7 +237,7 @@
     "nom_orig": "Cuss[SP]High[SP]student",
     "texte_orig": "Whoa,[SP]whoa,[SP]what's[SP]with[SP]the[SP]preaching\nin[SP]our[SP]place?[SP]You[SP]think[SP]you're[SP]hot[SP]shit\nor[SP]something!?",
     "nom_fr": "Élève de Kasu",
-    "texte_fr": "Whoa, whoa, c'est quoi ces prêches chez nous?\nTu te prends pour la reine du monde ou quoi!?"
+    "texte_fr": "Whoa, whoa, t'as quoi à prêcher chez nous?\nTu te prends pour la reine du monde\nou quoi!?"
   },
   {
     "id": 15,
@@ -253,7 +253,7 @@
     "nom_orig": "Cuss[SP]High[SP]student",
     "texte_orig": "You[SP]mopes[SP]are[SP]Sevens[SP]students,[SP]yeah?\nBetter[SP]head[SP]straight[SP]home[SP]after[SP]school\nor[SP]your[SP]scaaary[SP]principal's[SP]gonna[SP]get[SP]ya!",
     "nom_fr": "Élève de Kasu",
-    "texte_fr": "Vous êtes du lycée des Sept Sœurs, hein?\nRentrez direct après les cours ou votre\neffrayant directeur va vous choper!"
+    "texte_fr": "Vous êtes du lycée Sevens, hein?\nRentrez direct après les cours ou votre\nterriiiifiant directeur va vous choper!"
   },
   {
     "id": 16,
@@ -269,7 +269,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That's[SP]enough,[SP]everyone![1205][001E][SP]I[SP]think[SP]we[SP]all\nneed[SP]to[SP]be[SP]shinier,[SP]happier[SP]people[SP]here.\nYou[SP]don't[SP]want[SP]to[SP]make[SP]me[SP]mad,[SP]do[SP]you?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ça suffit![1205][001E] Je pense qu'on doit\ntous être plus radieux et heureux\nici. Me fâchez pas, compris?"
+    "texte_fr": "Ça suffit![1205][001E] Je pense qu'on devrait tous être plus\nradieux et heureux ici. Vous ne voudriez\npas me mettre en colère, si?"
   },
   {
     "id": 17,
@@ -317,7 +317,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What...?[1205][001E][SP]You[SP]want[SP]to[SP]repeat[SP]that,\nyou[SP]worthless[SP]punk!?",
     "nom_fr": "Michel",
-    "texte_fr": "Quoi...?[1205][001E] Tu veux répéter\nça, espèce de minable!?"
+    "texte_fr": "Quoi...?[1205][001E] Répète voir, espèce de voyou\nà deux balles!?"
   },
   {
     "id": 20,
@@ -333,7 +333,7 @@
     "nom_orig": "Cuss[SP]High[SP]student",
     "texte_orig": "We[SP]got[SP]a[SP]new[SP]Leader![1205][001E][SP]And[SP]he's[SP]way,[SP]WAY\nstronger[SP]than[SP]any[SP]Boss![E1][E2]\n[E3][E4][NULL][NULL]\"Cuss[SP]High[SP]student\nAll[SP]your[SP]cronies[SP]at[SP]Cuss[SP]High[SP]have\nswitched[SP]sides[SP]for[SP]our[SP]new[SP]Leader,\nSugimoto-san!",
     "nom_fr": "Élève de Kasu",
-    "texte_fr": "Nouveau Leader![1205][001E] Bien plus fort que\nn'importe quel Boss![E1][E2] [E3][E4][NULL][NULL]\"Élève de Kasu\n[1205][U+000F]\nTous tes potes de Kasu ont rejoint[1101]Sugimoto-san, notre nouveau Leader!"
+    "texte_fr": "On a un nouveau Leader![1205][001E] Bien plus fort que\nn'importe quel Boss![E1][E2] [E3][E4][NULL][NULL]\"Élève de Kasu\n[1205][U+000F]\nTous tes potes de Kasu ont rejoint[1101]Sugimoto-san, notre nouveau Leader!"
   },
   {
     "id": 21,
@@ -365,7 +365,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Quit[SP]joking[SP]around!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Arrête ça!"
+    "texte_fr": "Déconne pas!"
   },
   {
     "id": 23,
@@ -413,7 +413,7 @@
     "nom_orig": "Cuss[SP]High[SP]student",
     "texte_orig": "I-It's[SP]the[SP]rumor[SP]going[SP]around![SP]I[SP]just\nheard[SP]everyone[SP]say[SP]that[SP][1432][NULL][NULL][0014]Cuss[SP]High's\nnew[SP]Leader[SP]is[SP]stronger[SP]than[SP]the[SP]Boss![1432][NULL][NULL][0014]",
     "nom_fr": "Élève de Kasu",
-    "texte_fr": "C'est la rumeur! J'ai juste entendu dire que\n[1432][NULL][NULL][0014]le nouveau Leader est plus fort que le Boss![1432][NULL][NULL][0014]"
+    "texte_fr": "C'est la rumeur! J'ai juste entendu dire \nque [1432][NULL][NULL][0014]le nouveau Leader est plus fort que le\nBoss![1432][NULL][NULL][0014]"
   },
   {
     "id": 26,
@@ -429,7 +429,7 @@
     "nom_orig": "Maya",
     "texte_orig": "So[SP]there's[SP]a[SP]new[SP]head[SP]honcho[SP]right[SP]under\nthe[SP]old[SP]one's[SP]nose...?[1205][001E][SP]Doesn't[SP]that[SP]sound\na[SP]little[SP]sudden?",
     "nom_fr": "Maya",
-    "texte_fr": "Un nouveau chef sous le nez de l'ancien...?[1205][001E]\nÇa ne vous semble pas un peu soudain?"
+    "texte_fr": "Un nouveau chef apparaît sans que l'ancien\nne le sache...?[1205][001E] Ça ne vous semble pas un peu soudain?"
   },
   {
     "id": 27,
@@ -445,7 +445,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Sounds[SP]like[SP]the[SP]result[SP]of[SP]another\nrumor...[1205][001E][SP]Maybe[SP]that[SP]Sugimoto's[SP]in[SP]league\nwith[SP]Joker[SP]too.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est sûrement une autre rumeur...[1205][001E] Sugimoto\nest peut-être de mèche avec le Joker."
+    "texte_fr": "C'est sûrement dû à une autre rumeur...[1205][001E] Sugimoto est peut-être de mèche avec\nJoker."
   },
   {
     "id": 28,
@@ -477,7 +477,7 @@
     "nom_orig": "Maya",
     "texte_orig": "By[SP]the[SP]way,[SP]I'm[SP]sure[SP]you[SP]know[SP]the[SP]rumor\nabout[SP]the[SP]Sevens'[SP]emblem[SP]being[SP]cursed.",
     "nom_fr": "Maya",
-    "texte_fr": "Au fait, vous connaissez la rumeur\nde l'emblème maudit des 7 Sœurs?"
+    "texte_fr": "Au fait, vous connaissez la rumeur\nde l'emblème maudit de Sevens?"
   },
   {
     "id": 30,
@@ -493,7 +493,7 @@
     "nom_orig": "Maya",
     "texte_orig": "From[SP]what[SP]I[SP]understand,[SP]that[SP]rumor\nstarted[SP]at[SP]Cuss[SP]High.[SP]Do[SP]you[SP]know\nanything[SP]about[SP]it?",
     "nom_fr": "Maya",
-    "texte_fr": "Cette rumeur vient de Kasu. Vous\nsavez quelque chose là-dessus?"
+    "texte_fr": "De ce que je sais, cette rumeur vient de\nKasu. Vous savez quelque chose là-dessus?"
   },
   {
     "id": 31,
@@ -509,7 +509,7 @@
     "nom_orig": "Cuss[SP]High[SP]student",
     "texte_orig": "We[SP]spread[SP]that[SP]rumor[SP]'cause[SP]the[SP]Leader\ntold[SP]us[SP]to![SP]He[SP]said[SP]he'd[SP]throw[SP]mud[SP]on\nSevens'[SP]reputation[SP]'cause[SP]he[SP]hated[SP]'em...",
     "nom_fr": "Élève de Kasu",
-    "texte_fr": "Le Leader nous a ordonné de répandre\nla rumeur! Il voulait salir les Sept\nSœurs car il les déteste..."
+    "texte_fr": "Le Leader nous a ordonné de répandre la\nrumeur! Il voulait salir la réputation de\nSevens car il détestait ses élèves..."
   },
   {
     "id": 32,
@@ -525,7 +525,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![SP]What's[SP]up[SP]with[SP]that!?[SP]Why[SP]would\nthis[SP]Hiroki[SP]guy[SP]have[SP]such[SP]a[SP]grudge\nagainst[SP]our[SP]school!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei! C'est quoi ce délire!? Pourquoi ce\nHiroki a une telle dent contre notre lycée!?"
+    "texte_fr": "Kehhei! C'est quoi ce délire!? Pourquoi ce\nHiroki a une telle dent contre notre\nlycée!?"
   },
   {
     "id": 33,
@@ -541,7 +541,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We'll[SP]just[SP]have[SP]to[SP]ask[SP]him[SP]in[SP]person!",
     "nom_fr": "Michel",
-    "texte_fr": "On n'a qu'à lui demander en personne!"
+    "texte_fr": "On a qu'à lui demander en personne!"
   },
   {
     "id": 34,
@@ -573,7 +573,7 @@
     "nom_orig": "Cuss[SP]High[SP]student",
     "texte_orig": "H-H-He's[SP]here,[SP]at[SP]the[SP]secret[SP]lounge\nfurther[SP]in...",
     "nom_fr": "Élève de Kasu",
-    "texte_fr": "I-I-Il est là, dans le\nsalon secret plus loin..."
+    "texte_fr": "I-I-Il est là-bas, dans le salon secret\nplus loin..."
   },
   {
     "id": 36,
@@ -589,7 +589,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "A[SP]secret[SP]lounge!?[SP]I'll[SP]smack[SP]the[SP]smile\noff[SP]that[SP]cocky[SP]bastard's[SP]face!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Un salon secret!? Je vais lui\neffacer son sourire arrogant!"
+    "texte_fr": "Un salon secret!? Je vais lui effacer son\nsourire arrogant!"
   },
   {
     "id": 37,
@@ -621,7 +621,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP]was[SP]there[SP]a[SP]girl[SP]called[SP]Kozy[SP]here?\nShe[SP]was[SP]investigating[SP]the[SP]emblem[SP]curse\nrumor[SP]too.",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, y avait une Kozy ici? Elle\nenquêtait aussi sur l'emblème."
+    "texte_fr": "Hé, est-qu'il y avait une certaine Kozy \nici? Elle enquêtait aussi sur l'emblème."
   },
   {
     "id": 39,
@@ -637,7 +637,7 @@
     "nom_orig": "Cuss[SP]High[SP]student",
     "texte_orig": "I[SP]don't[SP]know[SP]no[SP]Kozy.[SP]Though[SP]there[SP]was\nthis[SP]girl,[SP]said[SP]her[SP]name[SP]was[SP]Miyabi\nHanakouji,[SP]who[SP]went[SP]to[SP]see[SP]our[SP]Leader...",
     "nom_fr": "Élève de Kasu",
-    "texte_fr": "Connais pas Kozy. Mais une fille, Miyabi\nHanakouji, est allée voir notre Leader..."
+    "texte_fr": "Je connais pas de Kozy. Mais une fille qui\ndisait s'appeler Miyabi Hanakouji est\nallée voir notre Leader..."
   },
   {
     "id": 40,
@@ -685,7 +685,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Wait,[SP]Eikichi-kun![SP]It's[SP]too[SP]dangerous\nto[SP]go[SP]alone!",
     "nom_fr": "Maya",
-    "texte_fr": "Attends, Eikichi! C'est trop risqué tout seul!"
+    "texte_fr": "Attends, Eikichi! C'est trop risqué\ntout seul!"
   },
   {
     "id": 43,
@@ -701,7 +701,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah!?[SP]The[SP]Undie[SP]Boss[SP]took[SP]off[SP]by[SP]himself...",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiya!? Le Boss des Calbutes s'est tiré..."
+    "texte_fr": "Aiyah!? Le Boss des Calbutes s'est tiré..."
   },
   {
     "id": 44,
@@ -733,7 +733,7 @@
     "nom_orig": "Maya",
     "texte_orig": "If[SP]the[SP]rumor[SP]that[SP]the[SP]Leader[SP]is[SP]stronger\nthan[SP]the[SP]Boss[SP]has[SP]spread[SP]far[SP]enough...[1205][001E]\nEikichi-kun[SP]might[SP]be[SP]in[SP]trouble.",
     "nom_fr": "Maya",
-    "texte_fr": "Si la rumeur du Leader plus fort\nque le Boss s'est répandue...[1205][001E]\nEikichi pourrait avoir des ennuis."
+    "texte_fr": "Si la rumeur du Leader plus fort que le \nBoss s'est trop répandue...[1205][001E]\nEikichi-kun pourrait avoir\ndes ennuis."
   },
   {
     "id": 46,
@@ -765,7 +765,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "If[SP]she[SP]was[SP]going[SP]out[SP]with[SP]him[SP]like[SP]Undie\nBoss[SP]said,[SP]wouldn't[SP]she[SP]want[SP]him[SP]to[SP]know?\nMaybe[SP]he[SP]was[SP]lying[SP]about[SP]her.",
     "nom_fr": "Ginko",
-    "texte_fr": "Si elle sortait avec lui, elle voudrait qu'il\nle sache, non? Peut-être qu'il a menti."
+    "texte_fr": "Si elle sortait avec lui, elle voudrait\nqu'il le sache, non? Peut-être qu'il\na menti."
   },
   {
     "id": 48,
@@ -797,7 +797,7 @@
     "nom_orig": "Cuss[SP]High[SP]student",
     "texte_orig": "Sugimoto's[SP]actually[SP]kind[SP]of[SP]a[SP]shitty[SP]dude.\nHe[SP]sucks[SP]up[SP]to[SP]the[SP]strong[SP]and[SP]stomps[SP]on\nthe[SP]weak.[SP]Huh...[1205][001E][SP]Why[SP]IS[SP]he[SP]our[SP]Leader?",
     "nom_fr": "Élève de Kasu",
-    "texte_fr": "Sugimoto est un gars minable. Il lèche\nles bottes des forts et écrase les[1205][U+000F]\nfaibles. Pourquoi est-il notre Leader?"
+    "texte_fr": "Sugimoto est un gars minable. Il lèche\nles bottes des forts et écrase les\nfaibles. Pff...[1205][U+000F]pourquoi est-il notre Leader?"
   },
   {
     "id": 50,
@@ -813,7 +813,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I'd[SP]heard[SP]the[SP]rumors[SP]for[SP]a[SP]while[SP]now...\nBut[SP]it[SP]looks[SP]like[SP]there[SP]actually[SP]is[SP]a\nsecret[SP]lounge[SP]somewhere[SP]here!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "J'avais entendu les rumeurs... Il\ny a vraiment un salon secret ici!"
+    "texte_fr": "J'avais déjà entendu les rumeurs...\nMais il y a vraiment un salon secret ici!"
   },
   {
     "id": 51,
@@ -829,7 +829,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "There[SP]must[SP]be[SP]some[SP]kind[SP]of[SP]special\nqualification[SP]to[SP]get[SP]in,[SP]right?[SP]I[SP]wonder\nif[SP]I'm[SP]eligible...[SP]I[SP]want[SP]to[SP]go[SP]so[SP]bad!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Faut une qualification pour y entrer? Je suis\néligible? J'ai tellement envie d'y aller!"
+    "texte_fr": "Faut une qualification pour y entrer?\nJe me demande si je suis éligible?\nJ'ai tellement envie d'y aller!"
   },
   {
     "id": 52,
@@ -845,7 +845,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I've[SP]been[SP]hearing[SP]people[SP]talk[SP]about\nCuss[SP]High's[SP]new[SP]Leader,[SP]too.[SP]Huh?[SP]He's\nhere[SP]now?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "J'ai entendu parler du nouveau Leader\nde Kasu. Hein? Il est ici maintenant?"
+    "texte_fr": "J'ai aussi entendu parler du nouveau\nLeader de Kasu. Hein? Il est ici?"
   },
   {
     "id": 53,
@@ -861,7 +861,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]reminds[SP]me,[SP]a[SP]group[SP]of[SP]Cuss[SP]High\nstudents[SP]headed[SP]upstairs[SP]a[SP]moment[SP]ago...\nWonder[SP]if[SP]their[SP]new[SP]Leader[SP]was[SP]with[SP]them.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Un groupe de Kasu est monté à l'étage... Je\nme demande si leur nouveau Leader y était."
+    "texte_fr": "Un groupe d'élèves de Kasu est monté à\nl'étage... Je me demande si leur nouveau\nLeader y était."
   },
   {
     "id": 54,
@@ -893,6 +893,6 @@
     "nom_orig": "Employee",
     "texte_orig": "Wow,[SP]things[SP]sound[SP]like[SP]they're[SP]getting\nheated[SP]upstairs.[SP]I[SP]wonder[SP]what[SP]they're\ndoing[SP]up[SP]there?",
     "nom_fr": "Employé",
-    "texte_fr": "Wow, on dirait que ça s'échauffe à l'étage.\nJe me demande ce qu'ils font là-haut?"
+    "texte_fr": "Wow, on dirait que ça chauffe à l'étage.\nJe me demande ce qu'ils font là-haut?"
   }
 ]

--- a/traduction/event_scripts/script_015.json
+++ b/traduction/event_scripts/script_015.json
@@ -13,7 +13,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I'd[SP]heard[SP]the[SP]rumor[SP]about[SP]this[SP]secret\nlounge,[SP]too...[1205][001E][SP]But[SP]actually[SP]seeing[SP]it\nfor[SP]myself[SP]is[SP]kinda[SP]weird.",
     "nom_fr": "Ginko",
-    "texte_fr": "J'avais entendu la rumeur sur ce\nsalon secret, aussi...[1205][001E] Mais le\nvoir en vrai, c'est assez bizarre."
+    "texte_fr": "J'avais moi aussi entendu la rumeur sur ce\nsalon secret...[1205][001E] Mais le voir en vrai, c'est\nassez bizarre."
   },
   {
     "id": 1,
@@ -29,7 +29,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]used[SP]to[SP]come[SP]here[SP]about[SP]as[SP]often[SP]as[SP]I\ncame[SP]to[SP]school.[SP]When[SP]did[SP]this[SP]city[SP]get\nso[SP]messed[SP]up...?",
     "nom_fr": "Ginko",
-    "texte_fr": "Avant, je venais ici autant qu'au lycée.\nQuand la ville est elle devenue [1205][U+000F] pourrie...?"
+    "texte_fr": "Avant, je venais ici autant qu'au lycée.\nQuand la ville est-elle devenue[1205][U+000F] si pourrie...?"
   },
   {
     "id": 2,
@@ -45,7 +45,7 @@
     "nom_orig": "Maya",
     "texte_orig": "A[SP]gathering...?[SP]I[SP]wonder[SP]what[SP]that's\nabout.[SP]It[SP]seems[SP]like[SP]someone[SP]summoned[SP]them\nhere...[1205][001E][SP]I[SP]don't[SP]like[SP]the[SP]sound[SP]of[SP]this.",
     "nom_fr": "Maya",
-    "texte_fr": "Un rassemblement? Qui les a\nconvoques ici? [1205][001E] Ça sent mauvais."
+    "texte_fr": "Un rassemblement? Je me demande quelle en\nest la raison. Qui les a convoqués ici?[1205][001E] Ça sent mauvais."
   },
   {
     "id": 3,
@@ -61,7 +61,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Eikichi's[SP]not[SP]here[SP]either.[SP]Won't[SP]he[SP]be[SP]in\ntrouble[SP]if[SP]we[SP]don't[SP]hurry[SP]and[SP]go[SP]after[SP]him?",
     "nom_fr": "Yukino",
-    "texte_fr": "Eikichi n'est pas là non plus. Si\non tarde, il va avoir des ennuis?"
+    "texte_fr": "Eikichi n'est pas là non plus. Si on\ntarde trop, il va avoir des ennuis, non?"
   },
   {
     "id": 4,
@@ -77,7 +77,7 @@
     "nom_orig": "Masked[SP]man",
     "texte_orig": "I'm[SP]glad[SP]that[SP]my[SP]leg[SP]hair[SP]is[SP]completely[SP]gone,\nbut[SP]I[SP]really[SP]hate[SP]having[SP]to[SP]come[SP]to[SP]these\ngatherings.",
     "nom_fr": "Homme masqué",
-    "texte_fr": "Content que mes poils aient disparu,\nmais je déteste ces réunions."
+    "texte_fr": "Je suis content que mes poils de jambes\naient disparu, mais je déteste venir à ces\nréunions."
   },
   {
     "id": 5,
@@ -93,7 +93,7 @@
     "nom_orig": "Masked[SP]man",
     "texte_orig": "It[SP]was[SP]a[SP]shock[SP]to[SP]find[SP]that[SP]summons[SP]at[SP]the\nbottom[SP]of[SP]my[SP]boxed[SP]lunch.[SP]Feels[SP]like[SP]I'm\nbeing[SP]watched.",
     "nom_fr": "Homme masqué",
-    "texte_fr": "C'était un choc de trouver une convocation\ndans mon bento. On me surveille?"
+    "texte_fr": "C'était un choc de trouver une convocation\ndans mon bento. J'ai l'impression qu'on me\nsurveille."
   },
   {
     "id": 6,
@@ -109,6 +109,6 @@
     "nom_orig": "Masked[SP]woman",
     "texte_orig": "I[SP]totally[SP]had[SP]a[SP]summons[SP]in[SP]my[SP]purse[SP]too,\nyesterday?[SP]I[SP]was[SP]like,[SP]is[SP]someone[SP]stalking[SP]me?",
     "nom_fr": "Femme masquée",
-    "texte_fr": "Moi aussi, une convocation dans mon\nsac hier. On me suit peut-etre?"
+    "texte_fr": "Moi aussi j'ai reçu une convocation dans\nmon sac hier. Genre, on me surveille?"
   }
 ]

--- a/traduction/event_scripts/script_016.json
+++ b/traduction/event_scripts/script_016.json
@@ -13,7 +13,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "That[SP]stupid[SP]Boss[SP]isn't[SP]here[SP]either!\nThere's[SP]always[SP]one[SP]bad[SP]apple[SP]in[SP]every\nbunch.[SP]Geez,[SP]he's[SP]so[SP]self-centered!",
     "nom_fr": "Ginko",
-    "texte_fr": "Ce stupide Boss n'est pas là non\nplus! Il y a toujours un boulet dans\nchaque groupe. Punaise, quel égoïste!"
+    "texte_fr": "Ce stupide Boss n'est pas là non\nplus! Il y a toujours un boulet dans\nchaque groupe. Bon sang, quel égoïste!"
   },
   {
     "id": 1,
@@ -45,7 +45,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm...[SP]I'm[SP]worried[SP]about[SP]Eikichi-kun,[SP]too.\nHopefully[SP]we[SP]can[SP]find[SP]a[SP]way[SP]into[SP]this\nsecret[SP]lounge...",
     "nom_fr": "Maya",
-    "texte_fr": "Hmm... Je m'inquiète aussi pour\nEikichi. J'espère qu'on pourra\nentrer dans ce salon secret..."
+    "texte_fr": "Hmm... Je m'inquiète aussi pour Eikichi.\nJ'espère qu'on pourra entrer dans\nce salon secret..."
   },
   {
     "id": 3,
@@ -61,7 +61,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "You're[SP]pretty[SP]deadly[SP]with[SP]that[SP]katana,\n[1113].",
     "nom_fr": "Yukino",
-    "texte_fr": "Tu es plutôt mortel avec ce katana, [1113]."
+    "texte_fr": "Tu es redoutable avec ce katana, [1113]."
   },
   {
     "id": 4,
@@ -77,7 +77,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "One[SP]of[SP]my[SP]old[SP]pals[SP]was[SP]a[SP]whiz[SP]with[SP]a[SP]katana,\nbut[SP]you're[SP]not[SP]bad[SP]yourself.[SP]Bet[SP]you're[SP]pretty\nhandy[SP]with[SP]your[SP]fists[SP]too,[SP]huh?",
     "nom_fr": "Yukino",
-    "texte_fr": "Un vieux pote était un as au katana, mais\ntu te débrouilles bien. Je parie que tu[1205][U+000F]\nsais aussi te servir de tes poings, hein?"
+    "texte_fr": "Un vieux pote était un as au katana, mais\ntu te débrouilles bien. Je parie que tu\nsais aussi te servir de tes poings, hein?"
   },
   {
     "id": 5,
@@ -183,6 +183,6 @@
     "nom_orig": "Masked[SP]female[SP]student",
     "texte_orig": "These[SP]gatherings[SP]are[SP]so[SP]lame,[SP]but[SP]it[SP]helps[SP]to\nthink[SP]of[SP]it[SP]as[SP]a[SP]free[SP]ticket[SP]to[SP]a[SP]party.[SP]It's\nworth[SP]it[SP]to[SP]have[SP]a[SP]smaller[SP]mouth,[SP]anyway.",
     "nom_fr": "Élève masquée",
-    "texte_fr": "Ces rassemblements sont nuls, mais faut voir\nça comme un billet gratuit pour une fête.[1205][U+000F] Ça\nvaut le coup pour réduire sa bouche, bref."
+    "texte_fr": "Ces réunions sont nuls, mais faut voir ça\ncomme un billet gratuit pour une fête. Ça\nvaut le coup pour réduire sa bouche, bref."
   }
 ]

--- a/traduction/event_scripts/script_018.json
+++ b/traduction/event_scripts/script_018.json
@@ -13,7 +13,7 @@
     "nom_orig": "Leader",
     "texte_orig": "Oh[SP]man,[SP]check[SP]it[SP]out![SP]The[SP]Boss![SP]What're[SP]you\nholdin'[SP]your[SP]stomach[SP]for?[SP]Gotta[SP]take[SP]a[SP]shit?\nWant[SP]me[SP]to[SP]drop[SP]your[SP]drawers[SP]for[SP]you?",
     "nom_fr": "Leader",
-    "texte_fr": "Oh mec, matez un peu ça! Le Boss! Pourquoi\ntu te tiens le bide comme ça? Envie de\nchier?[1205][U+000F] Tu veux que je te baisse ton froc?"
+    "texte_fr": "Les mecs, matez ça! Le Boss! Pourquoi tu\nte tiens le bide comme ça? T'as envie de\nchier? Tu veux que je te baisse ton froc?"
   },
   {
     "id": 1,
@@ -77,7 +77,7 @@
     "nom_orig": "Cuss[SP]High[SP]student",
     "texte_orig": "That[SP][1432][NULL][NULL][0014]gathering[1432][NULL][NULL][0014][SP]stuff[SP]seemed[SP]like[SP]a[SP]pain[SP]in\nthe[SP]ass,[SP]but[SP]I'm[SP]glad[SP]I[SP]came[SP]if[SP]it[SP]meant\nseeing[SP]something[SP]this[SP]awesome!",
     "nom_fr": "Élève de Kasu",
-    "texte_fr": "Ce [1432][NULL][NULL][0014]rassemblement[1432][NULL][NULL][0014] avait l'air chiant, mais ravi\nd'être venu pour voir un truc aussi génial!"
+    "texte_fr": "Ce [1432][NULL][NULL][0014]rassemblement[1432][NULL][NULL][0014] avait l'air chiant, mais\nheureux d'être venu pour voir un\ntruc aussi génial!"
   },
   {
     "id": 5,
@@ -93,7 +93,7 @@
     "nom_orig": "Leader",
     "texte_orig": "Sheesh,[SP]you're[SP]a[SP]mess.[SP]Is[SP]Fatty[SP]here[SP]really\nthat[SP]important[SP]to[SP]ya?",
     "nom_fr": "Leader",
-    "texte_fr": "T'es amoché. Bouboule ici\ncompte tant pour toi?"
+    "texte_fr": "T'es amoché. Bouboule ici compte tant\npour toi?"
   },
   {
     "id": 6,
@@ -109,7 +109,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Whatever...[1205][001E][SP]She[SP]was[SP]only[SP]tagging[SP]along!\nBut[SP]if[SP]anything[SP]happens[SP]to[SP]Hanakouji-san,\nyou[SP]punks[SP]are[SP]in[SP]for[SP]a[SP]world[SP]of[SP]pain!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Bref...[1205][001E] Elle faisait que me suivre!\nMais si vous touchez à Hanakouji-san,\nvous allez le regretter!"
+    "texte_fr": "Qu'importe...[1205][001E] Elle faisait que me suivre!\nMais si vous touchez à Hanakouji-san, vous\nallez le regretter!"
   },
   {
     "id": 7,
@@ -253,7 +253,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]nothing[SP]like[SP]that![SP]I[SP]admired[SP]the\nHanakouji-san[SP]I[SP]knew[SP]back[SP]then!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pas du tout! J'admirais la\nHanakouji-san de l'époque!"
+    "texte_fr": "Ça n'a rien à voir! J'admirais la\nHanakouji-san de l'époque!"
   },
   {
     "id": 16,
@@ -381,7 +381,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "That[SP]Hiroki[SP]guy's[SP]the[SP]worst![SP]Alright,[SP]I'm\ngonna[SP]bust[SP]out[SP]my[SP]Persona[SP]and--",
     "nom_fr": "Ginko",
-    "texte_fr": "Ce Hiroki est le pire de tous! Très\nbien, je vais sortir ma Persona et--"
+    "texte_fr": "Ce Hiroki est la pire des ordures ! Allez,\nje vais sortir ma Persona et--"
   },
   {
     "id": 24,
@@ -397,7 +397,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Wait![SP]We[SP]storm[SP]in[SP]there,[SP]we[SP]hurt\nEikichi's[SP]pride.",
     "nom_fr": "Yukino",
-    "texte_fr": "Attends! Ça blesserait la fierté de Eikichi."
+    "texte_fr": "Attends! Ça blesserait la fierté de\nEikichi."
   },
   {
     "id": 25,
@@ -429,7 +429,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "You[SP]want[SP]us[SP]to[SP]just[SP]sit[SP]back...!?[SP]Fanna!\nNo[SP]way![SP]Let's[SP]go[SP]save[SP]them,[SP][1113]!",
     "nom_fr": "Ginko",
-    "texte_fr": "Rien faire...!? Sérieux! Jamais!\nAllons les aider, [1113]!"
+    "texte_fr": "On doit rien faire...!? Fanna! Jamais!\nAllons les aider, [1113]!"
   },
   {
     "id": 27,
@@ -445,7 +445,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Let's[SP]go[SP]save[SP]them!\n[1208][0002]Save[SP]them\nWait[SP]and[SP]see[SP]what[SP]happens",
     "nom_fr": "Ginko",
-    "texte_fr": "Allons les aider!\n[1208][0002]Les aider\nAttendre de voir",
+    "texte_fr": "Allons les aider!\n[1208][0002]Les aider\nAttendre et regarder",
     "question_fr": "",
     "choix_fr": [
       ""
@@ -561,7 +561,7 @@
     "nom_orig": "Leader",
     "texte_orig": "I[SP]ain't[SP]gonna[SP]go[SP]soft[SP]and[SP]take[SP]only[SP]an[SP]arm\nhere.[SP]To[SP]get[SP]back[SP]for[SP]what[SP]you[SP]put[SP]me[SP]through,\nI'm[SP]gonna[SP]have[SP]to[SP]take[SP]both[SP]arms[SP]and[SP]legs!",
     "nom_fr": "Leader",
-    "texte_fr": "Je vais pas juste prendre un bras.\nPour me venger de ce que tu m'as fait,\nje vais te briser bras et jambes!"
+    "texte_fr": "Je vais pas juste te casser un bras.\nPour me venger de ce que tu m'as fait,\nje vais te briser les bras et les jambes!"
   },
   {
     "id": 35,
@@ -577,7 +577,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Are[SP]you[SP]still[SP]bitching[SP]about[SP]me[SP]pantsing\nyou[SP]in[SP]middle[SP]school?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tu pleures encore car j'ai\nbaissé ton froc au collège?"
+    "texte_fr": "Tu chiales encore car j'ai baissé ton froc\nau collège?"
   },
   {
     "id": 36,
@@ -609,7 +609,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That[SP]wasn't[SP]it.[SP]She[SP]got[SP]fed[SP]up[SP]with[SP]the[SP]way\nyou'd[SP]pick[SP]on[SP]anyone[SP]weaker[SP]than[SP]you.",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'était pas ça. Elle en avait marre\nque tu t'en prennes aux plus faibles."
+    "texte_fr": "C'était pas pour ça. Elle en avait marre\nque tu t'en prennes aux plus faibles."
   },
   {
     "id": 38,
@@ -625,7 +625,7 @@
     "nom_orig": "Leader",
     "texte_orig": "Th-That's[SP]a[SP]lie![SP]You're[SP]lying![SP]It[SP]was[SP]your\nfault![SP]Everything[SP]is!",
     "nom_fr": "Leader",
-    "texte_fr": "C-C'est faux! Tu mens! C'était\nta faute! Tout est ta faute!"
+    "texte_fr": "C-C'est faux! Tu mens! C'était\n de ta faute! Tout est ta faute!"
   },
   {
     "id": 39,
@@ -673,7 +673,7 @@
     "nom_orig": "Leader",
     "texte_orig": "...Uh?",
     "nom_fr": "Leader",
-    "texte_fr": "... Eh?"
+    "texte_fr": "...Eh?"
   },
   {
     "id": 42,
@@ -689,6 +689,6 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]Leader[SP]might[SP]be[SP]stronger[SP]than[SP]the[SP]Boss,\nbut[SP]there's[SP]no[SP]way[SP]Hiroki[SP]Sugimoto[SP]is[SP]ever\nstronger[SP]than[SP]Eikichi[SP]Mishina!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le Leader bat peut-être le Boss,\nmais jamais Hiroki Sugimoto ne\nsera plus fort qu'Eikichi Mishina!"
+    "texte_fr": "Le Leader bat peut-être le Boss, mais\njamais Hiroki Sugimoto ne\nsera plus fort qu'Eikichi Mishina!"
   }
 ]

--- a/traduction/event_scripts/script_019.json
+++ b/traduction/event_scripts/script_019.json
@@ -29,7 +29,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I've[SP]got[SP]no[SP]right[SP]to[SP]act[SP]all[SP]superior[SP]about\nwhat[SP]Hiroki[SP]did.[SP]There's[SP]no[SP]difference[SP]between\nthat[SP]and[SP]what[SP]I've[SP]done,[SP]not[SP]really.",
     "nom_fr": "Michel",
-    "texte_fr": "J'ai pas le droit de faire le malin\nface à Hiroki. Y a pas de différence\nentre ça et ce que j'ai fait, en vrai."
+    "texte_fr": "J'ai pas le droit de faire le malin\nface à Hiroki. Y a pas vraiment de\ndifférence entre ça et ce que j'ai fait,."
   },
   {
     "id": 2,
@@ -141,7 +141,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Uhh,[SP]Hanakouji-san?[SP]Are[SP]you...[SP]well,[SP]I[SP]guess\nyou're[SP]not[SP]okay,[SP]huh...",
     "nom_fr": "Michel",
-    "texte_fr": "Euh, Hanakouji-san? Tu es... bon,\nje suppose que ça va pas, hein..."
+    "texte_fr": "Euh, Hanakouji-san? Tu vas... bon,\nje suppose que ça va pas, hein..."
   },
   {
     "id": 9,
@@ -189,7 +189,7 @@
     "nom_orig": "Miyabi",
     "texte_orig": "No![SP]Don't[SP]look,[SP]Eikichi-kun...[1205][001E][SP]I'm[SP]sorry!",
     "nom_fr": "Miyabi",
-    "texte_fr": "Non! Regarde pas, Michel...[1205][001E] Pardon!"
+    "texte_fr": "Non! Ne me regarde pas, Michel...[1205][001E] Pardon!"
   },
   {
     "id": 12,
@@ -253,7 +253,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Why'd[SP]you[SP]order[SP]your[SP]stooges[SP]to[SP]spread[SP]a\nrumor[SP]that[SP]the[SP]Sevens[SP]emblem[SP]was[SP]cursed?",
     "nom_fr": "Yukino",
-    "texte_fr": "Pourquoi ordonner de répandre la rumeur\nque l'emblème des Sept Sœurs est maudit?"
+    "texte_fr": "Pourquoi ordonner de répandre la rumeur\nque l'emblème de Seven est maudit?"
   },
   {
     "id": 16,
@@ -269,7 +269,7 @@
     "nom_orig": "Leader",
     "texte_orig": "Th-The[SP]student[SP]council[SP]president[SP]asked[SP]me[SP]to!\nHe[SP]said[SP]he'd[SP]make[SP]me[SP]Leader[SP]with[SP]Master[SP]Joker's\npowers[SP]if[SP]I[SP]ruined[SP]Sevens'[SP]reputation!",
     "nom_fr": "Leader",
-    "texte_fr": "Le président des élèves l'a demandé! Il a\ndit me nommer Leader avec les pouvoirs de\nMaître Joker[1205][U+000F] si je ruinais leur réputation!"
+    "texte_fr": "Le président du BDE me l'a demandé! Il a\ndit que si je ruinais leur réputation il\nme nommerait Leader grâce à Maître Joker!"
   },
   {
     "id": 17,
@@ -301,7 +301,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]people[SP]here[SP]said[SP]something[SP]about[SP]a\n[1432][NULL][NULL][0014]gathering[1432][NULL][NULL][0014][SP]going[SP]on[SP]today.[SP]What[SP]did[SP]they\nmean[SP]by[SP]that?",
     "nom_fr": "Maya",
-    "texte_fr": "Des gens ont parlé d'un [1432][NULL][NULL][0014]rassemblement[1432][NULL][NULL][0014]\naujourd'hui. Qu'est-ce qu'ils voulaient[1205][U+000F] dire\npar là?"
+    "texte_fr": "Des gens ont parlé d'un [1432][NULL][NULL][0014]rassemblement[1432][NULL][NULL][0014]\naujourd'hui.\nQu'est-ce qu'ils voulaient dire par là?"
   },
   {
     "id": 19,
@@ -317,7 +317,7 @@
     "nom_orig": "Leader",
     "texte_orig": "There's[SP]an[SP]organization[SP]you[SP]have[SP]to[SP]join[SP]once\nMaster[SP]Joker[SP]grants[SP]your[SP]ideal.[SP]I[SP]heard[SP]the\ngathering[SP]was[SP]an[SP]initiation[SP]ceremony[SP]for[SP]it.",
     "nom_fr": "Leader",
-    "texte_fr": "Il y a une orga à rejoindre quand Maître Joker\nexauce ton vœu. J'ai entendu que ce\nrassemblement[1205][U+000F] était une cérémonie[1101]d'initiation."
+    "texte_fr": "Il y a une orga à rejoindre quand Maître Joker\nexauce ton vœu. Apparemment, cette\nréunion[1205][U+000F] était une cérémonie[1101]d'initiation."
   },
   {
     "id": 20,
@@ -333,7 +333,7 @@
     "nom_orig": "Leader",
     "texte_orig": "Wh-Which[SP]reminds[SP]me...[1205][001E][SP]I[SP]also[SP]heard[SP]that[SP]one\nof[SP]their[SP]executives,[SP][1432][NULL][NULL][0014]Lady[SP]Scorpio,[1432][NULL][NULL][0014][SP]was[SP]gonna\nbe[SP]at[SP]the[SP]gathering.",
     "nom_fr": "Leader",
-    "texte_fr": "C-Ce qui me rappelle...[1205][001E] J'ai aussi\nentendu qu'un de leurs cadres, [1432][NULL][NULL][0014]Dame\nScorpion,[1432][NULL][NULL][0014] serait à[1205][U+000F] ce rassemblement."
+    "texte_fr": "C-Ce qui me rappelle...[1205][001E] J'ai aussi\nentendu qu'un de leurs cadres, [1432][NULL][NULL][0014]Dame\nScorpion,[1432][NULL][NULL][0014] serait à ce rassemblement."
   },
   {
     "id": 21,

--- a/traduction/event_scripts/script_020.json
+++ b/traduction/event_scripts/script_020.json
@@ -77,7 +77,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Grazie![1205][001E][SP]Now[SP]I[SP]can[SP]see--\n[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\n...You[SP]know,[SP][1113]-kun...[1205][001E][SP]I[SP]think[SP]next\ntime[SP]you[SP]have[SP]something[SP]useful[SP]like[SP]that,\nyou[SP]should[SP]take[SP]it[SP]out[SP]a[SP]little[SP]sooner.",
     "nom_fr": "Maya",
-    "texte_fr": "Grazie![1205][001E] J'y vois clair- [E1][E2] [E3][E4][NULL][NULL]\"Maya\n[1205][U+000F] ... Tu\nsais, [1113]...[1205][001E] La prochaine fois que t'as[1101]un truc utile, sors-le un peu plus tôt."
+    "texte_fr": "Grazie![1205][001E] J'y vois clair maintenant-- [E1][E2] [E3][E4][NULL][NULL]\"Maya\n[1205][U+000F] ... Tu\nsais, [1113]...[1205][001E] La prochaine fois que t'as[1101]un truc utile, sors-le un peu plus tôt."
   },
   {
     "id": 5,
@@ -157,7 +157,7 @@
     "nom_orig": "Yasuo",
     "texte_orig": "I'm[SP]making[SP]this[SP]school[SP]an[SP]ideal[SP]educational\nfacility,[SP]worthy[SP]of[SP]a[SP]genius[SP]like[SP]myself.\nBut[SP]first,[SP]the[SP]vermin[SP]must[SP]be[SP]exterminated.",
     "nom_fr": "Yasuo",
-    "texte_fr": "Je fais de ce lycée une école idéale,\ndigne d'un génie comme moi. Mais d'abord,\nla vermine doit[1205][U+000F] être exterminée."
+    "texte_fr": "Je fais de ce lycée une école idéale,\ndigne d'un génie comme moi. Mais d'abord,\nla vermine doit être exterminée."
   },
   {
     "id": 10,
@@ -189,7 +189,7 @@
     "nom_orig": "Yasuo",
     "texte_orig": "Sugimoto-kun[SP]was[SP]only[SP]a[SP]stalking[SP]horse.\nI[SP]set[SP]the[SP]stage[SP]by[SP]spreading[SP]a[SP]rumor[SP]that\nthe[SP]Leader[SP]was[SP]stronger[SP]than[SP]the[SP]Boss.",
     "nom_fr": "Yasuo",
-    "texte_fr": "Sugimoto n'était qu'un leurre. J'ai\npréparé le terrain en lançant la rumeur\nque le Leader était[1205][U+000F] plus fort que le Boss."
+    "texte_fr": "Sugimoto n'était qu'un leurre. J'ai\npréparé le terrain en lançant la rumeur\nque le Leader était plus fort que le Boss."
   },
   {
     "id": 12,
@@ -205,7 +205,7 @@
     "nom_orig": "Yasuo",
     "texte_orig": "I[SP]hadn't[SP]factored[SP]in[SP][1112]-kun[SP]and[SP]the\nothers[SP]becoming[SP]involved.[SP]Hence,[SP]my[SP]plan[SP]to\nplay[SP]the[SP]vermin[SP]against[SP]each[SP]other[SP]misfired.",
     "nom_fr": "Yasuo",
-    "texte_fr": "J'avais pas prévu que [1112] et les autres\ns'en mêlent. Mon plan pour monter la\nvermine les uns[1205][U+000F] contre les autres a échoué."
+    "texte_fr": "J'avais pas prévu que [1112] et les autres\ns'en mêlent. Mon plan pour monter la\nvermine contre ses amis a échoué."
   },
   {
     "id": 13,
@@ -221,7 +221,7 @@
     "nom_orig": "Yasuo",
     "texte_orig": "Sugimoto-kun[SP]was[SP]only[SP]a[SP]stalking[SP]horse.\nI[SP]set[SP]the[SP]stage[SP]by[SP]spreading[SP]a[SP]rumor[SP]that\nthe[SP]Leader[SP]was[SP]stronger[SP]than[SP]the[SP]Boss.",
     "nom_fr": "Yasuo",
-    "texte_fr": "Sugimoto n'était qu'un leurre. J'ai\npréparé le terrain en lançant la rumeur\nque le Leader était[1205][U+000F] plus fort que le Boss."
+    "texte_fr": "Sugimoto n'était qu'un leurre. J'ai\npréparé le terrain en lançant la rumeur\nque le Leader était plus fort que le Boss."
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Yasuo",
     "texte_orig": "I[SP]hadn't[SP]considered[SP]that[SP]you'd[SP]use[SP]it[SP]to\nyour[SP]advantage.[SP]Hence,[SP]my[SP]plan[SP]to[SP]play[SP]the\nthe[SP]vermin[SP]against[SP]each[SP]other[SP]misfired.",
     "nom_fr": "Yasuo",
-    "texte_fr": "J'ignorais que vous l'utiliseriez.\nMon plan pour monter la vermine\ncontre elle-même a donc échoué."
+    "texte_fr": "Je n'ai pu prévoir que vous l'utiliseriez\nà votre avantage. Mon plan pour monter\ncette vermine contre ses amis a échoué."
   },
   {
     "id": 15,
@@ -269,7 +269,7 @@
     "nom_orig": "Yasuo",
     "texte_orig": "I[SP]think[SP]not.[SP]Savage[SP]elements[SP]must[SP]be[SP]isolated\nlest[SP]they[SP]contaminate[SP]the[SP]rest[SP]of[SP]society.\nGheeeheehehehe!",
     "nom_fr": "Yasuo",
-    "texte_fr": "Je crois pas. Les éléments sauvages\ndoivent être isolés pour ne pas\ncontaminer la société. Ghihihi!"
+    "texte_fr": "J'en doute. Les éléments sauvages\ndoivent être isolés pour ne pas\ncontaminer la société. Ghiiihiihihihi!"
   },
   {
     "id": 17,
@@ -285,7 +285,7 @@
     "nom_orig": "Yasuo",
     "texte_orig": "But[SP]if[SP]the[SP]ladies[SP]give[SP]me[SP]a[SP]writeup[SP]in[SP]their\nperiodical[SP]and[SP]Lisa-san[SP]becomes[SP]my[SP]g-girlfriend,\nI'll[SP]make[SP]an[SP]exception[SP]for[SP]the[SP]females.",
     "nom_fr": "Yasuo",
-    "texte_fr": "Mais si les filles font un article sur moi\net que Lisa-san devient ma p-petite amie,\nje ferai une[1205][U+000F] exception pour les femmes."
+    "texte_fr": "Mais si les filles font un article sur moi\net que Lisa-san devient ma p-petite amie,\nje ferai une exception pour les femmes."
   },
   {
     "id": 18,
@@ -301,7 +301,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Sorry![SP]Our[SP]next[SP]special[SP]report's[SP]already\nbeen[SP]decided:[SP][1432][NULL][NULL][0014]Boss[SP]vs.[SP]President:[SP]The\nTrue[SP]Champion[SP]of[SP]Cuss[SP]High![1432][NULL][NULL][0014]",
     "nom_fr": "Maya",
-    "texte_fr": "Désolée! Notre prochain article est déjà\nprévu: [1432][NULL][NULL][0014]Boss vs Président: Le vrai champion[1205][U+000F] de\nKasu![1432][NULL][NULL][0014]"
+    "texte_fr": "Désolée! Notre prochain article est déjà\nprévu: [1432][NULL][NULL][0014]Boss vs Président: Le vrai champion\nde Kasu![1432][NULL][NULL][0014]"
   },
   {
     "id": 19,
@@ -333,7 +333,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Holeen![SP]How[SP]sad![SP]That[SP]means[SP]the[SP]only[SP]place\nI[SP]could[SP]take[SP]you[SP]on[SP]a[SP]date[SP]would[SP]be[SP]a\ncustomer[SP]service[SP]center!",
     "nom_fr": "Ginko",
-    "texte_fr": "Holeen! Triste! Le seul endroit où on pourrait\nsortir ensemble, c'est un service client!"
+    "texte_fr": "Holeen! Comme c'est triste! Le seul\nendroit où on pourrait avoir un\nrendez-vous, c'est un service client!"
   },
   {
     "id": 21,
@@ -397,7 +397,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Yeah,[SP]what[SP]she[SP]said,[SP]you[SP]moron![SP]Why'd[SP]you\ngo[SP]and[SP]break[SP]our[SP]only[SP]contact[SP]with[SP]the\noutside!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Ouais, pareil, pauvre nase! Pourquoi t'as\ncassé notre seul contact avec l'extérieur!?"
+    "texte_fr": "Ouais, c'est vrai, pauvre nase! Pourquoi\nt'as cassé notre seul contact avec\nl'extérieur!?"
   },
   {
     "id": 25,
@@ -445,7 +445,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]at[SP]times[SP]like[SP]this[SP]that[SP]you[SP]gotta\nremember[SP]to[SP]think[SP]positive,[SP]guys![1205][001E]\nTogether,[SP]we[SP]can[SP]find[SP]a[SP]way[SP]out!",
     "nom_fr": "Maya",
-    "texte_fr": "C'est là qu'il faut rester positifs, les\namis![1205][001E] Ensemble, on trouvera une[1205][U+000F] sortie!"
+    "texte_fr": "C'est là qu'il faut rester positifs, les\namis! Ensemble, on trouvera une[1205][U+000F] sortie!"
   },
   {
     "id": 28,
@@ -461,7 +461,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "There[SP]was[SP]a[SP]rumor[SP]that[SP]someone[SP]did[SP]get\noutta[SP]here[SP]alive,[SP]but...[1205][001E][SP]Guh.[SP]Sorry,[SP]it's[SP]my\nfault[SP]that[SP]we're[SP]stuck[SP]in[SP]here...",
     "nom_fr": "Michel",
-    "texte_fr": "Une rumeur dit que quelqu'un en est\nsorti vivant, mais...[1205][001E] Argh. Désolé,\nc'est ma faute si[1205][U+000F] on est coincés ici..."
+    "texte_fr": "Une rumeur dit que quelqu'un s'en est\nsorti vivant, mais...[1205][001E] Argh. Désolé,\nc'est ma faute si on est coincés ici..."
   },
   {
     "id": 29,
@@ -477,7 +477,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I-It's[SP]just[SP]my[SP]imagination[SP]that[SP]this[SP]place\nlooks[SP]like[SP]the[SP]first[SP]room[SP]we[SP]saw,[SP]right?\nAhahaha...",
     "nom_fr": "Michel",
-    "texte_fr": "C-C'est juste mon imagination si cet endroit\nressemble à la première salle, non? Ahahaha..."
+    "texte_fr": "C-C'est juste mon imagination ou cet\nendroit ressemble à la première salle?\nAhahaha..."
   },
   {
     "id": 30,
@@ -509,7 +509,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Don't[SP]worry.[SP]We[SP]got[SP]in[SP]here,[SP]and[SP]we\ncan[SP]get[SP]out!",
     "nom_fr": "Maya",
-    "texte_fr": "Pas de panique. On est\nentrés, on saura sortir!"
+    "texte_fr": "Pas de panique. On estbentré, on saura\nsortir!"
   },
   {
     "id": 32,
@@ -525,7 +525,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I'd[SP]hate[SP]to[SP]get[SP]lost,[SP]so[SP]I'm[SP]going[SP]to[SP]leave\na[SP]mark[SP]here.",
     "nom_fr": "Maya",
-    "texte_fr": "Pour éviter de se perdre,\nje fais une marque ici."
+    "texte_fr": "Pour éviter de se perdre, je fais une\nmarque ici."
   },
   {
     "id": 33,
@@ -541,7 +541,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]is[SP]the[SP]first[SP]room[SP]we[SP]were[SP]in...[1205][001E]\nLook,[SP]you[SP]can[SP]see[SP]my[SP]mark[SP]on[SP]the[SP]wall.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est notre 1ère salle...[1205][001E]\nRegardez, ma marque est au mur."
+    "texte_fr": "C'est notre première salle...[1205][001E]\nRegardez, ma marque est au mur."
   },
   {
     "id": 34,
@@ -573,7 +573,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Back[SP]to[SP]square[SP]one...?[1205][001E][SP]I[SP]think[SP]we're[SP]just\ngoing[SP]in[SP]circles.",
     "nom_fr": "Maya",
-    "texte_fr": "Retour à la case départ...?[1205][001E] Je\ncrois qu'on tourne en rond."
+    "texte_fr": "Retour à la case départ...?[1205][001E] Je crois\nqu'on tourne en rond."
   },
   {
     "id": 36,
@@ -621,7 +621,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah...[1205][001E][SP]Is[SP]it[SP]just[SP]me,[SP]or[SP]is[SP]Maya-san\nsounding[SP]a[SP]little[SP]forced?",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiya...[1205][001E] C'est moi, ou Maya a\nl'air de se forcer un peu?"
+    "texte_fr": "Aiyah...[1205][001E] C'est moi, ou Maya a\nl'air d'un peu se forcer?"
   },
   {
     "id": 39,
@@ -653,7 +653,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]think...[1205][001E][SP]that's[SP]the[SP]way[SP]we[SP]came[SP]in.\nOr[SP]is[SP]it...?",
     "nom_fr": "Yukino",
-    "texte_fr": "Je crois...[1205][001E] qu'on est\nentrés par là. Ou pas...?"
+    "texte_fr": "Je crois...[1205][001E] qu'on est\nentré par là. Ou pas...?"
   },
   {
     "id": 41,
@@ -669,7 +669,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Did[SP]you[SP]see[SP]anything[SP]that[SP]looked[SP]like[SP]an\nexit[SP]back[SP]there...?[1205][001E][SP]Oh[SP]well,[SP]let's[SP]make\nanother[SP]pass.",
     "nom_fr": "Yukino",
-    "texte_fr": "T'as vu un truc qui ressemblait à une sortie\nlà-bas...?[1205][001E] Bon, faisons un autre tour."
+    "texte_fr": "T'as vu un truc qui ressemblait à une\nsortie là-bas...?[1205][U+000F] Bon, faisons\nun autre tour."
   },
   {
     "id": 42,


### PR DESCRIPTION
Corrections proposées par Seb via le panier -> issue GitHub de p2is-relecture (27 issues, #12 à #39 sur HamzaKarrouchi/P2-FR-IS-PSP), appliquées dans l'ordre de création (une entrée reproposée dans une issue plus récente est corrigée par la version la plus récente).

234 remplacées telles quelles, 6 fusionnées avec des corrections de mise en forme faites indépendamment depuis (retrait de pauses, retours à la ligne : seul le texte de Seb est repris, la mise en forme la plus récente est conservée). 8 des 248 corrections d'origine exclues : déjà équivalentes au texte actuel, ou adjacentes à une balise [1101] de troncature anti- débordement qu'on préfère ne pas recalculer sans certitude sur son fonctionnement exact.