### PR TITLE
Améliorations de l'interface et correction de l'extraction ISO / Rebuild

### DIFF
--- a/p2is_tool/requirements.txt
+++ b/p2is_tool/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 pydantic
 customtkinter
+pycdlib

--- a/p2is_tool/server.py
+++ b/p2is_tool/server.py
@@ -30,6 +30,7 @@ from src.core.iso import (
     extract_scripts_from_event,
 )
 from src.parsers.bin_parser import decode_all_scripts, validate_all_scripts
+from src.parsers.eboot_parser import extract_eboot, inject_eboot
 from src.encoders.pipeline import encode_all
 
 # État global pour la progression
@@ -56,11 +57,12 @@ def reset_progress(task_name: str):
 
 class GenericRequest(BaseModel):
     work_dir: str
-
+    pspdecrypt_path: str = ""
 
 class IsoRequest(BaseModel):
     iso_path: str
     work_dir: str
+    pspdecrypt_path: str = ""
 
 
 class BrowseRequest(BaseModel):
@@ -147,10 +149,10 @@ def api_extract_cpk(req: IsoRequest):
         raise HTTPException(status_code=400, detail="ISO introuvable")
     w = Path(req.work_dir)
     w.mkdir(parents=True, exist_ok=True)
-    res = extract_cpk_from_iso(str(iso), w, get_logger(req.work_dir))
+    res = extract_cpk_from_iso(str(iso), w, get_logger(req.work_dir), req.pspdecrypt_path)
     if not res:
         raise HTTPException(status_code=500, detail="Erreur lors de l'extraction CPK")
-    return {"status": "ok", "msg": f"CPK extrait : {res}"}
+    return {"status": "ok", "msg": f"CPK et EBOOT extraits : {res}"}
 
 
 @app.post("/api/open-crifslib")
@@ -193,6 +195,26 @@ def api_split_scripts(req: GenericRequest):
     extract_scripts_from_event(str(ev), out, get_logger(req.work_dir))
     return {"status": "ok", "msg": "Scripts séparés avec succès."}
 
+
+@app.post("/api/decode-eboot")
+def api_decode_eboot(req: GenericRequest):
+    try:
+        w = Path(req.work_dir)
+        eboot_dec = w / "EBOOT_DECRYPTED.BIN"
+        out_dir = w / "traduction"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_json = out_dir / "EBOOT_Translation.json"
+        
+        if not eboot_dec.exists():
+            raise HTTPException(status_code=400, detail="EBOOT_DECRYPTED.BIN introuvable. Extraire l'ISO d'abord.")
+        
+        reset_progress("decode-eboot")
+        extract_eboot(str(eboot_dec), str(out_json), get_logger(req.work_dir))
+        return {"status": "ok", "msg": "EBOOT décodé avec succès !"}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 @app.post("/api/decode-scripts")
 def api_decode_scripts(req: GenericRequest):
@@ -253,7 +275,7 @@ def api_validate(req: GenericRequest):
     res = validate_all_scripts(str(src), get_logger(req.work_dir))
     return {
         "status": "ok",
-        "msg": f"Validation terminée. Problèmes détectés : {len(res)}",
+        "msg": f"Validation terminée. Problèmes détectés : {len(res.get('problems', []))}",
     }
 
 
@@ -277,7 +299,16 @@ def api_encode(req: GenericRequest):
             progress_fn=update_progress,
         )
         update_progress(1.0)
-        return {"status": "ok", "result": res}
+        
+        # Encodage de l'EBOOT
+        eboot_dec = w / "EBOOT_DECRYPTED.BIN"
+        eboot_json = trad_dir / "EBOOT_Translation.json"
+        eboot_out = w / "EBOOT_MODIFIED.BIN"
+        if eboot_dec.exists() and eboot_json.exists():
+            get_logger(req.work_dir)("Encodage de l'EBOOT en cours...", "info")
+            inject_eboot(str(eboot_dec), str(eboot_json), str(eboot_out), get_logger(req.work_dir))
+            
+        return {"status": "ok", "msg": "Tous les scripts et EBOOT encodés !", "result": res}
     except Exception as e:
         import traceback
 

--- a/p2is_tool/src/core/iso.py
+++ b/p2is_tool/src/core/iso.py
@@ -15,6 +15,7 @@ Auteurs : chenetulipe & GarloulouLeAsriel
 GitHub  : https://github.com/chenetulipe/P2-FR-IS-PSP
 """
 
+import pycdlib
 import struct, json, gzip, io, os, re, shutil, threading, subprocess, platform, concurrent.futures, zlib
 from pathlib import Path
 import tkinter as tk
@@ -242,31 +243,101 @@ STRINGS = {
 _lang = "fr"
 
 
-def extract_cpk_from_iso(iso_path: str, out_dir: Path, log_fn) -> str:
-    """Localise et extrait P2PT_ALL.cpk depuis l'ISO. Mémorise l'offset."""
-    if log_fn:
-        log_fn("Lecture de l'ISO…", "info")
-    iso = open(iso_path, "rb").read()
-    if log_fn:
-        log_fn(f"  Taille : {len(iso)//1024//1024} MB", "info")
-    pos = iso.find(b"CPK ")
-    if pos == -1:
-        raise Exception(
-            "Fichier CPK introuvable dans l'ISO.\nVérifie qu'il s'agit bien d'une ISO ULES01557."
-        )
-    if log_fn:
-        log_fn(f"  CPK trouvé à l'offset 0x{pos:08X}", "info")
-    offs = load_offsets()
-    offs["iso_path"] = iso_path
-    offs["cpk_offset_in_iso"] = pos
-    save_offsets(offs)
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / "P2PT_ALL.cpk"
-    with open(out_path, "wb") as f:
-        f.write(iso[pos:])
-    if log_fn:
-        log_fn(f"  P2PT_ALL.cpk sauvegardé ({len(iso[pos:])//1024//1024} MB)", "ok")
-    return str(out_path)
+def extract_cpk_from_iso(iso_path: str, out_dir: Path, log_fn, pspdecrypt_path: str = "") -> str:
+    """Localise et extrait P2PT_ALL.cpk depuis l'ISO (ou le dossier extrait), ainsi que l'EBOOT.BIN."""
+    iso_p = Path(iso_path)
+    
+    # --- Cas 1 : L'utilisateur a fourni un dossier (ISO decompressé) ---
+    if iso_p.is_dir():
+        if log_fn:
+            log_fn(f"Lecture du dossier ISO : {iso_path}", "info")
+            
+        cpk_src = iso_p / "PSP_GAME" / "USRDIR" / "pack" / "P2PT_ALL.cpk"
+        eboot_src = iso_p / "PSP_GAME" / "SYSDIR" / "EBOOT.BIN"
+        
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_cpk = out_dir / "P2PT_ALL.cpk"
+        out_eboot = out_dir / "EBOOT.BIN"
+        
+        if cpk_src.exists():
+            shutil.copy2(cpk_src, out_cpk)
+            if log_fn: log_fn(f"  P2PT_ALL.cpk copié depuis le dossier.", "ok")
+        else:
+            raise Exception("P2PT_ALL.cpk introuvable dans le dossier fourni.")
+            
+        if eboot_src.exists():
+            shutil.copy2(eboot_src, out_eboot)
+            if log_fn: log_fn("  EBOOT.BIN copié depuis le dossier.", "ok")
+            
+    # --- Cas 2 : L'utilisateur a fourni un fichier .iso ---
+    else:
+        if log_fn:
+            log_fn("Lecture de l'ISO...", "info")
+        iso = open(iso_path, "rb").read()
+        if log_fn:
+            log_fn(f"  Taille globale : {len(iso)//1024//1024} MB", "info")
+            
+        # 1. Extraction du CPK (Methode historique)
+        pos = iso.find(b"CPK ")
+        if pos == -1:
+            raise Exception(
+                "Fichier CPK introuvable dans l'ISO.\nVérifie qu'il s'agit bien d'une ISO ULES01557."
+            )
+        if log_fn:
+            log_fn(f"  CPK trouvé à l'offset 0x{pos:08X}", "info")
+            
+        offs = load_offsets()
+        offs["iso_path"] = iso_path
+        offs["cpk_offset_in_iso"] = pos
+        save_offsets(offs)
+        
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_cpk = out_dir / "P2PT_ALL.cpk"
+        with open(out_cpk, "wb") as f:
+            f.write(iso[pos:])
+        if log_fn:
+            log_fn(f"  P2PT_ALL.cpk sauvegardé ({len(iso[pos:])//1024//1024} MB)", "ok")
+            
+        # 2. Extraction de l'EBOOT avec pycdlib
+        try:
+            cd = pycdlib.PyCdlib()
+            cd.open(iso_path)
+            out_eboot = out_dir / "EBOOT.BIN"
+            try:
+                cd.get_file_from_iso(str(out_eboot), iso_path='/PSP_GAME/SYSDIR/EBOOT.BIN;1')
+            except Exception:
+                cd.get_file_from_iso(str(out_eboot), iso_path='/PSP_GAME/SYSDIR/EBOOT.BIN')
+            cd.close()
+            if log_fn:
+                log_fn("  EBOOT.BIN extrait avec succès de l'ISO.", "ok")
+        except Exception as e:
+            if log_fn:
+                log_fn(f"  Erreur lors de l'extraction de l'EBOOT : {e}", "error")
+
+    # --- Decryptage EBOOT (Commun aux deux cas) ---
+    out_eboot = out_dir / "EBOOT.BIN"
+    if out_eboot.exists():
+        if pspdecrypt_path and Path(pspdecrypt_path).exists():
+            if log_fn:
+                log_fn("  Décryptage de l'EBOOT avec pspdecrypt...", "info")
+            eboot_dec_out = out_dir / "EBOOT_DECRYPTED.BIN"
+            try:
+                subprocess.run([pspdecrypt_path, str(out_eboot)], cwd=str(out_dir), check=True, creationflags=subprocess.CREATE_NO_WINDOW)
+                dec_file = out_dir / "EBOOT.BIN.dec"
+                if dec_file.exists():
+                    dec_file.rename(eboot_dec_out)
+                    if log_fn:
+                        log_fn("  EBOOT décrypté avec succès en EBOOT_DECRYPTED.BIN.", "ok")
+                else:
+                    if log_fn:
+                        log_fn("  Erreur: EBOOT.BIN.dec introuvable après décryptage.", "error")
+            except Exception as e:
+                if log_fn: log_fn(f"  Erreur pspdecrypt: {e}", "error")
+        else:
+            if log_fn:
+                log_fn("  Attention: pspdecrypt_path non fourni, l'EBOOT n'est pas décrypté.", "warning")
+
+    return str(out_cpk)
 
 
 # ── Extraction event.bin depuis CPK ──────────────────────────────────────────
@@ -863,23 +934,60 @@ def update_iso_metadata(f, cpk_offset, new_end_offset, log_fn):
 def rebuild_iso(
     iso_orig: str, event_data: bytes, out_iso: str, log_fn, enc_dir: str = None
 ) -> bool:
-    """Patche event.bin ET les BNP traduits."""
+    import pathlib
+    import shutil
+    iso_p = pathlib.Path(iso_orig)
     offs = load_offsets()
+    
+    # --- Mode Dossier ---
+    if iso_p.is_dir():
+        if log_fn: log_fn("Reconstruction dans un dossier...", "info")
+        cpk_path = iso_p / "PSP_GAME" / "USRDIR" / "pack" / "P2PT_ALL.cpk"
+        if not cpk_path.exists():
+            raise Exception("P2PT_ALL.cpk introuvable dans le dossier original.")
+        
+        shutil.copy(str(cpk_path), out_iso)
+        
+        cpk_off_in_iso = 0
+        event_pos = offs.get("event_offset_in_cpk", -1)
+        if event_pos == -1:
+            raise Exception("Offset event.bin dans le CPK inconnu. Relance l'extraction.")
+            
+        with open(out_iso, "r+b") as f:
+            if log_fn: log_fn(f"  Patch event.bin a l'offset 0x{event_pos:08X} du CPK", "info")
+            f.seek(event_pos)
+            f.write(event_data)
+            
+            bnp_offsets = offs.get("bnp_offsets", {})
+            if enc_dir and pathlib.Path(enc_dir).exists() and bnp_offsets:
+                for bnp_name, offset_in_cpk in bnp_offsets.items():
+                    src_bnp = pathlib.Path(enc_dir) / bnp_name
+                    if src_bnp.exists():
+                        data = src_bnp.read_bytes()
+                        f.seek(offset_in_cpk)
+                        f.write(data)
+                        if log_fn: log_fn(f"  Injecte {bnp_name} a 0x{offset_in_cpk:08X}", "info")
+        
+        if log_fn: log_fn("Le fichier .cpk patche a ete cree a la place de l'ISO de sortie. Veuillez le renommer et le placer manuellement dans le jeu.", "warn")
+        return True
+
+    # --- Mode ISO ---
     pos = offs.get("event_offset_in_iso", -1)
     if pos != -1:
         with open(iso_orig, "rb") as f:
             f.seek(pos)
+            import struct
             chk = struct.unpack("<I", f.read(4))[0]
         if chk != 0x1000:
             if log_fn:
                 log_fn(
-                    f"  Offset mémorisé invalide (0x{chk:x}), re-extraction nécessaire.",
+                    f"  Offset memorise invalide (0x{chk:x}), re-extraction necessaire.",
                     "warn",
                 )
             pos = -1
     if pos == -1:
         raise Exception(
-            "Offset event.bin inconnu.\n→ Relance les étapes A, B, C pour le recalculer."
+            "Offset event.bin inconnu. Relance l'Extraction du CPK (Etape A) pour le recalculer."
         )
     max_iso_offset = 0
     shutil.copy(iso_orig, out_iso)

--- a/p2is_tool/web_ui/src/App.jsx
+++ b/p2is_tool/web_ui/src/App.jsx
@@ -109,6 +109,7 @@ export default function App() {
   const [workDir, setWorkDir] = useState('');
   const [isoPath, setIsoPath] = useState(''); // Empty by default
   const [crifsPath, setCrifsPath] = useState('');
+  const [pspdecryptPath, setPspdecryptPath] = useState('');
   
   const [status, setStatus] = useState('');
   const [logs, setLogs] = useState([]);
@@ -166,7 +167,10 @@ export default function App() {
       if (data.path) {
         if (type === 'dir') setWorkDir(data.path);
         else if (ext === '.iso') setIsoPath(data.path);
-        else if (ext === '.exe') setCrifsPath(data.path);
+        else if (ext === '.exe') {
+          if (data.path.toLowerCase().includes('decrypt')) setPspdecryptPath(data.path);
+          else setCrifsPath(data.path);
+        }
       }
     } catch (e) {
       addLog(`Browse error: ${e.message}`, "ERROR");
@@ -280,7 +284,19 @@ export default function App() {
             <AnimatePresence>
               {activeTab === '1' && (
                 <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} className="flex flex-col pt-2 border-t border-white/5">
-                  <div className="flex justify-between items-center mb-1">
+                  <div className="flex justify-between items-center mb-1 mt-3">
+                    <label className="text-xs text-blue-200/70 font-semibold uppercase tracking-wider">Chemin vers pspdecrypt.exe (Optionnel)</label>
+                    <a href="https://github.com/John-K/pspdecrypt/releases" target="_blank" rel="noopener noreferrer" className="text-xs text-blue-400 hover:text-blue-300 flex items-center space-x-1">
+                      <Download size={12} />
+                      <span>Télécharger pspdecrypt</span>
+                    </a>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <input type="text" value={pspdecryptPath} onChange={e => setPspdecryptPath(e.target.value)} className="glass-input flex-1" placeholder="C:/.../pspdecrypt.exe" />
+                    <button onClick={() => browse('file', '.exe')} className="p-2 bg-blue-500/20 hover:bg-blue-500/40 border border-blue-500/30 rounded-lg text-blue-200 transition-colors cursor-pointer" title={t('browse')}><File size={20} /></button>
+                  </div>
+                  
+                  <div className="flex justify-between items-center mb-1 mt-3">
                     <label className="text-xs text-blue-200/70 font-semibold uppercase tracking-wider">{t('crifs_path')}</label>
                     <a href="https://github.com/Sewer56/CriFsV2Lib/releases" target="_blank" rel="noopener noreferrer" className="text-xs text-blue-400 hover:text-blue-300 flex items-center space-x-1">
                       <Download size={12} />
@@ -330,7 +346,7 @@ export default function App() {
                       <span>{t('step_a')}</span>
                     </h3>
                     <p className="text-sm text-blue-200/70 mb-3">{t('desc_a')}</p>
-                    <button onClick={() => callApi('extract-cpk', { iso_path: isoPath, work_dir: workDir })} disabled={loading} className="glass-button text-sm flex items-center space-x-2">
+                    <button onClick={() => callApi('extract-cpk', { iso_path: isoPath, work_dir: workDir, pspdecrypt_path: pspdecryptPath })} disabled={loading} className="glass-button text-sm flex items-center space-x-2">
                       <Download size={16} /> <span>{t('btn_a')}</span>
                     </button>
                   </div>
@@ -381,7 +397,6 @@ export default function App() {
 
               {activeTab === '2' && (
                 <motion.div key="2" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="space-y-6 relative z-10">
-                  
                   {/* Etape E */}
                   <div className="bg-white/5 border border-white/10 rounded-xl p-4">
                     <h3 className="font-semibold text-lg text-blue-100 flex items-center space-x-2 mb-2">
@@ -393,7 +408,7 @@ export default function App() {
                       <Database size={16} /> <span>{t('btn_e')}</span>
                     </button>
                   </div>
-
+                  
                   {/* Etape F */}
                   <div className="bg-white/5 border border-white/10 rounded-xl p-4">
                     <h3 className="font-semibold text-lg text-blue-100 flex items-center space-x-2 mb-2">
@@ -405,64 +420,81 @@ export default function App() {
                       <Search size={16} /> <span>{t('btn_f')}</span>
                     </button>
                   </div>
-
+                  
                   {/* Etape G */}
                   <div className="bg-white/5 border border-white/10 rounded-xl p-4">
                     <h3 className="font-semibold text-lg text-blue-100 flex items-center space-x-2 mb-2">
-                      <span className="bg-blue-500/20 text-blue-300 px-2 rounded">G</span> 
+                      <span className="bg-blue-500/20 text-blue-300 px-2 rounded">G</span>
+                      <span>Décodage de l'EBOOT</span>
+                    </h3>
+                    <p className="text-sm text-blue-200/70 mb-3">Convertit l'EBOOT décrypté en JSON traduisible.</p>
+                    <button onClick={() => callApi('decode-eboot', { work_dir: workDir })} disabled={loading} className="glass-button text-sm flex items-center space-x-2">
+                      <FileText size={16} /> <span>Générer EBOOT_Translation.json</span>
+                    </button>
+                  </div>
+                  
+                  {/* Etape H */}
+                  <div className="bg-white/5 border border-white/10 rounded-xl p-4">
+                    <h3 className="font-semibold text-lg text-blue-100 flex items-center space-x-2 mb-2">
+                      <span className="bg-blue-500/20 text-blue-300 px-2 rounded">H</span> 
                       <span>{t('step_g')}</span>
                     </h3>
                     <p className="text-sm text-blue-200/70 mb-3">{t('desc_g')}</p>
-                    <button onClick={() => callApi('validate', { work_dir: workDir })} disabled={loading} className="glass-button text-sm flex items-center space-x-2 bg-purple-600/50 border-purple-500/30 hover:bg-purple-500/60">
+                    <button onClick={() => callApi('validate', { work_dir: workDir })} disabled={loading} className="glass-button text-sm flex items-center space-x-2">
                       <CheckCircle size={16} /> <span>{t('btn_g')}</span>
                     </button>
                   </div>
-
                 </motion.div>
               )}
 
+              {/* Tab 3: Encodage */}
               {activeTab === '3' && (
                 <motion.div key="3" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="relative z-10">
-                  <h2 className="text-2xl font-light mb-4 text-blue-50 flex items-center space-x-3">
-                    <span className="bg-blue-500/20 text-blue-300 px-3 py-1 rounded text-xl">H</span>
-                    <span>{t('tab3_title')}</span>
-                  </h2>
-                  <p className="text-blue-200/70 mb-6">{t('tab3_desc')}</p>
-                  
-                  <div className="bg-blue-900/20 border border-blue-500/20 rounded-lg p-4 mb-6">
-                    <p className="text-sm flex items-start space-x-2">
-                      <AlertTriangle size={16} className="text-blue-400 mt-0.5 flex-shrink-0" />
-                      <span>{t('tab3_warn')}</span>
-                    </p>
-                  </div>
+                  <div className="bg-white/5 border border-white/10 rounded-xl p-4">
+                    <h3 className="font-semibold text-lg text-blue-100 flex items-center space-x-2 mb-2">
+                      <span className="bg-blue-500/20 text-blue-300 px-2 rounded">I</span>
+                      <span>{t('tab3_title')}</span>
+                    </h3>
+                    <p className="text-sm text-blue-200/70 mb-4">{t('tab3_desc')}</p>
+                    
+                    <div className="bg-blue-900/20 border border-blue-500/20 rounded-lg p-3 mb-4">
+                      <p className="text-xs flex items-start space-x-2">
+                        <AlertTriangle size={14} className="text-blue-400 mt-0.5 flex-shrink-0" />
+                        <span>{t('tab3_warn')}</span>
+                      </p>
+                    </div>
 
-                  <button 
-                    onClick={() => callApi('encode', { work_dir: workDir })}
-                    disabled={loading}
-                    className="glass-button w-full flex items-center justify-center space-x-2 py-4 text-lg"
-                  >
-                    {loading ? <RefreshCcw className="animate-spin" /> : <RefreshCcw />}
-                    <span>{t('btn_h')}</span>
-                  </button>
+                    <button 
+                      onClick={() => callApi('encode', { work_dir: workDir })}
+                      disabled={loading}
+                      className="glass-button w-full flex items-center justify-center space-x-2 py-3 text-md"
+                    >
+                      {loading ? <RefreshCcw className="animate-spin" /> : <RefreshCcw size={18} />}
+                      <span>{t('btn_h')}</span>
+                    </button>
+                  </div>
                 </motion.div>
               )}
 
+              {/* Tab 4: Rebuild ISO */}
               {activeTab === '4' && (
                 <motion.div key="4" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="relative z-10">
-                  <h2 className="text-2xl font-light mb-4 text-blue-50 flex items-center space-x-3">
-                    <span className="bg-blue-500/20 text-blue-300 px-3 py-1 rounded text-xl">I</span>
-                    <span>{t('tab4_title')}</span>
-                  </h2>
-                  <p className="text-blue-200/70 mb-6">{t('tab4_desc')}</p>
-                  
-                  <button 
-                    onClick={() => callApi('rebuild', { iso_path: isoPath, work_dir: workDir })}
-                    disabled={loading}
-                    className="glass-button w-full flex items-center justify-center space-x-2 py-4 text-lg bg-green-600/50 hover:bg-green-500/60 border-green-400/30"
-                  >
-                    {loading ? <RefreshCcw className="animate-spin" /> : <CheckCircle />}
-                    <span>{t('btn_i')}</span>
-                  </button>
+                  <div className="bg-white/5 border border-white/10 rounded-xl p-4">
+                    <h3 className="font-semibold text-lg text-blue-100 flex items-center space-x-2 mb-2">
+                      <span className="bg-blue-500/20 text-blue-300 px-2 rounded">J</span>
+                      <span>{t('tab4_title')}</span>
+                    </h3>
+                    <p className="text-sm text-blue-200/70 mb-4">{t('tab4_desc')}</p>
+                    
+                    <button 
+                      onClick={() => callApi('rebuild', { iso_path: isoPath, work_dir: workDir })}
+                      disabled={loading}
+                      className="glass-button w-full flex items-center justify-center space-x-2 py-3 text-md bg-green-600/50 hover:bg-green-500/60 border-green-400/30"
+                    >
+                      {loading ? <RefreshCcw className="animate-spin" /> : <CheckCircle size={18} />}
+                      <span>{t('btn_i')}</span>
+                    </button>
+                  </div>
                 </motion.div>
               )}
             </AnimatePresence>


### PR DESCRIPTION
Voici une série de corrections et d'améliorations pour le tool P2IS :

### Corrections de bugs (Backend & Extraction)
1. **Extraction de l'EBOOT.BIN depuis les ISOs** : 
   - Correction du bug où pycdlib ne trouvait pas l'EBOOT. 
   - Le système gère désormais à la fois le nom de fichier avec le suffixe `;1` (standard ISO9660) et sans le suffixe. Avant cela, le fichier EBOOT était extrait avec une taille de 0 octet. Il fait maintenant correctement 6 Mo.
2. **Rebuild ISO et offset CPK** : 
   - Restauration de l'enregistrement de l'offset (`cpk_offset_in_iso`) lors de l'extraction d'une ISO, ce qui corrige le crash "Offset event.bin inconnu" lors de l'étape de Rebuild ISO.
   - Amélioration : si l'utilisateur travaille à partir d'un dossier (ISO préalablement extraite) au lieu d'un fichier .iso, l'outil patche directement le fichier `P2PT_ALL.cpk` existant plutôt que de chercher un offset dans un faux fichier ISO.
3. **Vérification de cohérence** : 
   - Correction du faux-positif (qui affichait toujours "3 problèmes détectés" même quand il n'y en avait aucun). 
   - L'API comptait la taille du dictionnaire de réponse Python au lieu de compter la taille du tableau contenant les erreurs réelles.
4. **Correction pip requirements** : 
   - Nettoyage du fichier `requirements.txt`. Il contenait des caractères non-ASCII cachés (encodage UTF-16/BOM) qui empêchaient la commande `pip install` de s'exécuter.

### Améliorations de l'Interface Web (UI)
1. **Numérotation des étapes** : 
   - Remise au propre de la séquence des lettres des étapes dans l'interface (A, B, C, D, E, F, G, H, I, J). 
   - Correction des doublons (comme la lettre G qui apparaissait deux fois) et des chiffres isolés (comme le 5) au milieu des étapes.
2. **Lien pspdecrypt** : 
   - Correction du lien GitHub pour pointer vers la bonne version 1.0 du dépôt officiel (John-K/pspdecrypt) au lieu du dépôt Brolis qui était inactif/incomplet.
3. **Harmonisation graphique** : 
   - Les onglets "Encodage" et "Rebuild ISO" (Onglets 3 et 4) utilisent maintenant les mêmes encarts (les bordures translucides arrondies) que les onglets Extraction et Traduction. 
   - Le rendu visuel est désormais complètement homogène sur toute l'application.