### PR TITLE
Correctif critique de l'encodeur MMAP et fusion des traductions

### DIFF
--- a/p2is_tool/src/encoders/mmap_encoder.py
+++ b/p2is_tool/src/encoders/mmap_encoder.py
@@ -185,6 +185,8 @@ def encode_mmap_bnp_from_json(
         n_orig = d.get('nom_orig', '')
         t_orig = d.get('texte_orig', '')
 
+        t_fr = t_fr.replace('[NL]', '\n')
+
         # Alignement des menus de choix pour éviter les crashs
         t_fr = _align_menu_text(n_orig, t_orig, n_fr, t_fr)
 

--- a/p2is_tool/src/encoders/mmap_encoder.py
+++ b/p2is_tool/src/encoders/mmap_encoder.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+P2IS FR Tool  ·  Persona 2 Innocent Sin PSP (EUR ULES01557)
+============================================================
+Module spécialisé pour le parsing et l'encodage des fichiers MMAP01-06.BNP.
+
+Les fichiers MMAP (carte du monde, dialogues de PNJ par zone) utilisent un
+format binaire propre différent de l'event.bin :
+
+  - Format conteneur : MIG.00.1PSP (format propriétaire Atlus)
+  - Terminateur de dialogue MMAP : [0x1106][0x1102][0x1103][0x1431][0x0000][0x0000]
+    (12 octets) — différent de l'event.bin qui utilise [E1][E2][E3][E4]
+  - Pas de zéros de padding entre dialogues : slot_size == data_size
+  - Les dialogues sont contigus dans la zone de données du BNP
+
+IMPORTANT : Le 'nettoyage' effectué par find_dialogs() de bin_parser.py
+supprime des codes de contrôle critiques ([0x1106], [0x1431]) qui font partie
+du terminateur MMAP, cassant ainsi l'encodage.
+
+Ce module contourne ce problème avec une logique dédiée.
+"""
+
+import struct, json, re
+from pathlib import Path
+from src.config import *
+from src.core.text import decode_text, text_to_bytes, _align_menu_text
+
+# ── Terminateur spécifique MMAP ───────────────────────────────────────────────
+# [0x1106][E2=0x1102][E3=0x1103][0x1431][NULL=0x0000][NULL=0x0000]
+MMAP_TERM = [0x1106, 0x1102, 0x1103, 0x1431, 0x0000, 0x0000]
+MMAP_TERM_BYTES = b''.join(struct.pack('<H', w) for w in MMAP_TERM)
+MMAP_TERM_SIZE = len(MMAP_TERM_BYTES)  # 12 octets
+
+# Codes de contrôle à nettoyer du texte extrait (sans toucher au terminateur)
+_CTRL_MMAP = {
+    0x1101: '[NL]', 0x1102: '[E2]', 0x1103: '[E3]', 0x1104: '[E4]',
+    0x1106: '[1106]', 0x1109: '[1109]', 0x1120: '[SP]',
+    0x1113: '[1113]', 0x1112: '[1112]', 0x1208: '[1208]', 0x1205: '[1205]',
+    0x1431: '[1431]',
+}
+
+
+def _valid_mmap_name(data: bytes, offset: int) -> bool:
+    """
+    Vérifie qu'un guillemet ouvrant 0x0022 est suivi d'un nom de personnage valide
+    dans le contexte MMAP (même logique que bin_parser._valid_name).
+    """
+    j = offset + 2
+    if j + 1 >= len(data):
+        return False
+    first = struct.unpack_from('<H', data, j)[0]
+    if first == SP:
+        return False
+    chars = []
+    pr = al = uk = 0
+    while j < len(data) - 1:
+        cp = struct.unpack_from('<H', data, j)[0]
+        if cp == NL:  # 0x1101 = fin du nom
+            n = len(chars)
+            if not (1 <= n <= 40):
+                return False
+            return al >= 1 and (pr / max(1, n)) >= 0.6
+        if 0x20 <= cp <= 0x7E:
+            pr += 1
+            al += 0x41 <= cp <= 0x7A
+        elif cp == SP:
+            pr += 1
+        else:
+            uk += 1
+        if uk > 2:
+            return False
+        chars.append(cp)
+        if len(chars) > 40:
+            return False
+        j += 2
+    return False
+
+
+def _decode_mmap_text(raw: bytes) -> str:
+    """Décode le texte binaire Atlus MMAP en texte lisible, en excluant le terminateur."""
+    out = ""
+    for i in range(0, len(raw) - 1, 2):
+        cp = struct.unpack_from('<H', raw, i)[0]
+        if cp in _CTRL_MMAP:
+            out += _CTRL_MMAP[cp]
+        elif 0x20 <= cp <= 0x7E:
+            out += chr(cp)
+        elif 0x80 <= cp <= 0xFF:
+            out += chr(cp)
+        else:
+            out += f'[U+{cp:04X}]'
+    return out
+
+
+def scan_mmap_bnp(data: bytes, stem: str, out_dir: Path, log_fn) -> int:
+    """
+    Parse un fichier MMAP.BNP et extrait tous les dialogues dans un JSON.
+
+    Contrairement à scan_bnp_bin(), cette fonction utilise le terminateur
+    propre aux MMAP et ne cherche pas de blocs gzip embeddés.
+
+    Returns: nombre de dialogues extraits.
+    """
+    dialogs = []
+    i = 0
+
+    while i < len(data) - 1:
+        w = struct.unpack_from('<H', data, i)[0]
+        if w != 0x0022 or not _valid_mmap_name(data, i):
+            i += 2
+            continue
+
+        start = i
+        # Chercher le terminateur MMAP à partir de start
+        term_idx = data.find(MMAP_TERM_BYTES, start + 2)
+        if term_idx == -1 or term_idx > start + 4000:
+            # Pas de terminateur MMAP dans la fenêtre → pas un dialogue valide
+            i += 2
+            continue
+
+        end = term_idx + MMAP_TERM_SIZE  # inclut le terminateur
+
+        # Décoder le texte (sans le terminateur final)
+        raw_text = data[start:term_idx]
+        full_text = _decode_mmap_text(raw_text)
+
+        lines = full_text.split('[NL]')
+        nom = lines[0].lstrip('"') if lines else ''
+        body = '[NL]'.join(lines[1:]) if len(lines) > 1 else ''
+        body_clean = body.strip()
+
+        entry = {
+            'id': len(dialogs),
+            'offset': start,
+            'data_size': end - start,   # inclut le terminateur
+            'slot_size': end - start,   # = data_size (pas de padding dans MMAP)
+            '_term': MMAP_TERM,
+            'nom_orig': nom,
+            'texte_orig': body_clean,
+            'nom_fr': '',
+            'texte_fr': '',
+        }
+        dialogs.append(entry)
+        i = end
+
+    if not dialogs:
+        if log_fn:
+            log_fn(f'  {stem.upper()}: aucun dialogue trouvé', 'warn')
+        return 0
+
+    out_path = out_dir / f'{stem.upper()}.json'
+    with open(out_path, 'w', encoding='utf-8') as f:
+        json.dump(dialogs, f, ensure_ascii=False, indent=2)
+
+    if log_fn:
+        log_fn(f'  {stem.upper()}: {len(dialogs)} dialogues -> {out_path.name}', 'ok')
+    return len(dialogs)
+
+
+def encode_mmap_bnp_from_json(
+    bin_path: str, json_path: str, log_fn, out_path: str = None
+) -> str:
+    data = bytearray(open(bin_path, 'rb').read())
+    dlgs = json.loads(open(json_path, encoding='utf-8').read(), strict=False)
+
+    ok = skip = kept = 0
+    nl_bytes = struct.pack('<H', NL)
+    
+    dlgs.sort(key=lambda x: x['offset'])
+    
+    new_data = bytearray()
+    last_offset = 0
+
+    for d in dlgs:
+        n_fr = d.get('nom_fr', '').strip()
+        t_fr = d.get('texte_fr', '').strip()
+
+        if not n_fr and not t_fr:
+            kept += 1
+            continue
+
+        n_fr = n_fr or d.get('nom_orig', '').replace('[SP]', ' ').strip()
+        t_fr = t_fr or d.get('texte_orig', '').strip()
+        n_orig = d.get('nom_orig', '')
+        t_orig = d.get('texte_orig', '')
+
+        # Alignement des menus de choix pour éviter les crashs
+        t_fr = _align_menu_text(n_orig, t_orig, n_fr, t_fr)
+
+        enc = text_to_bytes('"' + n_fr + '\n' + t_fr)
+
+        # Terminateur exact du JSON
+        term_seq = d.get('_term', MMAP_TERM)
+        term_bytes = b''.join(struct.pack('<H', w) for w in term_seq)
+        
+        orig_offset = d['offset']
+        orig_size = d['slot_size']
+
+        avail = orig_size - len(term_bytes)
+
+        if len(enc) > avail:
+            depassement = len(enc) - avail
+            if log_fn:
+                log_fn(
+                    f'  [!] [MMAP] [id {d["id"]}] Texte FR trop long de {depassement} '
+                    f'octets. Troncature automatique.',
+                    'warn'
+                )
+            tokens = re.split(r'(\[[a-zA-Z0-9+\-_]+\]|\s|\[SP\])', t_fr)
+            tokens = [t for t in tokens if t]
+            while tokens and len(text_to_bytes('"' + n_fr + '\n' + ''.join(tokens))) > avail:
+                tokens.pop()
+            t_fr = ''.join(tokens)
+            enc = text_to_bytes('"' + n_fr + '\n' + t_fr)
+
+        # Pad avec des espaces pour maintenir la taille exacte du slot
+        pad_len = avail - len(enc)
+        if pad_len > 0:
+            enc += struct.pack('<H', 0x1120) * (pad_len // 2)
+
+        # Construire la séquence stricte
+        full = enc + term_bytes
+        
+        # Sécurité maximale : on force la taille
+        if len(full) != orig_size:
+            if log_fn: log_fn(f'  [!] Erreur fatale de taille pour {d["id"]}: {len(full)} != {orig_size}', 'err')
+            full = full[:orig_size].ljust(orig_size, b'\x00')
+
+        # On copie l'original jusqu'a l'offset de ce dialogue
+        new_data += data[last_offset : orig_offset]
+        # On ajoute le nouveau dialogue
+        new_data += full
+        
+        last_offset = orig_offset + orig_size
+        ok += 1
+
+    # On ajoute le reste du fichier
+    new_data += data[last_offset:]
+    
+    # Combien de bytes avons-nous gagne ?
+    total_delta = len(data) - len(new_data)
+    
+    # On met a jour la taille du chunk 0x08000001 (qui contient les dialogues)
+    idx = 0
+    while idx < len(new_data):
+        if idx + 8 > len(new_data): break
+        ctype, csize = struct.unpack_from('<II', new_data, idx)
+        if ctype == 0x08000001:
+            new_csize = csize - total_delta
+            struct.pack_into('<I', new_data, idx + 4, new_csize)
+            break
+        idx += 8 + csize
+        idx = (idx + 0x7FF) & ~0x7FF
+        
+    # On pad la fin du fichier avec des zeros pour conserver la meme taille globale
+    if total_delta > 0:
+        new_data += b'\x00' * total_delta
+        
+    out = Path(out_path) if out_path else Path(bin_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with open(out, 'wb') as f:
+        f.write(new_data)
+
+    if log_fn:
+        log_fn(f'  [OK]   [MMAP] {ok} traduits | {skip} ignores | {kept} conserves -> {out.name}', 'ok')
+    return str(out)

--- a/traduction/MMAP01.json
+++ b/traduction/MMAP01.json
@@ -1,5863 +1,4124 @@
 [
-  {
-    "id": 0,
-    "offset": 406974,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Lisa",
-    "texte_orig": "Oh,[SP]wait[SP]a[SP]sec,[SP][1113].[SP]We[SP]should[SP]go[SP]to[SP]the\ndetective[SP]agency[SP]to[SP]ask[SP]them[SP]about[SP]the[SP]secret\ndish[SP]and[SP]stuff.",
-    "nom_fr": "Lisa",
-    "texte_fr": "Attends, [1113]. Allons à l'agence\nde détectives pour demander\ndes infos sur le plat secret."
-  },
-  {
-    "id": 1,
-    "offset": 407198,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Lisa",
-    "texte_orig": "Not[SP]yet,[SP][1113]![SP]We[SP]gotta[SP]go[SP]get[SP]weapons\nfirst.[SP]Let's[SP]go[SP]to[SP]that[SP]ramen[SP]shop[SP]like[SP]the\nrumor[SP]says.",
-    "nom_fr": "Lisa",
-    "texte_fr": "Pas encore, [1113] ! Il nous faut\ndes armes. Allons au ramen shop\nde la rumeur."
-  },
-  {
-    "id": 2,
-    "offset": 407404,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Lisa",
-    "texte_orig": "Geez,[SP]where[SP]are[SP]you[SP]going,[SP][1113]?[SP]We[SP]need\nto[SP]go[SP]to[SP]Shiraishi[SP]Ramen[SP]to[SP]check[SP]and[SP]see[SP]if\nthe[SP]experiment[SP]worked!",
-    "nom_fr": "Lisa",
-    "texte_fr": "Urgh, où vas-tu [1113] ?\nOn doit aller à Shiraishi Ramen voir si\nnotre expérience a porté ses fruits !"
-  },
-  {
-    "id": 3,
-    "offset": 407638,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "Hirasaka[SP]might[SP]seem[SP]a[SP]bit[SP]run-down[SP]because[SP]of\nCuss[SP]High,[SP]but[SP]it's[SP]not[SP]really[SP]that[SP]bad.",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Hirasaka semble délabrée à cause\ndu lycée Kakasu, mais ça va."
-  },
-  {
-    "id": 4,
-    "offset": 407860,
-    "data_size": 238,
-    "slot_size": 242,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "The[SP]students[SP]there[SP]have[SP]settled[SP]down[SP]lately,\nand[SP]I[SP]like[SP]this[SP]neighborhood's[SP]working-class\nfeel.",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Les étudiants se sont calmés dernièrement et\nj'aime bien l'air modeste de cet endroit."
-  },
-  {
-    "id": 5,
-    "offset": 408102,
-    "data_size": 334,
-    "slot_size": 338,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "Hah...[SP]The[SP]Kasuga[SP]Festival,[SP]eh?[SP]I[SP]think[SP]this[SP]is\nthe[SP]first[SP]time[SP]Cuss[SP]High[SP]has[SP]ever[SP]had[SP]an[SP]actual\nschool[SP]festival.[SP]They're[SP]moving[SP]up[SP]in[SP]the[SP]world.",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Le festival de Kasuga ? Je crois bien que c'est\nune première pour le lycée Kakasu. Ils gagnent en\ncrédibilité."
-  },
-  {
-    "id": 6,
-    "offset": 408440,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "I'm[SP]from[SP]here,[SP]so[SP]seeing[SP]that[SP]makes[SP]me[SP]happy.[1205][U+000F]\nTakes[SP]me[SP]back[SP]to[SP]my[SP]high[SP]school[SP]days,[SP]it[SP]does.",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Je viens d'ici, donc voir ça me rend heureux.[1205][U+000F]\nAh, les années lycée."
-  },
-  {
-    "id": 7,
-    "offset": 408678,
-    "data_size": 312,
-    "slot_size": 316,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "Huh?[SP]That's[SP]weird...[1205][U+000F][SP]I[SP]haven't[SP]seen[SP]Cuss[SP]High\nstudents[SP]around[SP]lately.[SP]Did[SP]their[SP]enrollment\nnumbers[SP]drop?[1205][U+000F][SP]Nah,[SP]that[SP]can't[SP]be[SP]it...",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Bizarre...[1205][U+000F] Pas d'élèves du lycée\nKakasu récemment. Moins d'inscrits ?[1205][U+000F]\nNan, impossible..."
-  },
-  {
-    "id": 8,
-    "offset": 408994,
-    "data_size": 184,
-    "slot_size": 188,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "You[SP]can[SP]buy[SP]CDs[SP]at[SP]Giga[SP]Macho[SP]in[SP]Yumezaki.[1205][U+000F]\nI[SP]go[SP]there[SP]all[SP]the[SP]time.",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Achète tes CD à Giga Macho\nà Yumezaki.[1205][U+000F] J'y vais tout le temps."
-  },
-  {
-    "id": 9,
-    "offset": 409182,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "This[SP]terrorism[SP]wave's[SP]the[SP]talk[SP]of[SP]the[SP]city.\nHonestly,[SP]I'm[SP]scared[SP]too.[1205][U+000F][SP]Even[SP]the[SP]police\nstation[SP]and[SP]fire[SP]department[SP]got[SP]hit.",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Cette vague terroriste fait parler.\nJ'ai peur aussi.[1205][U+000F] Même la police\net les pompiers sont touchés."
-  },
-  {
-    "id": 10,
-    "offset": 409480,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "Who's[SP]left[SP]to[SP]protect[SP]this[SP]city[SP]or[SP]put[SP]out\nany[SP]fires[SP]that[SP]get[SP]started?",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Qui reste-t-il pour protéger cette ville et\néteindre les feux ?"
-  },
-  {
-    "id": 11,
-    "offset": 409670,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "We're[SP]just[SP]stuck[SP]waiting[SP]for[SP]the[SP]terrorists\nto[SP]strike[SP]again!",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "On est coincés à attendre\nla prochaine attaque !"
-  },
-  {
-    "id": 12,
-    "offset": 409840,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "Now[SP]that[SP]was[SP]strange...[1205][U+000F][SP]This[SP]girl[SP]in[SP]crazy\nclothes[SP]just[SP]ran[SP]out[SP]of[SP]Smile[SP]Hirasaka.",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Étrange...[1205][U+000F] Cette fille en\ntenue folle a fui de Smile Hirasaka."
-  },
-  {
-    "id": 13,
-    "offset": 410058,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "I[SP]think[SP]I[SP]heard[SP]her[SP]say[SP]something[SP]like,[SP][1432][NULL][NULL][0014]You'll\npay[SP]for[SP]this![1432][NULL][NULL][0014][SP]as[SP]she[SP]went...",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Je crois que je l'ai entendu dire un truc comme\n[1432][NULL][NULL][0014]Tu vas le regretter ![1432][NULL][NULL][0014]"
-  },
-  {
-    "id": 14,
-    "offset": 410274,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "Now[SP]that[SP]was[SP]strange...[1205][U+000F][SP]This[SP]girl[SP]with[SP]crazy\nclothes[SP]and[SP]a[SP]burning[SP]ass[SP]ran[SP]out[SP]of[SP]Smile\nHirasaka[SP]when[SP]it[SP]was[SP]on[SP]fire[SP]just[SP]now.",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "C'est étrange...[1205][U+000F] Cette fille habillée\nbizarrement vient de sortir de Smile Hirasaka qui flambait\nen courant."
-  },
-  {
-    "id": 15,
-    "offset": 410580,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "I[SP]think[SP]I[SP]heard[SP]her[SP]say[SP]something[SP]like,\n[1432][NULL][NULL][0014]This[SP]wasn't[SP]how[SP]it[SP]was[SP]supposed[SP]to[SP]go![1432][NULL][NULL][0014]\nas[SP]she[SP]went...",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Je crois que je l'ai entendu dire un truc comme\n[1432][NULL][NULL][0014]C'était pas censé se passer comme ça ![1432][NULL][NULL][0014]"
-  },
-  {
-    "id": 16,
-    "offset": 410832,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "Huh?[SP]It's[SP]that[SP]girl[SP]again...[1205][U+000F][SP]I[SP]mean[SP]the[SP]one[SP]in\nthe[SP]weird[SP]getup[SP]who[SP]ran[SP]out[SP]of[SP]Smile[SP]Hirasaka\nbefore.[1205][U+000F]",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "C'est encore cette fille ?[1205][U+000F] Celle que j'ai vu sortir\nde Smile Hirasaka en courant.[1205][U+000F]"
-  },
-  {
-    "id": 17,
-    "offset": 411090,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "And[SP]it[SP]seemed[SP]like[SP]there[SP]were[SP]a[SP]bunch[SP]of[SP]kids\nwith[SP]her[SP]this[SP]time...",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Et cette fois, elle était accompagnée\nd'une bande de gamins..."
-  },
-  {
-    "id": 18,
-    "offset": 411274,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "They[SP]said[SP]something[SP]about[SP]how[SP]the[SP]five[SP]people\non[SP]the[SP]news[SP]are[SP]actually[SP]heroes[SP]fighting\nagainst[SP]the[SP]Masked[SP]Circle...[1205][U+000F][SP]Is[SP]that[SP]true?",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Ils disent que les cinq personnes dans le journal\nsont en fait des héros qui combattent le cercle masqué.[1205][U+000F]\nC'est vrai, ça ?"
-  },
-  {
-    "id": 19,
-    "offset": 411586,
-    "data_size": 150,
-    "slot_size": 154,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "That[SP]girl[SP]gets[SP]around.[SP]I[SP]just[SP]saw[SP]her[SP]on\nthe[SP]news.[1205][U+000F]",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Cette fille bouge beaucoup.\nVue aux infos.[1205][U+000F]"
-  },
-  {
-    "id": 20,
-    "offset": 411740,
-    "data_size": 146,
-    "slot_size": 150,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "She[SP]said[SP]the[SP]five[SP]suspects[SP]are[SP]heroes\nthere[SP]too...",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Elle dit que ces 5 suspects\nsont des héros..."
-  },
-  {
-    "id": 21,
-    "offset": 411890,
-    "data_size": 222,
-    "slot_size": 226,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "I-I'm[SP]starting[SP]to[SP]feel[SP]like[SP]I[SP]might[SP]believe\nher...[1205][U+000F][SP]Huh?[SP]Hey,[SP]don't[SP]get[SP]the[SP]wrong[SP]idea!",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Elle a peut-être raison...[1205][U+000F] Hah ?\nEh, ne te fais pas d'idées !"
-  },
-  {
-    "id": 22,
-    "offset": 412116,
-    "data_size": 312,
-    "slot_size": 316,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Healthy[SP]young[SP]man",
-    "texte_orig": "Wh-Where[SP]are[SP]those[SP]soldiers[SP]going?[1205][U+000F][SP]There's\nnothing[SP]over[SP]there[SP]but[SP]Mt.[SP]Katatsumuri.[1205][U+000F][SP]What\nare[SP]they[SP]doing[SP]there[SP]with[SP]all[SP]those[SP]guns?",
-    "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Où vont ces soldats ?[1205][U+000F] Il n'y a rien là-bas\nà part le Mt Katatsumuri.[1205][U+000F] Qu'est-ce qu'ils\nfont avec tous ces flingues ?"
-  },
-  {
-    "id": 23,
-    "offset": 412432,
-    "data_size": 80,
-    "slot_size": 84,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Dude,[SP]what's[SP]going[SP]on!?[1205][U+0008]",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Que se passe-t-il !?[1205][U+0008]"
-  },
-  {
-    "id": 24,
-    "offset": 412516,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "First[SP]that[SP]weird[SP]temple[SP]shows[SP]up,[SP]then[SP]the\nLast[SP]Battalion[SP]and[SP]Masked[SP]Circle[SP]goons[SP]show\nup[SP]and[SP]swarm[SP]into[SP]it!",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "D'abord ce temple bizarre, puis\nle Bataillon et le Cercle masqué\nl'envahissent !"
-  },
-  {
-    "id": 25,
-    "offset": 412766,
-    "data_size": 224,
-    "slot_size": 228,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "They[SP]all[SP]went[SP]inside...[1205][U+000A][SP]I[SP]can[SP]hear[SP]gunshots[SP]and\nstuff[SP]from[SP]in[SP]there.[1205][U+000F][SP]Are[SP]they[SP]still[SP]fighting?",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Ils y sont entrés...[1205][U+000A] J'entends des tirs\nà l'intérieur.[1205][U+000F] Ils se battent encore ?"
-  },
-  {
-    "id": 26,
-    "offset": 412994,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Looks[SP]like[SP]the[SP]war[SP]between[SP]the[SP]Masked[SP]Circle\nand[SP]the[SP]Last[SP]Battalion's[SP]being[SP]fought[SP]in[SP]that\ntemple...[1205][U+000F][SP]Will[SP]they[SP]fight[SP]to[SP]the[SP]death?",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "La guerre entre le Cercle masqué\net le Bataillon a lieu dans ce\ntemple...[1205][U+000F] S'entretueront-ils ?"
-  },
-  {
-    "id": 27,
-    "offset": 413292,
-    "data_size": 226,
-    "slot_size": 230,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "I[SP]was[SP]like,[SP]Cuss[SP]High?[SP]Totally[SP]not[SP]my[SP]thing.\nBut[SP]then[SP]lately[SP]they've[SP]been[SP]getting[SP]these\nhot[SP]guys?",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Le lycée Kakasu ? Pas mon truc.\nMais ces temps-ci, ils ont eu plein\nde beaux garçons, non ?"
-  },
-  {
-    "id": 28,
-    "offset": 413522,
-    "data_size": 236,
-    "slot_size": 240,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "So[SP]now[SP]I[SP]go[SP]watch[SP]their[SP]shows[SP]at[SP]the[SP]Prison.\nYou're[SP]kinda[SP]cute[SP]too,[SP]but[SP]you're[SP]just[SP]a\nSevens[SP]student.",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Donc je vais voir leurs shows à la Prison.\nT'es mignon, mais t'es juste\nun élève de Seven."
-  },
-  {
-    "id": 29,
-    "offset": 413762,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "So[SP]like,[SP]the[SP]new[SP]Leader[SP]of[SP]Cuss[SP]High[SP]was\ndecided?[1205][U+000F][SP]He's[SP]waaaay[SP]better.",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Le nouveau chef de Kakasu a\nété choisi ?[1205][U+000F] Il est carrément mieux."
-  },
-  {
-    "id": 30,
-    "offset": 413940,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "I[SP]mean,[SP]Undie[SP]Boss?[SP]Puh-lease.[SP]Like[SP]the[SP]name\nwasn't[SP]bad[SP]enough,[SP]he[SP]kept[SP]making[SP]these[SP]rules.",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Boss Calbute ? Pitié. En plus de son\nnom, il n'arrêtait pas d'imposer des règles."
-  },
-  {
-    "id": 31,
-    "offset": 414158,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "Honestly,[SP]he[SP]was[SP]a[SP]total[SP]drag.[1205][U+000F][SP]Plus[SP]the[SP]new\nLeader[SP]seems,[SP]like,[SP]way[SP]stronger?[SP]It's[SP]like,\nyeah![SP]Go[SP]crush[SP]that[SP]old[SP]Boss!",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Franchement, il était chiant.[1205][U+000F] Et le\nnouveau chef a l'air bien plus fort !\nOuais ! Écrase ce vieux Boss !"
-  },
-  {
-    "id": 32,
-    "offset": 414434,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "The[SP]new[SP]student[SP]council[SP]president's[SP]so[SP]cool\nthat[SP]he[SP]set[SP]up[SP]a[SP]masquerade[SP]at[SP]our[SP]school\nfestival.[1205][U+000F][SP]I[SP]got[SP]a[SP]ticket,[SP]like,[SP]day[SP]one.",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Le président du BDE est si cool. Il a\norganisé un bal masqué pour notre\nfestival.[1205][U+000F] J'ai eu un billet direct."
-  },
-  {
-    "id": 33,
-    "offset": 414726,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "Now[SP]I[SP]just[SP]gotta[SP]get[SP]with[SP]a[SP]cool[SP]Cuss[SP]High\nguy.[1205][U+000F][SP]Or[SP]maybe[SP]you[SP]wanna[SP]come[SP]with[SP]me?[SP]You're\nkinda[SP]cute[SP]yourself,[SP]so[SP]I[SP]wouldn't[SP]mind.",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Il me faut juste un mec cool de Kakasu.[1205][U+000F]\nOu tu veux venir avec moi ? T'es plutôt\nmignon, ça m'irait."
-  },
-  {
-    "id": 34,
-    "offset": 415022,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "Masquerade?[1205][U+000F][SP]Oh,[SP]that[SP]old[SP]thing?[1205][U+000F][SP]I[SP]like,[SP]ditched\non[SP]it[SP]'cause[SP]I[SP]had[SP]other[SP]stuff[SP]to[SP]do?[SP]Anyway,\nthe[SP]new[SP]hotness[SP]is[SP]Muses!",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Le bal masqué ?[1205][U+000F] Oh, ce vieux truc ?[1205][U+000F]\nJ'ai zappé, j'avais d'autres trucs à faire.\nBref, la nouveauté c'est les Muses !"
-  },
-  {
-    "id": 35,
-    "offset": 415302,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "You[SP]know,[SP]that[SP]new[SP]idol[SP]trio[SP]that[SP]Ginji\nSasaki's[SP]producing?[1205][U+000F][SP]I[SP]wonder[SP]what[SP]they're\nlike...[SP]I[SP]can't[SP]wait[SP]for[SP]their[SP]debut!",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Tu sais, le trio d'idoles produit\npar Ginji Sasaki ?[1205][U+000F] Je me demande comment\nelles sont... Vivement leurs débuts !"
-  },
-  {
-    "id": 36,
-    "offset": 415580,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "The[SP]girls[SP]that[SP]got[SP]picked[SP]for[SP]Muses[SP]are[SP]soooo\nlucky.[1205][U+000F][SP]I[SP]mean,[SP]Ginji[SP]Sasaki[SP]producing[SP]you?\nThere's[SP]like,[SP]no[SP]way[SP]they[SP]won't[SP]be[SP]huge.",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Les filles choisies pour Muses ont trop\nde chance.[1205][U+000F] Être produite par Ginji\nSasaki ? C'est sûr qu'elles vont percer."
-  },
-  {
-    "id": 37,
-    "offset": 415878,
-    "data_size": 64,
-    "slot_size": 68,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "This[SP]suuuucks...",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Ça craint..."
-  },
-  {
-    "id": 38,
-    "offset": 415946,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "I[SP]went[SP]to[SP]go[SP]buy[SP]concert[SP]tickets,[SP]and[SP]they[SP]were\nlike,[SP][1432][NULL][NULL][0014]Durrr,[SP]we're[SP]sold[SP]out.[1432][NULL][NULL][0014][1205][U+000F][SP]That[SP]receptionist\nwas[SP]such[SP]a[SP]bitch!",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "J'allais acheter un billet et on me dit :\n[1432][NULL][NULL][0014]Euh, c'est complet.[1432][NULL][NULL][0014][1205][U+000F]\nCette réceptionniste était si chiante !"
-  },
-  {
-    "id": 39,
-    "offset": 416226,
-    "data_size": 322,
-    "slot_size": 326,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "The[SP]Masked[SP]Circle's[SP]behind[SP]this[SP]terrorist[SP]stuff,\nright?[1205][U+000F][SP]Some[SP]of[SP]their[SP]members[SP]were[SP]making[SP]trouble\nin[SP]the[SP]city,[SP]too.[SP]They're[SP]some[SP]real[SP]bad[SP]guys.",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Le Cercle masqué est derrière ces attaques,\nnon ?[1205][U+000F] Certains membres ont fait du\ngrabuge en ville. Ce sont de vrais méchants."
-  },
-  {
-    "id": 40,
-    "offset": 416552,
-    "data_size": 242,
-    "slot_size": 246,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "What[SP]the[SP]hell!?[SP]Why[SP]did[SP]the[SP]terrorists[SP]go\nafter[SP]Smile[SP]Hirasaka?[SP]Why[SP]target[SP]a[SP]station\nbuilding[SP]like[SP]that!?",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "C'est quoi ce bordel !? Pourquoi les\nterroristes ont attaqué Smile Hirasaka ?\nPourquoi viser ça !?"
-  },
-  {
-    "id": 41,
-    "offset": 416798,
-    "data_size": 250,
-    "slot_size": 254,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "Is[SP]this,[SP]like,[SP]one[SP]of[SP]those[SP][1432][NULL][NULL][0014]random[SP]acts[SP]of\nviolence[1432][NULL][NULL][0014][SP]they[SP]talk[SP]about?[1205][U+000F][SP]'Cause[SP]like,[SP]this\nisn't[SP]funny!",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Est-ce un [1432][NULL][NULL][0014]acte de violence\ngratuite[1432][NULL][NULL][0014] dont on parle ?[1205][U+000F]\nParce que là, c'est pas drôle !"
-  },
-  {
-    "id": 42,
-    "offset": 417052,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "I-Is[SP]this[SP]some[SP]kind[SP]of[SP]joke?[SP]Why'd[SP]those\nterrorists[SP]blow[SP]up[SP]Smile[SP]Hirasaka!?[1205][U+000F][SP]Bombing\na[SP]place[SP]like[SP]that[SP]doesn't[SP]get[SP]them[SP]anything!",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "C'est une blague ? Pourquoi ces terroristes\nont fait sauter Smile Hirasaka !?[1205][U+000F] Cibler\nun tel endroit ne leur apporte rien !"
-  },
-  {
-    "id": 43,
-    "offset": 417350,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "Geez,[SP]what's[SP]the[SP]Masked[SP]Circle[SP]thinking!?[1205][U+000F]\nWhy[SP]would[SP]they[SP]do[SP]this!?",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Urgh, à quoi pense le Cercle masqué !?[1205][U+000F]\nPourquoi faire ça !?"
-  },
-  {
-    "id": 44,
-    "offset": 417522,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "Huh?[SP]You[SP]haven't[SP]seen[SP]the[SP]composite[SP]sketches[SP]yet?[1205][U+000F]\nWell,[SP]one[SP]of[SP]them[SP]had[SP]hair[SP]like[SP]yours,[SP]and[SP]his\nface[SP]looked[SP]kinda[SP]like[SP]you[SP]too...",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Hein ? T'as pas vu les portraits-robots ?[1205][U+000F]\nY en a un qui a tes cheveux, et son\nvisage te ressemble..."
-  },
-  {
-    "id": 45,
-    "offset": 417822,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "His[SP]nose...[1205][U+000A][SP]was[SP]like[SP]yours...[1205][U+000F][SP]And[SP]his[SP]mouth...[1205][U+000A]\nYeah,[SP]that[SP]matches[SP]too...[1205][U+000F][SP]See?[SP]Doesn't[SP]he[SP]seem\ntotally[SP]evil?",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Son nez...[1205][U+000A] Comme le tien...[1205][U+000F] Et sa bouche...[1205][U+000A]\nOuais, ça colle...[1205][U+000F] Tu vois ?\nIl a l'air si maléfique."
-  },
-  {
-    "id": 46,
-    "offset": 418088,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "I[SP]like,[SP]wondered[SP]after[SP]I[SP]read[SP]the[SP]In[SP]Lak'ech...\nCould[SP]the[SP]Last[SP]Battalion[SP]have[SP]been[SP]blowing[SP]stuff\nup[SP]to[SP]find[SP]Sumaru[SP]City's[SP]secret[SP]treasure?",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Je me suis demandé en lisant l'In Lak'ech...\nLe Bataillon a-t-il fait sauter des trucs\npour trouver le trésor de Sumaru ?"
-  },
-  {
-    "id": 47,
-    "offset": 418400,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "Those[SP]soldiers[SP]a[SP]moment[SP]ago[SP]saw[SP]me![SP]But[SP]then,\nlike,[SP]some[SP]Masked[SP]Circle[SP]guys[SP]totally[SP]saved\nmy[SP]bacon.",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Ces soldats m'ont vue ! Mais ensuite,\ndes gars du Cercle masqué m'ont sauvée."
-  },
-  {
-    "id": 48,
-    "offset": 418634,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "They[SP]were[SP]all,[SP][1432][NULL][NULL][0014]Joker[SP]ordered[SP]us[SP]to[SP]protect[SP]the\npeople[SP]of[SP]this[SP]city![1432][NULL][NULL][0014][1205][U+000F][SP]I[SP]wonder[SP]if[SP]I[SP]had[SP]the\nwrong[SP]idea[SP]about[SP]him.",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Ils disaient : [1432][NULL][NULL][0014]Le Joker a ordonné de\nprotéger les civils ![1432][NULL][NULL][0014][1205][U+000F] Je me\nsuis peut-être trompée sur lui."
-  },
-  {
-    "id": 49,
-    "offset": 418912,
-    "data_size": 134,
-    "slot_size": 138,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "Maybe[SP]he's[SP]actually,[SP]like,[SP]Sumaru's[SP]guardian\nangel.",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "C'est peut-être l'ange gardien de Sumaru."
-  },
-  {
-    "id": 50,
-    "offset": 419050,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "I[SP]almost[SP]got[SP]attacked[SP]again[SP]by[SP]some[SP]more[SP]Last\nBattalion[SP]thugs...[1205][U+000F][SP]And[SP]this[SP]time[SP]a[SP]couple[SP]of\nwomen[SP]saved[SP]me!",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Le Bataillon a failli m'attaquer de\nnouveau...[1205][U+000F] Et cette fois,\ndes femmes m'ont sauvée !"
-  },
-  {
-    "id": 51,
-    "offset": 419302,
-    "data_size": 142,
-    "slot_size": 146,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "They[SP]were[SP]so[SP]cool...[1205][U+000A][SP]I[SP]gotta[SP]get[SP]my[SP]act\ntogether[SP]too.",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Elles étaient si cool...[1205][U+000A] Je dois me\nreprendre."
-  },
-  {
-    "id": 52,
-    "offset": 419448,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "Some[SP]Last[SP]Battalion[SP]guys[SP]with[SP]long[SP]spears[SP]went\ninto[SP]that[SP]temple[SP]a[SP]minute[SP]ago.[1205][U+000F][SP]They[SP]were\ncarrying[SP]something[SP]shiny,[SP]too...",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Des gars du Bataillon avec de longues\nlances sont entrés là-dedans.[1205][U+000F]\nIls portaient un objet brillant..."
-  },
-  {
-    "id": 53,
-    "offset": 419728,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]girl",
-    "texte_orig": "I-I[SP]just[SP]saw[SP]them[SP]pulling[SP]a[SP]woman[SP]out[SP]of[SP]the\ndetective[SP]agency![1205][U+000F][SP]Were[SP]they[SP]kidnapping[SP]her...?",
-    "nom_fr": "Jeune fille",
-    "texte_fr": "Je les ai vus sortir une femme de l'agence\nde détectives ![1205][U+000F] Ils la kidnappaient... ?"
-  },
-  {
-    "id": 54,
-    "offset": 419950,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]don't[SP]know[SP]much[SP]about[SP]it,[SP]but[SP]there's[SP]some\nJoker[SP]Game[SP]that's[SP]popular[SP]with[SP]the[SP]kids[SP]today,\nright?[SP]It[SP]grants[SP]any[SP]wish?",
-    "nom_fr": "Homme",
-    "texte_fr": "Y a un Jeu du Joker populaire chez les\njeunes, non ? Ça exauce les vœux ?"
-  },
-  {
-    "id": 55,
-    "offset": 420230,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Well,[SP]I[SP]doubt[SP]that,[SP]but[SP]there's[SP]nothing[SP]wrong\nwith[SP]dreaming.[SP]You[SP]can[SP]focus[SP]on[SP]your[SP]troubles\nlater,[SP]once[SP]you're[SP]older.",
-    "nom_fr": "Homme",
-    "texte_fr": "J'en doute, mais on peut rêver.\nTu te soucieras de tes soucis plus tard."
-  },
-  {
-    "id": 56,
-    "offset": 420510,
-    "data_size": 184,
-    "slot_size": 188,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]the[SP]lady[SP]at[SP]Shiraishi[SP]Ramen\nwas[SP]really[SP]a[SP]Russian[SP]spy.",
-    "nom_fr": "Homme",
-    "texte_fr": "Il paraît que la dame de Shiraishi Ramen\nest une espionne russe."
-  },
-  {
-    "id": 57,
-    "offset": 420698,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "You[SP]can[SP]tell[SP]because[SP]she'll[SP]sell[SP]you[SP]real\nweapons[SP]if[SP]you[SP]order[SP]banana[SP]char[SP]siu[SP]ramen![1205][U+000F]\nFunny[SP]old[SP]world,[SP]huh?",
-    "nom_fr": "Homme",
-    "texte_fr": "Si tu commandes des ramens au porc et à la\nbanane, elle te vend des armes ![1205][U+000F]\nDrôle de monde, hein ?"
-  },
-  {
-    "id": 58,
-    "offset": 420962,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]the[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High\nwasn't[SP]stronger[SP]than[SP]Eikichi[SP]at[SP]all.[1205][U+000F][SP]But[SP]then,\nwho[SP]is[SP]stronger[SP]than[SP]that[SP]kid?",
-    "nom_fr": "Homme",
-    "texte_fr": "Le nouveau chef de Kakasu n'est pas plus\nfort qu'Eikichi.[1205][U+000F] Mais qui est plus fort\nque ce gamin ?"
-  },
-  {
-    "id": 59,
-    "offset": 421258,
-    "data_size": 128,
-    "slot_size": 132,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Guess[SP]the[SP]Undie[SP]Boss[SP]hasn't[SP]lost[SP]his[SP]touch.",
-    "nom_fr": "Homme",
-    "texte_fr": "Le Boss Calbute n'a pas perdu la main."
-  },
-  {
-    "id": 60,
-    "offset": 421390,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "You[SP]can[SP]buy[SP]real[SP]shooters[SP]and[SP]blades[SP]at[SP]this\nguy[SP]Tony's[SP]shop[SP]in[SP]Yumezaki?[1205][U+000F][SP]Damn...[SP]sounds\ndangerous,[SP]if[SP]you[SP]ask[SP]me.",
-    "nom_fr": "Homme",
-    "texte_fr": "On peut acheter des armes à feu et des lames\nchez Tony à Yumezaki ?[1205][U+000F] Mince... ça craint."
-  },
-  {
-    "id": 61,
-    "offset": 421666,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]just[SP]heard[SP]it[SP]from[SP]this[SP]porker[SP]called[SP]Toro\nat[SP]Gatten[SP]Sushi.[1205][U+000F][SP]If[SP]you[SP]wanna[SP]know[SP]more,[SP]go\nask[SP]him.",
-    "nom_fr": "Homme",
-    "texte_fr": "Je l'ai appris du gros Toro à Gatten Sushi.[1205][U+000F]\nSi tu veux en savoir plus, va lui demander."
-  },
-  {
-    "id": 62,
-    "offset": 421910,
-    "data_size": 196,
-    "slot_size": 200,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]guess[SP]people[SP]are[SP]pretty[SP]worked[SP]up[SP]over[SP]this\nnew[SP]singer.[1205][U+000F][SP]Me,[SP]I[SP]prefer[SP]enka.",
-    "nom_fr": "Homme",
-    "texte_fr": "Les gens sont à fond sur cette nouvelle\nchanteuse.[1205][U+000F] Moi, je préfère l'enka."
-  },
-  {
-    "id": 63,
-    "offset": 422110,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Aren't[SP]they[SP]doing[SP]some[SP]live[SP]event[SP]right[SP]now[SP]at\nthat[SP]Giga[SP]Macho[SP]place?[1205][U+000F][SP]What,[SP]you're[SP]not\ngonna[SP]go[SP]check[SP]it[SP]out?",
-    "nom_fr": "Homme",
-    "texte_fr": "Il n'y a pas un événement live en ce moment à\nGiga Macho ?[1205][U+000F] Quoi, tu vas pas y aller ?"
-  },
-  {
-    "id": 64,
-    "offset": 422378,
-    "data_size": 316,
-    "slot_size": 320,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "You[SP]one[SP]of[SP]them[SP]guys[SP]that[SP]missed[SP]out[SP]on[SP]the\nconcert?[SP]I[SP]heard[SP]there[SP]weren't[SP]enough[SP]tickets.[1205][U+000F]\nMan[SP]like[SP]you[SP]didn't[SP]need[SP]to[SP]be[SP]there[SP]anyway.",
-    "nom_fr": "Homme",
-    "texte_fr": "T'es un de ceux qui ont raté le concert ? J'ai\nentendu qu'il manquait de billets.[1205][U+000F] Un gars\ncomme toi n'avait rien à y faire de toute façon."
-  },
-  {
-    "id": 65,
-    "offset": 422698,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "There[SP]seems[SP]to[SP]have[SP]been[SP]a[SP]group[SP]of[SP]five[SP]in\nthe[SP]concert[SP]hall[SP]when[SP]it[SP]burned[SP]down.[SP]Rumor[SP]is\nit[SP]was[SP]them[SP]who[SP]set[SP]the[SP]fire.",
-    "nom_fr": "Homme",
-    "texte_fr": "Il y avait un groupe de cinq dans la salle quand\nelle a brûlé. On dit qu'ils ont allumé le feu."
-  },
-  {
-    "id": 66,
-    "offset": 422984,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]it[SP]wasn't[SP]just[SP]the[SP]concert[SP]hall.\nThose[SP]five[SP]guys[SP]were[SP]inside[SP]Smile[SP]Hirasaka\ntoo,[SP]just[SP]before[SP]things[SP]went[SP]down[SP]there.",
-    "nom_fr": "Homme",
-    "texte_fr": "Pas que la salle de concert. Ces cinq-là étaient\naussi à Smile Hirasaka avant que ça dégénère."
-  },
-  {
-    "id": 67,
-    "offset": 423282,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Sounds[SP]connected[SP]to[SP]me.[SP]These[SP]five[SP]guys[SP]are\nsome[SP]shady[SP]characters,[SP]ya[SP]ask[SP]me.[SP]Don't[SP]you\nthink[SP]so,[SP]kid?",
-    "nom_fr": "Homme",
-    "texte_fr": "Ça me semble lié. Ce sont des individus louches,\nà mon avis. Tu ne crois pas, petit ?"
-  },
-  {
-    "id": 68,
-    "offset": 423532,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Jesus![SP]Smile[SP]Hirasaka[SP]just[SP]went[SP]down[SP]in[SP]flames\nright[SP]in[SP]front[SP]of[SP]me![SP]Where's[SP]the[SP]damn[SP]fire\ndepartment!?[SP]What's[SP]going[SP]on[SP]here!?",
-    "nom_fr": "Homme",
-    "texte_fr": "Bon sang ! Smile Hirasaka a pris feu sous mes\nyeux ! Où sont les pompiers !? Il se passe quoi !?"
-  },
-  {
-    "id": 69,
-    "offset": 423830,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Huh?[1205][U+000F][SP]D-Did[SP]you[SP]just[SP]get[SP]here?[SP]Coulda[SP]sworn[SP]I\njust[SP]saw[SP]you[SP]go[SP]that[SP]way...[1205][U+000F][SP]H-Hahaha,[SP]I[SP]must\nbe[SP]seein'[SP]things...",
-    "nom_fr": "Homme",
-    "texte_fr": "Hein ?[1205][U+000F] T-Tu viens d'arriver ? J'aurais juré\nt'avoir vu passer par là...[1205][U+000F] H-Hahaha, je\ndois halluciner..."
-  },
-  {
-    "id": 70,
-    "offset": 424102,
-    "data_size": 136,
-    "slot_size": 140,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "What[SP]the!?[SP]D-Didn't[SP]you[SP]guys[SP]just[SP]pass[SP]by[SP]here?",
-    "nom_fr": "Homme",
-    "texte_fr": "Quel délire !? V-Vous ne venez pas\nde passer là ?"
-  },
-  {
-    "id": 71,
-    "offset": 424242,
-    "data_size": 134,
-    "slot_size": 138,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Then[SP]who[SP]was[SP]that...?[1205][U+000F][SP]I-I'm[SP]seein'[SP]double...",
-    "nom_fr": "Homme",
-    "texte_fr": "Alors qui c'était... ?[1205][U+000F] J-Je vois double..."
-  },
-  {
-    "id": 72,
-    "offset": 424380,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "H-Hahaha...[1205][U+000F][SP]Guess[SP]I[SP]did[SP]have[SP]a[SP]few[SP]too[SP]many\nlast[SP]night...[SP]I[SP]really[SP]oughtta[SP]cut[SP]back[SP]on\nthe[SP]booze...",
-    "nom_fr": "Homme",
-    "texte_fr": "H-Hahaha...[1205][U+000F] J'ai dû trop boire hier soir...\nIl faut vraiment que je lève le pied sur l'alcool..."
-  },
-  {
-    "id": 73,
-    "offset": 424628,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Whoa,[SP]what[SP]the[SP]hell[SP]was[SP]that!?[SP]A[SP]whole[SP]army\nof[SP]guys[SP]with[SP]spears[SP]just[SP]went[SP]flyin'[SP]by!",
-    "nom_fr": "Homme",
-    "texte_fr": "Waouh, c'était quoi !? Une armée de types avec\ndes lances vient de passer en trombe !"
-  },
-  {
-    "id": 74,
-    "offset": 424840,
-    "data_size": 146,
-    "slot_size": 150,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]didn't[SP]know[SP]the[SP]Last[SP]Battalion[SP]had[SP]guys\nlike[SP]that!",
-    "nom_fr": "Homme",
-    "texte_fr": "Je savais pas que le Bataillon avait des gars comme ça !"
-  },
-  {
-    "id": 75,
-    "offset": 424990,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Well,[SP]I'll[SP]be[SP]damned![1205][U+000F][SP]That[SP]Xibalba[SP]thing[SP]was\nthis[SP]big!?[1205][U+000A][SP]Not[SP]too[SP]many[SP]people[SP]can[SP]say[SP]they\nlive[SP]in[SP]a[SP]city[SP]in[SP]the[SP]sky.",
-    "nom_fr": "Homme",
-    "texte_fr": "Nom d'un chien ![1205][U+000F] Ce Xibalba était aussi grand !?[1205][U+000A]\nPeu de gens peuvent dire qu'ils vivent\ndans une ville dans le ciel."
-  },
-  {
-    "id": 76,
-    "offset": 425272,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "But[SP]I[SP]don't[SP]hold[SP]with[SP]this[SP]business[SP]about[SP]the\nworld[SP]ending.[1205][U+000A][SP]Can't[SP]you[SP]do[SP]anything[SP]about[SP]it,\nkid!?",
-    "nom_fr": "Homme",
-    "texte_fr": "Mais je ne crois pas à cette histoire de fin\ndu monde.[1205][U+000A] Tu peux rien y faire, petit !?"
-  },
-  {
-    "id": 77,
-    "offset": 425516,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Everyone[SP]I[SP]know's[SP]talkin'[SP]about[SP]how[SP]the[SP]world's\ngonna[SP]end![1205][U+000A]",
-    "nom_fr": "Homme",
-    "texte_fr": "Tout le monde dit que c'est la fin du monde ![1205][U+000A]"
-  },
-  {
-    "id": 78,
-    "offset": 425682,
-    "data_size": 190,
-    "slot_size": 194,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Floods[SP]this,[SP]meteors[SP]that...[SP]All[SP]as[SP]soon[SP]as\nthis[SP]Grand[SP]Whatever[SP]happens...",
-    "nom_fr": "Homme",
-    "texte_fr": "Inondations, météores... Dès que cette Grande\nJe-Sais-Pas-Quoi arrivera..."
-  },
-  {
-    "id": 79,
-    "offset": 425876,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "What[SP]I[SP]don't[SP]get[SP]is,[SP]it's[SP]gonna[SP]kill[SP]everyone\ndown[SP]there,[SP]right?[SP]What's[SP]the[SP]fun[SP]in[SP]predicting\nhow[SP]they're[SP]gonna[SP]die?",
-    "nom_fr": "Homme",
-    "texte_fr": "Ce que je pige pas, c'est que ça va tous les tuer\nen bas, non ? Quel intérêt de prédire comment\nils vont mourir ?"
-  },
-  {
-    "id": 80,
-    "offset": 426154,
-    "data_size": 322,
-    "slot_size": 326,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]when[SP]the[SP]Grand[SP]Cross[SP]is[SP]done,\nthe[SP]gravity[SP]of[SP]the[SP]stars[SP]is[SP]gonna[SP]pulverize[SP]the\nEarth.[1205][U+000F][SP]Is[SP]that[SP]how[SP]the[SP]world's[SP]gonna[SP]end?",
-    "nom_fr": "Homme",
-    "texte_fr": "Quand la Croix Cosmique sera finie, la gravité des\nétoiles va pulvériser la Terre.[1205][U+000F]\nC'est ça la fin du monde ?"
-  },
-  {
-    "id": 81,
-    "offset": 426480,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hey,[SP]I[SP]heard[SP]the[SP]world[SP]will[SP]stop[SP]spinning[SP]if\nthe[SP]Grand[SP]Cross[SP]happens.[1205][U+000A][SP]Somethin'[SP]about[SP]the\nbalance[SP]of[SP]gravity[SP]and[SP]stuff...[SP]Over[SP]my[SP]head.",
-    "nom_fr": "Homme",
-    "texte_fr": "J'ai entendu dire que la Terre arrêtera de tourner\navec la Croix.[1205][U+000A] Un truc sur la gravité...\nÇa me dépasse."
-  },
-  {
-    "id": 82,
-    "offset": 426798,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "How[SP]bad[SP]would[SP]that[SP]really[SP]be[SP]if[SP]it[SP]happened,\nthough?[SP]I[SP]dunno...",
-    "nom_fr": "Homme",
-    "texte_fr": "À quel point ce serait grave si ça arrivait ?\nJ'en sais rien..."
-  },
-  {
-    "id": 83,
-    "offset": 426970,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Well,[SP]don't[SP]that[SP]beat[SP]all...[SP]I[SP]heard[SP]the\nflowers[SP]in[SP]Aoba[SP]Park[SP]can[SP]talk.[SP]Guess[SP]it[SP]takes\nall[SP]kinds[SP]to[SP]make[SP]a[SP]world.",
-    "nom_fr": "Homme",
-    "texte_fr": "Eh ben, ça par exemple... Il paraît que les fleurs\ndu parc Aoba parlent. Faut de tout pour faire\nun monde."
-  },
-  {
-    "id": 84,
-    "offset": 427242,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hey,[SP]kid.[SP]Ya[SP]know[SP]that[SP]club[SP]Zodiac?[SP]People[SP]say\nthe[SP]second[SP]floor's[SP]a[SP]huge[SP]dungeon,[SP]packed[SP]with\ngreat[SP]stuff.",
-    "nom_fr": "Homme",
-    "texte_fr": "Hé, petit. Tu connais le Zodiac ? On dit que\nle 2e étage est un immense donjon rempli\nde super trucs."
-  },
-  {
-    "id": 85,
-    "offset": 427500,
-    "data_size": 236,
-    "slot_size": 240,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Why[SP]not[SP]go[SP]snoop[SP]around[SP]it?[SP]Show[SP]off[SP]some\nskills[SP]and[SP]I[SP]bet[SP]your[SP]girl'll[SP]be[SP]all[SP]over[SP]ya.\nHahahaha!",
-    "nom_fr": "Homme",
-    "texte_fr": "Pourquoi tu vas pas fouiner ? Montre tes talents\net je parie que ta copine va te sauter dessus.\nHahahaha !"
-  },
-  {
-    "id": 86,
-    "offset": 427740,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]there's[SP]a[SP]ghost[SP]girl[SP]called\nHanako[SP]at[SP]Sevens.[1205][U+000F][SP]First[SP]a[SP]curse,[SP]and[SP]now[SP]a\nghost?[SP]That[SP]school,[SP]I[SP]tell[SP]ya.",
-    "nom_fr": "Homme",
-    "texte_fr": "J'ai ouï-dire qu'un fantôme nommé Hanako\nest à Seven.[1205][U+000F] D'abord une malédiction, puis un\nfantôme ? Cette école, sérieux."
-  },
-  {
-    "id": 87,
-    "offset": 428030,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "What,[SP]there's[SP]another[SP]ghost[SP]at[SP]Cuss[SP]High?\nBukimi[SP]this[SP]time?",
-    "nom_fr": "Homme",
-    "texte_fr": "Quoi, y a un autre fantôme au lycée Kakasu ?\nBukimi cette fois ?"
-  },
-  {
-    "id": 88,
-    "offset": 428194,
-    "data_size": 194,
-    "slot_size": 198,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Guess[SP]I[SP]can't[SP]blame[SP]a[SP]girl[SP]called[SP]Bukimi[SP]for\nwantin'[SP]vengeance[SP]on[SP]the[SP]world.",
-    "nom_fr": "Homme",
-    "texte_fr": "Je peux pas blâmer une fille appelée Bukimi de\nvouloir se venger."
-  },
-  {
-    "id": 89,
-    "offset": 428392,
-    "data_size": 222,
-    "slot_size": 226,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]hear[SP]a[SP]dead[SP]idol's[SP]ghost[SP]is[SP]hauntin'[SP]Aoba\nPark.[SP]Guess[SP]dead[SP]or[SP]alive,[SP]girls[SP]like[SP]flowers.",
-    "nom_fr": "Homme",
-    "texte_fr": "Le fantôme d'une idole morte hante le parc Aoba.\nMortes ou vives, les filles aiment les fleurs."
-  },
-  {
-    "id": 90,
-    "offset": 428618,
-    "data_size": 194,
-    "slot_size": 198,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "But[SP]a[SP]poor[SP]dead[SP]girl[SP]playin'[SP]in[SP]the[SP]flowers...\nThat's[SP]pretty[SP]sad,[SP]ya[SP]ask[SP]me.",
-    "nom_fr": "Homme",
-    "texte_fr": "Mais une fille morte jouant dans les\nfleurs... C'est bien triste, à mon avis."
-  },
-  {
-    "id": 91,
-    "offset": 428816,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Huh...[SP]A[SP]Cursed[SP]Taxi?[SP]They[SP]got[SP]one[SP]at[SP]that\nabandoned[SP]factory?[SP]What[SP]kinda[SP]passengers[SP]it\nthinks[SP]it's[SP]gonna[SP]pick[SP]up[SP]there?",
-    "nom_fr": "Homme",
-    "texte_fr": "Un Taxi Maudit ? Y en a un à l'usine abandonnée ?\nQuels genres de passagers il espère\nprendre là-bas ?"
-  },
-  {
-    "id": 92,
-    "offset": 429100,
-    "data_size": 188,
-    "slot_size": 192,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "What?[SP]It[SP]was[SP]a[SP]Cursed[SP]Escort[SP]at[SP]the[SP]abandoned\nfactory,[SP]not[SP]a[SP]Cursed[SP]Taxi?",
-    "nom_fr": "Homme",
-    "texte_fr": "Quoi ? C'est une Escorte Maudite à l'usine\nabandonnée, pas un Taxi Maudit ?"
-  },
-  {
-    "id": 93,
-    "offset": 429292,
-    "data_size": 72,
-    "slot_size": 76,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Who[SP]cares,[SP]kid?",
-    "nom_fr": "Homme",
-    "texte_fr": "On s'en tape, petit."
-  },
-  {
-    "id": 94,
-    "offset": 429368,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]guess[SP]kids[SP]your[SP]age[SP]wouldn't[SP]know[SP]about\nKuchisake-onna,[SP]huh?",
-    "nom_fr": "Homme",
-    "texte_fr": "Les gosses de ton âge connaissent pas\nKuchisake-onna, hein ?"
-  },
-  {
-    "id": 95,
-    "offset": 429538,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "She[SP]comes[SP]up[SP]to[SP]ya[SP]with[SP]her[SP]mouth[SP]covered\nand[SP]asks[SP]if[SP]ya[SP]think[SP]she's[SP]pretty...",
-    "nom_fr": "Homme",
-    "texte_fr": "Elle vient te voir la bouche couverte et te\ndemande si tu la trouves jolie..."
-  },
-  {
-    "id": 96,
-    "offset": 429740,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]Kuchisake-onna's[SP]started\nshowin'[SP]up[SP]at[SP]Mt.[SP]Iwato.",
-    "nom_fr": "Homme",
-    "texte_fr": "La rumeur dit que Kuchisake-onna est\napparue au Mt Iwato."
-  },
-  {
-    "id": 97,
-    "offset": 429910,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]gotta[SP]admit,[SP]stories[SP]like[SP]that[SP]used[SP]to[SP]give\nme[SP]the[SP]willies[SP]when[SP]I[SP]was[SP]a[SP]kid.",
-    "nom_fr": "Homme",
-    "texte_fr": "Faut avouer que ce genre d'histoires me donnait\nla chair de poule quand j'étais gosse."
-  },
-  {
-    "id": 98,
-    "offset": 430112,
-    "data_size": 316,
-    "slot_size": 320,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Jumping[SP]Geezer,[SP]eh?[SP]Sounds[SP]like[SP]one[SP]stylish\nguy.[SP]I[SP]hope[SP]I'm[SP]that[SP]full[SP]of[SP]energy[SP]when[SP]I[SP]get\nto[SP]be[SP]his[SP]age.[SP]He's[SP]at[SP]Mt.[SP]Katatsumuri,[SP]right?",
-    "nom_fr": "Homme",
-    "texte_fr": "Le Vieux Sauteur, hein ? Quel gars stylé.\nJ'espère avoir autant d'énergie à son âge.\nIl est au Mt Katatsumuri, non ?"
-  },
-  {
-    "id": 99,
-    "offset": 430432,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I-I[SP]just[SP]heard[SP]a[SP]hell[SP]of[SP]a[SP]thing...[SP]Do[SP]you\nknow[SP]about[SP]this?",
-    "nom_fr": "Homme",
-    "texte_fr": "J-Je viens d'entendre un truc de fou...\nT'es au courant ?"
-  },
-  {
-    "id": 100,
-    "offset": 430596,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Th-That[SP]Kudan...[SP]It's[SP]at[SP]the[SP]abandoned[SP]factory,\nand...[SP]Gaaah,[SP]I[SP]can't[SP]even[SP]say[SP]it...!",
-    "nom_fr": "Homme",
-    "texte_fr": "C-Ce Kudan... Il est à l'usine abandonnée,\net... Gaaah, je peux même pas le dire... !"
-  },
-  {
-    "id": 101,
-    "offset": 430812,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hey,[SP]kid.[SP]Hear[SP]there's[SP]a[SP]hidden[SP]CD[SP]at[SP]that\nGiga[SP]Macho[SP]place.",
-    "nom_fr": "Homme",
-    "texte_fr": "Hé petit. Paraît qu'y a un CD caché à Giga Macho."
-  },
-  {
-    "id": 102,
-    "offset": 430976,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hidden[SP]from[SP]who,[SP]is[SP]what[SP]I[SP]wanna[SP]know.\nYou[SP]know[SP]anything[SP]about[SP]this?",
-    "nom_fr": "Homme",
-    "texte_fr": "Caché de qui, c'est ce que je veux savoir.\nT'en sais quelque chose ?"
-  },
-  {
-    "id": 103,
-    "offset": 431158,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]there's[SP]this[SP]Dresser[SP]Hag\nmonster[SP]at[SP]the[SP]abandoned[SP]factory...[SP]Really,\nnow?[SP][1432][NULL][NULL][0014]Dresser[SP]Hag[1432][NULL][NULL][0014]?",
-    "nom_fr": "Homme",
-    "texte_fr": "Il paraît qu'il y a un monstre Mégère à Commode\nà l'usine... Vraiment ?\n[1432][NULL][NULL][0014]Mégère à Commode[1432][NULL][NULL][0014] ?"
-  },
-  {
-    "id": 104,
-    "offset": 431428,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "It's[SP]not[SP]like[SP]it's[SP]a[SP]dresser[SP]with[SP]arms[SP]and\nlegs,[SP]is[SP]it?[SP]Sheesh.[SP]All[SP]these[SP]monsters[SP]got\nthe[SP]worst[SP]names,[SP]I[SP]tell[SP]ya.",
-    "nom_fr": "Homme",
-    "texte_fr": "C'est pas une commode avec des bras et\ndes jambes, si ? Pfff. Ces monstres ont de ces noms..."
-  },
-  {
-    "id": 105,
-    "offset": 431702,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Does[SP]Time[SP]Castle[SP]in[SP]Rengedai[SP]really[SP]sell[SP]real\nweapons?[SP]I[SP]hear[SP]the[SP]quality[SP]and[SP]price[SP]of[SP]their\nstuff[SP]is[SP]about[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "Time Castle à Rengedai vendrait de vraies armes ?\nIl paraît que la qualité et les prix sont moyens."
-  },
-  {
-    "id": 106,
-    "offset": 431978,
-    "data_size": 132,
-    "slot_size": 136,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "It's[SP]a[SP]dangerous[SP]world[SP]we[SP]live[SP]in,[SP]I[SP]tell[SP]ya.",
-    "nom_fr": "Homme",
-    "texte_fr": "On vit dans un monde dangereux, crois-moi."
-  },
-  {
-    "id": 107,
-    "offset": 432114,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Does[SP]Time[SP]Castle[SP]in[SP]Rengedai[SP]really[SP]sell[SP]real\nweapons?[SP]I[SP]hear[SP]the[SP]quality[SP]of[SP]their[SP]stuff[SP]is\ngood,[SP]but[SP]it's[SP]expensive.",
-    "nom_fr": "Homme",
-    "texte_fr": "Time Castle à Rengedai vendrait de vraies armes ?\nIl paraît que la qualité est bonne, mais c'est cher."
-  },
-  {
-    "id": 108,
-    "offset": 432392,
-    "data_size": 132,
-    "slot_size": 136,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "It's[SP]a[SP]dangerous[SP]world[SP]we[SP]live[SP]in,[SP]I[SP]tell[SP]ya.",
-    "nom_fr": "Homme",
-    "texte_fr": "On vit dans un monde dangereux, crois-moi."
-  },
-  {
-    "id": 109,
-    "offset": 432528,
-    "data_size": 250,
-    "slot_size": 254,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Does[SP]Time[SP]Castle[SP]in[SP]Rengedai[SP]really[SP]sell[SP]real\nweapons?[SP]I[SP]hear[SP]their[SP]stuff[SP]is[SP]cheap,[SP]but[SP]it's\nlow[SP]quality.",
-    "nom_fr": "Homme",
-    "texte_fr": "Time Castle à Rengedai vendrait de vraies armes ?\nIl paraît que c'est pas cher, mais de piètre qualité."
-  },
-  {
-    "id": 110,
-    "offset": 432782,
-    "data_size": 132,
-    "slot_size": 136,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "It's[SP]a[SP]dangerous[SP]world[SP]we[SP]live[SP]in,[SP]I[SP]tell[SP]ya.",
-    "nom_fr": "Homme",
-    "texte_fr": "On vit dans un monde dangereux, crois-moi."
-  },
-  {
-    "id": 111,
-    "offset": 432918,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]that[SP]poser[SP]Tony[SP]has[SP]been[SP]selling\nreal[SP]weapons[SP]on[SP]the[SP]sly.",
-    "nom_fr": "Homme",
-    "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce."
-  },
-  {
-    "id": 112,
-    "offset": 433100,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]hear[SP]his[SP]selection's[SP]good,[SP]but[SP]his[SP]resale\nprice[SP]ain't[SP]so[SP]hot.",
-    "nom_fr": "Homme",
-    "texte_fr": "Son choix est bon, mais son prix de rachat est naze."
-  },
-  {
-    "id": 113,
-    "offset": 433272,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]that[SP]poser[SP]Tony[SP]has[SP]been[SP]selling\nreal[SP]weapons[SP]on[SP]the[SP]sly.",
-    "nom_fr": "Homme",
-    "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce."
-  },
-  {
-    "id": 114,
-    "offset": 433454,
-    "data_size": 158,
-    "slot_size": 162,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]hear[SP]his[SP]stuff's[SP]cheap,[SP]but[SP]not[SP]what[SP]you'd\ncall[SP]quality.",
-    "nom_fr": "Homme",
-    "texte_fr": "C'est pas cher, mais on peut pas parler de qualité."
-  },
-  {
-    "id": 115,
-    "offset": 433616,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]that[SP]poser[SP]Tony[SP]has[SP]been[SP]selling\nreal[SP]weapons[SP]on[SP]the[SP]sly.",
-    "nom_fr": "Homme",
-    "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce."
-  },
-  {
-    "id": 116,
-    "offset": 433798,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]hear[SP]the[SP]quality[SP]and[SP]price[SP]of[SP]his[SP]stuff\nis[SP]pretty[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "La qualité et le prix de ses trucs sont dans la moyenne."
-  },
-  {
-    "id": 117,
-    "offset": 433964,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]that[SP]poser[SP]Tony[SP]has[SP]been[SP]selling\nreal[SP]weapons[SP]on[SP]the[SP]sly.",
-    "nom_fr": "Homme",
-    "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce."
-  },
-  {
-    "id": 118,
-    "offset": 434146,
-    "data_size": 132,
-    "slot_size": 136,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]hear[SP]he[SP]has[SP]good[SP]stuff,[SP]but[SP]it's[SP]expensive.",
-    "nom_fr": "Homme",
-    "texte_fr": "Il a de bons trucs, mais ça coûte cher."
-  },
-  {
-    "id": 119,
-    "offset": 434282,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]selection[SP]sucks,\nbut[SP]their[SP]resale[SP]prices[SP]are[SP]high.",
-    "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nLeur choix craint, mais leurs prix de rachat sont élevés."
-  },
-  {
-    "id": 120,
-    "offset": 434572,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][U+000F][SP]They're[SP]cheap,[SP]but\nthe[SP]quality[SP]sucks.",
-    "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nC'est pas cher, mais la qualité est nulle."
-  },
-  {
-    "id": 121,
-    "offset": 434824,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][U+000F][SP]The[SP]quality's[SP]good,\nbut[SP]the[SP]prices[SP]are[SP]high.",
-    "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nLa qualité est là, mais les prix sont élevés."
-  },
-  {
-    "id": 122,
-    "offset": 435090,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]selection's\ngood,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]the[SP]pits.",
-    "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nLe choix est bon, mais les prix de rachat sont à chier."
-  },
-  {
-    "id": 123,
-    "offset": 435382,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]quality[SP]and\nprice[SP]are[SP]basically[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nLeur qualité et leurs prix sont dans la moyenne."
-  },
-  {
-    "id": 124,
-    "offset": 435652,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality[SP]and[SP]price\nis[SP]just[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nIl paraît que la qualité et les prix sont moyens."
-  },
-  {
-    "id": 125,
-    "offset": 435900,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][U+000F][SP]I[SP]hear[SP]they're[SP]cheap,[SP]but[SP]not\nexactly[SP]quality[SP]stuff.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nC'est pas cher, mais c'est pas de la top qualité."
-  },
-  {
-    "id": 126,
-    "offset": 436158,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][U+000F][SP]I[SP]hear[SP]his[SP]selection's[SP]good,\nbut[SP]his[SP]resale[SP]value[SP]sucks.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nIl a du choix, mais les prix de rachat sont nuls."
-  },
-  {
-    "id": 127,
-    "offset": 436424,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][U+000F][SP]I[SP]hear[SP]his[SP]selection[SP]sucks,\nbut[SP]his[SP]resale[SP]prices[SP]are[SP]great.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nLe choix craint, mais les prix de rachat sont super."
-  },
-  {
-    "id": 128,
-    "offset": 436698,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality's[SP]good,\nbut[SP]the[SP]prices[SP]are[SP]high.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nLa qualité est bonne, mais les prix sont élevés."
-  },
-  {
-    "id": 129,
-    "offset": 436958,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "It[SP]takes[SP]balls[SP]to[SP]sell[SP]armor[SP]at[SP]a[SP]fancy\nboutique[SP]like[SP]Rosa[SP]Candida[SP]at[SP]Rengedai.[1205][U+000F]\nTheir[SP]quality[SP]and[SP]price[SP]is[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[1205][U+000F] Qualité et prix moyens."
-  },
-  {
-    "id": 130,
-    "offset": 437238,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "It[SP]takes[SP]balls[SP]to[SP]sell[SP]armor[SP]at[SP]a[SP]fancy\nboutique[SP]like[SP]Rosa[SP]Candida[SP]at[SP]Rengedai.[1205][U+000F]\nIt's[SP]cheap,[SP]but[SP]low[SP]quality.",
-    "nom_fr": "Homme",
-    "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[1205][U+000F] Pas cher, mais qualité nulle."
-  },
-  {
-    "id": 131,
-    "offset": 437504,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "It[SP]takes[SP]balls[SP]to[SP]sell[SP]armor[SP]at[SP]a[SP]fancy\nboutique[SP]like[SP]Rosa[SP]Candida[SP]at[SP]Rengedai.[1205][U+000F]\nIt's[SP]good[SP]quality,[SP]but[SP]expensive.",
-    "nom_fr": "Homme",
-    "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[1205][U+000F] Bonne qualité, mais cher."
-  },
-  {
-    "id": 132,
-    "offset": 437780,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[SP]real\narmor,[SP]not[SP]just[SP]clothes.[SP]The[SP]price[SP]and[SP]quality\nof[SP]their[SP]stuff[SP]is[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "Anima Mundi vend de vraies armures, pas que\ndes fringues. Prix et qualité dans la moyenne."
-  },
-  {
-    "id": 133,
-    "offset": 438064,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[SP]real\narmor,[SP]not[SP]just[SP]clothes.[SP]It's[SP]cheap[SP]stuff,[SP]but\nyou[SP]get[SP]what[SP]you[SP]pay[SP]for.",
-    "nom_fr": "Homme",
-    "texte_fr": "Anima Mundi vend de vraies armures, pas que\ndes fringues. C'est pas cher, mais on en a pour son argent."
-  },
-  {
-    "id": 134,
-    "offset": 438346,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[SP]real\narmor,[SP]not[SP]just[SP]clothes.[SP]Their[SP]selection's\ngreat,[SP]but[SP]the[SP]resale[SP]value[SP]isn't.",
-    "nom_fr": "Homme",
-    "texte_fr": "Anima Mundi vend de vraies armures. Bon choix,\nmais prix de rachat très bas."
-  },
-  {
-    "id": 135,
-    "offset": 438638,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Looks[SP]like[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[SP]real\narmor,[SP]not[SP]just[SP]clothes.[SP]Their[SP]quality's[SP]good,\nbut[SP]it's[SP]expensive[SP]stuff.",
-    "nom_fr": "Homme",
-    "texte_fr": "Anima Mundi vend de vraies armures. Bonne qualité,\nmais ça coûte cher."
-  },
-  {
-    "id": 136,
-    "offset": 438920,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]selection's[SP]the\npits,[SP]but[SP]they[SP]have[SP]great[SP]resale[SP]prices.",
-    "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nLe choix craint, mais les prix de rachat sont excellents."
-  },
-  {
-    "id": 137,
-    "offset": 439222,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality[SP]and\nprices[SP]are[SP]just[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nLa qualité et les prix sont très moyens."
-  },
-  {
-    "id": 138,
-    "offset": 439484,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]stuff[SP]is[SP]top-\nnotch,[SP]but[SP]it's[SP]expensive.",
-    "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nC'est du matos top niveau, mais c'est cher."
-  },
-  {
-    "id": 139,
-    "offset": 439754,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]prices[SP]are\nlow,[SP]but[SP]so's[SP]the[SP]quality.",
-    "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nC'est pas cher, mais la qualité suit."
-  },
-  {
-    "id": 140,
-    "offset": 440018,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]selection's[SP]good,\nbut[SP]their[SP]resale[SP]value[SP]is[SP]awful.",
-    "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nBon choix, mais le prix de rachat est affreux."
-  },
-  {
-    "id": 141,
-    "offset": 440308,
-    "data_size": 300,
-    "slot_size": 304,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]selection\nis[SP]great,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]low.",
-    "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nLe choix est super, mais le prix de rachat est bas."
-  },
-  {
-    "id": 142,
-    "offset": 440612,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]stuff\nis[SP]cheap,[SP]but[SP]really[SP]low[SP]quality.",
-    "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nC'est pas cher, mais de mauvaise qualité."
-  },
-  {
-    "id": 143,
-    "offset": 440898,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality's\ngreat,[SP]if[SP]you[SP]can[SP]afford[SP]it.",
-    "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nLa qualité est top, si tu peux te le permettre."
-  },
-  {
-    "id": 144,
-    "offset": 441182,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality\nand[SP]prices[SP]are[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nLa qualité et les prix sont moyens."
-  },
-  {
-    "id": 145,
-    "offset": 441452,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]selection\nis[SP]terrible,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]great.",
-    "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nLe choix est nul, mais le prix de rachat est excellent."
-  },
-  {
-    "id": 146,
-    "offset": 441766,
-    "data_size": 300,
-    "slot_size": 304,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "You[SP]can[SP]win[SP]weapons[SP]in[SP]a[SP]magazine[SP]sweepstakes?\nWhat[SP]is[SP]this[SP]world[SP]coming[SP]to?[SP]I[SP]hear[SP]you[SP]don't\nwin[SP]often,[SP]but[SP]the[SP]prizes[SP]are[SP]nice.",
-    "nom_fr": "Homme",
-    "texte_fr": "Gagner des armes à un concours de magazine ?\nOn gagne pas souvent, mais les prix sont sympas."
-  },
-  {
-    "id": 147,
-    "offset": 442070,
-    "data_size": 316,
-    "slot_size": 320,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "You[SP]can[SP]win[SP]weapons[SP]in[SP]a[SP]magazine[SP]sweepstakes?\nWhat[SP]is[SP]this[SP]world[SP]coming[SP]to?[SP]I[SP]hear[SP]it's[SP]rare\nanyone[SP]wins,[SP]but[SP]the[SP]prizes[SP]are[SP]first-rate.",
-    "nom_fr": "Homme",
-    "texte_fr": "Gagner des armes à un concours de magazine ?\nC'est rare de gagner, mais les prix sont top."
-  },
-  {
-    "id": 148,
-    "offset": 442390,
-    "data_size": 316,
-    "slot_size": 320,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "You[SP]can[SP]win[SP]weapons[SP]in[SP]a[SP]magazine[SP]sweepstakes?\nWhat[SP]is[SP]this[SP]world[SP]coming[SP]to?[SP]I[SP]hear[SP]it's[SP]easy\nto[SP]win,[SP]but[SP]the[SP]prizes[SP]are[SP]barely[SP]worth[SP]it.",
-    "nom_fr": "Homme",
-    "texte_fr": "Gagner des armes à un concours de magazine ?\nC'est facile de gagner, mais c'est pas dingue."
-  },
-  {
-    "id": 149,
-    "offset": 442710,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "So[SP]Mu[SP]is[SP]actually[SP]a[SP]gambling[SP]parlor?[SP]I[SP]didn't\nknow[SP]that.[SP]Now[SP]I'm[SP]excited![SP]I[SP]hear[SP]you[SP]can\nwin[SP]big[SP]there[SP]at[SP]poker.",
-    "nom_fr": "Homme",
-    "texte_fr": "Mu a un casino ? Je savais pas.\nC'est génial ! On gagne gros au poker."
-  },
-  {
-    "id": 150,
-    "offset": 442980,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "So[SP]Mu[SP]is[SP]actually[SP]a[SP]gambling[SP]parlor?[SP]I[SP]didn't\nknow[SP]that.[SP]Now[SP]I'm[SP]excited![SP]I[SP]hear[SP]you[SP]can\nwin[SP]big[SP]there[SP]at[SP]slots.",
-    "nom_fr": "Homme",
-    "texte_fr": "Mu a un casino ? Je savais pas.\nC'est génial ! On gagne gros aux machines."
-  },
-  {
-    "id": 151,
-    "offset": 443250,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "So[SP]Mu[SP]is[SP]actually[SP]a[SP]gambling[SP]parlor?[SP]I[SP]didn't\nknow[SP]that![SP]I[SP]love[SP]gambling![SP]Now[SP]I'm[SP]excited!",
-    "nom_fr": "Homme",
-    "texte_fr": "Mu a un casino ? Je savais pas !\nJ'adore ça ! Je suis à fond !"
-  },
-  {
-    "id": 152,
-    "offset": 443474,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Plus,[SP]I[SP]hear[SP]you[SP]can[SP]win[SP]big[SP]there[SP]at\nblackjack.[SP]Hah,[SP]my[SP]favorite!",
-    "nom_fr": "Homme",
-    "texte_fr": "En plus, tu gagnes gros au\nblackjack. Hah, mon préféré !"
-  },
-  {
-    "id": 153,
-    "offset": 443652,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]hear[SP]there's[SP]a[SP]legendary[SP]weapon[SP]for[SP]sale[SP]at\nShiraishi[SP]Ramen.[SP]Is[SP]that[SP]true?[SP]Sheesh...[SP]First\na[SP]Russian[SP]spy,[SP]now[SP]a[SP]legendary[SP]weapon...",
-    "nom_fr": "Homme",
-    "texte_fr": "Shiraishi Ramen vend une arme légendaire ?\nSérieux ? Une espionne, puis ça..."
-  },
-  {
-    "id": 154,
-    "offset": 443964,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hey,[SP]sounds[SP]like[SP]there's[SP]some[SP]legendary[SP]weapon\nat[SP]Clair[SP]de[SP]Lune.[SP]Man,[SP]there[SP]ain't[SP]any\nupstanding[SP]shops[SP]in[SP]this[SP]city[SP]at[SP]all.",
-    "nom_fr": "Homme",
-    "texte_fr": "Une arme légendaire chez Clair de Lune...\nIl n'y a plus de boutiques honnêtes ici."
-  },
-  {
-    "id": 155,
-    "offset": 444256,
-    "data_size": 300,
-    "slot_size": 304,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]hear[SP]the[SP]owner[SP]at[SP]Time[SP]Castle[SP]is[SP]sitting[SP]on\nthe[SP]legendary[SP]weapon[SP]to[SP]jack[SP]up[SP]its[SP]price.\nShysters[SP]like[SP]that[SP]rub[SP]me[SP]the[SP]wrong[SP]way.",
-    "nom_fr": "Homme",
-    "texte_fr": "Le boss de Time Castle garde son arme\nlégendaire pour monter le prix. Quel rapiat."
-  },
-  {
-    "id": 156,
-    "offset": 444560,
-    "data_size": 316,
-    "slot_size": 320,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hahaha,[SP]I[SP]hear[SP]the[SP]owner[SP]of[SP]Time[SP]Castle[SP]is[SP]too\nscared[SP]of[SP]monsters[SP]to[SP]fetch[SP]the[SP]legendary[SP]weapon\nwaiting[SP]for[SP]him[SP]at[SP]the[SP]abandoned[SP]factory.",
-    "nom_fr": "Homme",
-    "texte_fr": "Hahaha, le boss de Time Castle a trop peur\ndes monstres pour aller chercher son arme à l'usine."
-  },
-  {
-    "id": 157,
-    "offset": 444880,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hey,[SP]is[SP]it[SP]true[SP]some[SP]demons[SP]stole[SP]the[SP]legendary\nweapon[SP]from[SP]Time[SP]Castle?",
-    "nom_fr": "Homme",
-    "texte_fr": "Hé, des démons ont vraiment volé l'arme\nlégendaire de Time Castle ?"
-  },
-  {
-    "id": 158,
-    "offset": 445070,
-    "data_size": 182,
-    "slot_size": 186,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "What[SP]a[SP]load[SP]of[SP]it.[1205][U+000F][SP]Then[SP]again,[SP]lately[SP]it[SP]seems\nlike[SP]anything[SP]goes...",
-    "nom_fr": "Homme",
-    "texte_fr": "Quelle connerie.[1205][U+000F] M'enfin, on\npeut s'attendre à tout de nos jours..."
-  },
-  {
-    "id": 159,
-    "offset": 445256,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "I[SP]heard[SP]some[SP]unlucky[SP]woman[SP]bought[SP]the[SP]legendary\nweapon[SP]at[SP]Time[SP]Castle.[SP]A[SP]lady's[SP]got[SP]no[SP]business\nownin'[SP]something[SP]that[SP]dangerous.",
-    "nom_fr": "Homme",
-    "texte_fr": "Une femme malchanceuse a acheté l'arme\nlégendaire de Time Castle. Une dame avec ça, sérieux."
-  },
-  {
-    "id": 160,
-    "offset": 445556,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Huh?[SP]My[SP]attitude's[SP]out[SP]of[SP]date?[SP]Heh,[SP]that's\nfine[SP]by[SP]me![SP]In[SP]my[SP]book,[SP]men[SP]are[SP]supposed[SP]to\nprotect[SP]women!",
-    "nom_fr": "Homme",
-    "texte_fr": "Hein ? Je suis ringard ? M'en fiche !\nPour moi, les hommes protègent les femmes !"
-  },
-  {
-    "id": 161,
-    "offset": 445806,
-    "data_size": 238,
-    "slot_size": 242,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hey,[SP]did[SP]ya[SP]hear?[SP]The[SP]owner[SP]of[SP]Time[SP]Castle[SP]gave\nthat[SP]legendary[SP]weapon[SP]to[SP]some[SP]girl[SP]with[SP]short\nhair.",
-    "nom_fr": "Homme",
-    "texte_fr": "Hé, t'as entendu ? Le boss de Time Castle a\ndistribué son arme légendaire à une fille\naux cheveux courts."
-  },
-  {
-    "id": 162,
-    "offset": 446048,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Blue-collar[SP]man",
-    "texte_orig": "Hahaha,[SP]pretty[SP]generous[SP]of[SP]him,[SP]huh?[SP]Now[SP]there's\na[SP]man[SP]for[SP]you.",
-    "nom_fr": "Homme",
-    "texte_fr": "Hahaha, plutôt généreux, non ? C'est ça\nun vrai homme."
-  },
-  {
-    "id": 163,
-    "offset": 446220,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaaah![SP]I'm[SP]not[SP]a[SP]Cuss[SP]High[SP]student[SP]anymore.\nI[SP]used[SP]to[SP]be[SP]one,[SP]but[SP]no[SP]longer.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaaah ! Je ne suis plus à Kakasu.\nJ'y étais, mais plus maintenant."
-  },
-  {
-    "id": 164,
-    "offset": 446442,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Now,[SP]I[SP]am[SP]a[SP]washout[SP]who's[SP]fighting[SP]to[SP]study\nhard[SP]and[SP]make[SP]it[SP]into[SP]the[SP]best[SP]university[SP]in\nthe[SP]country!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Maintenant, j'étudie dur pour intégrer\nla meilleure université du pays !"
-  },
-  {
-    "id": 165,
-    "offset": 446708,
-    "data_size": 336,
-    "slot_size": 340,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "However![SP]The[SP]recent[SP]influx[SP]of[SP]women[SP]into[SP]this\ncity[SP]is[SP]troubling![SP]While[SP]I'm[SP]happy[SP]my[SP]alma[SP]mater\nis[SP]gaining[SP]popularity,[SP]they're[SP]distracting!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Cependant ! L'afflux de femmes ici est troublant !\nMon école est populaire, mais ça me distrait !"
-  },
-  {
-    "id": 166,
-    "offset": 447048,
-    "data_size": 350,
-    "slot_size": 354,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Was[SP]it[SP]only[SP]a[SP]groundless[SP]rumor?[1205][U+000F][SP]I[SP]hear\ntell[SP]of[SP]a[SP]walking[SP]statue[SP]at[SP]Sevens,[SP]my[SP]alma\nmater's[SP]rival...[1205][U+000F][SP]Hate[SP]the[SP]sin,[SP]love[SP]the[SP]sinner!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] C'était juste une rumeur ?[1205][U+000F] On\nparle d'une statue vivante à Seven...\n[1205][U+000F]Aime le pécheur, hais le péché !"
-  },
-  {
-    "id": 167,
-    "offset": 447402,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Having[SP]such[SP]a[SP]statue[SP]on[SP]school[SP]grounds[SP]must[SP]be\na[SP]serious[SP]impediment[SP]to[SP]the[SP]education[SP]of[SP]the\nstudents[SP]there.[1205][U+000F]",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Avoir une telle statue à l'école doit\ngêner sérieusement l'éducation de ces\nélèves.[1205][U+000F]"
-  },
-  {
-    "id": 168,
-    "offset": 447684,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "As[SP]a[SP]fighting[SP]student,[SP]I[SP]will[SP]bring[SP]divine\npunishment[SP]to[SP]that[SP]vexing[SP]statue![SP]Eventually,\nthat[SP]is...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "En tant qu'étudiant, j'apporterai le châtiment\ndivin à cette statue ! Éventuellement..."
-  },
-  {
-    "id": 169,
-    "offset": 447946,
-    "data_size": 250,
-    "slot_size": 254,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "H-Hyaaaah...![1205][U+000F][SP]My[SP]vision[SP]is[SP]blurry[SP]with[SP]tears...\nThe[SP]students[SP]at[SP]my[SP]alma[SP]mater[SP]are[SP]incredible!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "H-Hyaaaah... ![1205][U+000F] J'ai les larmes aux yeux...\nLes élèves de mon école sont incroyables !"
-  },
-  {
-    "id": 170,
-    "offset": 448200,
-    "data_size": 190,
-    "slot_size": 194,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "You[SP]are[SP]all[SP]shining[SP]examples![1205][U+000F][SP]I[SP]have[SP]long\nawaited[SP]such[SP]a[SP]sight!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Vous êtes de brillants exemples ![1205][U+000F]\nJ'ai longtemps attendu une telle chose !"
-  },
-  {
-    "id": 171,
-    "offset": 448394,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "A[SP]school[SP]festival[SP]is[SP]an[SP]important[SP]event[SP]that\nshows[SP]the[SP]fruits[SP]of[SP]daily[SP]education[SP]and[SP]school\ntraditions![1205][U+000F]",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Le festival montre les fruits de l'éducation\net des traditions scolaires ![1205][U+000F]"
-  },
-  {
-    "id": 172,
-    "offset": 448668,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "To[SP]host[SP]a[SP]foreign[SP]dance[SP]like[SP]this[SP]masquerade\ntruly[SP]speaks[SP]of[SP]your[SP]international[SP]spirit!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Faire un bal masqué comme ça prouve\nvotre esprit international !"
-  },
-  {
-    "id": 173,
-    "offset": 448906,
-    "data_size": 196,
-    "slot_size": 200,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "It[SP]is[SP]in[SP]the[SP]nature[SP]of[SP]youth[SP]to[SP]be[SP]reckless\nin[SP]the[SP]name[SP]of[SP]freedom![1205][U+000F]",
-    "nom_fr": "Étudiant",
-    "texte_fr": "C'est dans la nature de la jeunesse d'être\nimprudent au nom de la liberté ![1205][U+000F]"
-  },
-  {
-    "id": 174,
-    "offset": 449106,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Even[SP]drops[SP]of[SP]water[SP]wear[SP]away[SP]at[SP]stone![1205][U+000F][SP]Do[SP]your\nbest[SP]to[SP]work[SP]towards[SP]your[SP]future,[SP]and[SP]a[SP]bright\ntomorrow[SP]will[SP]await[SP]you[SP]all!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Les gouttes d'eau usent la pierre ![1205][U+000F] Faites de\nvotre mieux pour votre avenir, et des\nlendemains radieux vous attendent !"
-  },
-  {
-    "id": 175,
-    "offset": 449420,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![SP]I[SP]can't[SP]believe[SP]I[SP]let[SP]myself[SP]be[SP]taken\nin[SP]by[SP]a[SP]groundless[SP]rumor![1205][U+000F][SP]What?[SP]You[SP]wish[SP]to\nknow[SP]more[SP]of[SP]my[SP]folly?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! J'arrive pas à croire que j'ai\ngobé une rumeur infondée ![1205][U+000F] Quoi ? Tu\nveux en savoir plus sur ma folie ?"
-  },
-  {
-    "id": 176,
-    "offset": 449714,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "I[SP]heard[SP]a[SP]rumor[SP]that[SP]there[SP]was[SP]real[SP]armor[SP]to\nbe[SP]had[SP]at[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "J'ai entendu une rumeur disant qu'il y avait\nde vraies armures à Anima Mundi à Yumezaki."
-  },
-  {
-    "id": 177,
-    "offset": 449936,
-    "data_size": 242,
-    "slot_size": 246,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "But[SP]in[SP]truth,[SP]there[SP]was[SP]nothing[SP]of[SP]the[SP]kind!\nThe[SP]employees[SP]there[SP]even[SP]mocked[SP]me[SP]for[SP]asking!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Mais en fait, il n'y avait rien de tel !\nLes employés se sont même moqués de moi !"
-  },
-  {
-    "id": 178,
-    "offset": 450182,
-    "data_size": 324,
-    "slot_size": 328,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "But[SP]perhaps[SP]my[SP]information[SP]was[SP]bad...[1205][U+000F][SP]Maybe\nthat[SP]stout[SP]man[SP]knows[SP]something.[1205][U+000F][SP]I[SP]believe[SP]his\nname[SP]is[SP]Toro,[SP]and[SP]he[SP]loves[SP]fatty[SP]tuna.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Mais mes infos étaient peut-être fausses...[1205][U+000F]\nCe grand costaud sait peut-être\nquelque chose.[1205][U+000F] Il s'appelle Toro,\net adore le thon gras."
-  },
-  {
-    "id": 179,
-    "offset": 450510,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]heard[SP]that[SP]the[SP]members[SP]of[SP]Muses[SP]are\nall[SP]still[SP]in[SP]high[SP]school!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu dire que les membres de\nMuses sont toutes encore au lycée !"
-  },
-  {
-    "id": 180,
-    "offset": 450722,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "What[SP]about[SP]their[SP]studies!?[1205][U+000A][SP]What[SP]about[SP]their\ncollege[SP]entrance[SP]exams!?[1205][U+000A][SP]Have[SP]you[SP]even[SP]taken\nyour[SP]finals[SP]yet!?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Qu'en est-il de leurs études !?[1205][U+000A] Et leurs\nexamens d'entrée à la fac !?[1205][U+000A] Avez-vous\nseulement passé vos examens finaux !?"
-  },
-  {
-    "id": 181,
-    "offset": 451006,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "One's[SP]good[SP]looks[SP]will[SP]not[SP]keep[SP]one[SP]afloat![1205][U+000F]\nHow[SP]dare[SP]they[SP]be[SP]dazzled[SP]by[SP]show[SP]business!?\nA[SP]student's[SP]first[SP]duty[SP]is[SP]studying!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "La beauté seule ne suffit pas ![1205][U+000F]\nComment osent-elles se laisser éblouir par le show-biz !?\nLe premier devoir d'un étudiant est d'étudier !"
-  },
-  {
-    "id": 182,
-    "offset": 451318,
-    "data_size": 336,
-    "slot_size": 340,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]like[SP]Ginji[SP]Sasaki[SP]too![1205][U+000F][SP]I[SP]don't[SP]really\nlisten[SP]to[SP]them,[SP]but[SP]I've[SP]bought[SP]everything[SP]he's\nproduced![SP]Even[SP]his[SP]compilation[SP]album!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] J'aime Ginji Sasaki moi aussi ![1205][U+000F]\nJe ne les écoute pas vraiment, mais j'ai acheté\ntout ce qu'il a produit ! Même sa compil !"
-  },
-  {
-    "id": 183,
-    "offset": 451658,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "But[SP]I[SP]cannot[SP]abide[SP]by[SP]his[SP]dragging[SP]innocent\nmaidens[SP]who[SP]should[SP]be[SP]studying[SP]into[SP]his[SP]tawdry\nindustry!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Mais je hais qu'il entraîne des filles\ninnocentes devant étudier dans cette\nindustrie tape-à-l'œil !"
-  },
-  {
-    "id": 184,
-    "offset": 451922,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Though[SP]I[SP]don't[SP]necessarily[SP]hate[SP]his[SP]music.[1205][U+000F]\nAm[SP]I[SP]contradicting[SP]myself?[1205][U+000F][SP]I[SP]am,[SP]aren't[SP]I...?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Bien que je ne déteste pas vraiment sa musique.[1205][U+000F]\nEst-ce que je me contredis ?[1205][U+000F] Oui, n'est-ce pas... ?"
-  },
-  {
-    "id": 185,
-    "offset": 452170,
-    "data_size": 318,
-    "slot_size": 322,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]don't[SP]know[SP]if[SP]it[SP]was[SP]actually[SP]a\nterrorism[SP]wave,[SP]but[SP]my[SP]cram[SP]school[SP]was[SP]shut\ndown[SP]because[SP]of[SP]fools[SP]playing[SP]with[SP]fire!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Je ne sais pas s'il y a vraiment\nune vague de terrorisme, mais ma prépa a\nfermé à cause d'idiots qui jouent avec le feu !"
-  },
-  {
-    "id": 186,
-    "offset": 452492,
-    "data_size": 318,
-    "slot_size": 322,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Nothing[SP]will[SP]get[SP]in[SP]the[SP]way[SP]of[SP]my[SP]studies!\nThe[SP]pen[SP]is[SP]mightier[SP]than[SP]the[SP]sword![SP]I'll[SP]bring\ndown[SP]the[SP]Masked[SP]Circle![1205][U+000F][SP]Eventually...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Rien ne m'empêchera d'étudier !\nLa plume est plus forte que l'épée !\nJe ferai tomber le Cercle masqué ![1205][U+000F] Bientôt..."
-  },
-  {
-    "id": 187,
-    "offset": 452814,
-    "data_size": 332,
-    "slot_size": 336,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]People[SP]talk[SP]about[SP]terrorism[SP]this[SP]and\nterrorism[SP]that,[SP]but[SP]if[SP]this[SP]is[SP]the[SP]work[SP]of\nterrorists,[SP]we[SP]should[SP]know[SP]their[SP]demands[SP]now.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] On parle de terrorisme par-ci\npar-là, mais on devrait connaître leurs\nrevendications maintenant."
-  },
-  {
-    "id": 188,
-    "offset": 453150,
-    "data_size": 330,
-    "slot_size": 334,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Yet[SP]none[SP]have[SP]been[SP]made.[SP]It's[SP]possible[SP]that\nthis[SP]is[SP]being[SP]perpetrated[SP]for[SP]someone's[SP]sick\namusement...[1205][U+000F][SP]My[SP]anger[SP]will[SP]never[SP]be[SP]stilled!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Pourtant, aucune n'a été faite. C'est peut-être\nl'œuvre de quelqu'un qui s'amuse...[1205][U+000F]\nMa colère ne s'apaisera jamais !"
-  },
-  {
-    "id": 189,
-    "offset": 453484,
-    "data_size": 332,
-    "slot_size": 336,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]People[SP]talk[SP]about[SP]terrorism[SP]this[SP]and\nterrorism[SP]that,[SP]but[SP]if[SP]this[SP]is[SP]the[SP]work[SP]of\nterrorists,[SP]we[SP]should[SP]know[SP]their[SP]demands[SP]now.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] On parle de terrorisme par-ci\npar-là, mais on devrait connaître leurs\nrevendications maintenant."
-  },
-  {
-    "id": 190,
-    "offset": 453820,
-    "data_size": 330,
-    "slot_size": 334,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Yet[SP]none[SP]have[SP]been[SP]made.[SP]It's[SP]possible[SP]that\nthis[SP]is[SP]being[SP]perpetrated[SP]for[SP]someone's[SP]sick\namusement...[1205][U+000F][SP]My[SP]anger[SP]will[SP]never[SP]be[SP]stilled!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Pourtant, aucune n'a été faite. C'est peut-être\nl'œuvre de quelqu'un qui s'amuse...[1205][U+000F]\nMa colère ne s'apaisera jamais !"
-  },
-  {
-    "id": 191,
-    "offset": 454154,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Hmm,[SP]if[SP]my[SP]high[SP]school[SP]memories[SP]are\naccurate,[SP]that[SP]lady[SP]a[SP]moment[SP]ago[SP]was[SP]Sevens'...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Hmm, si mes souvenirs du lycée\nsont exacts, cette dame d'il y a un\ninstant était de Seven..."
-  },
-  {
-    "id": 192,
-    "offset": 454404,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Did[SP]something[SP]happen[SP]for[SP]her[SP]to[SP]rush[SP]into[SP]the\ndetective[SP]agency[SP]like[SP]that?[1205][U+000F][SP]*gasp*[SP]No![SP]What[SP]an\nawful[SP]thought!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Il s'est passé un truc pour qu'elle se rue\nainsi à l'agence de détectives ?[1205][U+000F]\n*gasp* Non ! Quelle pensée affreuse !"
-  },
-  {
-    "id": 193,
-    "offset": 454684,
-    "data_size": 334,
-    "slot_size": 338,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "It's[SP]terribly[SP]vulgar[SP]to[SP]pry[SP]into[SP]the[SP]privacy[SP]of\nothers.[1205][U+000F][SP]I[SP]must[SP]admonish[SP]myself![1205][U+000F][SP]Time[SP]to[SP]copy\nall[SP]the[SP]pages[SP]of[SP]the[SP]Compendium[SP]of[SP]Laws!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "C'est terriblement vulgaire de s'immiscer dans\nla vie privée des autres.[1205][U+000F] Je dois me faire une\nraison ![1205][U+000F] Je vais copier le code civil !"
-  },
-  {
-    "id": 194,
-    "offset": 455022,
-    "data_size": 232,
-    "slot_size": 236,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Fear[SP]makes[SP]men[SP]panic[SP]and[SP]become\nconfused![SP]What[SP]is[SP]right[SP]and[SP]what[SP]is[SP]wrong...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaah![1205][U+000F] La peur fait paniquer\nles hommes et les rend confus ! Ce qui\nest bien et ce qui est mal..."
-  },
-  {
-    "id": 195,
-    "offset": 455258,
-    "data_size": 326,
-    "slot_size": 330,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "That[SP]must[SP]be[SP]made[SP]clear,[SP]or[SP]man[SP]will[SP]continue\nto[SP]make[SP]foolish[SP]mistakes.[1205][U+000F][SP]Let[SP]us[SP]all[SP]calm\nourselves...[1205][U+000F][SP]and[SP]trust[SP]in[SP]the[SP]In[SP]Lak'ech.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Ça doit être clarifié, ou l'homme continuera\nà faire des erreurs stupides.[1205][U+000F] Calmons-nous\ntous...[1205][U+000F] et faisons confiance à l'In Lak'ech."
-  },
-  {
-    "id": 196,
-    "offset": 455588,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]The[SP]Last[SP]Battalion's[SP]invasion[SP]is[SP]a\nserious[SP]problem,[SP]but[SP]even[SP]more[SP]serious[SP]is[SP]the\nIn[SP]Lak'ech!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] L'invasion du Bataillon est un\ngrave problème, mais l'In Lak'ech est\nencore plus sérieux !"
-  },
-  {
-    "id": 197,
-    "offset": 455858,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "If[SP]it[SP]speaks[SP]truly,[SP]the[SP]world[SP]will[SP]face[SP]utter\ndestruction[SP]soon.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "S'il dit vrai, le monde fera face à\nune destruction totale bientôt."
-  },
-  {
-    "id": 198,
-    "offset": 456048,
-    "data_size": 336,
-    "slot_size": 340,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "If[SP]that[SP]happens,[SP]what[SP]will[SP]become[SP]of[SP]my[SP]dream!?[1205][U+000F]\nHow[SP]will[SP]I[SP]make[SP]it[SP]into[SP]the[SP]best[SP]university[SP]in\nthe[SP]country[SP]if[SP]the[SP]country[SP]is[SP]destroyed!?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Si ça arrive, que deviendra mon rêve !?[1205][U+000F]\nComment intégrer la meilleure université\ndu pays si le pays est détruit !?"
-  },
-  {
-    "id": 199,
-    "offset": 456388,
-    "data_size": 322,
-    "slot_size": 326,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+0008][SP]What[SP]should[SP]I[SP]do?[1205][U+000A][SP]A[SP]city[SP]soaring[SP]in\nthe[SP]sky[SP]is[SP]the[SP]epitome[SP]of[SP]absurdity![1205][U+000A][SP]Worse,\nthere[SP]are[SP]no[SP]colleges[SP]in[SP]Sumaru[SP]City!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+0008] Que dois-je faire ?[1205][U+000A] Une ville dans\nle ciel, c'est le comble de l'absurdité ![1205][U+000A] Pire,\nil n'y a pas de facultés à Sumaru !"
-  },
-  {
-    "id": 200,
-    "offset": 456714,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hrrrgh...[1205][U+000A][SP]If[SP]the[SP]world[SP]does[SP]end,[SP]what[SP]was[SP]all\nmy[SP]hard[SP]work[SP]for...?[1205][U+000F][SP]It[SP]pains[SP]my[SP]heart[SP]to[SP]even\nthink[SP]about[SP]it!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hrrrgh...[1205][U+000A] Si le monde s'arrête, à quoi tout ce\ntravail aura-t-il servi... ?[1205][U+000F] Rien que\nd'y penser, ça me brise le cœur !"
-  },
-  {
-    "id": 201,
-    "offset": 457002,
-    "data_size": 350,
-    "slot_size": 354,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+0008][SP]Making[SP]it[SP]into[SP]a[SP]top[SP]college,[SP]working\nfor[SP]the[SP]best[SP]company...[1205][U+000A][SP]This[SP]has[SP]been[SP]my[SP]dream\nfor[SP]31[SP]years...[1205][U+000F][SP]Now[SP]neither[SP]will[SP]come[SP]true...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+0008] Entrer dans une grande faculté, bosser\npour la meilleure boîte...[1205][U+000A] C'est mon rêve\ndepuis 31 ans...[1205][U+000F] Aucun ne se réalisera..."
-  },
-  {
-    "id": 202,
-    "offset": 457356,
-    "data_size": 656,
-    "slot_size": 660,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "At[SP]the[SP]very[SP]least,[SP]I'll[SP]witness[SP]the[SP]end[SP]of\nMother[SP]Earth,[SP]since[SP]my[SP]life[SP]will[SP]be[SP]spared.[1205][U+000F]\nShould[SP]auld[SP]acquaintance[SP]be[SP]forgot...[1205][U+000A][SP]*sniff*[E1][E2]\n[E3][E4][NULL][NULL]\"Fighting[SP]washout[SP]student\nHyaaaah![1205][U+0008][SP]I[SP]hear[SP]tell[SP]that[SP]when[SP]the[SP]Grand[SP]Cross\nis[SP]complete,[SP]a[SP]black[SP]hole[SP]will[SP]form[SP]at[SP]its\ncenter[SP]and[SP]swallow[SP]this[SP]planet[SP]whole.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Au moins, je verrai la fin de notre\nTerre, puisque ma vie sera épargnée.[1205][U+000F]\nFaut-il oublier les vieilles connaissances...[1205][U+000A]\n*sniff*[E1][E2]\n[E3][E4][NULL][NULL]\"Étudiant\nHyaaaah ![1205][U+0008] J'entends dire que quand la Croix\nCosmique sera terminée, un trou noir va se\nformer au centre et engloutir cette planète."
-  },
-  {
-    "id": 203,
-    "offset": 458016,
-    "data_size": 226,
-    "slot_size": 230,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "But[SP]if[SP]that[SP]were[SP]to[SP]happen,[SP]then[SP]we[SP]won't[SP]be\nsafe,[SP]either.[1205][U+000A][SP]It[SP]sounds[SP]like[SP]a[SP]hoax.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Mais si ça arrivait, alors nous ne\nserions pas non plus en sécurité.[1205][U+000A]\nÇa ressemble à un canular."
-  },
-  {
-    "id": 204,
-    "offset": 458246,
-    "data_size": 320,
-    "slot_size": 324,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+0008][SP]I[SP]doubt[SP]any[SP]severe[SP]natural[SP]disaster\nbut[SP]this[SP]one[SP]could[SP]happen![1205][U+000A][SP]It[SP]seems[SP]that[SP]the\nEarth's[SP]rotation[SP]will[SP]suddenly[SP]halt.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+0008] Je doute qu'une autre catastrophe\nnaturelle puisse se produire ![1205][U+000A] Il semble\nque la Terre va soudainement s'arrêter."
-  },
-  {
-    "id": 205,
-    "offset": 458570,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Such[SP]is[SP]the[SP]effect[SP]of[SP]the[SP]Grand[SP]Cross.[1205][U+000A]\nNo[SP]one[SP]can[SP]defy[SP]the[SP]will[SP]of[SP]space...[1205][U+000F]\nA[SP]sad[SP]thought[SP]indeed.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Tel est l'effet de la Croix Cosmique.[1205][U+000A]\nPersonne ne défie la volonté de\nl'espace...[1205][U+000F] Triste pensée, en effet."
-  },
-  {
-    "id": 206,
-    "offset": 458836,
-    "data_size": 326,
-    "slot_size": 330,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+0008][SP]What[SP]strange[SP]news![SP]It[SP]seems[SP]there[SP]are\nflowers[SP]in[SP]Aoba[SP]Park[SP]who[SP]talk.[SP]Perhaps[SP]the\nmystery[SP]of[SP]the[SP]plants[SP]will[SP]be[SP]revealed...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+0008] Quelle étrange nouvelle ! Il\nsemble y avoir des fleurs au parc Aoba qui\nparlent. Peut-être que le mystère sera révélé..."
-  },
-  {
-    "id": 207,
-    "offset": 459166,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "It[SP]must[SP]be[SP]a[SP]sign[SP]from[SP]God,[SP]pointing[SP]me[SP]to\nthe[SP]way[SP]to[SP]win[SP]the[SP]Nobel[SP]Peace[SP]Prize![1205][0014]\n...Or[SP]so[SP]I[SP]thought,[SP]but[SP]I'm[SP]no[SP]scientist.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Ce doit être un signe de Dieu, m'indiquant\nle chemin du prix Nobel de la paix ![1205][0014]\n...Ou c'est ce que je croyais. Je suis pas scientifique."
-  },
-  {
-    "id": 208,
-    "offset": 459478,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+0008][SP]Did[SP]you[SP]hear?[SP]Club[SP]Zodiac's[SP]second\nfloor[SP]is[SP]undergoing[SP]extensive[SP]remodeling![1205][U+000A]\nIt's[SP]now[SP]an[SP]item-filled[SP]labyrinth.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+0008] Tu as entendu ? Le deuxième\nétage du club Zodiac est en rénovation ![1205][U+000A]\nC'est maintenant un labyrinthe rempli d'objets."
-  },
-  {
-    "id": 209,
-    "offset": 459790,
-    "data_size": 324,
-    "slot_size": 328,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hmm,[SP]this[SP]ordeal[SP]must[SP]have[SP]been[SP]made[SP]for[SP]me...[1205][U+000A]\nBut[SP]I'm[SP]too[SP]busy[SP]with[SP]my[SP]studies.[SP]I[SP]will[SP]be\ngenerous[SP]and[SP]allow[SP]you[SP]to[SP]challenge[SP]it!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hmm, cette épreuve a sûrement été faite pour moi...[1205][U+000A]\nMais je suis trop pris par mes études. Je serai\ngénéreux et te permettrai de la relever !"
-  },
-  {
-    "id": 210,
-    "offset": 460118,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]even[SP]the[SP]ghost[SP]Hanako[SP]is[SP]appearing\nat[SP]Sevens!?[SP]What[SP]an[SP]ill-fated[SP]institution.\nI[SP]pity[SP]its[SP]students.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Même le fantôme Hanako apparaît\nà Seven !? Quelle institution\nmaudite. J'ai pitié de ses étudiants."
-  },
-  {
-    "id": 211,
-    "offset": 460406,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]This[SP]is[SP]serious[SP]indeed![SP]It[SP]seems[SP]the\nghost[SP]of[SP]Bukimi[SP]is[SP]haunting[SP]my[SP]beloved[SP]alma\nmater,[SP]Kasugayama[SP]High!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] C'est vraiment sérieux ! Il\nsemble que le fantôme de Bukimi hante\nmon école adorée, le lycée Kasugayama !"
-  },
-  {
-    "id": 212,
-    "offset": 460700,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Ahh,[SP]but[SP]fear[SP]not,[SP]my[SP]fellow[SP]students...\nAs[SP]a[SP]Kasugayama[SP]graduate,[SP]I[SP]shall[SP]dispose[SP]of\nthis[SP]Bukimi![1205][U+000F][SP]Eventually...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Ahh, mais ne craignez rien, mes amis...\nEn tant qu'ancien de Kasugayama, je me\ndébarrasserai de Bukimi ![1205][U+000F] Éventuellement..."
-  },
-  {
-    "id": 213,
-    "offset": 460992,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![SP]It[SP]seems[SP]the[SP]ghost[SP]of[SP]a[SP]former[SP]idol\nis[SP]haunting[SP]Aoba[SP]Park...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! Il semble que le fantôme d'une\nancienne idole hante le parc Aoba..."
-  },
-  {
-    "id": 214,
-    "offset": 461194,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "A[SP]pity,[SP]truly[SP]it[SP]is,[SP]but[SP]such[SP]is[SP]the[SP]fate[SP]of\nmany[SP]who[SP]are[SP]tempted[SP]by[SP]showbiz.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "C'est dommage, vraiment, mais c'est le\ndestin de beaucoup de gens tentés\npar le show-biz."
-  },
-  {
-    "id": 215,
-    "offset": 461412,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Apparently,[SP]a[SP]monster[SP]known[SP]as[SP]a\nCursed[SP]Taxi[SP]is[SP]menacing[SP]the[SP]abandoned[SP]factory.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Apparemment, un monstre connu sous le\nnom de Taxi Maudit menace l'usine abandonnée."
-  },
-  {
-    "id": 216,
-    "offset": 461656,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Normally,[SP]I[SP]wouldn't[SP]suffer[SP]such[SP]a[SP]monster[SP]to\nlive,[SP]but[SP]I'm[SP]rather[SP]busy[SP]today.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Normalement, je ne laisserais pas vivre un\ntel monstre, mais je suis\noccupé aujourd'hui."
-  },
-  {
-    "id": 217,
-    "offset": 461876,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Dear[SP]me...[SP]So[SP]it[SP]was[SP]a[SP]Cursed[SP]Escort,\nand[SP]not[SP]a[SP]Cursed[SP]Taxi,[SP]that[SP]made[SP]the[SP]abandoned\nfactory[SP]its[SP]home...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Mon Dieu... C'était donc une Escorte\nMaudite, et non un Taxi Maudit, qui a élu domicile\nà l'usine abandonnée..."
-  },
-  {
-    "id": 218,
-    "offset": 462170,
-    "data_size": 146,
-    "slot_size": 150,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Er,[SP]what[SP]is[SP]the[SP]difference[SP]between[SP]the[SP]two?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Euh, quelle est la différence entre les deux ?"
-  },
-  {
-    "id": 219,
-    "offset": 462320,
-    "data_size": 150,
-    "slot_size": 154,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]Kuchisake-onna[SP]is[SP]at[SP]Mt.[SP]Iwato?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Kuchisake-onna est au Mt Iwato ?"
-  },
-  {
-    "id": 220,
-    "offset": 462474,
-    "data_size": 334,
-    "slot_size": 338,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "I've[SP]had[SP]my[SP]share[SP]of[SP]run-ins[SP]with[SP]urban[SP]legends\nlike[SP]her[SP]in[SP]my[SP]youth.[SP]She[SP]was[SP]said[SP]to[SP]chase\nafter[SP]children[SP]who[SP]didn't[SP]head[SP]straight[SP]home.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "J'ai eu mon lot de problèmes avec des légendes\nurbaines comme elle dans ma jeunesse. Elle chassait\nles enfants qui ne rentraient pas direct à la maison."
-  },
-  {
-    "id": 221,
-    "offset": 462812,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Thinking[SP]back,[SP]such[SP]stories[SP]were[SP]useful[SP]to\nwarn[SP]children[SP]against[SP]unacceptable[SP]behavior...\nI[SP]shall[SP]let[SP]this[SP]Kuchisake-onna[SP]be.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "En y repensant, ces contes étaient utiles pour\nmettre en garde les enfants contre les mauvais\ncomportements... J'ignorerai Kuchisake-onna."
-  },
-  {
-    "id": 222,
-    "offset": 463126,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]An[SP]oddity[SP]by[SP]the[SP]name[SP]of[SP]Jumping\nGeezer[SP]has[SP]been[SP]sighted[SP]at[SP]Mt.[SP]Katatsumuri.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Une bizarrerie nommée Vieux\nSauteur a été aperçue au Mt Katatsumuri."
-  },
-  {
-    "id": 223,
-    "offset": 463364,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Why[SP]would[SP]a[SP]man[SP]in[SP]his[SP]nineties[SP]be[SP]jumping\naround...?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Pourquoi un homme de quatre-vingt-dix ans\nsauterait-il partout... ?"
-  },
-  {
-    "id": 224,
-    "offset": 463534,
-    "data_size": 330,
-    "slot_size": 334,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "H-Hyaa...aaah...[1205][U+000F][SP]Oh,[SP]who[SP]am[SP]I[SP]kidding?[1205][U+000F][SP]I'm[SP]so\nfrightened,[SP]my[SP]legs[SP]won't[SP]stop[SP]shaking.[1205][U+000F]\nK-Kudan...[SP]It's[SP]at[SP]the[SP]abandoned[SP]factory...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "H-Hyaa...aaah...[1205][U+000F] Oh, à qui je veux faire\ncroire ça ?[1205][U+000F] J'ai tellement peur que mes jambes\nne s'arrêtent pas de trembler.[1205][U+000F] Kudan... À l'usine..."
-  },
-  {
-    "id": 225,
-    "offset": 463868,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]How[SP]dare[SP]a[SP]merchant[SP]hide[SP]his[SP]own\nmerchandise!?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Comment un marchand ose-t-il\ncacher sa propre marchandise !?"
-  },
-  {
-    "id": 226,
-    "offset": 464046,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "And[SP]a[SP]secret[SP]CD,[SP]no[SP]less!?[SP]What[SP]is[SP]the\nproprietor[SP]of[SP]Giga[SP]Macho[SP]thinking?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Et un CD secret, en plus !? À quoi\npense le propriétaire de Giga Macho ?"
-  },
-  {
-    "id": 227,
-    "offset": 464256,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]It[SP]seems[SP]there's[SP]a[SP]creature[SP]known[SP]as\na[SP]Dresser[SP]Hag[SP]at[SP]the[SP]abandoned[SP]factory.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Il semble qu'il y ait une créature\nconnue sous le nom de Mégère à Commode à l'usine."
-  },
-  {
-    "id": 228,
-    "offset": 464494,
-    "data_size": 250,
-    "slot_size": 254,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "That[SP]place[SP]has[SP]spawned[SP]so[SP]many[SP]rumors.[1205][U+000F]\nThey[SP]should[SP]do[SP]what[SP]needs[SP]doing[SP]and[SP]condemn\nthe[SP]place.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Cet endroit a engendré tellement de rumeurs.[1205][U+000F]\nIls devraient faire ce qu'il faut et condamner\ncet endroit."
-  },
-  {
-    "id": 229,
-    "offset": 464748,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Selling[SP]weapons[SP]at[SP]an[SP]antique[SP]shop...[1205][U+000F]\nTime[SP]Castle's[SP]owner[SP]is[SP]no[SP]ordinary[SP]man.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Vendre des armes chez un antiquaire...[1205][U+000F]\nLe propriétaire de Time Castle est audacieux."
-  },
-  {
-    "id": 230,
-    "offset": 464992,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "The[SP]quality[SP]and[SP]price[SP]of[SP]his[SP]goods[SP]seems[SP]to\nbe[SP]average,[SP]though.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "La qualité et le prix de ses biens semblent\ncependant être dans la moyenne."
-  },
-  {
-    "id": 231,
-    "offset": 465182,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Selling[SP]weapons[SP]at[SP]an[SP]antique[SP]shop...[1205][U+000F]\nTime[SP]Castle's[SP]owner[SP]is[SP]no[SP]ordinary[SP]man.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Vendre des armes chez un antiquaire...[1205][U+000F]\nLe propriétaire de Time Castle est audacieux."
-  },
-  {
-    "id": 232,
-    "offset": 465426,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "The[SP]quality[SP]of[SP]his[SP]goods[SP]is[SP]superb,[SP]but[SP]his\nprices[SP]are[SP]very[SP]steep.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "La qualité de ses biens est superbe, mais ses\nprix sont très élevés."
-  },
-  {
-    "id": 233,
-    "offset": 465622,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Selling[SP]weapons[SP]at[SP]an[SP]antique[SP]shop...[1205][U+000F]\nTime[SP]Castle's[SP]owner[SP]is[SP]no[SP]ordinary[SP]man.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Vendre des armes chez un antiquaire...[1205][U+000F]\nLe propriétaire de Time Castle est audacieux."
-  },
-  {
-    "id": 234,
-    "offset": 465866,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "I[SP]hear[SP]tell[SP]that[SP]the[SP]price[SP]is[SP]right,[SP]but[SP]the\nquality[SP]is[SP]shoddy.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "On m'a dit que le prix est correct, mais\nque la qualité laisse à désirer."
-  },
-  {
-    "id": 235,
-    "offset": 466056,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street\nvendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in\nreal[SP]weapons.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes."
-  },
-  {
-    "id": 236,
-    "offset": 466318,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "I[SP]hear[SP]that[SP]his[SP]selection[SP]is[SP]quite[SP]varied,\nbut[SP]his[SP]buyback[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "On m'a dit que son choix est très varié,\nmais que ses prix de rachat sont bas."
-  },
-  {
-    "id": 237,
-    "offset": 466530,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street\nvendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in\nreal[SP]weapons.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes."
-  },
-  {
-    "id": 238,
-    "offset": 466792,
-    "data_size": 148,
-    "slot_size": 152,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "I[SP]hear[SP]that[SP]they're[SP]cheap,[SP]but[SP]poor[SP]quality.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Moins cher, mais de mauvaise qualité."
-  },
-  {
-    "id": 239,
-    "offset": 466944,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street\nvendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in\nreal[SP]weapons.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes."
-  },
-  {
-    "id": 240,
-    "offset": 467206,
-    "data_size": 196,
-    "slot_size": 200,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "It[SP]appears[SP]that[SP]the[SP]quality[SP]and[SP]price[SP]of[SP]his\ngoods[SP]are[SP]both[SP]average.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Il semble que la qualité et le prix de\nses biens soient tous deux moyens."
-  },
-  {
-    "id": 241,
-    "offset": 467406,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street\nvendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in\nreal[SP]weapons.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes."
-  },
-  {
-    "id": 242,
-    "offset": 467668,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "I[SP]heard[SP]the[SP]quality[SP]is[SP]superb,[SP]but[SP]the[SP]prices\nare[SP]commensurately[SP]high.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "On m'a dit que la qualité était superbe,\nmais que les prix étaient élevés."
-  },
-  {
-    "id": 243,
-    "offset": 467872,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire..."
-  },
-  {
-    "id": 244,
-    "offset": 468150,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Their[SP]selection[SP]seems[SP]to[SP]be[SP]poor,[SP]but[SP]at\nleast[SP]their[SP]buyback[SP]prices[SP]are[SP]good.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Leur choix semble être limité, mais au\nmoins leurs prix de rachat sont bons."
-  },
-  {
-    "id": 245,
-    "offset": 468368,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire..."
-  },
-  {
-    "id": 246,
-    "offset": 468646,
-    "data_size": 152,
-    "slot_size": 156,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Their[SP]goods[SP]are[SP]cheap,[SP]but[SP]lacking[SP]in[SP]quality.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Leurs biens sont bon marché, mais manquent de qualité."
-  },
-  {
-    "id": 247,
-    "offset": 468802,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire..."
-  },
-  {
-    "id": 248,
-    "offset": 469080,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "The[SP]quality[SP]of[SP]their[SP]goods[SP]is[SP]high,[SP]but[SP]it\ncomes[SP]at[SP]a[SP]price.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "La qualité de leurs produits est élevée,\nmais cela a un prix."
-  },
-  {
-    "id": 249,
-    "offset": 469264,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire..."
-  },
-  {
-    "id": 250,
-    "offset": 469542,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "They[SP]seem[SP]to[SP]have[SP]a[SP]wide[SP]selection[SP]of[SP]goods,\nbut[SP]their[SP]buyback[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Ils semblent avoir un grand choix de produits,\nmais leurs prix de rachat sont bas."
-  },
-  {
-    "id": 251,
-    "offset": 469762,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire..."
-  },
-  {
-    "id": 252,
-    "offset": 470040,
-    "data_size": 170,
-    "slot_size": 174,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "The[SP]quality[SP]and[SP]price[SP]of[SP]their[SP]goods[SP]is\nmerely[SP]average.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "La qualité et le prix de leurs produits\nsont tout juste moyens."
-  },
-  {
-    "id": 253,
-    "offset": 470214,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
-  },
-  {
-    "id": 254,
-    "offset": 470500,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "The[SP]quality[SP]and[SP]price[SP]of[SP]their[SP]things[SP]seems\nfairly[SP]average.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "La qualité et le prix de leurs articles\nsemblent plutôt moyens."
-  },
-  {
-    "id": 255,
-    "offset": 470682,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
-  },
-  {
-    "id": 256,
-    "offset": 470968,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Their[SP]goods[SP]are[SP]inexpensive,[SP]but[SP]unfortunately\nlacking[SP]in[SP]quality.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Leurs produits sont bon marché, mais manquent\nmalheureusement de qualité."
-  },
-  {
-    "id": 257,
-    "offset": 471164,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
-  },
-  {
-    "id": 258,
-    "offset": 471450,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Their[SP]selection[SP]is[SP]great,[SP]but[SP]their[SP]buyback\nprices[SP]seem[SP]to[SP]be[SP]low.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Leur choix est excellent, mais leurs prix de\nrachat semblent être bas."
-  },
-  {
-    "id": 259,
-    "offset": 471646,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
-  },
-  {
-    "id": 260,
-    "offset": 471932,
-    "data_size": 210,
-    "slot_size": 214,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Their[SP]selection[SP]is[SP]quite[SP]poor,[SP]but[SP]I[SP]suppose\ntheir[SP]buyback[SP]prices[SP]are[SP]good.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Leur sélection est assez pauvre, mais je suppose\nque leurs prix de rachat sont bons."
-  },
-  {
-    "id": 261,
-    "offset": 472146,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes."
-  },
-  {
-    "id": 262,
-    "offset": 472432,
-    "data_size": 194,
-    "slot_size": 198,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "The[SP]quality[SP]of[SP]their[SP]goods[SP]is[SP]excellent,\nbut[SP]it's[SP]expensive[SP]indeed.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "La qualité de leurs produits est excellente,\nmais elle est très chère."
-  },
-  {
-    "id": 263,
-    "offset": 472630,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]reminds[SP]me,[SP]I[SP]heard[SP]an[SP]interesting\nrumor[SP]that[SP]Rosa[SP]Candida[SP]sells[SP]armor.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures."
-  },
-  {
-    "id": 264,
-    "offset": 472868,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "I've[SP]heard[SP]lately[SP]that[SP]the[SP]quality[SP]and[SP]price\nof[SP]their[SP]stock[SP]is[SP]average.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "J'ai entendu récemment que la qualité et le prix\nde leur stock sont moyens."
-  },
-  {
-    "id": 265,
-    "offset": 473074,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]reminds[SP]me,[SP]I[SP]heard[SP]an[SP]interesting\nrumor[SP]that[SP]Rosa[SP]Candida[SP]sells[SP]armor.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures."
-  },
-  {
-    "id": 266,
-    "offset": 473312,
-    "data_size": 190,
-    "slot_size": 194,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "I've[SP]heard[SP]lately[SP]that[SP]their[SP]goods[SP]are[SP]cheap,\nbut[SP]low[SP]in[SP]quality.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "J'ai entendu récemment que leurs biens sont\nbon marché, mais de piètre qualité."
-  },
-  {
-    "id": 267,
-    "offset": 473506,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]reminds[SP]me,[SP]I[SP]heard[SP]an[SP]interesting\nrumor[SP]that[SP]Rosa[SP]Candida[SP]sells[SP]armor.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures."
-  },
-  {
-    "id": 268,
-    "offset": 473744,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "I've[SP]heard[SP]lately[SP]that[SP]the[SP]quality[SP]of[SP]their\nstock[SP]is[SP]high,[SP]but[SP]it's[SP]expensive.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "J'ai entendu récemment que la qualité de leur\nstock est élevée, mais que c'est cher."
-  },
-  {
-    "id": 269,
-    "offset": 473964,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi\nsells[SP]armor!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Donc il est VRAI qu'Anima Mundi\nvend des armures !"
-  },
-  {
-    "id": 270,
-    "offset": 474136,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "I[SP]hear[SP]that[SP]their[SP]quality[SP]and[SP]prices[SP]are\nentirely[SP]average,[SP]though.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "J'entends dire que leur qualité et leurs prix\nsont dans la moyenne, cela dit."
-  },
-  {
-    "id": 271,
-    "offset": 474332,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi\nsells[SP]armor!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Donc il est VRAI qu'Anima Mundi\nvend des armures !"
-  },
-  {
-    "id": 272,
-    "offset": 474504,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "I[SP]hear[SP]that[SP]their[SP]goods[SP]are[SP]cheap,[SP]but[SP]the\nquality[SP]suffers.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Leur matos est pas cher,\nmais de mauvaise qualité."
-  },
-  {
-    "id": 273,
-    "offset": 474686,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi\nsells[SP]armor!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Donc il est VRAI qu'Anima Mundi\nvend des armures !"
-  },
-  {
-    "id": 274,
-    "offset": 474858,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "I[SP]hear[SP]that[SP]their[SP]selection[SP]is[SP]a[SP]fine[SP]one,\nbut[SP]their[SP]buyback[SP]prices[SP]are[SP]cheap.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "J'entends dire que leur sélection est belle,\nmais que leurs prix de rachat sont bas."
-  },
-  {
-    "id": 275,
-    "offset": 475078,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi\nsells[SP]armor!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Donc il est VRAI qu'Anima Mundi\nvend des armures !"
-  },
-  {
-    "id": 276,
-    "offset": 475250,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "It[SP]seems[SP]that[SP]their[SP]quality[SP]is[SP]high[SP]indeed,\nbut[SP]few[SP]can[SP]afford[SP]it.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Leur qualité semble élevée en effet,\nmais peu peuvent se le permettre."
-  },
-  {
-    "id": 277,
-    "offset": 475446,
-    "data_size": 322,
-    "slot_size": 326,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters\nare[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]selection\nis[SP]bad,[SP]but[SP]the[SP]buyback[SP]price[SP]is[SP]good.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leur choix\nest pauvre, mais le prix de rachat est bon."
-  },
-  {
-    "id": 278,
-    "offset": 475772,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters\nare[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]quality[SP]and\nprices[SP]are[SP]average.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leur qualité et\nleurs prix sont moyens."
-  },
-  {
-    "id": 279,
-    "offset": 476064,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters\nare[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]merchandise\nis[SP]good,[SP]but[SP]expensive.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leurs marchandises\nsont bonnes, mais chères."
-  },
-  {
-    "id": 280,
-    "offset": 476364,
-    "data_size": 316,
-    "slot_size": 320,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters\nare[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]merchandise\nis[SP]cheap,[SP]but[SP]lacking[SP]in[SP]quality.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs\nsont des marchandes hors pair... Leurs biens\nsont bon marché, mais manquent de qualité."
-  },
-  {
-    "id": 281,
-    "offset": 476684,
-    "data_size": 328,
-    "slot_size": 332,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters\nare[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]selection\nis[SP]good,[SP]but[SP]the[SP]buyback[SP]price[SP]is[SP]dismal.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leur choix\nest bon, mais le prix de rachat est lamentable."
-  },
-  {
-    "id": 282,
-    "offset": 477016,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier."
-  },
-  {
-    "id": 283,
-    "offset": 477298,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "They[SP]seem[SP]to[SP]have[SP]an[SP]impressive[SP]selection,\nbut[SP]their[SP]buyback[SP]prices[SP]are[SP]cheap.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Ils semblent avoir un choix impressionnant,\nmais leurs prix de rachat sont bas."
-  },
-  {
-    "id": 284,
-    "offset": 477518,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier."
-  },
-  {
-    "id": 285,
-    "offset": 477800,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Their[SP]prices[SP]are[SP]cheap,[SP]but[SP]their[SP]goods[SP]are\nlow[SP]in[SP]quality.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Leurs prix sont bas, mais leurs biens sont\nde mauvaise qualité."
-  },
-  {
-    "id": 286,
-    "offset": 477982,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier."
-  },
-  {
-    "id": 287,
-    "offset": 478264,
-    "data_size": 194,
-    "slot_size": 198,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "The[SP]quality[SP]of[SP]their[SP]goods[SP]is[SP]first-rate,\nbut[SP]it's[SP]quite[SP]expensive.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "La qualité de leurs biens est de premier ordre,\nmais c'est assez cher."
-  },
-  {
-    "id": 288,
-    "offset": 478462,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier."
-  },
-  {
-    "id": 289,
-    "offset": 478744,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Their[SP]quality[SP]and[SP]prices[SP]are[SP]just[SP]average.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Leur qualité et leurs prix sont tout à fait moyens."
-  },
-  {
-    "id": 290,
-    "offset": 478892,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier."
-  },
-  {
-    "id": 291,
-    "offset": 479174,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Their[SP]selection[SP]is[SP]poor,[SP]but[SP]the[SP]buyback[SP]prices\nthey[SP]offer[SP]are[SP]generous.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Leur sélection est pauvre, mais les prix\nde rachat qu'ils offrent sont généreux."
-  },
-  {
-    "id": 292,
-    "offset": 479382,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Is[SP]it[SP]true[SP]one[SP]may[SP]win[SP]real[SP]weapons\nin[SP]a[SP]magazine[SP]sweepstakes?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?"
-  },
-  {
-    "id": 293,
-    "offset": 479592,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "It's[SP]not[SP]easy[SP]to[SP]win,[SP]but[SP]you'll[SP]get[SP]some[SP]nice\nitems[SP]for[SP]your[SP]trouble.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Il n'est pas facile de gagner, mais on reçoit\nde beaux objets en récompense."
-  },
-  {
-    "id": 294,
-    "offset": 479796,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Is[SP]it[SP]true[SP]one[SP]may[SP]win[SP]real[SP]weapons\nin[SP]a[SP]magazine[SP]sweepstakes?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?"
-  },
-  {
-    "id": 295,
-    "offset": 480006,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "People[SP]very[SP]rarely[SP]win,[SP]but[SP]the[SP]prizes[SP]for\nthose[SP]who[SP]do[SP]are[SP]exquisite.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "On gagne très rarement, mais les prix\npour ceux qui y parviennent sont exquis."
-  },
-  {
-    "id": 296,
-    "offset": 480210,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Is[SP]it[SP]true[SP]one[SP]may[SP]win[SP]real[SP]weapons\nin[SP]a[SP]magazine[SP]sweepstakes?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?"
-  },
-  {
-    "id": 297,
-    "offset": 480420,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "It's[SP]not[SP]hard[SP]to[SP]win[SP]one,[SP]but[SP]if[SP]you[SP]do,[SP]you[SP]may\nwonder[SP]why[SP]you[SP]bothered.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Il n'est pas difficile de gagner, mais on peut\nse demander pourquoi on a pris la peine."
-  },
-  {
-    "id": 298,
-    "offset": 480630,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]am[SP]a[SP]mere[SP]student[SP]striving[SP]to[SP]make\nit[SP]into[SP]the[SP]country's[SP]best[SP]college.[SP]I[SP]have[SP]no\ntime[SP]to[SP]fritter[SP]away[SP]on[SP]gambling!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent !"
-  },
-  {
-    "id": 299,
-    "offset": 480948,
-    "data_size": 326,
-    "slot_size": 330,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "...Still,[SP]it[SP]doesn't[SP]pay[SP]to[SP]neglect[SP]the[SP]real\nworld.[SP]I[SP]hear[SP]that[SP]one[SP]can[SP]win[SP]big[SP]on[SP]the[SP]#5\npoker[SP]machine...[1205][U+000F][SP]It[SP]wouldn't[SP]hurt[SP]to[SP]try.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "...Cependant, il ne faut pas négliger le monde réel.\nJ'entends qu'on peut gagner gros à la\nmachine #5...[1205][U+000F] Ça ne ferait pas de mal d'essayer."
-  },
-  {
-    "id": 300,
-    "offset": 481278,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]am[SP]a[SP]mere[SP]student[SP]striving[SP]to[SP]make\nit[SP]into[SP]the[SP]country's[SP]best[SP]college.[SP]I[SP]have[SP]no\ntime[SP]to[SP]fritter[SP]away[SP]on[SP]gambling!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent !"
-  },
-  {
-    "id": 301,
-    "offset": 481596,
-    "data_size": 326,
-    "slot_size": 330,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "...Still,[SP]it[SP]doesn't[SP]pay[SP]to[SP]neglect[SP]the[SP]real\nworld.[SP]I[SP]hear[SP]that[SP]one[SP]can[SP]win[SP]big[SP]on[SP]the[SP]#1\nslots[SP]machine...[1205][U+000F][SP]It[SP]wouldn't[SP]hurt[SP]to[SP]try.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "...Cependant, il ne faut pas négliger le monde réel.\nJ'entends qu'on peut gagner gros à la\nmachine #1...[1205][U+000F] Ça ne ferait pas de mal d'essayer."
-  },
-  {
-    "id": 302,
-    "offset": 481926,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]am[SP]a[SP]mere[SP]student[SP]striving[SP]to[SP]make\nit[SP]into[SP]the[SP]country's[SP]best[SP]college.[SP]I[SP]have[SP]no\ntime[SP]to[SP]fritter[SP]away[SP]on[SP]gambling!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent !"
-  },
-  {
-    "id": 303,
-    "offset": 482244,
-    "data_size": 318,
-    "slot_size": 322,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "But[SP]blackjack[SP]is[SP]an[SP]exception.[SP]I[SP]don't[SP]enjoy\nit,[SP]not[SP]really,[SP]but[SP]I[SP]hear[SP]you[SP]can[SP]win[SP]big[SP]at\nit.[SP]My[SP]studies[SP]aren't[SP]free,[SP]after[SP]all!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Mais le blackjack est une exception. Je n'aime pas ça,\npas vraiment, mais il paraît qu'on peut y gagner\ngros. Mes études ne sont pas gratuites !"
-  },
-  {
-    "id": 304,
-    "offset": 482566,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]A[SP]legendary[SP]weapon...[SP]They[SP]have[SP]such\na[SP]thing[SP]at[SP]Shiraishi[SP]Ramen...[SP]I'd[SP]like[SP]to[SP]see\nit[SP]for[SP]myself,[SP]just[SP]once.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Une arme légendaire... Ils ont ça\nchez Shiraishi Ramen... J'aimerais la voir\nde mes propres yeux, juste une fois."
-  },
-  {
-    "id": 305,
-    "offset": 482868,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]Is[SP]there[SP]really[SP]a[SP]legendary[SP]weapon\nin[SP]stock[SP]at[SP]Clair[SP]de[SP]Lune?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Y a-t-il vraiment une arme légendaire\nen stock chez Clair de Lune ?"
-  },
-  {
-    "id": 306,
-    "offset": 483076,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Bah![SP]The[SP]weapons[SP]of[SP]a[SP]student[SP]are[SP]pens[SP]and\nbooks![SP]This[SP]doesn't[SP]concern[SP]me.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Bah ! Les armes d'un étudiant sont les stylos\net les livres ! Cela ne me concerne pas."
-  },
-  {
-    "id": 307,
-    "offset": 483288,
-    "data_size": 322,
-    "slot_size": 326,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]owner[SP]at[SP]Time[SP]Castle...[SP]Claiming\nnot[SP]to[SP]have[SP]what[SP]he[SP]in[SP]fact[SP]does,[SP]in[SP]a[SP]bid[SP]to\ndrive[SP]up[SP]its[SP]price,[SP]is[SP]unforgivable.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Ce propriétaire de Time Castle... Prétendre\nne pas avoir ce qu'il a en fait, dans le but\nde faire monter son prix, est impardonnable."
-  },
-  {
-    "id": 308,
-    "offset": 483614,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "But[SP]does[SP]Time[SP]Castle[SP]really[SP]have[SP]a[SP]legendary\nweapon[SP]to[SP]begin[SP]with?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Mais Time Castle a-t-il vraiment une arme\nlégendaire, pour commencer ?"
-  },
-  {
-    "id": 309,
-    "offset": 483810,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]A[SP]merchant[SP]should[SP]meet[SP]the[SP]needs[SP]of\nhis[SP]customers[SP]even[SP]at[SP]the[SP]risk[SP]of[SP]his[SP]own[SP]life!\nYet[SP]that[SP]owner[SP]at[SP]Time[SP]Castle...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Un marchand doit répondre aux besoins\nde ses clients au péril de sa vie !\nPourtant ce propriétaire..."
-  },
-  {
-    "id": 310,
-    "offset": 484128,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "He[SP]has[SP]yet[SP]to[SP]claim[SP]his[SP]legendary[SP]weapon.\nEven[SP]now,[SP]the[SP]seller[SP]waits[SP]at[SP]the[SP]abandoned\nfactory[SP]for[SP]the[SP]owner[SP]to[SP]come.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Il n'a pas encore réclamé son arme légendaire.\nMême maintenant, le vendeur attend à l'usine\nabandonnée que le propriétaire vienne."
-  },
-  {
-    "id": 311,
-    "offset": 484424,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "But[SP]he's[SP]too[SP]afraid[SP]of[SP]monsters[SP]to[SP]venture\nout![SP]How[SP]utterly[SP]pathetic![SP]I[SP]wish[SP]someone[SP]else\nwould[SP]go[SP]buy[SP]the[SP]weapon[SP]in[SP]his[SP]stead.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Mais il a trop peur des monstres pour sortir !\nC'est pitoyable ! J'aimerais que quelqu'un d'autre\naille acheter l'arme à sa place."
-  },
-  {
-    "id": 312,
-    "offset": 484742,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "The[SP]legendary[SP]weapon[SP]belonging[SP]to[SP]Time[SP]Castle\nwas[SP]stolen[SP]by[SP]a[SP]demon.[SP]But[SP]is[SP]it[SP]possible[SP]that\nthe[SP]owner[SP]is[SP]lying?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "L'arme légendaire de Time Castle a été volée par un\ndémon. Mais est-il possible que le propriétaire mente ?"
-  },
-  {
-    "id": 313,
-    "offset": 485030,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Honestly,[SP]do[SP]demons[SP]actually[SP]exist?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Honnêtement, les démons existent-ils vraiment ?"
-  },
-  {
-    "id": 314,
-    "offset": 485164,
-    "data_size": 300,
-    "slot_size": 304,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]It[SP]seems[SP]the[SP]legendary[SP]weapon[SP]at\nTime[SP]Castle[SP]has[SP]been[SP]sold![SP]I[SP]hear[SP]that[SP]an\nunusually[SP]unlucky[SP]woman[SP]bought[SP]it.",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] L'arme légendaire de\nTime Castle a été vendue ! J'entends qu'une femme\nparticulièrement malchanceuse l'a achetée."
-  },
-  {
-    "id": 315,
-    "offset": 485468,
-    "data_size": 320,
-    "slot_size": 324,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hrghhh...[SP]What[SP]cheek![SP]What[SP]if[SP]she[SP]were[SP]to[SP]use\nit[SP]to[SP]end[SP]her[SP]life!?[SP]If[SP]only[SP]he'd[SP]entrusted[SP]it\nto[SP]me,[SP]I'd[SP]have[SP]put[SP]it[SP]to[SP]good[SP]use...",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hrghhh... Quel culot ! Et si elle l'utilisait pour\nmettre fin à ses jours !? S'il me l'avait\nconfiée, j'en aurais fait bon usage..."
-  },
-  {
-    "id": 316,
-    "offset": 485792,
-    "data_size": 332,
-    "slot_size": 336,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]dastardly[SP]owner[SP]of[SP]Time[SP]Castle!\nHe[SP]gave[SP]the[SP]legendary[SP]weapon[SP]to[SP]a[SP]woman[SP]with\nshort[SP]hair![SP]How[SP]dare[SP]he[SP]become[SP]so[SP]smitten!?",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Ce lâche propriétaire de Time Castle !\nIl a donné l'arme légendaire à une femme\naux cheveux courts ! Comment a-t-il pu !?"
-  },
-  {
-    "id": 317,
-    "offset": 486128,
-    "data_size": 250,
-    "slot_size": 254,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Fighting[SP]washout[SP]student",
-    "texte_orig": "Eh?[SP]What[SP]kind[SP]of[SP]woman[SP]was[SP]she?[SP]B-Beautiful,[SP]I\nsuppose...[1205][U+000F][SP]N-Not[SP]that[SP]I'm[SP]envious,[SP]not[SP]at[SP]all!",
-    "nom_fr": "Étudiant",
-    "texte_fr": "Eh ? Quel genre de femme était-ce ? B-Belle, je\nsuppose...[1205][U+000F] J-Je ne suis pas envieux, pas du tout !"
-  },
-  {
-    "id": 318,
-    "offset": 486382,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Masked[SP]Circle[SP]member",
-    "texte_orig": "Many[SP]of[SP]my[SP]comrades[SP]are[SP]complaining,[SP]but[SP]I\nintend[SP]to[SP]follow[SP]Joker's[SP]orders![1205][U+000F][SP]This[SP]is[SP]our\ncity,[SP]after[SP]all!",
-    "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Beaucoup de camarades se plaignent,\nmais j'obéirai au Joker ![1205][U+000F] C'est\nnotre ville, après tout !"
-  },
-  {
-    "id": 319,
-    "offset": 486650,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Last[SP]Battalion[SP]soldier",
-    "texte_orig": "Our[SP]Fuhrer[SP]has[SP]already[SP]reached[SP]his[SP]destination.[1205][U+000F]\nAll[SP]nearby[SP]civilians[SP]must[SP]surrender[SP]immediately.",
-    "nom_fr": "Bataillon",
-    "texte_fr": "Notre Führer a atteint sa destination.[1205][U+000F]\nLes civils à proximité doivent se rendre."
-  },
-  {
-    "id": 320,
-    "offset": 486906,
-    "data_size": 196,
-    "slot_size": 200,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "This[SP]is[SP]Kasugayama[SP]High,[SP]the[SP]great[SP]Michel's\nschool![SP]We're[SP]gonna[SP]have[SP]a[SP]festival[SP]soon.",
-    "nom_fr": "Eikichi",
-    "texte_fr": "C'est le lycée Kasu, l'école du grand\nMichel ! On aura bientôt un festival."
-  },
-  {
-    "id": 321,
-    "offset": 487106,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "The[SP]guys[SP]here[SP]hate[SP]Sevens[SP]because[SP]they're[SP]not\nthe[SP]popular[SP]ones,[SP]right?[SP]How[SP]appropriate[SP]for\nUndie[SP]Boss's[SP]school.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Ils détestent Seven car ce ne sont pas eux\nles plus populaires, hein ? Typique de\nl'école du Boss Calbute."
-  },
-  {
-    "id": 322,
-    "offset": 487354,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Wait[SP]for[SP]me...[SP]I'll[SP]get[SP]you[SP]guys[SP]back[SP]to\nnormal[SP]if[SP]it's[SP]the[SP]last[SP]thing[SP]I[SP]do!",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Attendez... Je vous rendrai normaux,\ncoûte que coûte !"
-  },
-  {
-    "id": 323,
-    "offset": 487536,
-    "data_size": 64,
-    "slot_size": 68,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "C'mon,[SP][1113].[SP]Let's[SP]go!",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Viens [1113], on y va !"
-  },
-  {
-    "id": 324,
-    "offset": 487604,
-    "data_size": 176,
-    "slot_size": 180,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "I[SP]bet[SP]everyone's[SP]waiting[SP]at[SP]the[SP]detective\nagency.[SP]We[SP]should[SP]hurry[SP]back[SP]there!",
-    "nom_fr": "Ginko",
-    "texte_fr": "Tous nous attendent à l'agence de détectives.\nDépêchons-nous !"
-  },
-  {
-    "id": 325,
-    "offset": 487784,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "It's[SP]like[SP]the[SP]school's[SP]dead...[SP]There's[SP]no[SP]one\naround[SP]and[SP]I[SP]don't[SP]hear[SP]any[SP]voices,[SP]either...\nIs[SP]this[SP]really[SP]my[SP]Kasugayama[SP]High?",
-    "nom_fr": "Eikichi",
-    "texte_fr": "C'est comme si l'école était morte... Y a personne\net je n'entends aucune voix, non plus...\nC'est vraiment mon lycée Kasu ?"
-  },
-  {
-    "id": 326,
-    "offset": 488066,
-    "data_size": 108,
-    "slot_size": 112,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Lisa",
-    "texte_orig": "Aiyah...[SP]You[SP]want[SP]to[SP]go[SP]into[SP]Smile[SP]Hirasaka?",
-    "nom_fr": "Lisa",
-    "texte_fr": "Aïe... Tu veux aller à Smile Hirasaka ?"
-  },
-  {
-    "id": 327,
-    "offset": 488178,
-    "data_size": 120,
-    "slot_size": 124,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Lisa",
-    "texte_orig": "Let's[SP]skip[SP]this[SP]hole[SP]and[SP]go[SP]somewhere\nlike[SP]Zodiac!",
-    "nom_fr": "Lisa",
-    "texte_fr": "Zappons ce trou et allons plutôt à Zodiac !"
-  },
-  {
-    "id": 328,
-    "offset": 488302,
-    "data_size": 110,
-    "slot_size": 114,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Aiyah...[SP]You[SP]want[SP]to[SP]go[SP]into[SP]Smile[SP]Hirasaka?",
-    "nom_fr": "Ginko",
-    "texte_fr": "Aïe... Tu veux aller à Smile Hirasaka ?"
-  },
-  {
-    "id": 329,
-    "offset": 488416,
-    "data_size": 122,
-    "slot_size": 126,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Let's[SP]skip[SP]this[SP]hole[SP]and[SP]go[SP]somewhere\nlike[SP]Zodiac!",
-    "nom_fr": "Ginko",
-    "texte_fr": "Zappons ce trou et allons plutôt à Zodiac !"
-  },
-  {
-    "id": 330,
-    "offset": 488542,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Smile[SP]Hirasaka?[SP]You[SP]really[SP]enjoy[SP]detours,\nhuh,[SP][1113]?[SP]Weren't[SP]we[SP]supposed[SP]to[SP]be\ngoing[SP]to[SP]Peace[SP]Diner?",
-    "nom_fr": "Yukino",
-    "texte_fr": "Smile Hirasaka ? Tu aimes les détours,\nhein, [1113] ? On ne devait pas\naller au Peace Diner ?"
-  },
-  {
-    "id": 331,
-    "offset": 488764,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "I[SP]come[SP]here[SP]with[SP]my[SP]friend[SP]a[SP]lot.[SP]Hm?[SP]Who[SP]am\nI[SP]talking[SP]about?[SP]Haha...[SP]I'll[SP]introduce[SP]you\nsometime.",
-    "nom_fr": "Maya",
-    "texte_fr": "Je viens souvent ici avec mon amie. Hm ? De qui\nje parle ? Haha... Je te la présenterai bientôt."
-  },
-  {
-    "id": 332,
-    "offset": 488984,
-    "data_size": 112,
-    "slot_size": 116,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Smile[SP]Hirasaka...[1205][U+000F][SP]Is[SP]this[SP]the[SP]target?\nOr...?",
-    "nom_fr": "Maya",
-    "texte_fr": "Smile Hirasaka...[1205][U+000F] Est-ce la cible ?\nOu... ?"
-  },
-  {
-    "id": 333,
-    "offset": 489100,
-    "data_size": 150,
-    "slot_size": 154,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "We[SP]can't[SP]overthink[SP]this.[1205][U+000F][SP]Let's[SP]just[SP]hurry[SP]up\nand[SP]get[SP]inside.",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Faut pas trop y penser.[1205][U+000F] Dépêchons-nous\nd'entrer."
-  },
-  {
-    "id": 334,
-    "offset": 489254,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4361,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?\n[1208][0002][1432][NULL][NULL][0014]Yeah,[SP]let's[SP]check[SP]it[SP]out.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]No,[SP]this[SP]isn't[SP]the[SP]place.[1432][NULL][NULL][0014]",
-    "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun ?[1205][U+000F] On devrait chercher par ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, jetons un œil.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas le bon endroit.[1432][NULL][NULL][0014]",
-    "question_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?",
-    "choix_orig": [
-      "Yeah,[SP]let's[SP]check[SP]it[SP]out.",
-      "No,[SP]this[SP]isn't[SP]the[SP]place."
-    ],
-    "question_fr": "",
-    "choix_fr": [
-      "",
-      ""
-    ]
-  },
-  {
-    "id": 335,
-    "offset": 489564,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Alright.[SP]If[SP]it's[SP]decided,[SP]then[SP]let's[SP]hurry.\nWe[SP]don't[SP]have[SP]time[SP]to[SP]waste.",
-    "nom_fr": "Yukino",
-    "texte_fr": "Ok. Si c'est décidé, dépêchons-nous.\nOn a peu de temps à perdre."
-  },
-  {
-    "id": 336,
-    "offset": 489736,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Then[SP]we[SP]don't[SP]need[SP]to[SP]be[SP]here.[SP]Let's[SP]hurry\nto[SP]the[SP]Sakanoue[SP]Building.",
-    "nom_fr": "Yukino",
-    "texte_fr": "Alors on n'a rien à faire ici. Vite,\nallons au Bâtiment Sakanoue."
-  },
-  {
-    "id": 337,
-    "offset": 489900,
-    "data_size": 210,
-    "slot_size": 214,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "This[SP]place[SP]is[SP]safe[SP]and[SP]sound.\nQuestion[SP]is,[SP]where's[SP]the[SP]next[SP]target...?\nGOLD[SP]or[SP]Pachinko[SP]Silver?",
-    "nom_fr": "Maya",
-    "texte_fr": "Cet endroit est sain et sauf.\nMais où est la prochaine cible... ?\nGOLD ou Pachinko Silver ?"
-  },
-  {
-    "id": 338,
-    "offset": 490114,
-    "data_size": 164,
-    "slot_size": 168,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "It's[SP]up[SP]to[SP]you,[SP][1113]-kun.[SP]But[SP]we[SP]don't\nhave[SP]much[SP]time,[SP]so[SP]let's[SP]get[SP]moving.",
-    "nom_fr": "Maya",
-    "texte_fr": "C'est à toi de voir, [1113]-kun. Mais on a\npeu de temps, alors en route."
-  },
-  {
-    "id": 339,
-    "offset": 490282,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "How[SP]could[SP]this[SP]happen...?[SP]There[SP]must've[SP]been\nso[SP]many[SP]people[SP]still[SP]inside...[SP]The[SP]flames[SP]are\nswallowing[SP]lives[SP]again...",
-    "nom_fr": "Maya",
-    "texte_fr": "C'est pas vrai... ? Il devait y avoir tant\nde gens à l'intérieur... Les flammes\nôtent encore des vies..."
-  },
-  {
-    "id": 340,
-    "offset": 490538,
-    "data_size": 250,
-    "slot_size": 254,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "We[SP]have[SP]to[SP]prevent[SP]any[SP]more[SP]casualties!\nThe[SP]next[SP]target[SP]is[SP]either[SP]GOLD[SP]or[SP]Pachinko\nSilver...[SP]It's[SP]up[SP]to[SP]you,[SP][1113]-kun!",
-    "nom_fr": "Maya",
-    "texte_fr": "On doit empêcher d'autres victimes !\nLa prochaine cible est GOLD ou Pachinko\nSilver... Ça dépend de toi, [1113]-kun !"
-  },
-  {
-    "id": 341,
-    "offset": 490792,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Are[SP]you[SP]angry[SP]I[SP]let[SP]that[SP]Ixquic[SP]girl[SP]go?\nI[SP]think[SP]it's[SP]just[SP]my[SP]nature...[SP]I'm[SP]sorry\nif[SP]you[SP]were[SP]upset.",
-    "nom_fr": "Maya",
-    "texte_fr": "Fâché que j'aie laissé fuir Ixquic ?\nC'est dans ma nature... Désolée si ça\nt'a contrarié."
-  },
-  {
-    "id": 342,
-    "offset": 491016,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "I'm[SP]sure[SP]King[SP]Leo[SP]is[SP]waiting[SP]for[SP]us[SP]at[SP]the\nAerospace[SP]Museum.[SP]I'll[SP]put[SP]an[SP]end[SP]to[SP]this...\nFor[SP]both[SP]him[SP]and[SP]myself.",
-    "nom_fr": "Maya",
-    "texte_fr": "Le Roi Lion nous attend au Musée de\nl'Aérospatiale. Je vais y mettre fin...\nPour lui comme pour moi."
-  },
-  {
-    "id": 343,
-    "offset": 491264,
-    "data_size": 182,
-    "slot_size": 186,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "This[SP]is[SP]horrible...[SP]Is[SP]this[SP]their[SP]will[SP]too?\nIf[SP]so...[SP]What[SP]are[SP]we[SP]going[SP]to[SP]do...?",
-    "nom_fr": "Ginko",
-    "texte_fr": "C'est horrible... Est-ce leur volonté aussi ?\nSi oui... Que va-t-on faire... ?"
-  },
-  {
-    "id": 344,
-    "offset": 491450,
-    "data_size": 422,
-    "slot_size": 426,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "It's[SP]not[SP]like[SP]Jun-kun[SP]to[SP]wish[SP]for[SP]something\nlike[SP]this.[SP]Wait[SP]for[SP]me...[SP]I'm[SP]coming[SP]to[SP]get\nyou[SP]this[SP]time...[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nThe[SP]Sakanoue[SP]Building?[1205][U+000A][SP]Why[SP]would[SP]we[SP]go[SP]there?[1205][U+000A]\nC'mon,[SP]let's[SP]go[SP]somewhere[SP]else.",
-    "nom_fr": "Maya",
-    "texte_fr": "Ce n'est pas le genre de Jun-kun de souhaiter\nune telle chose. Attends-moi... Je viens\nte chercher cette fois...[NULL][NULL]\"Eikichi\nLe Bâtiment Sakanoue ?[1205][U+000A] Pourquoi on irait là-bas ?[1205][U+000A]\nAllez, allons ailleurs."
-  },
-  {
-    "id": 345,
-    "offset": 491876,
-    "data_size": 94,
-    "slot_size": 98,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Oh...[SP]It's[SP]closed...[SP]We[SP]can't[SP]get[SP]in.",
-    "nom_fr": "Maya",
-    "texte_fr": "Oh... C'est fermé... On n'entre pas."
-  },
-  {
-    "id": 346,
-    "offset": 491974,
-    "data_size": 128,
-    "slot_size": 132,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "The[SP]Sakanoue[SP]Building...[1205][U+000F][SP]Is[SP]this[SP]the[SP]next\ntarget...?",
-    "nom_fr": "Maya",
-    "texte_fr": "Bâtiment Sakanoue...[1205][U+000F] Est-ce la prochaine\ncible... ?"
-  },
-  {
-    "id": 347,
-    "offset": 492106,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Let's[SP]worry[SP]about[SP]that[SP]later.[1205][U+000F][SP]We[SP]gotta[SP]hurry\nand[SP]take[SP]care[SP]of[SP]those[SP]bombs!",
-    "nom_fr": "Eikichi",
-    "texte_fr": "On s'en souciera plus tard.[1205][U+000F] Faut se dépêcher\nde s'occuper de ces bombes !"
-  },
-  {
-    "id": 348,
-    "offset": 492288,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4361,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?\n[1208][0002][1432][NULL][NULL][0014]Yeah,[SP]let's[SP]check[SP]it[SP]out.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]No,[SP]this[SP]isn't[SP]the[SP]place.[1432][NULL][NULL][0014]",
-    "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun ?[1205][U+000F] On devrait chercher par ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, jetons un œil.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas le bon endroit.[1432][NULL][NULL][0014]",
-    "question_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?",
-    "choix_orig": [
-      "Yeah,[SP]let's[SP]check[SP]it[SP]out.",
-      "No,[SP]this[SP]isn't[SP]the[SP]place."
-    ],
-    "question_fr": "",
-    "choix_fr": [
-      "",
-      ""
-    ]
-  },
-  {
-    "id": 349,
-    "offset": 492598,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Alright.[SP]If[SP]it's[SP]decided,[SP]then[SP]let's[SP]hurry.\nWe[SP]don't[SP]have[SP]time[SP]to[SP]waste.",
-    "nom_fr": "Yukino",
-    "texte_fr": "Ok. Si c'est décidé, dépêchons-nous.\nOn n'a pas de temps à perdre."
-  },
-  {
-    "id": 350,
-    "offset": 492770,
-    "data_size": 86,
-    "slot_size": 90,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "H-Hey,[SP]wait[SP]a[SP]sec![SP]Look[SP]at[SP]that!",
-    "nom_fr": "Ginko",
-    "texte_fr": "Hé, attendez ! Regardez ça !"
-  },
-  {
-    "id": 351,
-    "offset": 492860,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "If[SP]we'd[SP]picked[SP]this[SP]building,[SP]Smile[SP]Hirasaka\nwould[SP]be[SP]ashes[SP]by[SP]now...[SP]Oof,[SP]just[SP]thinking\nabout[SP]it[SP]gives[SP]me[SP]the[SP]chills.",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Si on avait choisi ici, Smile Hirasaka\nserait en cendres... Pfiou, y penser\nme donne des frissons."
-  },
-  {
-    "id": 352,
-    "offset": 493126,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "It's[SP]all[SP]this[SP]building's[SP]fault![SP]They[SP]shouldn't\nhave[SP]put[SP]it[SP]in[SP]such[SP]a[SP]misleading[SP]place![SP]I[SP]want\nthis[SP]thing[SP]outta[SP]my[SP]sight![SP]Let's[SP]go!",
-    "nom_fr": "Eikichi",
-    "texte_fr": "C'est la faute de ce bâtiment ! Ils n'auraient\npas dû le mettre dans un endroit si trompeur !\nJe veux plus le voir ! Allons-y !"
-  },
-  {
-    "id": 353,
-    "offset": 493416,
-    "data_size": 154,
-    "slot_size": 158,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Everyone's[SP]waiting[SP]at[SP]the[SP]detective[SP]agency.\nWe[SP]should[SP]hurry[SP]there.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Tous attendent à l'agence de\ndétectives. Dépêchons-nous."
-  },
-  {
-    "id": 354,
-    "offset": 493574,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Huh?[SP]It's[SP]locked.[SP]Guess[SP]we[SP]can't[SP]get[SP]in.[1205][U+000F]\nOh[SP]well,[SP]let's[SP]go[SP]somewhere[SP]else.",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Hein ? C'est fermé, on ne peut pas\nentrer.[1205][U+000F] Tant pis, allons ailleurs."
-  },
-  {
-    "id": 355,
-    "offset": 493756,
-    "data_size": 196,
-    "slot_size": 200,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "There's[SP]nothing[SP]left[SP]for[SP]us[SP]to[SP]do[SP]here,[SP]right?\nLet's[SP]go[SP]get[SP]the[SP]rest[SP]of[SP]those[SP]skulls.",
-    "nom_fr": "Eikichi",
-    "texte_fr": "On n'a plus rien à faire ici, non ?\nAllons chercher le reste de ces crânes."
-  },
-  {
-    "id": 356,
-    "offset": 493956,
-    "data_size": 164,
-    "slot_size": 168,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "If[SP]this[SP]isn't[SP]the[SP]place...[SP]then[SP]it's[SP]Smile\nHirasaka.[SP]Let's[SP]move[SP]it,[SP][1113]!",
-    "nom_fr": "Yukino",
-    "texte_fr": "Si ce n'est pas ici... alors c'est Smile\nHirasaka. Bougeons-nous, [1113] !"
-  },
-  {
-    "id": 357,
-    "offset": 494124,
-    "data_size": 76,
-    "slot_size": 80,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "S-Smile[SP]Hirasaka...[1205][U+000F][SP]No...",
-    "nom_fr": "Ginko",
-    "texte_fr": "Smile Hirasaka...[1205][U+000F] Non..."
-  },
-  {
-    "id": 358,
-    "offset": 494204,
-    "data_size": 90,
-    "slot_size": 94,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Holy[SP]shit...[1205][U+000F][SP]We[SP]were[SP]so[SP]close!",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Merde...[1205][U+000F] On y était presque !"
-  },
-  {
-    "id": 359,
-    "offset": 494298,
-    "data_size": 32,
-    "slot_size": 36,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "......",
-    "nom_fr": "Maya",
-    "texte_fr": "....."
-  },
-  {
-    "id": 360,
-    "offset": 494334,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Elly's[SP]voice",
-    "texte_orig": "Hello?[1205][U+000F][SP]It's[SP]me,[SP]Elly.[1205][U+000F][SP]I've[SP]narrowed[SP]down[SP]the\nnext[SP]target.[SP]This[SP]clue's[SP]also[SP]related[SP]to\nastrology...",
-    "nom_fr": "Voix d'Elly",
-    "texte_fr": "Allô ?[1205][U+000F] C'est moi, Elly.[1205][U+000F] J'ai réduit la\nprochaine cible. Cet indice est aussi lié à\nl'astrologie..."
-  },
-  {
-    "id": 361,
-    "offset": 494578,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Elly's[SP]voice",
-    "texte_orig": "It's[SP]most[SP]likely[SP]north-northeast[SP]from[SP]Sevens.\nThe[SP]only[SP]things[SP]there[SP]are[SP]Pachinko[SP]Silver[SP]and\nGOLD[SP]in[SP]Yumezaki.[SP]So[SP]the[SP]next[SP]target[SP]is--",
-    "nom_fr": "Voix d'Elly",
-    "texte_fr": "C'est au nord-nord-est de Seven.\nLes seuls trucs là-bas sont Pachinko Silver\net GOLD à Yumezaki. La prochaine cible est--"
-  },
-  {
-    "id": 362,
-    "offset": 494884,
-    "data_size": 222,
-    "slot_size": 226,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Elly-san,[SP]please![SP]Can[SP]you[SP]be[SP]more[SP]specific\nabout[SP]the[SP]location?[1205][U+000F][SP]Which[SP]one[SP]is[SP]King[SP]Leo's\nnext[SP]target?",
-    "nom_fr": "Maya",
-    "texte_fr": "Elly-san ! Sois plus précise\nsur le lieu.[1205][U+000F] Quelle est la\nprochaine cible du Roi Lion ?"
-  },
-  {
-    "id": 363,
-    "offset": 495110,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Elly's[SP]voice",
-    "texte_orig": "Then...[1205][U+000F][SP]You...[1205][U+000F][SP]You[SP]couldn't[SP]prevent[SP]the\nfire...[1205][U+000F][SP]I-I'm[SP]sorry...[1205][U+000F][SP]There's[SP]not[SP]much[SP]more\nI[SP]can[SP]tell[SP]you...",
-    "nom_fr": "Voix d'Elly",
-    "texte_fr": "Alors...[1205][U+000F] Vous...[1205][U+000F] N'avez pas pu stopper\nl'incendie...[1205][U+000F] Désolée...[1205][U+000F] Je ne peux\nvous en dire plus..."
-  },
-  {
-    "id": 364,
-    "offset": 495370,
-    "data_size": 238,
-    "slot_size": 242,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Thanks,[SP]Eriko.[SP]That's[SP]more[SP]than[SP]enough[SP]to[SP]get\nus[SP]started.[SP]Contact[SP]us[SP]again[SP]if[SP]you[SP]figure[SP]out\nanything[SP]else.",
-    "nom_fr": "Yukino",
-    "texte_fr": "Merci, Eriko. C'est plus qu'assez pour commencer.\nRecontacte-nous si tu découvres\nautre chose."
-  },
-  {
-    "id": 365,
-    "offset": 495612,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Look[SP]alive,[SP]people![SP]This[SP]is[SP]not[SP]the[SP]time[SP]for\nmoping![SP]We[SP]have[SP]to[SP]get[SP]a[SP]grip[SP]if[SP]we[SP]want[SP]to\nstop[SP]any[SP]more[SP]deaths!",
-    "nom_fr": "Yukino",
-    "texte_fr": "Réveillez-vous ! Ce n'est pas le moment\nde broyer du noir ! Reprenons-nous si on veut\néviter d'autres morts !"
-  },
-  {
-    "id": 366,
-    "offset": 495860,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Hang[SP]in[SP]there![1205][U+000F][SP]Dig[SP]deep![1205][U+000F][SP]The[SP]next[SP]target[SP]is\neither[SP]GOLD[SP]or[SP]Pachinko[SP]Silver[SP]in[SP]Yumezaki!",
-    "nom_fr": "Yukino",
-    "texte_fr": "Tenez bon ![1205][U+000F] Courage ![1205][U+000F] La prochaine cible est\nGOLD ou Pachinko Silver à Yumezaki !"
-  },
-  {
-    "id": 367,
-    "offset": 496070,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "We[SP]HAVE[SP]to[SP]do[SP]this,[SP]or[SP]there's[SP]no[SP]stopping[SP]the\nnext[SP]bombing![SP][1113],[SP]don't[SP]steer[SP]us[SP]wrong\nthis[SP]time!",
-    "nom_fr": "Yukino",
-    "texte_fr": "Il LE faut, sinon la prochaine\nbombe explosera ! [1113], ne\nnous égare pas !"
-  },
-  {
-    "id": 368,
-    "offset": 496288,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Jun",
-    "texte_orig": "We[SP]already[SP]have[SP]the[SP]crystal[SP]skull[SP]that[SP]was[SP]here.\nLet's[SP]hurry[SP]and[SP]gather[SP]the[SP]remaining[SP]skulls.",
-    "nom_fr": "Jun",
-    "texte_fr": "On a déjà le crâne en cristal qui était ici.\nDépêchons-nous d'obtenir les autres."
-  },
-  {
-    "id": 369,
-    "offset": 496496,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Jun",
-    "texte_orig": "Some[SP]of[SP]the[SP]Masked[SP]Circle[SP]are[SP]still[SP]fighting\nin[SP]there...[SP]If[SP]I[SP]still[SP]had[SP]my[SP]powers[SP]as[SP]Joker,\nI[SP]could[SP]stop[SP]it[SP]in[SP]an[SP]instant...",
-    "nom_fr": "Jun",
-    "texte_fr": "Le Cercle se bat encore ici...\nSi j'avais mes pouvoirs de Joker,\nje les arrêterais de suite..."
-  },
-  {
-    "id": 370,
-    "offset": 496766,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Ken...[SP]Takeshi...[SP]Shogo...[SP]Don't[SP]worry,[SP]guys.\nI'll[SP]get[SP]you[SP]back[SP]to[SP]normal.",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Ken... Takeshi... Shogo... Vous en faites pas.\nJ'vais vous aider."
-  },
-  {
-    "id": 371,
-    "offset": 496944,
-    "data_size": 132,
-    "slot_size": 136,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "C'mon,[SP][1114].[SP]There's[SP]stuff[SP]we[SP]gotta[SP]take\ncare[SP]of.[SP]Right?",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Yo, [1114]. Faut qu'on s'occupe d'autre chose\nlà, nan ?"
-  },
-  {
-    "id": 372,
-    "offset": 497080,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Whoa,[SP]hold[SP]your[SP]horses.[SP]We[SP]haven't[SP]gotten[SP]the\nskull[SP]at[SP]Leo[SP]Temple[SP]yet,[SP]right?[SP]Let's[SP]take\ncare[SP]of[SP]that[SP]before[SP]we[SP]jump[SP]in[SP]here.",
-    "nom_fr": "Maya",
-    "texte_fr": "Wah, ralentis. On n'a pas encore acquis le crâne au\ntemple lion, non ? Faisons ça avant de venir ici."
-  },
-  {
-    "id": 373,
-    "offset": 497354,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Wait[SP]a[SP]sec,[SP]Chinyan![SP]We[SP]don't[SP]have[SP]the[SP]skull\nfrom[SP]Taurus[SP]Temple[SP]yet.[SP]We[SP]should[SP]stop[SP]by\nthere[SP]first.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Attends Chinyan ! On n'a pas encore le crâne\ndu temple taureau. On devrait y passer d'abord."
-  }
+    {
+        "id": 0,
+        "offset": 406974,
+        "data_size": 224,
+        "slot_size": 224,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Lisa",
+        "texte_orig": "Oh,[SP]wait[SP]a[SP]sec,[SP][1113].[SP]We[SP]should[SP]go[SP]to[SP]the[NL]detective[SP]agency[SP]to[SP]ask[SP]them[SP]about[SP]the[SP]secret[NL]dish[SP]and[SP]stuff.",
+        "nom_fr": "Lisa",
+        "texte_fr": "Attends, [1113]. Allons à l'agence\nde détectives pour demander\ndes infos sur le plat secret."
+    },
+    {
+        "id": 1,
+        "offset": 407198,
+        "data_size": 206,
+        "slot_size": 206,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Lisa",
+        "texte_orig": "Not[SP]yet,[SP][1113]![SP]We[SP]gotta[SP]go[SP]get[SP]weapons[NL]first.[SP]Let's[SP]go[SP]to[SP]that[SP]ramen[SP]shop[SP]like[SP]the[NL]rumor[SP]says.",
+        "nom_fr": "Lisa",
+        "texte_fr": "Pas encore, [1113] ! Il nous faut\ndes armes. Allons au ramen shop\nde la rumeur."
+    },
+    {
+        "id": 2,
+        "offset": 407404,
+        "data_size": 234,
+        "slot_size": 234,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Lisa",
+        "texte_orig": "Geez,[SP]where[SP]are[SP]you[SP]going,[SP][1113]?[SP]We[SP]need[NL]to[SP]go[SP]to[SP]Shiraishi[SP]Ramen[SP]to[SP]check[SP]and[SP]see[SP]if[NL]the[SP]experiment[SP]worked!",
+        "nom_fr": "Lisa",
+        "texte_fr": "Urgh, où vas-tu [1113] ?\nOn doit aller à Shiraishi Ramen voir si\nnotre expérience a porté ses fruits !"
+    },
+    {
+        "id": 3,
+        "offset": 407638,
+        "data_size": 464,
+        "slot_size": 464,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Healthy[SP]young[SP]man",
+        "texte_orig": "Hirasaka[SP]might[SP]seem[SP]a[SP]bit[SP]run-down[SP]because[SP]of[NL]Cuss[SP]High,[SP]but[SP]it's[SP]not[SP]really[SP]that[SP]bad.[NL][1106][E2][1431][U+0000][U+0000]\"Healthy[SP]young[SP]man[NL]The[SP]students[SP]there[SP]have[SP]settled[SP]down[SP]lately,[NL]and[SP]I[SP]like[SP]this[SP]neighborhood's[SP]working-class[NL]feel.[NL]",
+        "nom_fr": "Jeune homme vigoureux",
+        "texte_fr": "Hirasaka semble délabrée à cause\ndu lycée Kakasu, mais ça va.[1106][NL]Les étudiants se sont calmés dernièrement et\nj'aime bien l'air modeste de cet endroit."
+    },
+    {
+        "id": 4,
+        "offset": 408102,
+        "data_size": 576,
+        "slot_size": 576,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Healthy[SP]young[SP]man",
+        "texte_orig": "Hah...[SP]The[SP]Kasuga[SP]Festival,[SP]eh?[SP]I[SP]think[SP]this[SP]is[NL]the[SP]first[SP]time[SP]Cuss[SP]High[SP]has[SP]ever[SP]had[SP]an[SP]actual[NL]school[SP]festival.[SP]They're[SP]moving[SP]up[SP]in[SP]the[SP]world.[NL][1106][E2][1431][U+0000][U+0000]\"Healthy[SP]young[SP]man[NL]I'm[SP]from[SP]here,[SP]so[SP]seeing[SP]that[SP]makes[SP]me[SP]happy.[1205][U+000F][NL]Takes[SP]me[SP]back[SP]to[SP]my[SP]high[SP]school[SP]days,[SP]it[SP]does.",
+        "nom_fr": "Jeune homme vigoureux",
+        "texte_fr": "Le festival de Kasuga ? Je crois bien que c'est\nune première pour le lycée Kakasu. Ils gagnent en\ncrédibilité.[1106][NL]Je viens d'ici, donc voir ça me rend heureux.[1205][U+000F]\nAh, les années lycée."
+    },
+    {
+        "id": 5,
+        "offset": 408678,
+        "data_size": 316,
+        "slot_size": 316,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Healthy[SP]young[SP]man",
+        "texte_orig": "Huh?[SP]That's[SP]weird...[1205][U+000F][SP]I[SP]haven't[SP]seen[SP]Cuss[SP]High[NL]students[SP]around[SP]lately.[SP]Did[SP]their[SP]enrollment[NL]numbers[SP]drop?[1205][U+000F][SP]Nah,[SP]that[SP]can't[SP]be[SP]it...",
+        "nom_fr": "Jeune homme vigoureux",
+        "texte_fr": "Bizarre...[1205][U+000F] Pas d'élèves du lycée\nKakasu récemment. Moins d'inscrits ?[1205][U+000F]\nNan, impossible..."
+    },
+    {
+        "id": 6,
+        "offset": 408994,
+        "data_size": 188,
+        "slot_size": 188,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Healthy[SP]young[SP]man",
+        "texte_orig": "You[SP]can[SP]buy[SP]CDs[SP]at[SP]Giga[SP]Macho[SP]in[SP]Yumezaki.[1205][U+000F][NL]I[SP]go[SP]there[SP]all[SP]the[SP]time.",
+        "nom_fr": "Jeune homme vigoureux",
+        "texte_fr": "Achète tes CD à Giga Macho\nà Yumezaki.[1205][U+000F] J'y vais tout le temps."
+    },
+    {
+        "id": 7,
+        "offset": 409182,
+        "data_size": 658,
+        "slot_size": 658,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Healthy[SP]young[SP]man",
+        "texte_orig": "This[SP]terrorism[SP]wave's[SP]the[SP]talk[SP]of[SP]the[SP]city.[NL]Honestly,[SP]I'm[SP]scared[SP]too.[1205][U+000F][SP]Even[SP]the[SP]police[NL]station[SP]and[SP]fire[SP]department[SP]got[SP]hit.[NL][1106][E2][1431][U+0000][U+0000]\"Healthy[SP]young[SP]man[NL]Who's[SP]left[SP]to[SP]protect[SP]this[SP]city[SP]or[SP]put[SP]out[NL]any[SP]fires[SP]that[SP]get[SP]started?[NL][1106][E2][1431][U+0000][U+0000]\"Healthy[SP]young[SP]man[NL]We're[SP]just[SP]stuck[SP]waiting[SP]for[SP]the[SP]terrorists[NL]to[SP]strike[SP]again!",
+        "nom_fr": "Jeune homme vigoureux",
+        "texte_fr": "Cette vague terroriste fait parler.\nJ'ai peur aussi.[1205][U+000F] Même la police\net les pompiers sont touchés.[1106][NL]Qui reste-t-il pour protéger cette ville et\néteindre les feux ?[1106][NL]On est coincés à attendre\nla prochaine attaque !"
+    },
+    {
+        "id": 8,
+        "offset": 409840,
+        "data_size": 434,
+        "slot_size": 434,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Healthy[SP]young[SP]man",
+        "texte_orig": "Now[SP]that[SP]was[SP]strange...[1205][U+000F][SP]This[SP]girl[SP]in[SP]crazy[NL]clothes[SP]just[SP]ran[SP]out[SP]of[SP]Smile[SP]Hirasaka.[NL][1106][E2][1431][U+0000][U+0000]\"Healthy[SP]young[SP]man[NL]I[SP]think[SP]I[SP]heard[SP]her[SP]say[SP]something[SP]like,[SP][U+1432][U+0000][U+0000][U+0014]You'll[NL]pay[SP]for[SP]this![U+1432][U+0000][U+0000][U+0014][SP]as[SP]she[SP]went...",
+        "nom_fr": "Jeune homme vigoureux",
+        "texte_fr": "Étrange...[1205][U+000F] Cette fille en\ntenue folle a fui de Smile Hirasaka.[1106][NL]Je crois que je l'ai entendu dire un truc comme\n[1432][NULL][NULL][0014]Tu vas le regretter ![1432][NULL][NULL][0014]"
+    },
+    {
+        "id": 9,
+        "offset": 410274,
+        "data_size": 558,
+        "slot_size": 558,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Healthy[SP]young[SP]man",
+        "texte_orig": "Now[SP]that[SP]was[SP]strange...[1205][U+000F][SP]This[SP]girl[SP]with[SP]crazy[NL]clothes[SP]and[SP]a[SP]burning[SP]ass[SP]ran[SP]out[SP]of[SP]Smile[NL]Hirasaka[SP]when[SP]it[SP]was[SP]on[SP]fire[SP]just[SP]now.[NL][1106][E2][1431][U+0000][U+0000]\"Healthy[SP]young[SP]man[NL]I[SP]think[SP]I[SP]heard[SP]her[SP]say[SP]something[SP]like,[NL][U+1432][U+0000][U+0000][U+0014]This[SP]wasn't[SP]how[SP]it[SP]was[SP]supposed[SP]to[SP]go![U+1432][U+0000][U+0000][U+0014][NL]as[SP]she[SP]went...",
+        "nom_fr": "Jeune homme vigoureux",
+        "texte_fr": "C'est étrange...[1205][U+000F] Cette fille habillée\nbizarrement vient de sortir de Smile Hirasaka qui flambait\nen courant.[1106][NL]Je crois que je l'ai entendu dire un truc comme\n[1432][NULL][NULL][0014]C'était pas censé se passer comme ça ![1432][NULL][NULL][0014]"
+    },
+    {
+        "id": 10,
+        "offset": 410832,
+        "data_size": 754,
+        "slot_size": 754,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Healthy[SP]young[SP]man",
+        "texte_orig": "Huh?[SP]It's[SP]that[SP]girl[SP]again...[1205][U+000F][SP]I[SP]mean[SP]the[SP]one[SP]in[NL]the[SP]weird[SP]getup[SP]who[SP]ran[SP]out[SP]of[SP]Smile[SP]Hirasaka[NL]before.[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Healthy[SP]young[SP]man[NL]And[SP]it[SP]seemed[SP]like[SP]there[SP]were[SP]a[SP]bunch[SP]of[SP]kids[NL]with[SP]her[SP]this[SP]time...[NL][1106][E2][1431][U+0000][U+0000]\"Healthy[SP]young[SP]man[NL]They[SP]said[SP]something[SP]about[SP]how[SP]the[SP]five[SP]people[NL]on[SP]the[SP]news[SP]are[SP]actually[SP]heroes[SP]fighting[NL]against[SP]the[SP]Masked[SP]Circle...[1205][U+000F][SP]Is[SP]that[SP]true?",
+        "nom_fr": "Jeune homme vigoureux",
+        "texte_fr": "C'est encore cette fille ?[1205][U+000F] Celle que j'ai vu sortir\nde Smile Hirasaka en courant.[1205][U+000F][1106][NL]Et cette fois, elle était accompagnée\nd'une bande de gamins...[1106][NL]Ils disent que les cinq personnes dans le journal\nsont en fait des héros qui combattent le cercle masqué.[1205][U+000F]\nC'est vrai, ça ?"
+    },
+    {
+        "id": 11,
+        "offset": 411586,
+        "data_size": 530,
+        "slot_size": 530,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Healthy[SP]young[SP]man",
+        "texte_orig": "That[SP]girl[SP]gets[SP]around.[SP]I[SP]just[SP]saw[SP]her[SP]on[NL]the[SP]news.[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Healthy[SP]young[SP]man[NL]She[SP]said[SP]the[SP]five[SP]suspects[SP]are[SP]heroes[NL]there[SP]too...[NL][1106][E2][1431][U+0000][U+0000]\"Healthy[SP]young[SP]man[NL]I-I'm[SP]starting[SP]to[SP]feel[SP]like[SP]I[SP]might[SP]believe[NL]her...[1205][U+000F][SP]Huh?[SP]Hey,[SP]don't[SP]get[SP]the[SP]wrong[SP]idea!",
+        "nom_fr": "Jeune homme vigoureux",
+        "texte_fr": "Cette fille bouge beaucoup.\nVue aux infos.[1205][U+000F][1106][NL]Elle dit que ces 5 suspects\nsont des héros...[1106][NL]Elle a peut-être raison...[1205][U+000F] Hah ?\nEh, ne te fais pas d'idées !"
+    },
+    {
+        "id": 12,
+        "offset": 412116,
+        "data_size": 316,
+        "slot_size": 316,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Healthy[SP]young[SP]man",
+        "texte_orig": "Wh-Where[SP]are[SP]those[SP]soldiers[SP]going?[1205][U+000F][SP]There's[NL]nothing[SP]over[SP]there[SP]but[SP]Mt.[SP]Katatsumuri.[1205][U+000F][SP]What[NL]are[SP]they[SP]doing[SP]there[SP]with[SP]all[SP]those[SP]guns?",
+        "nom_fr": "Jeune homme vigoureux",
+        "texte_fr": "Où vont ces soldats ?[1205][U+000F] Il n'y a rien là-bas\nà part le Mt Katatsumuri.[1205][U+000F] Qu'est-ce qu'ils\nfont avec tous ces flingues ?"
+    },
+    {
+        "id": 13,
+        "offset": 412432,
+        "data_size": 562,
+        "slot_size": 562,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "Dude,[SP]what's[SP]going[SP]on!?[1205][U+0008][NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]man[NL]First[SP]that[SP]weird[SP]temple[SP]shows[SP]up,[SP]then[SP]the[NL]Last[SP]Battalion[SP]and[SP]Masked[SP]Circle[SP]goons[SP]show[NL]up[SP]and[SP]swarm[SP]into[SP]it![NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]man[NL]They[SP]all[SP]went[SP]inside...[1205][U+000A][SP]I[SP]can[SP]hear[SP]gunshots[SP]and[NL]stuff[SP]from[SP]in[SP]there.[1205][U+000F][SP]Are[SP]they[SP]still[SP]fighting?",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Que se passe-t-il !?[1205][U+0008][1106][NL]D'abord ce temple bizarre, puis\nle Bataillon et le Cercle masqué\nl'envahissent ![1106][NL]Ils y sont entrés...[1205][U+000A] J'entends des tirs\nà l'intérieur.[1205][U+000F] Ils se battent encore ?"
+    },
+    {
+        "id": 14,
+        "offset": 412994,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "Looks[SP]like[SP]the[SP]war[SP]between[SP]the[SP]Masked[SP]Circle[NL]and[SP]the[SP]Last[SP]Battalion's[SP]being[SP]fought[SP]in[SP]that[NL]temple...[1205][U+000F][SP]Will[SP]they[SP]fight[SP]to[SP]the[SP]death?",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "La guerre entre le Cercle masqué\net le Bataillon a lieu dans ce\ntemple...[1205][U+000F] S'entretueront-ils ?"
+    },
+    {
+        "id": 15,
+        "offset": 413292,
+        "data_size": 470,
+        "slot_size": 470,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "I[SP]was[SP]like,[SP]Cuss[SP]High?[SP]Totally[SP]not[SP]my[SP]thing.[NL]But[SP]then[SP]lately[SP]they've[SP]been[SP]getting[SP]these[NL]hot[SP]guys?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]girl[NL]So[SP]now[SP]I[SP]go[SP]watch[SP]their[SP]shows[SP]at[SP]the[SP]Prison.[NL]You're[SP]kinda[SP]cute[SP]too,[SP]but[SP]you're[SP]just[SP]a[NL]Sevens[SP]student.[NL]",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "Le lycée Kakasu ? Pas mon truc.\nMais ces temps-ci, ils ont eu plein\nde beaux garçons, non ?[1106][NL]Donc je vais voir leurs shows à la Prison.\nT'es mignon, mais t'es juste\nun élève de Seven."
+    },
+    {
+        "id": 16,
+        "offset": 413762,
+        "data_size": 672,
+        "slot_size": 672,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "So[SP]like,[SP]the[SP]new[SP]Leader[SP]of[SP]Cuss[SP]High[SP]was[NL]decided?[1205][U+000F][SP]He's[SP]waaaay[SP]better.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]girl[NL]I[SP]mean,[SP]Undie[SP]Boss?[SP]Puh-lease.[SP]Like[SP]the[SP]name[NL]wasn't[SP]bad[SP]enough,[SP]he[SP]kept[SP]making[SP]these[SP]rules.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]girl[NL]Honestly,[SP]he[SP]was[SP]a[SP]total[SP]drag.[1205][U+000F][SP]Plus[SP]the[SP]new[NL]Leader[SP]seems,[SP]like,[SP]way[SP]stronger?[SP]It's[SP]like,[NL]yeah![SP]Go[SP]crush[SP]that[SP]old[SP]Boss!",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "Le nouveau chef de Kakasu a\nété choisi ?[1205][U+000F] Il est carrément mieux.[1106][NL]Boss Calbute ? Pitié. En plus de son\nnom, il n'arrêtait pas d'imposer des règles.[1106][NL]Franchement, il était chiant.[1205][U+000F] Et le\nnouveau chef a l'air bien plus fort !\nOuais ! Écrase ce vieux Boss !"
+    },
+    {
+        "id": 17,
+        "offset": 414434,
+        "data_size": 588,
+        "slot_size": 588,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "The[SP]new[SP]student[SP]council[SP]president's[SP]so[SP]cool[NL]that[SP]he[SP]set[SP]up[SP]a[SP]masquerade[SP]at[SP]our[SP]school[NL]festival.[1205][U+000F][SP]I[SP]got[SP]a[SP]ticket,[SP]like,[SP]day[SP]one.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]girl[NL]Now[SP]I[SP]just[SP]gotta[SP]get[SP]with[SP]a[SP]cool[SP]Cuss[SP]High[NL]guy.[1205][U+000F][SP]Or[SP]maybe[SP]you[SP]wanna[SP]come[SP]with[SP]me?[SP]You're[NL]kinda[SP]cute[SP]yourself,[SP]so[SP]I[SP]wouldn't[SP]mind.",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "Le président du BDE est si cool. Il a\norganisé un bal masqué pour notre\nfestival.[1205][U+000F] J'ai eu un billet direct.[1106][NL]Il me faut juste un mec cool de Kakasu.[1205][U+000F]\nOu tu veux venir avec moi ? T'es plutôt\nmignon, ça m'irait."
+    },
+    {
+        "id": 18,
+        "offset": 415022,
+        "data_size": 558,
+        "slot_size": 558,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "Masquerade?[1205][U+000F][SP]Oh,[SP]that[SP]old[SP]thing?[1205][U+000F][SP]I[SP]like,[SP]ditched[NL]on[SP]it[SP]'cause[SP]I[SP]had[SP]other[SP]stuff[SP]to[SP]do?[SP]Anyway,[NL]the[SP]new[SP]hotness[SP]is[SP]Muses![1106][E2][1431][U+0000][U+0000]\"Young[SP]girl[NL]You[SP]know,[SP]that[SP]new[SP]idol[SP]trio[SP]that[SP]Ginji[NL]Sasaki's[SP]producing?[1205][U+000F][SP]I[SP]wonder[SP]what[SP]they're[NL]like...[SP]I[SP]can't[SP]wait[SP]for[SP]their[SP]debut!",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "Le bal masqué ?[1205][U+000F] Oh, ce vieux truc ?[1205][U+000F]\nJ'ai zappé, j'avais d'autres trucs à faire.\nBref, la nouveauté c'est les Muses ![1106][NL]Tu sais, le trio d'idoles produit\npar Ginji Sasaki ?[1205][U+000F] Je me demande comment\nelles sont... Vivement leurs débuts !"
+    },
+    {
+        "id": 19,
+        "offset": 415580,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "The[SP]girls[SP]that[SP]got[SP]picked[SP]for[SP]Muses[SP]are[SP]soooo[NL]lucky.[1205][U+000F][SP]I[SP]mean,[SP]Ginji[SP]Sasaki[SP]producing[SP]you?[NL]There's[SP]like,[SP]no[SP]way[SP]they[SP]won't[SP]be[SP]huge.",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "Les filles choisies pour Muses ont trop\nde chance.[1205][U+000F] Être produite par Ginji\nSasaki ? C'est sûr qu'elles vont percer."
+    },
+    {
+        "id": 20,
+        "offset": 415878,
+        "data_size": 348,
+        "slot_size": 348,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "This[SP]suuuucks...[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]girl[NL]I[SP]went[SP]to[SP]go[SP]buy[SP]concert[SP]tickets,[SP]and[SP]they[SP]were[NL]like,[SP][U+1432][U+0000][U+0000][U+0014]Durrr,[SP]we're[SP]sold[SP]out.[U+1432][U+0000][U+0000][U+0014][1205][U+000F][SP]That[SP]receptionist[NL]was[SP]such[SP]a[SP]bitch!",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "Ça craint...[1106][NL]J'allais acheter un billet et on me dit :\n[1432][NULL][NULL][0014]Euh, c'est complet.[1432][NULL][NULL][0014][1205][U+000F]\nCette réceptionniste était si chiante !"
+    },
+    {
+        "id": 21,
+        "offset": 416226,
+        "data_size": 326,
+        "slot_size": 326,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "The[SP]Masked[SP]Circle's[SP]behind[SP]this[SP]terrorist[SP]stuff,[NL]right?[1205][U+000F][SP]Some[SP]of[SP]their[SP]members[SP]were[SP]making[SP]trouble[NL]in[SP]the[SP]city,[SP]too.[SP]They're[SP]some[SP]real[SP]bad[SP]guys.",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "Le Cercle masqué est derrière ces attaques,\nnon ?[1205][U+000F] Certains membres ont fait du\ngrabuge en ville. Ce sont de vrais méchants."
+    },
+    {
+        "id": 22,
+        "offset": 416552,
+        "data_size": 500,
+        "slot_size": 500,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "What[SP]the[SP]hell!?[SP]Why[SP]did[SP]the[SP]terrorists[SP]go[NL]after[SP]Smile[SP]Hirasaka?[SP]Why[SP]target[SP]a[SP]station[NL]building[SP]like[SP]that!?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]girl[NL]Is[SP]this,[SP]like,[SP]one[SP]of[SP]those[SP][U+1432][U+0000][U+0000][U+0014]random[SP]acts[SP]of[NL]violence[U+1432][U+0000][U+0000][U+0014][SP]they[SP]talk[SP]about?[1205][U+000F][SP]'Cause[SP]like,[SP]this[NL]isn't[SP]funny!",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "C'est quoi ce bordel !? Pourquoi les\nterroristes ont attaqué Smile Hirasaka ?\nPourquoi viser ça !?[1106][NL]Est-ce un [1432][NULL][NULL][0014]acte de violence\ngratuite[1432][NULL][NULL][0014] dont on parle ?[1205][U+000F]\nParce que là, c'est pas drôle !"
+    },
+    {
+        "id": 23,
+        "offset": 417052,
+        "data_size": 470,
+        "slot_size": 470,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "I-Is[SP]this[SP]some[SP]kind[SP]of[SP]joke?[SP]Why'd[SP]those[NL]terrorists[SP]blow[SP]up[SP]Smile[SP]Hirasaka!?[1205][U+000F][SP]Bombing[NL]a[SP]place[SP]like[SP]that[SP]doesn't[SP]get[SP]them[SP]anything![NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]girl[NL]Geez,[SP]what's[SP]the[SP]Masked[SP]Circle[SP]thinking!?[1205][U+000F][NL]Why[SP]would[SP]they[SP]do[SP]this!?",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "C'est une blague ? Pourquoi ces terroristes\nont fait sauter Smile Hirasaka !?[1205][U+000F] Cibler\nun tel endroit ne leur apporte rien ![1106][NL]Urgh, à quoi pense le Cercle masqué !?[1205][U+000F]\nPourquoi faire ça !?"
+    },
+    {
+        "id": 24,
+        "offset": 417522,
+        "data_size": 566,
+        "slot_size": 566,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "Huh?[SP]You[SP]haven't[SP]seen[SP]the[SP]composite[SP]sketches[SP]yet?[1205][U+000F][NL]Well,[SP]one[SP]of[SP]them[SP]had[SP]hair[SP]like[SP]yours,[SP]and[SP]his[NL]face[SP]looked[SP]kinda[SP]like[SP]you[SP]too...[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]girl[NL]His[SP]nose...[1205][U+000A][SP]was[SP]like[SP]yours...[1205][U+000F][SP]And[SP]his[SP]mouth...[1205][U+000A][NL]Yeah,[SP]that[SP]matches[SP]too...[1205][U+000F][SP]See?[SP]Doesn't[SP]he[SP]seem[NL]totally[SP]evil?",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "Hein ? T'as pas vu les portraits-robots ?[1205][U+000F]\nY en a un qui a tes cheveux, et son\nvisage te ressemble...[1106][NL]Son nez...[1205][U+000A] Comme le tien...[1205][U+000F] Et sa bouche...[1205][U+000A]\nOuais, ça colle...[1205][U+000F] Tu vois ?\nIl a l'air si maléfique."
+    },
+    {
+        "id": 25,
+        "offset": 418088,
+        "data_size": 312,
+        "slot_size": 312,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "I[SP]like,[SP]wondered[SP]after[SP]I[SP]read[SP]the[SP]In[SP]Lak'ech...[NL]Could[SP]the[SP]Last[SP]Battalion[SP]have[SP]been[SP]blowing[SP]stuff[NL]up[SP]to[SP]find[SP]Sumaru[SP]City's[SP]secret[SP]treasure?",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "Je me suis demandé en lisant l'In Lak'ech...\nLe Bataillon a-t-il fait sauter des trucs\npour trouver le trésor de Sumaru ?"
+    },
+    {
+        "id": 26,
+        "offset": 418400,
+        "data_size": 650,
+        "slot_size": 650,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "Those[SP]soldiers[SP]a[SP]moment[SP]ago[SP]saw[SP]me![SP]But[SP]then,[NL]like,[SP]some[SP]Masked[SP]Circle[SP]guys[SP]totally[SP]saved[NL]my[SP]bacon.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]girl[NL]They[SP]were[SP]all,[SP][U+1432][U+0000][U+0000][U+0014]Joker[SP]ordered[SP]us[SP]to[SP]protect[SP]the[NL]people[SP]of[SP]this[SP]city![U+1432][U+0000][U+0000][U+0014][1205][U+000F][SP]I[SP]wonder[SP]if[SP]I[SP]had[SP]the[NL]wrong[SP]idea[SP]about[SP]him.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]girl[NL]Maybe[SP]he's[SP]actually,[SP]like,[SP]Sumaru's[SP]guardian[NL]angel.",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "Ces soldats m'ont vue ! Mais ensuite,\ndes gars du Cercle masqué m'ont sauvée.[1106][NL]Ils disaient : [1432][NULL][NULL][0014]Le Joker a ordonné de\nprotéger les civils ![1432][NULL][NULL][0014][1205][U+000F] Je me\nsuis peut-être trompée sur lui.[1106][NL]C'est peut-être l'ange gardien de Sumaru."
+    },
+    {
+        "id": 27,
+        "offset": 419050,
+        "data_size": 398,
+        "slot_size": 398,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "I[SP]almost[SP]got[SP]attacked[SP]again[SP]by[SP]some[SP]more[SP]Last[NL]Battalion[SP]thugs...[1205][U+000F][SP]And[SP]this[SP]time[SP]a[SP]couple[SP]of[NL]women[SP]saved[SP]me![NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]girl[NL]They[SP]were[SP]so[SP]cool...[1205][U+000A][SP]I[SP]gotta[SP]get[SP]my[SP]act[NL]together[SP]too.",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "Le Bataillon a failli m'attaquer de\nnouveau...[1205][U+000F] Et cette fois,\ndes femmes m'ont sauvée ![1106][NL]Elles étaient si cool...[1205][U+000A] Je dois me\nreprendre."
+    },
+    {
+        "id": 28,
+        "offset": 419448,
+        "data_size": 280,
+        "slot_size": 280,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "Some[SP]Last[SP]Battalion[SP]guys[SP]with[SP]long[SP]spears[SP]went[NL]into[SP]that[SP]temple[SP]a[SP]minute[SP]ago.[1205][U+000F][SP]They[SP]were[NL]carrying[SP]something[SP]shiny,[SP]too...",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "Des gars du Bataillon avec de longues\nlances sont entrés là-dedans.[1205][U+000F]\nIls portaient un objet brillant..."
+    },
+    {
+        "id": 29,
+        "offset": 419728,
+        "data_size": 222,
+        "slot_size": 222,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]girl",
+        "texte_orig": "I-I[SP]just[SP]saw[SP]them[SP]pulling[SP]a[SP]woman[SP]out[SP]of[SP]the[NL]detective[SP]agency![1205][U+000F][SP]Were[SP]they[SP]kidnapping[SP]her...?",
+        "nom_fr": "Jeune fille",
+        "texte_fr": "Je les ai vus sortir une femme de l'agence\nde détectives ![1205][U+000F] Ils la kidnappaient... ?"
+    },
+    {
+        "id": 30,
+        "offset": 419950,
+        "data_size": 560,
+        "slot_size": 560,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "I[SP]don't[SP]know[SP]much[SP]about[SP]it,[SP]but[SP]there's[SP]some[NL]Joker[SP]Game[SP]that's[SP]popular[SP]with[SP]the[SP]kids[SP]today,[NL]right?[SP]It[SP]grants[SP]any[SP]wish?[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Well,[SP]I[SP]doubt[SP]that,[SP]but[SP]there's[SP]nothing[SP]wrong[NL]with[SP]dreaming.[SP]You[SP]can[SP]focus[SP]on[SP]your[SP]troubles[NL]later,[SP]once[SP]you're[SP]older.",
+        "nom_fr": "Homme",
+        "texte_fr": "Y a un Jeu du Joker populaire chez les\njeunes, non ? Ça exauce les vœux ?[1106][NL]J'en doute, mais on peut rêver.\nTu te soucieras de tes soucis plus tard."
+    },
+    {
+        "id": 31,
+        "offset": 420510,
+        "data_size": 452,
+        "slot_size": 452,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]the[SP]lady[SP]at[SP]Shiraishi[SP]Ramen[NL]was[SP]really[SP]a[SP]Russian[SP]spy.[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]You[SP]can[SP]tell[SP]because[SP]she'll[SP]sell[SP]you[SP]real[NL]weapons[SP]if[SP]you[SP]order[SP]banana[SP]char[SP]siu[SP]ramen![1205][U+000F][NL]Funny[SP]old[SP]world,[SP]huh?",
+        "nom_fr": "Homme",
+        "texte_fr": "Il paraît que la dame de Shiraishi Ramen\nest une espionne russe.[1106][NL]Si tu commandes des ramens au porc et à la\nbanane, elle te vend des armes ![1205][U+000F]\nDrôle de monde, hein ?"
+    },
+    {
+        "id": 32,
+        "offset": 420962,
+        "data_size": 428,
+        "slot_size": 428,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]the[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High[NL]wasn't[SP]stronger[SP]than[SP]Eikichi[SP]at[SP]all.[1205][U+000F][SP]But[SP]then,[NL]who[SP]is[SP]stronger[SP]than[SP]that[SP]kid?[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Guess[SP]the[SP]Undie[SP]Boss[SP]hasn't[SP]lost[SP]his[SP]touch.",
+        "nom_fr": "Homme",
+        "texte_fr": "Le nouveau chef de Kakasu n'est pas plus\nfort qu'Eikichi.[1205][U+000F] Mais qui est plus fort\nque ce gamin ?[1106][NL]Le Boss Calbute n'a pas perdu la main."
+    },
+    {
+        "id": 33,
+        "offset": 421390,
+        "data_size": 520,
+        "slot_size": 520,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "You[SP]can[SP]buy[SP]real[SP]shooters[SP]and[SP]blades[SP]at[SP]this[NL]guy[SP]Tony's[SP]shop[SP]in[SP]Yumezaki?[1205][U+000F][SP]Damn...[SP]sounds[NL]dangerous,[SP]if[SP]you[SP]ask[SP]me.[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]I[SP]just[SP]heard[SP]it[SP]from[SP]this[SP]porker[SP]called[SP]Toro[NL]at[SP]Gatten[SP]Sushi.[1205][U+000F][SP]If[SP]you[SP]wanna[SP]know[SP]more,[SP]go[NL]ask[SP]him.",
+        "nom_fr": "Homme",
+        "texte_fr": "On peut acheter des armes à feu et des lames\nchez Tony à Yumezaki ?[1205][U+000F] Mince... ça craint.[1106][NL]Je l'ai appris du gros Toro à Gatten Sushi.[1205][U+000F]\nSi tu veux en savoir plus, va lui demander."
+    },
+    {
+        "id": 34,
+        "offset": 421910,
+        "data_size": 468,
+        "slot_size": 468,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "I[SP]guess[SP]people[SP]are[SP]pretty[SP]worked[SP]up[SP]over[SP]this[NL]new[SP]singer.[1205][U+000F][SP]Me,[SP]I[SP]prefer[SP]enka.[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Aren't[SP]they[SP]doing[SP]some[SP]live[SP]event[SP]right[SP]now[SP]at[NL]that[SP]Giga[SP]Macho[SP]place?[1205][U+000F][SP]What,[SP]you're[SP]not[NL]gonna[SP]go[SP]check[SP]it[SP]out?",
+        "nom_fr": "Homme",
+        "texte_fr": "Les gens sont à fond sur cette nouvelle\nchanteuse.[1205][U+000F] Moi, je préfère l'enka.[1106][NL]Il n'y a pas un événement live en ce moment à\nGiga Macho ?[1205][U+000F] Quoi, tu vas pas y aller ?"
+    },
+    {
+        "id": 35,
+        "offset": 422378,
+        "data_size": 320,
+        "slot_size": 320,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "You[SP]one[SP]of[SP]them[SP]guys[SP]that[SP]missed[SP]out[SP]on[SP]the[NL]concert?[SP]I[SP]heard[SP]there[SP]weren't[SP]enough[SP]tickets.[1205][U+000F][NL]Man[SP]like[SP]you[SP]didn't[SP]need[SP]to[SP]be[SP]there[SP]anyway.",
+        "nom_fr": "Homme",
+        "texte_fr": "T'es un de ceux qui ont raté le concert ? J'ai\nentendu qu'il manquait de billets.[1205][U+000F] Un gars\ncomme toi n'avait rien à y faire de toute façon."
+    },
+    {
+        "id": 36,
+        "offset": 422698,
+        "data_size": 286,
+        "slot_size": 286,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "There[SP]seems[SP]to[SP]have[SP]been[SP]a[SP]group[SP]of[SP]five[SP]in[NL]the[SP]concert[SP]hall[SP]when[SP]it[SP]burned[SP]down.[SP]Rumor[SP]is[NL]it[SP]was[SP]them[SP]who[SP]set[SP]the[SP]fire.",
+        "nom_fr": "Homme",
+        "texte_fr": "Il y avait un groupe de cinq dans la salle quand\nelle a brûlé. On dit qu'ils ont allumé le feu."
+    },
+    {
+        "id": 37,
+        "offset": 422984,
+        "data_size": 548,
+        "slot_size": 548,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]it[SP]wasn't[SP]just[SP]the[SP]concert[SP]hall.[NL]Those[SP]five[SP]guys[SP]were[SP]inside[SP]Smile[SP]Hirasaka[NL]too,[SP]just[SP]before[SP]things[SP]went[SP]down[SP]there.[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Sounds[SP]connected[SP]to[SP]me.[SP]These[SP]five[SP]guys[SP]are[NL]some[SP]shady[SP]characters,[SP]ya[SP]ask[SP]me.[SP]Don't[SP]you[NL]think[SP]so,[SP]kid?",
+        "nom_fr": "Homme",
+        "texte_fr": "Pas que la salle de concert. Ces cinq-là étaient\naussi à Smile Hirasaka avant que ça dégénère.[1106][NL]Ça me semble lié. Ce sont des individus louches,\nà mon avis. Tu ne crois pas, petit ?"
+    },
+    {
+        "id": 38,
+        "offset": 423532,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Jesus![SP]Smile[SP]Hirasaka[SP]just[SP]went[SP]down[SP]in[SP]flames[NL]right[SP]in[SP]front[SP]of[SP]me![SP]Where's[SP]the[SP]damn[SP]fire[NL]department!?[SP]What's[SP]going[SP]on[SP]here!?",
+        "nom_fr": "Homme",
+        "texte_fr": "Bon sang ! Smile Hirasaka a pris feu sous mes\nyeux ! Où sont les pompiers !? Il se passe quoi !?"
+    },
+    {
+        "id": 39,
+        "offset": 423830,
+        "data_size": 272,
+        "slot_size": 272,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Huh?[1205][U+000F][SP]D-Did[SP]you[SP]just[SP]get[SP]here?[SP]Coulda[SP]sworn[SP]I[NL]just[SP]saw[SP]you[SP]go[SP]that[SP]way...[1205][U+000F][SP]H-Hahaha,[SP]I[SP]must[NL]be[SP]seein'[SP]things...",
+        "nom_fr": "Homme",
+        "texte_fr": "Hein ?[1205][U+000F] T-Tu viens d'arriver ? J'aurais juré\nt'avoir vu passer par là...[1205][U+000F] H-Hahaha, je\ndois halluciner..."
+    },
+    {
+        "id": 40,
+        "offset": 424102,
+        "data_size": 526,
+        "slot_size": 526,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "What[SP]the!?[SP]D-Didn't[SP]you[SP]guys[SP]just[SP]pass[SP]by[SP]here?[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Then[SP]who[SP]was[SP]that...?[1205][U+000F][SP]I-I'm[SP]seein'[SP]double...[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]H-Hahaha...[1205][U+000F][SP]Guess[SP]I[SP]did[SP]have[SP]a[SP]few[SP]too[SP]many[NL]last[SP]night...[SP]I[SP]really[SP]oughtta[SP]cut[SP]back[SP]on[NL]the[SP]booze...",
+        "nom_fr": "Homme",
+        "texte_fr": "Quel délire !? V-Vous ne venez pas\nde passer là ?[1106][NL]Alors qui c'était... ?[1205][U+000F] J-Je vois double...[1106][NL]H-Hahaha...[1205][U+000F] J'ai dû trop boire hier soir...\nIl faut vraiment que je lève le pied sur l'alcool..."
+    },
+    {
+        "id": 41,
+        "offset": 424628,
+        "data_size": 362,
+        "slot_size": 362,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Whoa,[SP]what[SP]the[SP]hell[SP]was[SP]that!?[SP]A[SP]whole[SP]army[NL]of[SP]guys[SP]with[SP]spears[SP]just[SP]went[SP]flyin'[SP]by![1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]I[SP]didn't[SP]know[SP]the[SP]Last[SP]Battalion[SP]had[SP]guys[NL]like[SP]that!",
+        "nom_fr": "Homme",
+        "texte_fr": "Waouh, c'était quoi !? Une armée de types avec\ndes lances vient de passer en trombe ![1106][NL]Je savais pas que le Bataillon avait des gars comme ça !"
+    },
+    {
+        "id": 42,
+        "offset": 424990,
+        "data_size": 526,
+        "slot_size": 526,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Well,[SP]I'll[SP]be[SP]damned![1205][U+000F][SP]That[SP]Xibalba[SP]thing[SP]was[NL]this[SP]big!?[1205][U+000A][SP]Not[SP]too[SP]many[SP]people[SP]can[SP]say[SP]they[NL]live[SP]in[SP]a[SP]city[SP]in[SP]the[SP]sky.[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]But[SP]I[SP]don't[SP]hold[SP]with[SP]this[SP]business[SP]about[SP]the[NL]world[SP]ending.[1205][U+000A][SP]Can't[SP]you[SP]do[SP]anything[SP]about[SP]it,[NL]kid!?",
+        "nom_fr": "Homme",
+        "texte_fr": "Nom d'un chien ![1205][U+000F] Ce Xibalba était aussi grand !?[1205][U+000A]\nPeu de gens peuvent dire qu'ils vivent\ndans une ville dans le ciel.[1106][NL]Mais je ne crois pas à cette histoire de fin\ndu monde.[1205][U+000A] Tu peux rien y faire, petit !?"
+    },
+    {
+        "id": 43,
+        "offset": 425516,
+        "data_size": 638,
+        "slot_size": 638,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Everyone[SP]I[SP]know's[SP]talkin'[SP]about[SP]how[SP]the[SP]world's[NL]gonna[SP]end![1205][U+000A][NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Floods[SP]this,[SP]meteors[SP]that...[SP]All[SP]as[SP]soon[SP]as[NL]this[SP]Grand[SP]Whatever[SP]happens...[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]What[SP]I[SP]don't[SP]get[SP]is,[SP]it's[SP]gonna[SP]kill[SP]everyone[NL]down[SP]there,[SP]right?[SP]What's[SP]the[SP]fun[SP]in[SP]predicting[NL]how[SP]they're[SP]gonna[SP]die?",
+        "nom_fr": "Homme",
+        "texte_fr": "Tout le monde dit que c'est la fin du monde ![1205][U+000A][1106][NL]Inondations, météores... Dès que cette Grande\nJe-Sais-Pas-Quoi arrivera...[1106][NL]Ce que je pige pas, c'est que ça va tous les tuer\nen bas, non ? Quel intérêt de prédire comment\nils vont mourir ?"
+    },
+    {
+        "id": 44,
+        "offset": 426154,
+        "data_size": 326,
+        "slot_size": 326,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]when[SP]the[SP]Grand[SP]Cross[SP]is[SP]done,[NL]the[SP]gravity[SP]of[SP]the[SP]stars[SP]is[SP]gonna[SP]pulverize[SP]the[NL]Earth.[1205][U+000F][SP]Is[SP]that[SP]how[SP]the[SP]world's[SP]gonna[SP]end?",
+        "nom_fr": "Homme",
+        "texte_fr": "Quand la Croix Cosmique sera finie, la gravité des\nétoiles va pulvériser la Terre.[1205][U+000F]\nC'est ça la fin du monde ?"
+    },
+    {
+        "id": 45,
+        "offset": 426480,
+        "data_size": 490,
+        "slot_size": 490,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Hey,[SP]I[SP]heard[SP]the[SP]world[SP]will[SP]stop[SP]spinning[SP]if[NL]the[SP]Grand[SP]Cross[SP]happens.[1205][U+000A][SP]Somethin'[SP]about[SP]the[NL]balance[SP]of[SP]gravity[SP]and[SP]stuff...[SP]Over[SP]my[SP]head.[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]How[SP]bad[SP]would[SP]that[SP]really[SP]be[SP]if[SP]it[SP]happened,[NL]though?[SP]I[SP]dunno...",
+        "nom_fr": "Homme",
+        "texte_fr": "J'ai entendu dire que la Terre arrêtera de tourner\navec la Croix.[1205][U+000A] Un truc sur la gravité...\nÇa me dépasse.[1106][NL]À quel point ce serait grave si ça arrivait ?\nJ'en sais rien..."
+    },
+    {
+        "id": 46,
+        "offset": 426970,
+        "data_size": 272,
+        "slot_size": 272,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Well,[SP]don't[SP]that[SP]beat[SP]all...[SP]I[SP]heard[SP]the[NL]flowers[SP]in[SP]Aoba[SP]Park[SP]can[SP]talk.[SP]Guess[SP]it[SP]takes[NL]all[SP]kinds[SP]to[SP]make[SP]a[SP]world.",
+        "nom_fr": "Homme",
+        "texte_fr": "Eh ben, ça par exemple... Il paraît que les fleurs\ndu parc Aoba parlent. Faut de tout pour faire\nun monde."
+    },
+    {
+        "id": 47,
+        "offset": 427242,
+        "data_size": 498,
+        "slot_size": 498,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Hey,[SP]kid.[SP]Ya[SP]know[SP]that[SP]club[SP]Zodiac?[SP]People[SP]say[NL]the[SP]second[SP]floor's[SP]a[SP]huge[SP]dungeon,[SP]packed[SP]with[NL]great[SP]stuff.[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Why[SP]not[SP]go[SP]snoop[SP]around[SP]it?[SP]Show[SP]off[SP]some[NL]skills[SP]and[SP]I[SP]bet[SP]your[SP]girl'll[SP]be[SP]all[SP]over[SP]ya.[NL]Hahahaha!",
+        "nom_fr": "Homme",
+        "texte_fr": "Hé, petit. Tu connais le Zodiac ? On dit que\nle 2e étage est un immense donjon rempli\nde super trucs.[1106][NL]Pourquoi tu vas pas fouiner ? Montre tes talents\net je parie que ta copine va te sauter dessus.\nHahahaha !"
+    },
+    {
+        "id": 48,
+        "offset": 427740,
+        "data_size": 290,
+        "slot_size": 290,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]there's[SP]a[SP]ghost[SP]girl[SP]called[NL]Hanako[SP]at[SP]Sevens.[1205][U+000F][SP]First[SP]a[SP]curse,[SP]and[SP]now[SP]a[NL]ghost?[SP]That[SP]school,[SP]I[SP]tell[SP]ya.",
+        "nom_fr": "Homme",
+        "texte_fr": "J'ai ouï-dire qu'un fantôme nommé Hanako\nest à Seven.[1205][U+000F] D'abord une malédiction, puis un\nfantôme ? Cette école, sérieux."
+    },
+    {
+        "id": 49,
+        "offset": 428030,
+        "data_size": 362,
+        "slot_size": 362,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "What,[SP]there's[SP]another[SP]ghost[SP]at[SP]Cuss[SP]High?[NL]Bukimi[SP]this[SP]time?[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Guess[SP]I[SP]can't[SP]blame[SP]a[SP]girl[SP]called[SP]Bukimi[SP]for[NL]wantin'[SP]vengeance[SP]on[SP]the[SP]world.",
+        "nom_fr": "Homme",
+        "texte_fr": "Quoi, y a un autre fantôme au lycée Kakasu ?\nBukimi cette fois ?[1106][NL]Je peux pas blâmer une fille appelée Bukimi de\nvouloir se venger."
+    },
+    {
+        "id": 50,
+        "offset": 428392,
+        "data_size": 424,
+        "slot_size": 424,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "I[SP]hear[SP]a[SP]dead[SP]idol's[SP]ghost[SP]is[SP]hauntin'[SP]Aoba[NL]Park.[SP]Guess[SP]dead[SP]or[SP]alive,[SP]girls[SP]like[SP]flowers.[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]But[SP]a[SP]poor[SP]dead[SP]girl[SP]playin'[SP]in[SP]the[SP]flowers...[NL]That's[SP]pretty[SP]sad,[SP]ya[SP]ask[SP]me.",
+        "nom_fr": "Homme",
+        "texte_fr": "Le fantôme d'une idole morte hante le parc Aoba.\nMortes ou vives, les filles aiment les fleurs.[1106][NL]Mais une fille morte jouant dans les\nfleurs... C'est bien triste, à mon avis."
+    },
+    {
+        "id": 51,
+        "offset": 428816,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Huh...[SP]A[SP]Cursed[SP]Taxi?[SP]They[SP]got[SP]one[SP]at[SP]that[NL]abandoned[SP]factory?[SP]What[SP]kinda[SP]passengers[SP]it[NL]thinks[SP]it's[SP]gonna[SP]pick[SP]up[SP]there?",
+        "nom_fr": "Homme",
+        "texte_fr": "Un Taxi Maudit ? Y en a un à l'usine abandonnée ?\nQuels genres de passagers il espère\nprendre là-bas ?"
+    },
+    {
+        "id": 52,
+        "offset": 429100,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "What?[SP]It[SP]was[SP]a[SP]Cursed[SP]Escort[SP]at[SP]the[SP]abandoned[NL]factory,[SP]not[SP]a[SP]Cursed[SP]Taxi?[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Who[SP]cares,[SP]kid?",
+        "nom_fr": "Homme",
+        "texte_fr": "Quoi ? C'est une Escorte Maudite à l'usine\nabandonnée, pas un Taxi Maudit ?[1106][NL]On s'en tape, petit."
+    },
+    {
+        "id": 53,
+        "offset": 429368,
+        "data_size": 744,
+        "slot_size": 744,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "I[SP]guess[SP]kids[SP]your[SP]age[SP]wouldn't[SP]know[SP]about[NL]Kuchisake-onna,[SP]huh?[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]She[SP]comes[SP]up[SP]to[SP]ya[SP]with[SP]her[SP]mouth[SP]covered[NL]and[SP]asks[SP]if[SP]ya[SP]think[SP]she's[SP]pretty...[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Rumor[SP]has[SP]it[SP]Kuchisake-onna's[SP]started[NL]showin'[SP]up[SP]at[SP]Mt.[SP]Iwato.[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]I[SP]gotta[SP]admit,[SP]stories[SP]like[SP]that[SP]used[SP]to[SP]give[NL]me[SP]the[SP]willies[SP]when[SP]I[SP]was[SP]a[SP]kid.",
+        "nom_fr": "Homme",
+        "texte_fr": "Les gosses de ton âge connaissent pas\nKuchisake-onna, hein ?[1106][NL]Elle vient te voir la bouche couverte et te\ndemande si tu la trouves jolie...[1106][NL]La rumeur dit que Kuchisake-onna est\napparue au Mt Iwato.[1106][NL]Faut avouer que ce genre d'histoires me donnait\nla chair de poule quand j'étais gosse."
+    },
+    {
+        "id": 54,
+        "offset": 430112,
+        "data_size": 320,
+        "slot_size": 320,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Jumping[SP]Geezer,[SP]eh?[SP]Sounds[SP]like[SP]one[SP]stylish[NL]guy.[SP]I[SP]hope[SP]I'm[SP]that[SP]full[SP]of[SP]energy[SP]when[SP]I[SP]get[NL]to[SP]be[SP]his[SP]age.[SP]He's[SP]at[SP]Mt.[SP]Katatsumuri,[SP]right?",
+        "nom_fr": "Homme",
+        "texte_fr": "Le Vieux Sauteur, hein ? Quel gars stylé.\nJ'espère avoir autant d'énergie à son âge.\nIl est au Mt Katatsumuri, non ?"
+    },
+    {
+        "id": 55,
+        "offset": 430432,
+        "data_size": 380,
+        "slot_size": 380,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "I-I[SP]just[SP]heard[SP]a[SP]hell[SP]of[SP]a[SP]thing...[SP]Do[SP]you[NL]know[SP]about[SP]this?[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Th-That[SP]Kudan...[SP]It's[SP]at[SP]the[SP]abandoned[SP]factory,[NL]and...[SP]Gaaah,[SP]I[SP]can't[SP]even[SP]say[SP]it...!",
+        "nom_fr": "Homme",
+        "texte_fr": "J-Je viens d'entendre un truc de fou...\nT'es au courant ?[1106][NL]C-Ce Kudan... Il est à l'usine abandonnée,\net... Gaaah, je peux même pas le dire... !"
+    },
+    {
+        "id": 56,
+        "offset": 430812,
+        "data_size": 346,
+        "slot_size": 346,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Hey,[SP]kid.[SP]Hear[SP]there's[SP]a[SP]hidden[SP]CD[SP]at[SP]that[NL]Giga[SP]Macho[SP]place.[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Hidden[SP]from[SP]who,[SP]is[SP]what[SP]I[SP]wanna[SP]know.[NL]You[SP]know[SP]anything[SP]about[SP]this?",
+        "nom_fr": "Homme",
+        "texte_fr": "Hé petit. Paraît qu'y a un CD caché à Giga Macho.[1106][NL]Caché de qui, c'est ce que je veux savoir.\nT'en sais quelque chose ?"
+    },
+    {
+        "id": 57,
+        "offset": 431158,
+        "data_size": 544,
+        "slot_size": 544,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]there's[SP]this[SP]Dresser[SP]Hag[NL]monster[SP]at[SP]the[SP]abandoned[SP]factory...[SP]Really,[NL]now?[SP][U+1432][U+0000][U+0000][U+0014]Dresser[SP]Hag[U+1432][U+0000][U+0000][U+0014]?[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]It's[SP]not[SP]like[SP]it's[SP]a[SP]dresser[SP]with[SP]arms[SP]and[NL]legs,[SP]is[SP]it?[SP]Sheesh.[SP]All[SP]these[SP]monsters[SP]got[NL]the[SP]worst[SP]names,[SP]I[SP]tell[SP]ya.",
+        "nom_fr": "Homme",
+        "texte_fr": "Il paraît qu'il y a un monstre Mégère à Commode\nà l'usine... Vraiment ?\n[1432][NULL][NULL][0014]Mégère à Commode[1432][NULL][NULL][0014] ?[1106][NL]C'est pas une commode avec des bras et\ndes jambes, si ? Pfff. Ces monstres ont de ces noms..."
+    },
+    {
+        "id": 58,
+        "offset": 431702,
+        "data_size": 412,
+        "slot_size": 412,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Does[SP]Time[SP]Castle[SP]in[SP]Rengedai[SP]really[SP]sell[SP]real[NL]weapons?[SP]I[SP]hear[SP]the[SP]quality[SP]and[SP]price[SP]of[SP]their[NL]stuff[SP]is[SP]about[SP]average.[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]It's[SP]a[SP]dangerous[SP]world[SP]we[SP]live[SP]in,[SP]I[SP]tell[SP]ya.",
+        "nom_fr": "Homme",
+        "texte_fr": "Time Castle à Rengedai vendrait de vraies armes ?\nIl paraît que la qualité et les prix sont moyens.[1106][NL]On vit dans un monde dangereux, crois-moi."
+    },
+    {
+        "id": 59,
+        "offset": 432114,
+        "data_size": 414,
+        "slot_size": 414,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Does[SP]Time[SP]Castle[SP]in[SP]Rengedai[SP]really[SP]sell[SP]real[NL]weapons?[SP]I[SP]hear[SP]the[SP]quality[SP]of[SP]their[SP]stuff[SP]is[NL]good,[SP]but[SP]it's[SP]expensive.[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]It's[SP]a[SP]dangerous[SP]world[SP]we[SP]live[SP]in,[SP]I[SP]tell[SP]ya.",
+        "nom_fr": "Homme",
+        "texte_fr": "Time Castle à Rengedai vendrait de vraies armes ?\nIl paraît que la qualité est bonne, mais c'est cher.[1106][NL]On vit dans un monde dangereux, crois-moi."
+    },
+    {
+        "id": 60,
+        "offset": 432528,
+        "data_size": 390,
+        "slot_size": 390,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Does[SP]Time[SP]Castle[SP]in[SP]Rengedai[SP]really[SP]sell[SP]real[NL]weapons?[SP]I[SP]hear[SP]their[SP]stuff[SP]is[SP]cheap,[SP]but[SP]it's[NL]low[SP]quality.[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]It's[SP]a[SP]dangerous[SP]world[SP]we[SP]live[SP]in,[SP]I[SP]tell[SP]ya.",
+        "nom_fr": "Homme",
+        "texte_fr": "Time Castle à Rengedai vendrait de vraies armes ?\nIl paraît que c'est pas cher, mais de piètre qualité.[1106][NL]On vit dans un monde dangereux, crois-moi."
+    },
+    {
+        "id": 61,
+        "offset": 432918,
+        "data_size": 354,
+        "slot_size": 354,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]that[SP]poser[SP]Tony[SP]has[SP]been[SP]selling[NL]real[SP]weapons[SP]on[SP]the[SP]sly.[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]I[SP]hear[SP]his[SP]selection's[SP]good,[SP]but[SP]his[SP]resale[NL]price[SP]ain't[SP]so[SP]hot.",
+        "nom_fr": "Homme",
+        "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce.[1106][NL]Son choix est bon, mais son prix de rachat est naze."
+    },
+    {
+        "id": 62,
+        "offset": 433272,
+        "data_size": 344,
+        "slot_size": 344,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]that[SP]poser[SP]Tony[SP]has[SP]been[SP]selling[NL]real[SP]weapons[SP]on[SP]the[SP]sly.[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]I[SP]hear[SP]his[SP]stuff's[SP]cheap,[SP]but[SP]not[SP]what[SP]you'd[NL]call[SP]quality.",
+        "nom_fr": "Homme",
+        "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce.[1106][NL]C'est pas cher, mais on peut pas parler de qualité."
+    },
+    {
+        "id": 63,
+        "offset": 433616,
+        "data_size": 348,
+        "slot_size": 348,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]that[SP]poser[SP]Tony[SP]has[SP]been[SP]selling[NL]real[SP]weapons[SP]on[SP]the[SP]sly.[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]I[SP]hear[SP]the[SP]quality[SP]and[SP]price[SP]of[SP]his[SP]stuff[NL]is[SP]pretty[SP]average.",
+        "nom_fr": "Homme",
+        "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce.[1106][NL]La qualité et le prix de ses trucs sont dans la moyenne."
+    },
+    {
+        "id": 64,
+        "offset": 433964,
+        "data_size": 318,
+        "slot_size": 318,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]that[SP]poser[SP]Tony[SP]has[SP]been[SP]selling[NL]real[SP]weapons[SP]on[SP]the[SP]sly.[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]I[SP]hear[SP]he[SP]has[SP]good[SP]stuff,[SP]but[SP]it's[SP]expensive.",
+        "nom_fr": "Homme",
+        "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce.[1106][NL]Il a de bons trucs, mais ça coûte cher."
+    },
+    {
+        "id": 65,
+        "offset": 434282,
+        "data_size": 290,
+        "slot_size": 290,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba[NL]sells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]selection[SP]sucks,[NL]but[SP]their[SP]resale[SP]prices[SP]are[SP]high.",
+        "nom_fr": "Homme",
+        "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nLeur choix craint, mais leurs prix de rachat sont élevés."
+    },
+    {
+        "id": 66,
+        "offset": 434572,
+        "data_size": 252,
+        "slot_size": 252,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba[NL]sells[SP]real[SP]weapons.[1205][U+000F][SP]They're[SP]cheap,[SP]but[NL]the[SP]quality[SP]sucks.",
+        "nom_fr": "Homme",
+        "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nC'est pas cher, mais la qualité est nulle."
+    },
+    {
+        "id": 67,
+        "offset": 434824,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba[NL]sells[SP]real[SP]weapons.[1205][U+000F][SP]The[SP]quality's[SP]good,[NL]but[SP]the[SP]prices[SP]are[SP]high.",
+        "nom_fr": "Homme",
+        "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nLa qualité est là, mais les prix sont élevés."
+    },
+    {
+        "id": 68,
+        "offset": 435090,
+        "data_size": 292,
+        "slot_size": 292,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba[NL]sells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]selection's[NL]good,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]the[SP]pits.",
+        "nom_fr": "Homme",
+        "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nLe choix est bon, mais les prix de rachat sont à chier."
+    },
+    {
+        "id": 69,
+        "offset": 435382,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba[NL]sells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]quality[SP]and[NL]price[SP]are[SP]basically[SP]average.",
+        "nom_fr": "Homme",
+        "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][U+000F]\nLeur qualité et leurs prix sont dans la moyenne."
+    },
+    {
+        "id": 70,
+        "offset": 435652,
+        "data_size": 248,
+        "slot_size": 248,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells[NL]weapons...[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality[SP]and[SP]price[NL]is[SP]just[SP]average.",
+        "nom_fr": "Homme",
+        "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nIl paraît que la qualité et les prix sont moyens."
+    },
+    {
+        "id": 71,
+        "offset": 435900,
+        "data_size": 258,
+        "slot_size": 258,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells[NL]weapons...[1205][U+000F][SP]I[SP]hear[SP]they're[SP]cheap,[SP]but[SP]not[NL]exactly[SP]quality[SP]stuff.",
+        "nom_fr": "Homme",
+        "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nC'est pas cher, mais c'est pas de la top qualité."
+    },
+    {
+        "id": 72,
+        "offset": 436158,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells[NL]weapons...[1205][U+000F][SP]I[SP]hear[SP]his[SP]selection's[SP]good,[NL]but[SP]his[SP]resale[SP]value[SP]sucks.",
+        "nom_fr": "Homme",
+        "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nIl a du choix, mais les prix de rachat sont nuls."
+    },
+    {
+        "id": 73,
+        "offset": 436424,
+        "data_size": 274,
+        "slot_size": 274,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells[NL]weapons...[1205][U+000F][SP]I[SP]hear[SP]his[SP]selection[SP]sucks,[NL]but[SP]his[SP]resale[SP]prices[SP]are[SP]great.",
+        "nom_fr": "Homme",
+        "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nLe choix craint, mais les prix de rachat sont super."
+    },
+    {
+        "id": 74,
+        "offset": 436698,
+        "data_size": 260,
+        "slot_size": 260,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells[NL]weapons...[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality's[SP]good,[NL]but[SP]the[SP]prices[SP]are[SP]high.",
+        "nom_fr": "Homme",
+        "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][U+000F]\nLa qualité est bonne, mais les prix sont élevés."
+    },
+    {
+        "id": 75,
+        "offset": 436958,
+        "data_size": 280,
+        "slot_size": 280,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "It[SP]takes[SP]balls[SP]to[SP]sell[SP]armor[SP]at[SP]a[SP]fancy[NL]boutique[SP]like[SP]Rosa[SP]Candida[SP]at[SP]Rengedai.[1205][U+000F][NL]Their[SP]quality[SP]and[SP]price[SP]is[SP]average.",
+        "nom_fr": "Homme",
+        "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[1205][U+000F] Qualité et prix moyens."
+    },
+    {
+        "id": 76,
+        "offset": 437238,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "It[SP]takes[SP]balls[SP]to[SP]sell[SP]armor[SP]at[SP]a[SP]fancy[NL]boutique[SP]like[SP]Rosa[SP]Candida[SP]at[SP]Rengedai.[1205][U+000F][NL]It's[SP]cheap,[SP]but[SP]low[SP]quality.",
+        "nom_fr": "Homme",
+        "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[1205][U+000F] Pas cher, mais qualité nulle."
+    },
+    {
+        "id": 77,
+        "offset": 437504,
+        "data_size": 276,
+        "slot_size": 276,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "It[SP]takes[SP]balls[SP]to[SP]sell[SP]armor[SP]at[SP]a[SP]fancy[NL]boutique[SP]like[SP]Rosa[SP]Candida[SP]at[SP]Rengedai.[1205][U+000F][NL]It's[SP]good[SP]quality,[SP]but[SP]expensive.",
+        "nom_fr": "Homme",
+        "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[1205][U+000F] Bonne qualité, mais cher."
+    },
+    {
+        "id": 78,
+        "offset": 437780,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[SP]real[NL]armor,[SP]not[SP]just[SP]clothes.[SP]The[SP]price[SP]and[SP]quality[NL]of[SP]their[SP]stuff[SP]is[SP]average.",
+        "nom_fr": "Homme",
+        "texte_fr": "Anima Mundi vend de vraies armures, pas que\ndes fringues. Prix et qualité dans la moyenne."
+    },
+    {
+        "id": 79,
+        "offset": 438064,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[SP]real[NL]armor,[SP]not[SP]just[SP]clothes.[SP]It's[SP]cheap[SP]stuff,[SP]but[NL]you[SP]get[SP]what[SP]you[SP]pay[SP]for.",
+        "nom_fr": "Homme",
+        "texte_fr": "Anima Mundi vend de vraies armures, pas que\ndes fringues. C'est pas cher, mais on en a pour son argent."
+    },
+    {
+        "id": 80,
+        "offset": 438346,
+        "data_size": 292,
+        "slot_size": 292,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[SP]real[NL]armor,[SP]not[SP]just[SP]clothes.[SP]Their[SP]selection's[NL]great,[SP]but[SP]the[SP]resale[SP]value[SP]isn't.",
+        "nom_fr": "Homme",
+        "texte_fr": "Anima Mundi vend de vraies armures. Bon choix,\nmais prix de rachat très bas."
+    },
+    {
+        "id": 81,
+        "offset": 438638,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Looks[SP]like[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[SP]real[NL]armor,[SP]not[SP]just[SP]clothes.[SP]Their[SP]quality's[SP]good,[NL]but[SP]it's[SP]expensive[SP]stuff.",
+        "nom_fr": "Homme",
+        "texte_fr": "Anima Mundi vend de vraies armures. Bonne qualité,\nmais ça coûte cher."
+    },
+    {
+        "id": 82,
+        "offset": 438920,
+        "data_size": 302,
+        "slot_size": 302,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[NL]real[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]selection's[SP]the[NL]pits,[SP]but[SP]they[SP]have[SP]great[SP]resale[SP]prices.",
+        "nom_fr": "Homme",
+        "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nLe choix craint, mais les prix de rachat sont excellents."
+    },
+    {
+        "id": 83,
+        "offset": 439222,
+        "data_size": 262,
+        "slot_size": 262,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[NL]real[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality[SP]and[NL]prices[SP]are[SP]just[SP]average.",
+        "nom_fr": "Homme",
+        "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nLa qualité et les prix sont très moyens."
+    },
+    {
+        "id": 84,
+        "offset": 439484,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[NL]real[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]stuff[SP]is[SP]top-[NL]notch,[SP]but[SP]it's[SP]expensive.",
+        "nom_fr": "Homme",
+        "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nC'est du matos top niveau, mais c'est cher."
+    },
+    {
+        "id": 85,
+        "offset": 439754,
+        "data_size": 264,
+        "slot_size": 264,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[NL]real[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]prices[SP]are[NL]low,[SP]but[SP]so's[SP]the[SP]quality.",
+        "nom_fr": "Homme",
+        "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nC'est pas cher, mais la qualité suit."
+    },
+    {
+        "id": 86,
+        "offset": 440018,
+        "data_size": 290,
+        "slot_size": 290,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[NL]real[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]selection's[SP]good,[NL]but[SP]their[SP]resale[SP]value[SP]is[SP]awful.",
+        "nom_fr": "Homme",
+        "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][U+000F]\nBon choix, mais le prix de rachat est affreux."
+    },
+    {
+        "id": 87,
+        "offset": 440308,
+        "data_size": 304,
+        "slot_size": 304,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you[NL]can[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]selection[NL]is[SP]great,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]low.",
+        "nom_fr": "Homme",
+        "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nLe choix est super, mais le prix de rachat est bas."
+    },
+    {
+        "id": 88,
+        "offset": 440612,
+        "data_size": 286,
+        "slot_size": 286,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you[NL]can[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]stuff[NL]is[SP]cheap,[SP]but[SP]really[SP]low[SP]quality.",
+        "nom_fr": "Homme",
+        "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nC'est pas cher, mais de mauvaise qualité."
+    },
+    {
+        "id": 89,
+        "offset": 440898,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you[NL]can[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality's[NL]great,[SP]if[SP]you[SP]can[SP]afford[SP]it.",
+        "nom_fr": "Homme",
+        "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nLa qualité est top, si tu peux te le permettre."
+    },
+    {
+        "id": 90,
+        "offset": 441182,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you[NL]can[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]quality[NL]and[SP]prices[SP]are[SP]average.",
+        "nom_fr": "Homme",
+        "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nLa qualité et les prix sont moyens."
+    },
+    {
+        "id": 91,
+        "offset": 441452,
+        "data_size": 314,
+        "slot_size": 314,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you[NL]can[SP]wear,[SP]even[SP]armor?[1205][U+000F][SP]I[SP]hear[SP]their[SP]selection[NL]is[SP]terrible,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]great.",
+        "nom_fr": "Homme",
+        "texte_fr": "London Clothier fait même des armures ?[1205][U+000F]\nLe choix est nul, mais le prix de rachat est excellent."
+    },
+    {
+        "id": 92,
+        "offset": 441766,
+        "data_size": 304,
+        "slot_size": 304,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "You[SP]can[SP]win[SP]weapons[SP]in[SP]a[SP]magazine[SP]sweepstakes?[NL]What[SP]is[SP]this[SP]world[SP]coming[SP]to?[SP]I[SP]hear[SP]you[SP]don't[NL]win[SP]often,[SP]but[SP]the[SP]prizes[SP]are[SP]nice.",
+        "nom_fr": "Homme",
+        "texte_fr": "Gagner des armes à un concours de magazine ?\nOn gagne pas souvent, mais les prix sont sympas."
+    },
+    {
+        "id": 93,
+        "offset": 442070,
+        "data_size": 320,
+        "slot_size": 320,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "You[SP]can[SP]win[SP]weapons[SP]in[SP]a[SP]magazine[SP]sweepstakes?[NL]What[SP]is[SP]this[SP]world[SP]coming[SP]to?[SP]I[SP]hear[SP]it's[SP]rare[NL]anyone[SP]wins,[SP]but[SP]the[SP]prizes[SP]are[SP]first-rate.",
+        "nom_fr": "Homme",
+        "texte_fr": "Gagner des armes à un concours de magazine ?\nC'est rare de gagner, mais les prix sont top."
+    },
+    {
+        "id": 94,
+        "offset": 442390,
+        "data_size": 320,
+        "slot_size": 320,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "You[SP]can[SP]win[SP]weapons[SP]in[SP]a[SP]magazine[SP]sweepstakes?[NL]What[SP]is[SP]this[SP]world[SP]coming[SP]to?[SP]I[SP]hear[SP]it's[SP]easy[NL]to[SP]win,[SP]but[SP]the[SP]prizes[SP]are[SP]barely[SP]worth[SP]it.",
+        "nom_fr": "Homme",
+        "texte_fr": "Gagner des armes à un concours de magazine ?\nC'est facile de gagner, mais c'est pas dingue."
+    },
+    {
+        "id": 95,
+        "offset": 442710,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "So[SP]Mu[SP]is[SP]actually[SP]a[SP]gambling[SP]parlor?[SP]I[SP]didn't[NL]know[SP]that.[SP]Now[SP]I'm[SP]excited![SP]I[SP]hear[SP]you[SP]can[NL]win[SP]big[SP]there[SP]at[SP]poker.",
+        "nom_fr": "Homme",
+        "texte_fr": "Mu a un casino ? Je savais pas.\nC'est génial ! On gagne gros au poker."
+    },
+    {
+        "id": 96,
+        "offset": 442980,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "So[SP]Mu[SP]is[SP]actually[SP]a[SP]gambling[SP]parlor?[SP]I[SP]didn't[NL]know[SP]that.[SP]Now[SP]I'm[SP]excited![SP]I[SP]hear[SP]you[SP]can[NL]win[SP]big[SP]there[SP]at[SP]slots.",
+        "nom_fr": "Homme",
+        "texte_fr": "Mu a un casino ? Je savais pas.\nC'est génial ! On gagne gros aux machines."
+    },
+    {
+        "id": 97,
+        "offset": 443250,
+        "data_size": 402,
+        "slot_size": 402,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "So[SP]Mu[SP]is[SP]actually[SP]a[SP]gambling[SP]parlor?[SP]I[SP]didn't[NL]know[SP]that![SP]I[SP]love[SP]gambling![SP]Now[SP]I'm[SP]excited![1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Plus,[SP]I[SP]hear[SP]you[SP]can[SP]win[SP]big[SP]there[SP]at[NL]blackjack.[SP]Hah,[SP]my[SP]favorite!",
+        "nom_fr": "Homme",
+        "texte_fr": "Mu a un casino ? Je savais pas !\nJ'adore ça ! Je suis à fond ![1106][NL]En plus, tu gagnes gros au\nblackjack. Hah, mon préféré !"
+    },
+    {
+        "id": 98,
+        "offset": 443652,
+        "data_size": 312,
+        "slot_size": 312,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "I[SP]hear[SP]there's[SP]a[SP]legendary[SP]weapon[SP]for[SP]sale[SP]at[NL]Shiraishi[SP]Ramen.[SP]Is[SP]that[SP]true?[SP]Sheesh...[SP]First[NL]a[SP]Russian[SP]spy,[SP]now[SP]a[SP]legendary[SP]weapon...",
+        "nom_fr": "Homme",
+        "texte_fr": "Shiraishi Ramen vend une arme légendaire ?\nSérieux ? Une espionne, puis ça..."
+    },
+    {
+        "id": 99,
+        "offset": 443964,
+        "data_size": 292,
+        "slot_size": 292,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Hey,[SP]sounds[SP]like[SP]there's[SP]some[SP]legendary[SP]weapon[NL]at[SP]Clair[SP]de[SP]Lune.[SP]Man,[SP]there[SP]ain't[SP]any[NL]upstanding[SP]shops[SP]in[SP]this[SP]city[SP]at[SP]all.",
+        "nom_fr": "Homme",
+        "texte_fr": "Une arme légendaire chez Clair de Lune...\nIl n'y a plus de boutiques honnêtes ici."
+    },
+    {
+        "id": 100,
+        "offset": 444256,
+        "data_size": 304,
+        "slot_size": 304,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "I[SP]hear[SP]the[SP]owner[SP]at[SP]Time[SP]Castle[SP]is[SP]sitting[SP]on[NL]the[SP]legendary[SP]weapon[SP]to[SP]jack[SP]up[SP]its[SP]price.[NL]Shysters[SP]like[SP]that[SP]rub[SP]me[SP]the[SP]wrong[SP]way.",
+        "nom_fr": "Homme",
+        "texte_fr": "Le boss de Time Castle garde son arme\nlégendaire pour monter le prix. Quel rapiat."
+    },
+    {
+        "id": 101,
+        "offset": 444560,
+        "data_size": 320,
+        "slot_size": 320,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Hahaha,[SP]I[SP]hear[SP]the[SP]owner[SP]of[SP]Time[SP]Castle[SP]is[SP]too[NL]scared[SP]of[SP]monsters[SP]to[SP]fetch[SP]the[SP]legendary[SP]weapon[NL]waiting[SP]for[SP]him[SP]at[SP]the[SP]abandoned[SP]factory.",
+        "nom_fr": "Homme",
+        "texte_fr": "Hahaha, le boss de Time Castle a trop peur\ndes monstres pour aller chercher son arme à l'usine."
+    },
+    {
+        "id": 102,
+        "offset": 444880,
+        "data_size": 376,
+        "slot_size": 376,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Hey,[SP]is[SP]it[SP]true[SP]some[SP]demons[SP]stole[SP]the[SP]legendary[NL]weapon[SP]from[SP]Time[SP]Castle?[NL][1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]What[SP]a[SP]load[SP]of[SP]it.[1205][U+000F][SP]Then[SP]again,[SP]lately[SP]it[SP]seems[NL]like[SP]anything[SP]goes...",
+        "nom_fr": "Homme",
+        "texte_fr": "Hé, des démons ont vraiment volé l'arme\nlégendaire de Time Castle ?[1106][NL]Quelle connerie.[1205][U+000F] M'enfin, on\npeut s'attendre à tout de nos jours..."
+    },
+    {
+        "id": 103,
+        "offset": 445256,
+        "data_size": 550,
+        "slot_size": 550,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "I[SP]heard[SP]some[SP]unlucky[SP]woman[SP]bought[SP]the[SP]legendary[NL]weapon[SP]at[SP]Time[SP]Castle.[SP]A[SP]lady's[SP]got[SP]no[SP]business[NL]ownin'[SP]something[SP]that[SP]dangerous.[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Huh?[SP]My[SP]attitude's[SP]out[SP]of[SP]date?[SP]Heh,[SP]that's[NL]fine[SP]by[SP]me![SP]In[SP]my[SP]book,[SP]men[SP]are[SP]supposed[SP]to[NL]protect[SP]women!",
+        "nom_fr": "Homme",
+        "texte_fr": "Une femme malchanceuse a acheté l'arme\nlégendaire de Time Castle. Une dame avec ça, sérieux.[1106][NL]Hein ? Je suis ringard ? M'en fiche !\nPour moi, les hommes protègent les femmes !"
+    },
+    {
+        "id": 104,
+        "offset": 445806,
+        "data_size": 414,
+        "slot_size": 414,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Blue-collar[SP]man",
+        "texte_orig": "Hey,[SP]did[SP]ya[SP]hear?[SP]The[SP]owner[SP]of[SP]Time[SP]Castle[SP]gave[NL]that[SP]legendary[SP]weapon[SP]to[SP]some[SP]girl[SP]with[SP]short[NL]hair.[1106][E2][1431][U+0000][U+0000]\"Blue-collar[SP]man[NL]Hahaha,[SP]pretty[SP]generous[SP]of[SP]him,[SP]huh?[SP]Now[SP]there's[NL]a[SP]man[SP]for[SP]you.",
+        "nom_fr": "Homme",
+        "texte_fr": "Hé, t'as entendu ? Le boss de Time Castle a\ndistribué son arme légendaire à une fille\naux cheveux courts.[1106][NL]Hahaha, plutôt généreux, non ? C'est ça\nun vrai homme."
+    },
+    {
+        "id": 105,
+        "offset": 446220,
+        "data_size": 828,
+        "slot_size": 828,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaaah![SP]I'm[SP]not[SP]a[SP]Cuss[SP]High[SP]student[SP]anymore.[NL]I[SP]used[SP]to[SP]be[SP]one,[SP]but[SP]no[SP]longer.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Now,[SP]I[SP]am[SP]a[SP]washout[SP]who's[SP]fighting[SP]to[SP]study[NL]hard[SP]and[SP]make[SP]it[SP]into[SP]the[SP]best[SP]university[SP]in[NL]the[SP]country![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]However![SP]The[SP]recent[SP]influx[SP]of[SP]women[SP]into[SP]this[NL]city[SP]is[SP]troubling![SP]While[SP]I'm[SP]happy[SP]my[SP]alma[SP]mater[NL]is[SP]gaining[SP]popularity,[SP]they're[SP]distracting!",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaaah ! Je ne suis plus à Kakasu.\nJ'y étais, mais plus maintenant.[1106][NL]Maintenant, j'étudie dur pour intégrer\nla meilleure université du pays ![1106][NL]Cependant ! L'afflux de femmes ici est troublant !\nMon école est populaire, mais ça me distrait !"
+    },
+    {
+        "id": 106,
+        "offset": 447048,
+        "data_size": 898,
+        "slot_size": 898,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Was[SP]it[SP]only[SP]a[SP]groundless[SP]rumor?[1205][U+000F][SP]I[SP]hear[NL]tell[SP]of[SP]a[SP]walking[SP]statue[SP]at[SP]Sevens,[SP]my[SP]alma[NL]mater's[SP]rival...[1205][U+000F][SP]Hate[SP]the[SP]sin,[SP]love[SP]the[SP]sinner![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Having[SP]such[SP]a[SP]statue[SP]on[SP]school[SP]grounds[SP]must[SP]be[NL]a[SP]serious[SP]impediment[SP]to[SP]the[SP]education[SP]of[SP]the[NL]students[SP]there.[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]As[SP]a[SP]fighting[SP]student,[SP]I[SP]will[SP]bring[SP]divine[NL]punishment[SP]to[SP]that[SP]vexing[SP]statue![SP]Eventually,[NL]that[SP]is...",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] C'était juste une rumeur ?[1205][U+000F] On\nparle d'une statue vivante à Seven...\n[1205][U+000F]Aime le pécheur, hais le péché ![1106][NL]Avoir une telle statue à l'école doit\ngêner sérieusement l'éducation de ces\nélèves.[1205][U+000F][1106][NL]En tant qu'étudiant, j'apporterai le châtiment\ndivin à cette statue ! Éventuellement..."
+    },
+    {
+        "id": 107,
+        "offset": 447946,
+        "data_size": 1474,
+        "slot_size": 1474,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "H-Hyaaaah...![1205][U+000F][SP]My[SP]vision[SP]is[SP]blurry[SP]with[SP]tears...[NL]The[SP]students[SP]at[SP]my[SP]alma[SP]mater[SP]are[SP]incredible![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]You[SP]are[SP]all[SP]shining[SP]examples![1205][U+000F][SP]I[SP]have[SP]long[NL]awaited[SP]such[SP]a[SP]sight![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]A[SP]school[SP]festival[SP]is[SP]an[SP]important[SP]event[SP]that[NL]shows[SP]the[SP]fruits[SP]of[SP]daily[SP]education[SP]and[SP]school[NL]traditions![1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]To[SP]host[SP]a[SP]foreign[SP]dance[SP]like[SP]this[SP]masquerade[NL]truly[SP]speaks[SP]of[SP]your[SP]international[SP]spirit![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]It[SP]is[SP]in[SP]the[SP]nature[SP]of[SP]youth[SP]to[SP]be[SP]reckless[NL]in[SP]the[SP]name[SP]of[SP]freedom![1205][U+000F][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Even[SP]drops[SP]of[SP]water[SP]wear[SP]away[SP]at[SP]stone![1205][U+000F][SP]Do[SP]your[NL]best[SP]to[SP]work[SP]towards[SP]your[SP]future,[SP]and[SP]a[SP]bright[NL]tomorrow[SP]will[SP]await[SP]you[SP]all!",
+        "nom_fr": "Étudiant",
+        "texte_fr": "H-Hyaaaah... ![1205][U+000F] J'ai les larmes aux yeux...\nLes élèves de mon école sont incroyables ![1106][NL]Vous êtes de brillants exemples ![1205][U+000F]\nJ'ai longtemps attendu une telle chose ![1106][NL]Le festival montre les fruits de l'éducation\net des traditions scolaires ![1205][U+000F][1106][NL]Faire un bal masqué comme ça prouve\nvotre esprit international ![1106][NL]C'est dans la nature de la jeunesse d'être\nimprudent au nom de la liberté ![1205][U+000F][1106][NL]Les gouttes d'eau usent la pierre ![1205][U+000F] Faites de\nvotre mieux pour votre avenir, et des\nlendemains radieux vous attendent !"
+    },
+    {
+        "id": 108,
+        "offset": 449420,
+        "data_size": 1090,
+        "slot_size": 1090,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![SP]I[SP]can't[SP]believe[SP]I[SP]let[SP]myself[SP]be[SP]taken[NL]in[SP]by[SP]a[SP]groundless[SP]rumor![1205][U+000F][SP]What?[SP]You[SP]wish[SP]to[NL]know[SP]more[SP]of[SP]my[SP]folly?[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]I[SP]heard[SP]a[SP]rumor[SP]that[SP]there[SP]was[SP]real[SP]armor[SP]to[NL]be[SP]had[SP]at[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]But[SP]in[SP]truth,[SP]there[SP]was[SP]nothing[SP]of[SP]the[SP]kind![NL]The[SP]employees[SP]there[SP]even[SP]mocked[SP]me[SP]for[SP]asking![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]But[SP]perhaps[SP]my[SP]information[SP]was[SP]bad...[1205][U+000F][SP]Maybe[NL]that[SP]stout[SP]man[SP]knows[SP]something.[1205][U+000F][SP]I[SP]believe[SP]his[NL]name[SP]is[SP]Toro,[SP]and[SP]he[SP]loves[SP]fatty[SP]tuna.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ! J'arrive pas à croire que j'ai\ngobé une rumeur infondée ![1205][U+000F] Quoi ? Tu\nveux en savoir plus sur ma folie ?[1106][NL]J'ai entendu une rumeur disant qu'il y avait\nde vraies armures à Anima Mundi à Yumezaki.[1106][NL]Mais en fait, il n'y avait rien de tel !\nLes employés se sont même moqués de moi ![1106][NL]Mais mes infos étaient peut-être fausses...[1205][U+000F]\nCe grand costaud sait peut-être\nquelque chose.[1205][U+000F] Il s'appelle Toro,\net adore le thon gras."
+    },
+    {
+        "id": 109,
+        "offset": 450510,
+        "data_size": 808,
+        "slot_size": 808,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]heard[SP]that[SP]the[SP]members[SP]of[SP]Muses[SP]are[NL]all[SP]still[SP]in[SP]high[SP]school![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]What[SP]about[SP]their[SP]studies!?[1205][U+000A][SP]What[SP]about[SP]their[NL]college[SP]entrance[SP]exams!?[1205][U+000A][SP]Have[SP]you[SP]even[SP]taken[NL]your[SP]finals[SP]yet!?[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]One's[SP]good[SP]looks[SP]will[SP]not[SP]keep[SP]one[SP]afloat![1205][U+000F][NL]How[SP]dare[SP]they[SP]be[SP]dazzled[SP]by[SP]show[SP]business!?[NL]A[SP]student's[SP]first[SP]duty[SP]is[SP]studying!",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu dire que les membres de\nMuses sont toutes encore au lycée ![1106][NL]Qu'en est-il de leurs études !?[1205][U+000A] Et leurs\nexamens d'entrée à la fac !?[1205][U+000A] Avez-vous\nseulement passé vos examens finaux !?[1106][NL]La beauté seule ne suffit pas ![1205][U+000F]\nComment osent-elles se laisser éblouir par le show-biz !?\nLe premier devoir d'un étudiant est d'étudier !"
+    },
+    {
+        "id": 110,
+        "offset": 451318,
+        "data_size": 852,
+        "slot_size": 852,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]like[SP]Ginji[SP]Sasaki[SP]too![1205][U+000F][SP]I[SP]don't[SP]really[NL]listen[SP]to[SP]them,[SP]but[SP]I've[SP]bought[SP]everything[SP]he's[NL]produced![SP]Even[SP]his[SP]compilation[SP]album![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]But[SP]I[SP]cannot[SP]abide[SP]by[SP]his[SP]dragging[SP]innocent[NL]maidens[SP]who[SP]should[SP]be[SP]studying[SP]into[SP]his[SP]tawdry[NL]industry![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Though[SP]I[SP]don't[SP]necessarily[SP]hate[SP]his[SP]music.[1205][U+000F][NL]Am[SP]I[SP]contradicting[SP]myself?[1205][U+000F][SP]I[SP]am,[SP]aren't[SP]I...?",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] J'aime Ginji Sasaki moi aussi ![1205][U+000F]\nJe ne les écoute pas vraiment, mais j'ai acheté\ntout ce qu'il a produit ! Même sa compil ![1106][NL]Mais je hais qu'il entraîne des filles\ninnocentes devant étudier dans cette\nindustrie tape-à-l'œil ![1106][NL]Bien que je ne déteste pas vraiment sa musique.[1205][U+000F]\nEst-ce que je me contredis ?[1205][U+000F] Oui, n'est-ce pas... ?"
+    },
+    {
+        "id": 111,
+        "offset": 452170,
+        "data_size": 644,
+        "slot_size": 644,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]don't[SP]know[SP]if[SP]it[SP]was[SP]actually[SP]a[NL]terrorism[SP]wave,[SP]but[SP]my[SP]cram[SP]school[SP]was[SP]shut[NL]down[SP]because[SP]of[SP]fools[SP]playing[SP]with[SP]fire![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Nothing[SP]will[SP]get[SP]in[SP]the[SP]way[SP]of[SP]my[SP]studies![NL]The[SP]pen[SP]is[SP]mightier[SP]than[SP]the[SP]sword![SP]I'll[SP]bring[NL]down[SP]the[SP]Masked[SP]Circle![1205][U+000F][SP]Eventually...",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Je ne sais pas s'il y a vraiment\nune vague de terrorisme, mais ma prépa a\nfermé à cause d'idiots qui jouent avec le feu ![1106][NL]Rien ne m'empêchera d'étudier !\nLa plume est plus forte que l'épée !\nJe ferai tomber le Cercle masqué ![1205][U+000F] Bientôt..."
+    },
+    {
+        "id": 112,
+        "offset": 452814,
+        "data_size": 670,
+        "slot_size": 670,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]People[SP]talk[SP]about[SP]terrorism[SP]this[SP]and[NL]terrorism[SP]that,[SP]but[SP]if[SP]this[SP]is[SP]the[SP]work[SP]of[NL]terrorists,[SP]we[SP]should[SP]know[SP]their[SP]demands[SP]now.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Yet[SP]none[SP]have[SP]been[SP]made.[SP]It's[SP]possible[SP]that[NL]this[SP]is[SP]being[SP]perpetrated[SP]for[SP]someone's[SP]sick[NL]amusement...[1205][U+000F][SP]My[SP]anger[SP]will[SP]never[SP]be[SP]stilled!",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] On parle de terrorisme par-ci\npar-là, mais on devrait connaître leurs\nrevendications maintenant.[1106][NL]Pourtant, aucune n'a été faite. C'est peut-être\nl'œuvre de quelqu'un qui s'amuse...[1205][U+000F]\nMa colère ne s'apaisera jamais !"
+    },
+    {
+        "id": 113,
+        "offset": 453484,
+        "data_size": 670,
+        "slot_size": 670,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]People[SP]talk[SP]about[SP]terrorism[SP]this[SP]and[NL]terrorism[SP]that,[SP]but[SP]if[SP]this[SP]is[SP]the[SP]work[SP]of[NL]terrorists,[SP]we[SP]should[SP]know[SP]their[SP]demands[SP]now.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Yet[SP]none[SP]have[SP]been[SP]made.[SP]It's[SP]possible[SP]that[NL]this[SP]is[SP]being[SP]perpetrated[SP]for[SP]someone's[SP]sick[NL]amusement...[1205][U+000F][SP]My[SP]anger[SP]will[SP]never[SP]be[SP]stilled!",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] On parle de terrorisme par-ci\npar-là, mais on devrait connaître leurs\nrevendications maintenant.[1106][NL]Pourtant, aucune n'a été faite. C'est peut-être\nl'œuvre de quelqu'un qui s'amuse...[1205][U+000F]\nMa colère ne s'apaisera jamais !"
+    },
+    {
+        "id": 114,
+        "offset": 454154,
+        "data_size": 868,
+        "slot_size": 868,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Hmm,[SP]if[SP]my[SP]high[SP]school[SP]memories[SP]are[NL]accurate,[SP]that[SP]lady[SP]a[SP]moment[SP]ago[SP]was[SP]Sevens'...[1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Did[SP]something[SP]happen[SP]for[SP]her[SP]to[SP]rush[SP]into[SP]the[NL]detective[SP]agency[SP]like[SP]that?[1205][U+000F][SP]*gasp*[SP]No![SP]What[SP]an[NL]awful[SP]thought![1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]It's[SP]terribly[SP]vulgar[SP]to[SP]pry[SP]into[SP]the[SP]privacy[SP]of[NL]others.[1205][U+000F][SP]I[SP]must[SP]admonish[SP]myself![1205][U+000F][SP]Time[SP]to[SP]copy[NL]all[SP]the[SP]pages[SP]of[SP]the[SP]Compendium[SP]of[SP]Laws!",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Hmm, si mes souvenirs du lycée\nsont exacts, cette dame d'il y a un\ninstant était de Seven...[1106][NL]Il s'est passé un truc pour qu'elle se rue\nainsi à l'agence de détectives ?[1205][U+000F]\n*gasp* Non ! Quelle pensée affreuse ![1106][NL]C'est terriblement vulgaire de s'immiscer dans\nla vie privée des autres.[1205][U+000F] Je dois me faire une\nraison ![1205][U+000F] Je vais copier le code civil !"
+    },
+    {
+        "id": 115,
+        "offset": 455022,
+        "data_size": 566,
+        "slot_size": 566,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Fear[SP]makes[SP]men[SP]panic[SP]and[SP]become[NL]confused![SP]What[SP]is[SP]right[SP]and[SP]what[SP]is[SP]wrong...[1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]That[SP]must[SP]be[SP]made[SP]clear,[SP]or[SP]man[SP]will[SP]continue[NL]to[SP]make[SP]foolish[SP]mistakes.[1205][U+000F][SP]Let[SP]us[SP]all[SP]calm[NL]ourselves...[1205][U+000F][SP]and[SP]trust[SP]in[SP]the[SP]In[SP]Lak'ech.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaah![1205][U+000F] La peur fait paniquer\nles hommes et les rend confus ! Ce qui\nest bien et ce qui est mal...[1106][NL]Ça doit être clarifié, ou l'homme continuera\nà faire des erreurs stupides.[1205][U+000F] Calmons-nous\ntous...[1205][U+000F] et faisons confiance à l'In Lak'ech."
+    },
+    {
+        "id": 116,
+        "offset": 455588,
+        "data_size": 800,
+        "slot_size": 800,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]The[SP]Last[SP]Battalion's[SP]invasion[SP]is[SP]a[NL]serious[SP]problem,[SP]but[SP]even[SP]more[SP]serious[SP]is[SP]the[NL]In[SP]Lak'ech![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]If[SP]it[SP]speaks[SP]truly,[SP]the[SP]world[SP]will[SP]face[SP]utter[NL]destruction[SP]soon.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]If[SP]that[SP]happens,[SP]what[SP]will[SP]become[SP]of[SP]my[SP]dream!?[1205][U+000F][NL]How[SP]will[SP]I[SP]make[SP]it[SP]into[SP]the[SP]best[SP]university[SP]in[NL]the[SP]country[SP]if[SP]the[SP]country[SP]is[SP]destroyed!?",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] L'invasion du Bataillon est un\ngrave problème, mais l'In Lak'ech est\nencore plus sérieux ![1106][NL]S'il dit vrai, le monde fera face à\nune destruction totale bientôt.[1106][NL]Si ça arrive, que deviendra mon rêve !?[1205][U+000F]\nComment intégrer la meilleure université\ndu pays si le pays est détruit !?"
+    },
+    {
+        "id": 117,
+        "offset": 456388,
+        "data_size": 614,
+        "slot_size": 614,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+0008][SP]What[SP]should[SP]I[SP]do?[1205][U+000A][SP]A[SP]city[SP]soaring[SP]in[NL]the[SP]sky[SP]is[SP]the[SP]epitome[SP]of[SP]absurdity![1205][U+000A][SP]Worse,[NL]there[SP]are[SP]no[SP]colleges[SP]in[SP]Sumaru[SP]City![1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Hrrrgh...[1205][U+000A][SP]If[SP]the[SP]world[SP]does[SP]end,[SP]what[SP]was[SP]all[NL]my[SP]hard[SP]work[SP]for...?[1205][U+000F][SP]It[SP]pains[SP]my[SP]heart[SP]to[SP]even[NL]think[SP]about[SP]it!",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+0008] Que dois-je faire ?[1205][U+000A] Une ville dans\nle ciel, c'est le comble de l'absurdité ![1205][U+000A] Pire,\nil n'y a pas de facultés à Sumaru ![1106][NL]Hrrrgh...[1205][U+000A] Si le monde s'arrête, à quoi tout ce\ntravail aura-t-il servi... ?[1205][U+000F] Rien que\nd'y penser, ça me brise le cœur !"
+    },
+    {
+        "id": 118,
+        "offset": 457002,
+        "data_size": 1244,
+        "slot_size": 1244,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+0008][SP]Making[SP]it[SP]into[SP]a[SP]top[SP]college,[SP]working[NL]for[SP]the[SP]best[SP]company...[1205][U+000A][SP]This[SP]has[SP]been[SP]my[SP]dream[NL]for[SP]31[SP]years...[1205][U+000F][SP]Now[SP]neither[SP]will[SP]come[SP]true...[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]At[SP]the[SP]very[SP]least,[SP]I'll[SP]witness[SP]the[SP]end[SP]of[NL]Mother[SP]Earth,[SP]since[SP]my[SP]life[SP]will[SP]be[SP]spared.[1205][U+000F][NL]Should[SP]auld[SP]acquaintance[SP]be[SP]forgot...[1205][U+000A][SP]*sniff*[1106][E2][NL][E3][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Hyaaaah![1205][U+0008][SP]I[SP]hear[SP]tell[SP]that[SP]when[SP]the[SP]Grand[SP]Cross[NL]is[SP]complete,[SP]a[SP]black[SP]hole[SP]will[SP]form[SP]at[SP]its[NL]center[SP]and[SP]swallow[SP]this[SP]planet[SP]whole.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]But[SP]if[SP]that[SP]were[SP]to[SP]happen,[SP]then[SP]we[SP]won't[SP]be[NL]safe,[SP]either.[1205][U+000A][SP]It[SP]sounds[SP]like[SP]a[SP]hoax.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+0008] Entrer dans une grande faculté, bosser\npour la meilleure boîte...[1205][U+000A] C'est mon rêve\ndepuis 31 ans...[1205][U+000F] Aucun ne se réalisera...[1106][NL]Au moins, je verrai la fin de notre\nTerre, puisque ma vie sera épargnée.[1205][U+000F]\nFaut-il oublier les vieilles connaissances...[1205][U+000A]\n*sniff*[E1][E2]\n[E3][E4][NULL][NULL]\"Étudiant\nHyaaaah ![1205][U+0008] J'entends dire que quand la Croix\nCosmique sera terminée, un trou noir va se\nformer au centre et engloutir cette planète.[1106][NL]Mais si ça arrivait, alors nous ne\nserions pas non plus en sécurité.[1205][U+000A]\nÇa ressemble à un canular."
+    },
+    {
+        "id": 119,
+        "offset": 458246,
+        "data_size": 590,
+        "slot_size": 590,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+0008][SP]I[SP]doubt[SP]any[SP]severe[SP]natural[SP]disaster[NL]but[SP]this[SP]one[SP]could[SP]happen![1205][U+000A][SP]It[SP]seems[SP]that[SP]the[NL]Earth's[SP]rotation[SP]will[SP]suddenly[SP]halt.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Such[SP]is[SP]the[SP]effect[SP]of[SP]the[SP]Grand[SP]Cross.[1205][U+000A][NL]No[SP]one[SP]can[SP]defy[SP]the[SP]will[SP]of[SP]space...[1205][U+000F][NL]A[SP]sad[SP]thought[SP]indeed.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+0008] Je doute qu'une autre catastrophe\nnaturelle puisse se produire ![1205][U+000A] Il semble\nque la Terre va soudainement s'arrêter.[1106][NL]Tel est l'effet de la Croix Cosmique.[1205][U+000A]\nPersonne ne défie la volonté de\nl'espace...[1205][U+000F] Triste pensée, en effet."
+    },
+    {
+        "id": 120,
+        "offset": 458836,
+        "data_size": 642,
+        "slot_size": 642,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+0008][SP]What[SP]strange[SP]news![SP]It[SP]seems[SP]there[SP]are[NL]flowers[SP]in[SP]Aoba[SP]Park[SP]who[SP]talk.[SP]Perhaps[SP]the[NL]mystery[SP]of[SP]the[SP]plants[SP]will[SP]be[SP]revealed...[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]It[SP]must[SP]be[SP]a[SP]sign[SP]from[SP]God,[SP]pointing[SP]me[SP]to[NL]the[SP]way[SP]to[SP]win[SP]the[SP]Nobel[SP]Peace[SP]Prize![1205][U+0014][NL]...Or[SP]so[SP]I[SP]thought,[SP]but[SP]I'm[SP]no[SP]scientist.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+0008] Quelle étrange nouvelle ! Il\nsemble y avoir des fleurs au parc Aoba qui\nparlent. Peut-être que le mystère sera révélé...[1106][NL]Ce doit être un signe de Dieu, m'indiquant\nle chemin du prix Nobel de la paix ![1205][0014]\n...Ou c'est ce que je croyais. Je suis pas scientifique."
+    },
+    {
+        "id": 121,
+        "offset": 459478,
+        "data_size": 640,
+        "slot_size": 640,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+0008][SP]Did[SP]you[SP]hear?[SP]Club[SP]Zodiac's[SP]second[NL]floor[SP]is[SP]undergoing[SP]extensive[SP]remodeling![1205][U+000A][NL]It's[SP]now[SP]an[SP]item-filled[SP]labyrinth.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Hmm,[SP]this[SP]ordeal[SP]must[SP]have[SP]been[SP]made[SP]for[SP]me...[1205][U+000A][NL]But[SP]I'm[SP]too[SP]busy[SP]with[SP]my[SP]studies.[SP]I[SP]will[SP]be[NL]generous[SP]and[SP]allow[SP]you[SP]to[SP]challenge[SP]it!",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+0008] Tu as entendu ? Le deuxième\nétage du club Zodiac est en rénovation ![1205][U+000A]\nC'est maintenant un labyrinthe rempli d'objets.[1106][NL]Hmm, cette épreuve a sûrement été faite pour moi...[1205][U+000A]\nMais je suis trop pris par mes études. Je serai\ngénéreux et te permettrai de la relever !"
+    },
+    {
+        "id": 122,
+        "offset": 460118,
+        "data_size": 288,
+        "slot_size": 288,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]even[SP]the[SP]ghost[SP]Hanako[SP]is[SP]appearing[NL]at[SP]Sevens!?[SP]What[SP]an[SP]ill-fated[SP]institution.[NL]I[SP]pity[SP]its[SP]students.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Même le fantôme Hanako apparaît\nà Seven !? Quelle institution\nmaudite. J'ai pitié de ses étudiants."
+    },
+    {
+        "id": 123,
+        "offset": 460406,
+        "data_size": 586,
+        "slot_size": 586,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]This[SP]is[SP]serious[SP]indeed![SP]It[SP]seems[SP]the[NL]ghost[SP]of[SP]Bukimi[SP]is[SP]haunting[SP]my[SP]beloved[SP]alma[NL]mater,[SP]Kasugayama[SP]High![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Ahh,[SP]but[SP]fear[SP]not,[SP]my[SP]fellow[SP]students...[NL]As[SP]a[SP]Kasugayama[SP]graduate,[SP]I[SP]shall[SP]dispose[SP]of[NL]this[SP]Bukimi![1205][U+000F][SP]Eventually...",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] C'est vraiment sérieux ! Il\nsemble que le fantôme de Bukimi hante\nmon école adorée, le lycée Kasugayama ![1106][NL]Ahh, mais ne craignez rien, mes amis...\nEn tant qu'ancien de Kasugayama, je me\ndébarrasserai de Bukimi ![1205][U+000F] Éventuellement..."
+    },
+    {
+        "id": 124,
+        "offset": 460992,
+        "data_size": 420,
+        "slot_size": 420,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![SP]It[SP]seems[SP]the[SP]ghost[SP]of[SP]a[SP]former[SP]idol[NL]is[SP]haunting[SP]Aoba[SP]Park...[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]A[SP]pity,[SP]truly[SP]it[SP]is,[SP]but[SP]such[SP]is[SP]the[SP]fate[SP]of[NL]many[SP]who[SP]are[SP]tempted[SP]by[SP]showbiz.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ! Il semble que le fantôme d'une\nancienne idole hante le parc Aoba...[1106][NL]C'est dommage, vraiment, mais c'est le\ndestin de beaucoup de gens tentés\npar le show-biz."
+    },
+    {
+        "id": 125,
+        "offset": 461412,
+        "data_size": 464,
+        "slot_size": 464,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Apparently,[SP]a[SP]monster[SP]known[SP]as[SP]a[NL]Cursed[SP]Taxi[SP]is[SP]menacing[SP]the[SP]abandoned[SP]factory.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Normally,[SP]I[SP]wouldn't[SP]suffer[SP]such[SP]a[SP]monster[SP]to[NL]live,[SP]but[SP]I'm[SP]rather[SP]busy[SP]today.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Apparemment, un monstre connu sous le\nnom de Taxi Maudit menace l'usine abandonnée.[1106][NL]Normalement, je ne laisserais pas vivre un\ntel monstre, mais je suis\noccupé aujourd'hui."
+    },
+    {
+        "id": 126,
+        "offset": 461876,
+        "data_size": 444,
+        "slot_size": 444,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Dear[SP]me...[SP]So[SP]it[SP]was[SP]a[SP]Cursed[SP]Escort,[NL]and[SP]not[SP]a[SP]Cursed[SP]Taxi,[SP]that[SP]made[SP]the[SP]abandoned[NL]factory[SP]its[SP]home...[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Er,[SP]what[SP]is[SP]the[SP]difference[SP]between[SP]the[SP]two?",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Mon Dieu... C'était donc une Escorte\nMaudite, et non un Taxi Maudit, qui a élu domicile\nà l'usine abandonnée...[1106][NL]Euh, quelle est la différence entre les deux ?"
+    },
+    {
+        "id": 127,
+        "offset": 462320,
+        "data_size": 806,
+        "slot_size": 806,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]Kuchisake-onna[SP]is[SP]at[SP]Mt.[SP]Iwato?[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]I've[SP]had[SP]my[SP]share[SP]of[SP]run-ins[SP]with[SP]urban[SP]legends[NL]like[SP]her[SP]in[SP]my[SP]youth.[SP]She[SP]was[SP]said[SP]to[SP]chase[NL]after[SP]children[SP]who[SP]didn't[SP]head[SP]straight[SP]home.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Thinking[SP]back,[SP]such[SP]stories[SP]were[SP]useful[SP]to[NL]warn[SP]children[SP]against[SP]unacceptable[SP]behavior...[NL]I[SP]shall[SP]let[SP]this[SP]Kuchisake-onna[SP]be.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Kuchisake-onna est au Mt Iwato ?[1106][NL]J'ai eu mon lot de problèmes avec des légendes\nurbaines comme elle dans ma jeunesse. Elle chassait\nles enfants qui ne rentraient pas direct à la maison.[1106][NL]En y repensant, ces contes étaient utiles pour\nmettre en garde les enfants contre les mauvais\ncomportements... J'ignorerai Kuchisake-onna."
+    },
+    {
+        "id": 128,
+        "offset": 463126,
+        "data_size": 408,
+        "slot_size": 408,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]An[SP]oddity[SP]by[SP]the[SP]name[SP]of[SP]Jumping[NL]Geezer[SP]has[SP]been[SP]sighted[SP]at[SP]Mt.[SP]Katatsumuri.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Why[SP]would[SP]a[SP]man[SP]in[SP]his[SP]nineties[SP]be[SP]jumping[NL]around...?",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Une bizarrerie nommée Vieux\nSauteur a été aperçue au Mt Katatsumuri.[1106][NL]Pourquoi un homme de quatre-vingt-dix ans\nsauterait-il partout... ?"
+    },
+    {
+        "id": 129,
+        "offset": 463534,
+        "data_size": 334,
+        "slot_size": 334,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "H-Hyaa...aaah...[1205][U+000F][SP]Oh,[SP]who[SP]am[SP]I[SP]kidding?[1205][U+000F][SP]I'm[SP]so[NL]frightened,[SP]my[SP]legs[SP]won't[SP]stop[SP]shaking.[1205][U+000F][NL]K-Kudan...[SP]It's[SP]at[SP]the[SP]abandoned[SP]factory...",
+        "nom_fr": "Étudiant",
+        "texte_fr": "H-Hyaa...aaah...[1205][U+000F] Oh, à qui je veux faire\ncroire ça ?[1205][U+000F] J'ai tellement peur que mes jambes\nne s'arrêtent pas de trembler.[1205][U+000F] Kudan... À l'usine..."
+    },
+    {
+        "id": 130,
+        "offset": 463868,
+        "data_size": 388,
+        "slot_size": 388,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]How[SP]dare[SP]a[SP]merchant[SP]hide[SP]his[SP]own[NL]merchandise!?[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]And[SP]a[SP]secret[SP]CD,[SP]no[SP]less!?[SP]What[SP]is[SP]the[NL]proprietor[SP]of[SP]Giga[SP]Macho[SP]thinking?",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Comment un marchand ose-t-il\ncacher sa propre marchandise !?[1106][NL]Et un CD secret, en plus !? À quoi\npense le propriétaire de Giga Macho ?"
+    },
+    {
+        "id": 131,
+        "offset": 464256,
+        "data_size": 492,
+        "slot_size": 492,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]It[SP]seems[SP]there's[SP]a[SP]creature[SP]known[SP]as[NL]a[SP]Dresser[SP]Hag[SP]at[SP]the[SP]abandoned[SP]factory.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]That[SP]place[SP]has[SP]spawned[SP]so[SP]many[SP]rumors.[1205][U+000F][NL]They[SP]should[SP]do[SP]what[SP]needs[SP]doing[SP]and[SP]condemn[NL]the[SP]place.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Il semble qu'il y ait une créature\nconnue sous le nom de Mégère à Commode à l'usine.[1106][NL]Cet endroit a engendré tellement de rumeurs.[1205][U+000F]\nIls devraient faire ce qu'il faut et condamner\ncet endroit."
+    },
+    {
+        "id": 132,
+        "offset": 464748,
+        "data_size": 434,
+        "slot_size": 434,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Selling[SP]weapons[SP]at[SP]an[SP]antique[SP]shop...[1205][U+000F][NL]Time[SP]Castle's[SP]owner[SP]is[SP]no[SP]ordinary[SP]man.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]The[SP]quality[SP]and[SP]price[SP]of[SP]his[SP]goods[SP]seems[SP]to[NL]be[SP]average,[SP]though.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Vendre des armes chez un antiquaire...[1205][U+000F]\nLe propriétaire de Time Castle est audacieux.[1106][NL]La qualité et le prix de ses biens semblent\ncependant être dans la moyenne."
+    },
+    {
+        "id": 133,
+        "offset": 465182,
+        "data_size": 440,
+        "slot_size": 440,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Selling[SP]weapons[SP]at[SP]an[SP]antique[SP]shop...[1205][U+000F][NL]Time[SP]Castle's[SP]owner[SP]is[SP]no[SP]ordinary[SP]man.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]The[SP]quality[SP]of[SP]his[SP]goods[SP]is[SP]superb,[SP]but[SP]his[NL]prices[SP]are[SP]very[SP]steep.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Vendre des armes chez un antiquaire...[1205][U+000F]\nLe propriétaire de Time Castle est audacieux.[1106][NL]La qualité de ses biens est superbe, mais ses\nprix sont très élevés."
+    },
+    {
+        "id": 134,
+        "offset": 465622,
+        "data_size": 434,
+        "slot_size": 434,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Selling[SP]weapons[SP]at[SP]an[SP]antique[SP]shop...[1205][U+000F][NL]Time[SP]Castle's[SP]owner[SP]is[SP]no[SP]ordinary[SP]man.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]I[SP]hear[SP]tell[SP]that[SP]the[SP]price[SP]is[SP]right,[SP]but[SP]the[NL]quality[SP]is[SP]shoddy.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Vendre des armes chez un antiquaire...[1205][U+000F]\nLe propriétaire de Time Castle est audacieux.[1106][NL]On m'a dit que le prix est correct, mais\nque la qualité laisse à désirer."
+    },
+    {
+        "id": 135,
+        "offset": 466056,
+        "data_size": 474,
+        "slot_size": 474,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street[NL]vendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in[NL]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]I[SP]hear[SP]that[SP]his[SP]selection[SP]is[SP]quite[SP]varied,[NL]but[SP]his[SP]buyback[SP]prices[SP]are[SP]low.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes.[1106][NL]On m'a dit que son choix est très varié,\nmais que ses prix de rachat sont bas."
+    },
+    {
+        "id": 136,
+        "offset": 466530,
+        "data_size": 414,
+        "slot_size": 414,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street[NL]vendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in[NL]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]I[SP]hear[SP]that[SP]they're[SP]cheap,[SP]but[SP]poor[SP]quality.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes.[1106][NL]Moins cher, mais de mauvaise qualité."
+    },
+    {
+        "id": 137,
+        "offset": 466944,
+        "data_size": 462,
+        "slot_size": 462,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street[NL]vendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in[NL]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]It[SP]appears[SP]that[SP]the[SP]quality[SP]and[SP]price[SP]of[SP]his[NL]goods[SP]are[SP]both[SP]average.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes.[1106][NL]Il semble que la qualité et le prix de\nses biens soient tous deux moyens."
+    },
+    {
+        "id": 138,
+        "offset": 467406,
+        "data_size": 466,
+        "slot_size": 466,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street[NL]vendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in[NL]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]I[SP]heard[SP]the[SP]quality[SP]is[SP]superb,[SP]but[SP]the[SP]prices[NL]are[SP]commensurately[SP]high.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes.[1106][NL]On m'a dit que la qualité était superbe,\nmais que les prix étaient élevés."
+    },
+    {
+        "id": 139,
+        "offset": 467872,
+        "data_size": 496,
+        "slot_size": 496,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for[NL]sale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely[NL]believe[SP]it...[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Their[SP]selection[SP]seems[SP]to[SP]be[SP]poor,[SP]but[SP]at[NL]least[SP]their[SP]buyback[SP]prices[SP]are[SP]good.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[1106][NL]Leur choix semble être limité, mais au\nmoins leurs prix de rachat sont bons."
+    },
+    {
+        "id": 140,
+        "offset": 468368,
+        "data_size": 434,
+        "slot_size": 434,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for[NL]sale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely[NL]believe[SP]it...[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Their[SP]goods[SP]are[SP]cheap,[SP]but[SP]lacking[SP]in[SP]quality.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[1106][NL]Leurs biens sont bon marché, mais manquent de qualité."
+    },
+    {
+        "id": 141,
+        "offset": 468802,
+        "data_size": 462,
+        "slot_size": 462,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for[NL]sale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely[NL]believe[SP]it...[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]The[SP]quality[SP]of[SP]their[SP]goods[SP]is[SP]high,[SP]but[SP]it[NL]comes[SP]at[SP]a[SP]price.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[1106][NL]La qualité de leurs produits est élevée,\nmais cela a un prix."
+    },
+    {
+        "id": 142,
+        "offset": 469264,
+        "data_size": 498,
+        "slot_size": 498,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for[NL]sale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely[NL]believe[SP]it...[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]They[SP]seem[SP]to[SP]have[SP]a[SP]wide[SP]selection[SP]of[SP]goods,[NL]but[SP]their[SP]buyback[SP]prices[SP]are[SP]low.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[1106][NL]Ils semblent avoir un grand choix de produits,\nmais leurs prix de rachat sont bas."
+    },
+    {
+        "id": 143,
+        "offset": 469762,
+        "data_size": 452,
+        "slot_size": 452,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for[NL]sale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely[NL]believe[SP]it...[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]The[SP]quality[SP]and[SP]price[SP]of[SP]their[SP]goods[SP]is[NL]merely[SP]average.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[1106][NL]La qualité et le prix de leurs produits\nsont tout juste moyens."
+    },
+    {
+        "id": 144,
+        "offset": 470214,
+        "data_size": 468,
+        "slot_size": 468,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-[NL]you,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan[NL]sells[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]The[SP]quality[SP]and[SP]price[SP]of[SP]their[SP]things[SP]seems[NL]fairly[SP]average.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[1106][NL]La qualité et le prix de leurs articles\nsemblent plutôt moyens."
+    },
+    {
+        "id": 145,
+        "offset": 470682,
+        "data_size": 482,
+        "slot_size": 482,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-[NL]you,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan[NL]sells[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Their[SP]goods[SP]are[SP]inexpensive,[SP]but[SP]unfortunately[NL]lacking[SP]in[SP]quality.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[1106][NL]Leurs produits sont bon marché, mais manquent\nmalheureusement de qualité."
+    },
+    {
+        "id": 146,
+        "offset": 471164,
+        "data_size": 482,
+        "slot_size": 482,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-[NL]you,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan[NL]sells[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Their[SP]selection[SP]is[SP]great,[SP]but[SP]their[SP]buyback[NL]prices[SP]seem[SP]to[SP]be[SP]low.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[1106][NL]Leur choix est excellent, mais leurs prix de\nrachat semblent être bas."
+    },
+    {
+        "id": 147,
+        "offset": 471646,
+        "data_size": 500,
+        "slot_size": 500,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-[NL]you,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan[NL]sells[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Their[SP]selection[SP]is[SP]quite[SP]poor,[SP]but[SP]I[SP]suppose[NL]their[SP]buyback[SP]prices[SP]are[SP]good.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[1106][NL]Leur sélection est assez pauvre, mais je suppose\nque leurs prix de rachat sont bons."
+    },
+    {
+        "id": 148,
+        "offset": 472146,
+        "data_size": 484,
+        "slot_size": 484,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-[NL]you,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan[NL]sells[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]The[SP]quality[SP]of[SP]their[SP]goods[SP]is[SP]excellent,[NL]but[SP]it's[SP]expensive[SP]indeed.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[1106][NL]La qualité de leurs produits est excellente,\nmais elle est très chère."
+    },
+    {
+        "id": 149,
+        "offset": 472630,
+        "data_size": 444,
+        "slot_size": 444,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]reminds[SP]me,[SP]I[SP]heard[SP]an[SP]interesting[NL]rumor[SP]that[SP]Rosa[SP]Candida[SP]sells[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]I've[SP]heard[SP]lately[SP]that[SP]the[SP]quality[SP]and[SP]price[NL]of[SP]their[SP]stock[SP]is[SP]average.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures.[1106][NL]J'ai entendu récemment que la qualité et le prix\nde leur stock sont moyens."
+    },
+    {
+        "id": 150,
+        "offset": 473074,
+        "data_size": 432,
+        "slot_size": 432,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]reminds[SP]me,[SP]I[SP]heard[SP]an[SP]interesting[NL]rumor[SP]that[SP]Rosa[SP]Candida[SP]sells[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]I've[SP]heard[SP]lately[SP]that[SP]their[SP]goods[SP]are[SP]cheap,[NL]but[SP]low[SP]in[SP]quality.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures.[1106][NL]J'ai entendu récemment que leurs biens sont\nbon marché, mais de piètre qualité."
+    },
+    {
+        "id": 151,
+        "offset": 473506,
+        "data_size": 458,
+        "slot_size": 458,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]reminds[SP]me,[SP]I[SP]heard[SP]an[SP]interesting[NL]rumor[SP]that[SP]Rosa[SP]Candida[SP]sells[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]I've[SP]heard[SP]lately[SP]that[SP]the[SP]quality[SP]of[SP]their[NL]stock[SP]is[SP]high,[SP]but[SP]it's[SP]expensive.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures.[1106][NL]J'ai entendu récemment que la qualité de leur\nstock est élevée, mais que c'est cher."
+    },
+    {
+        "id": 152,
+        "offset": 473964,
+        "data_size": 368,
+        "slot_size": 368,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi[NL]sells[SP]armor![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]I[SP]hear[SP]that[SP]their[SP]quality[SP]and[SP]prices[SP]are[NL]entirely[SP]average,[SP]though.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Donc il est VRAI qu'Anima Mundi\nvend des armures ![1106][NL]J'entends dire que leur qualité et leurs prix\nsont dans la moyenne, cela dit."
+    },
+    {
+        "id": 153,
+        "offset": 474332,
+        "data_size": 354,
+        "slot_size": 354,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi[NL]sells[SP]armor![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]I[SP]hear[SP]that[SP]their[SP]goods[SP]are[SP]cheap,[SP]but[SP]the[NL]quality[SP]suffers.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Donc il est VRAI qu'Anima Mundi\nvend des armures ![1106][NL]Leur matos est pas cher,\nmais de mauvaise qualité."
+    },
+    {
+        "id": 154,
+        "offset": 474686,
+        "data_size": 392,
+        "slot_size": 392,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi[NL]sells[SP]armor![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]I[SP]hear[SP]that[SP]their[SP]selection[SP]is[SP]a[SP]fine[SP]one,[NL]but[SP]their[SP]buyback[SP]prices[SP]are[SP]cheap.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Donc il est VRAI qu'Anima Mundi\nvend des armures ![1106][NL]J'entends dire que leur sélection est belle,\nmais que leurs prix de rachat sont bas."
+    },
+    {
+        "id": 155,
+        "offset": 475078,
+        "data_size": 368,
+        "slot_size": 368,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi[NL]sells[SP]armor![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]It[SP]seems[SP]that[SP]their[SP]quality[SP]is[SP]high[SP]indeed,[NL]but[SP]few[SP]can[SP]afford[SP]it.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Donc il est VRAI qu'Anima Mundi\nvend des armures ![1106][NL]Leur qualité semble élevée en effet,\nmais peu peuvent se le permettre."
+    },
+    {
+        "id": 156,
+        "offset": 475446,
+        "data_size": 326,
+        "slot_size": 326,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters[NL]are[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]selection[NL]is[SP]bad,[SP]but[SP]the[SP]buyback[SP]price[SP]is[SP]good.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leur choix\nest pauvre, mais le prix de rachat est bon."
+    },
+    {
+        "id": 157,
+        "offset": 475772,
+        "data_size": 292,
+        "slot_size": 292,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters[NL]are[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]quality[SP]and[NL]prices[SP]are[SP]average.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leur qualité et\nleurs prix sont moyens."
+    },
+    {
+        "id": 158,
+        "offset": 476064,
+        "data_size": 300,
+        "slot_size": 300,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters[NL]are[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]merchandise[NL]is[SP]good,[SP]but[SP]expensive.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leurs marchandises\nsont bonnes, mais chères."
+    },
+    {
+        "id": 159,
+        "offset": 476364,
+        "data_size": 320,
+        "slot_size": 320,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters[NL]are[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]merchandise[NL]is[SP]cheap,[SP]but[SP]lacking[SP]in[SP]quality.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs\nsont des marchandes hors pair... Leurs biens\nsont bon marché, mais manquent de qualité."
+    },
+    {
+        "id": 160,
+        "offset": 476684,
+        "data_size": 332,
+        "slot_size": 332,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]armor.[SP]Those[SP]sisters[NL]are[SP]no[SP]ordinary[SP]merchants...[SP]Their[SP]selection[NL]is[SP]good,[SP]but[SP]the[SP]buyback[SP]price[SP]is[SP]dismal.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leur choix\nest bon, mais le prix de rachat est lamentable."
+    },
+    {
+        "id": 161,
+        "offset": 477016,
+        "data_size": 502,
+        "slot_size": 502,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?[NL]I[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man[NL]at[SP]London[SP]Clothier.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]They[SP]seem[SP]to[SP]have[SP]an[SP]impressive[SP]selection,[NL]but[SP]their[SP]buyback[SP]prices[SP]are[SP]cheap.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[1106][NL]Ils semblent avoir un choix impressionnant,\nmais leurs prix de rachat sont bas."
+    },
+    {
+        "id": 162,
+        "offset": 477518,
+        "data_size": 464,
+        "slot_size": 464,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?[NL]I[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man[NL]at[SP]London[SP]Clothier.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Their[SP]prices[SP]are[SP]cheap,[SP]but[SP]their[SP]goods[SP]are[NL]low[SP]in[SP]quality.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[1106][NL]Leurs prix sont bas, mais leurs biens sont\nde mauvaise qualité."
+    },
+    {
+        "id": 163,
+        "offset": 477982,
+        "data_size": 480,
+        "slot_size": 480,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?[NL]I[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man[NL]at[SP]London[SP]Clothier.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]The[SP]quality[SP]of[SP]their[SP]goods[SP]is[SP]first-rate,[NL]but[SP]it's[SP]quite[SP]expensive.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[1106][NL]La qualité de leurs biens est de premier ordre,\nmais c'est assez cher."
+    },
+    {
+        "id": 164,
+        "offset": 478462,
+        "data_size": 430,
+        "slot_size": 430,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?[NL]I[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man[NL]at[SP]London[SP]Clothier.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Their[SP]quality[SP]and[SP]prices[SP]are[SP]just[SP]average.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[1106][NL]Leur qualité et leurs prix sont tout à fait moyens."
+    },
+    {
+        "id": 165,
+        "offset": 478892,
+        "data_size": 490,
+        "slot_size": 490,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?[NL]I[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man[NL]at[SP]London[SP]Clothier.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Their[SP]selection[SP]is[SP]poor,[SP]but[SP]the[SP]buyback[SP]prices[NL]they[SP]offer[SP]are[SP]generous.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[1106][NL]Leur sélection est pauvre, mais les prix\nde rachat qu'ils offrent sont généreux."
+    },
+    {
+        "id": 166,
+        "offset": 479382,
+        "data_size": 414,
+        "slot_size": 414,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Is[SP]it[SP]true[SP]one[SP]may[SP]win[SP]real[SP]weapons[NL]in[SP]a[SP]magazine[SP]sweepstakes?[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]It's[SP]not[SP]easy[SP]to[SP]win,[SP]but[SP]you'll[SP]get[SP]some[SP]nice[NL]items[SP]for[SP]your[SP]trouble.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?[1106][NL]Il n'est pas facile de gagner, mais on reçoit\nde beaux objets en récompense."
+    },
+    {
+        "id": 167,
+        "offset": 479796,
+        "data_size": 414,
+        "slot_size": 414,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Is[SP]it[SP]true[SP]one[SP]may[SP]win[SP]real[SP]weapons[NL]in[SP]a[SP]magazine[SP]sweepstakes?[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]People[SP]very[SP]rarely[SP]win,[SP]but[SP]the[SP]prizes[SP]for[NL]those[SP]who[SP]do[SP]are[SP]exquisite.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?[1106][NL]On gagne très rarement, mais les prix\npour ceux qui y parviennent sont exquis."
+    },
+    {
+        "id": 168,
+        "offset": 480210,
+        "data_size": 420,
+        "slot_size": 420,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Is[SP]it[SP]true[SP]one[SP]may[SP]win[SP]real[SP]weapons[NL]in[SP]a[SP]magazine[SP]sweepstakes?[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]It's[SP]not[SP]hard[SP]to[SP]win[SP]one,[SP]but[SP]if[SP]you[SP]do,[SP]you[SP]may[NL]wonder[SP]why[SP]you[SP]bothered.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?[1106][NL]Il n'est pas difficile de gagner, mais on peut\nse demander pourquoi on a pris la peine."
+    },
+    {
+        "id": 169,
+        "offset": 480630,
+        "data_size": 648,
+        "slot_size": 648,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]am[SP]a[SP]mere[SP]student[SP]striving[SP]to[SP]make[NL]it[SP]into[SP]the[SP]country's[SP]best[SP]college.[SP]I[SP]have[SP]no[NL]time[SP]to[SP]fritter[SP]away[SP]on[SP]gambling![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]...Still,[SP]it[SP]doesn't[SP]pay[SP]to[SP]neglect[SP]the[SP]real[NL]world.[SP]I[SP]hear[SP]that[SP]one[SP]can[SP]win[SP]big[SP]on[SP]the[SP]#5[NL]poker[SP]machine...[1205][U+000F][SP]It[SP]wouldn't[SP]hurt[SP]to[SP]try.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent ![1106][NL]...Cependant, il ne faut pas négliger le monde réel.\nJ'entends qu'on peut gagner gros à la\nmachine #5...[1205][U+000F] Ça ne ferait pas de mal d'essayer."
+    },
+    {
+        "id": 170,
+        "offset": 481278,
+        "data_size": 648,
+        "slot_size": 648,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]am[SP]a[SP]mere[SP]student[SP]striving[SP]to[SP]make[NL]it[SP]into[SP]the[SP]country's[SP]best[SP]college.[SP]I[SP]have[SP]no[NL]time[SP]to[SP]fritter[SP]away[SP]on[SP]gambling![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]...Still,[SP]it[SP]doesn't[SP]pay[SP]to[SP]neglect[SP]the[SP]real[NL]world.[SP]I[SP]hear[SP]that[SP]one[SP]can[SP]win[SP]big[SP]on[SP]the[SP]#1[NL]slots[SP]machine...[1205][U+000F][SP]It[SP]wouldn't[SP]hurt[SP]to[SP]try.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent ![1106][NL]...Cependant, il ne faut pas négliger le monde réel.\nJ'entends qu'on peut gagner gros à la\nmachine #1...[1205][U+000F] Ça ne ferait pas de mal d'essayer."
+    },
+    {
+        "id": 171,
+        "offset": 481926,
+        "data_size": 640,
+        "slot_size": 640,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]I[SP]am[SP]a[SP]mere[SP]student[SP]striving[SP]to[SP]make[NL]it[SP]into[SP]the[SP]country's[SP]best[SP]college.[SP]I[SP]have[SP]no[NL]time[SP]to[SP]fritter[SP]away[SP]on[SP]gambling![NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]But[SP]blackjack[SP]is[SP]an[SP]exception.[SP]I[SP]don't[SP]enjoy[NL]it,[SP]not[SP]really,[SP]but[SP]I[SP]hear[SP]you[SP]can[SP]win[SP]big[SP]at[NL]it.[SP]My[SP]studies[SP]aren't[SP]free,[SP]after[SP]all!",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent ![1106][NL]Mais le blackjack est une exception. Je n'aime pas ça,\npas vraiment, mais il paraît qu'on peut y gagner\ngros. Mes études ne sont pas gratuites !"
+    },
+    {
+        "id": 172,
+        "offset": 482566,
+        "data_size": 302,
+        "slot_size": 302,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]A[SP]legendary[SP]weapon...[SP]They[SP]have[SP]such[NL]a[SP]thing[SP]at[SP]Shiraishi[SP]Ramen...[SP]I'd[SP]like[SP]to[SP]see[NL]it[SP]for[SP]myself,[SP]just[SP]once.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Une arme légendaire... Ils ont ça\nchez Shiraishi Ramen... J'aimerais la voir\nde mes propres yeux, juste une fois."
+    },
+    {
+        "id": 173,
+        "offset": 482868,
+        "data_size": 420,
+        "slot_size": 420,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]Is[SP]there[SP]really[SP]a[SP]legendary[SP]weapon[NL]in[SP]stock[SP]at[SP]Clair[SP]de[SP]Lune?[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Bah![SP]The[SP]weapons[SP]of[SP]a[SP]student[SP]are[SP]pens[SP]and[NL]books![SP]This[SP]doesn't[SP]concern[SP]me.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Y a-t-il vraiment une arme légendaire\nen stock chez Clair de Lune ?[1106][NL]Bah ! Les armes d'un étudiant sont les stylos\net les livres ! Cela ne me concerne pas."
+    },
+    {
+        "id": 174,
+        "offset": 483288,
+        "data_size": 522,
+        "slot_size": 522,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]owner[SP]at[SP]Time[SP]Castle...[SP]Claiming[NL]not[SP]to[SP]have[SP]what[SP]he[SP]in[SP]fact[SP]does,[SP]in[SP]a[SP]bid[SP]to[NL]drive[SP]up[SP]its[SP]price,[SP]is[SP]unforgivable.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]But[SP]does[SP]Time[SP]Castle[SP]really[SP]have[SP]a[SP]legendary[NL]weapon[SP]to[SP]begin[SP]with?",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Ce propriétaire de Time Castle... Prétendre\nne pas avoir ce qu'il a en fait, dans le but\nde faire monter son prix, est impardonnable.[1106][NL]Mais Time Castle a-t-il vraiment une arme\nlégendaire, pour commencer ?"
+    },
+    {
+        "id": 175,
+        "offset": 483810,
+        "data_size": 932,
+        "slot_size": 932,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]A[SP]merchant[SP]should[SP]meet[SP]the[SP]needs[SP]of[NL]his[SP]customers[SP]even[SP]at[SP]the[SP]risk[SP]of[SP]his[SP]own[SP]life![NL]Yet[SP]that[SP]owner[SP]at[SP]Time[SP]Castle...[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]He[SP]has[SP]yet[SP]to[SP]claim[SP]his[SP]legendary[SP]weapon.[NL]Even[SP]now,[SP]the[SP]seller[SP]waits[SP]at[SP]the[SP]abandoned[NL]factory[SP]for[SP]the[SP]owner[SP]to[SP]come.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]But[SP]he's[SP]too[SP]afraid[SP]of[SP]monsters[SP]to[SP]venture[NL]out![SP]How[SP]utterly[SP]pathetic![SP]I[SP]wish[SP]someone[SP]else[NL]would[SP]go[SP]buy[SP]the[SP]weapon[SP]in[SP]his[SP]stead.",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Un marchand doit répondre aux besoins\nde ses clients au péril de sa vie !\nPourtant ce propriétaire...[1106][NL]Il n'a pas encore réclamé son arme légendaire.\nMême maintenant, le vendeur attend à l'usine\nabandonnée que le propriétaire vienne.[1106][NL]Mais il a trop peur des monstres pour sortir !\nC'est pitoyable ! J'aimerais que quelqu'un d'autre\naille acheter l'arme à sa place."
+    },
+    {
+        "id": 176,
+        "offset": 484742,
+        "data_size": 422,
+        "slot_size": 422,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "The[SP]legendary[SP]weapon[SP]belonging[SP]to[SP]Time[SP]Castle[NL]was[SP]stolen[SP]by[SP]a[SP]demon.[SP]But[SP]is[SP]it[SP]possible[SP]that[NL]the[SP]owner[SP]is[SP]lying?[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Honestly,[SP]do[SP]demons[SP]actually[SP]exist?",
+        "nom_fr": "Étudiant",
+        "texte_fr": "L'arme légendaire de Time Castle a été volée par un\ndémon. Mais est-il possible que le propriétaire mente ?[1106][NL]Honnêtement, les démons existent-ils vraiment ?"
+    },
+    {
+        "id": 177,
+        "offset": 485164,
+        "data_size": 628,
+        "slot_size": 628,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]It[SP]seems[SP]the[SP]legendary[SP]weapon[SP]at[NL]Time[SP]Castle[SP]has[SP]been[SP]sold![SP]I[SP]hear[SP]that[SP]an[NL]unusually[SP]unlucky[SP]woman[SP]bought[SP]it.[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Hrghhh...[SP]What[SP]cheek![SP]What[SP]if[SP]she[SP]were[SP]to[SP]use[NL]it[SP]to[SP]end[SP]her[SP]life!?[SP]If[SP]only[SP]he'd[SP]entrusted[SP]it[NL]to[SP]me,[SP]I'd[SP]have[SP]put[SP]it[SP]to[SP]good[SP]use...",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] L'arme légendaire de\nTime Castle a été vendue ! J'entends qu'une femme\nparticulièrement malchanceuse l'a achetée.[1106][NL]Hrghhh... Quel culot ! Et si elle l'utilisait pour\nmettre fin à ses jours !? S'il me l'avait\nconfiée, j'en aurais fait bon usage..."
+    },
+    {
+        "id": 178,
+        "offset": 485792,
+        "data_size": 590,
+        "slot_size": 590,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Fighting[SP]washout[SP]student",
+        "texte_orig": "Hyaaaah![1205][U+000F][SP]That[SP]dastardly[SP]owner[SP]of[SP]Time[SP]Castle![NL]He[SP]gave[SP]the[SP]legendary[SP]weapon[SP]to[SP]a[SP]woman[SP]with[NL]short[SP]hair![SP]How[SP]dare[SP]he[SP]become[SP]so[SP]smitten!?[NL][1106][E2][1431][U+0000][U+0000]\"Fighting[SP]washout[SP]student[NL]Eh?[SP]What[SP]kind[SP]of[SP]woman[SP]was[SP]she?[SP]B-Beautiful,[SP]I[NL]suppose...[1205][U+000F][SP]N-Not[SP]that[SP]I'm[SP]envious,[SP]not[SP]at[SP]all!",
+        "nom_fr": "Étudiant",
+        "texte_fr": "Hyaaaah ![1205][U+000F] Ce lâche propriétaire de Time Castle !\nIl a donné l'arme légendaire à une femme\naux cheveux courts ! Comment a-t-il pu !?[1106][NL]Eh ? Quel genre de femme était-ce ? B-Belle, je\nsuppose...[1205][U+000F] J-Je ne suis pas envieux, pas du tout !"
+    },
+    {
+        "id": 179,
+        "offset": 486382,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Masked[SP]Circle[SP]member",
+        "texte_orig": "Many[SP]of[SP]my[SP]comrades[SP]are[SP]complaining,[SP]but[SP]I[NL]intend[SP]to[SP]follow[SP]Joker's[SP]orders![1205][U+000F][SP]This[SP]is[SP]our[NL]city,[SP]after[SP]all!",
+        "nom_fr": "Membre du Cercle masqué",
+        "texte_fr": "Beaucoup de camarades se plaignent,\nmais j'obéirai au Joker ![1205][U+000F] C'est\nnotre ville, après tout !"
+    },
+    {
+        "id": 180,
+        "offset": 486650,
+        "data_size": 256,
+        "slot_size": 256,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Last[SP]Battalion[SP]soldier",
+        "texte_orig": "Our[SP]Fuhrer[SP]has[SP]already[SP]reached[SP]his[SP]destination.[1205][U+000F][NL]All[SP]nearby[SP]civilians[SP]must[SP]surrender[SP]immediately.",
+        "nom_fr": "Bataillon",
+        "texte_fr": "Notre Führer a atteint sa destination.[1205][U+000F]\nLes civils à proximité doivent se rendre."
+    },
+    {
+        "id": 181,
+        "offset": 486906,
+        "data_size": 200,
+        "slot_size": 200,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "This[SP]is[SP]Kasugayama[SP]High,[SP]the[SP]great[SP]Michel's[NL]school![SP]We're[SP]gonna[SP]have[SP]a[SP]festival[SP]soon.",
+        "nom_fr": "Eikichi",
+        "texte_fr": "C'est le lycée Kasu, l'école du grand\nMichel ! On aura bientôt un festival."
+    },
+    {
+        "id": 182,
+        "offset": 487106,
+        "data_size": 248,
+        "slot_size": 248,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "The[SP]guys[SP]here[SP]hate[SP]Sevens[SP]because[SP]they're[SP]not[NL]the[SP]popular[SP]ones,[SP]right?[SP]How[SP]appropriate[SP]for[NL]Undie[SP]Boss's[SP]school.",
+        "nom_fr": "Ginko",
+        "texte_fr": "Ils détestent Seven car ce ne sont pas eux\nles plus populaires, hein ? Typique de\nl'école du Boss Calbute."
+    },
+    {
+        "id": 183,
+        "offset": 487354,
+        "data_size": 182,
+        "slot_size": 182,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Wait[SP]for[SP]me...[SP]I'll[SP]get[SP]you[SP]guys[SP]back[SP]to[NL]normal[SP]if[SP]it's[SP]the[SP]last[SP]thing[SP]I[SP]do!",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Attendez... Je vous rendrai normaux,\ncoûte que coûte !"
+    },
+    {
+        "id": 184,
+        "offset": 487536,
+        "data_size": 68,
+        "slot_size": 68,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "C'mon,[SP][1113].[SP]Let's[SP]go!",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Viens [1113], on y va !"
+    },
+    {
+        "id": 185,
+        "offset": 487604,
+        "data_size": 180,
+        "slot_size": 180,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "I[SP]bet[SP]everyone's[SP]waiting[SP]at[SP]the[SP]detective[NL]agency.[SP]We[SP]should[SP]hurry[SP]back[SP]there!",
+        "nom_fr": "Ginko",
+        "texte_fr": "Tous nous attendent à l'agence de détectives.\nDépêchons-nous !"
+    },
+    {
+        "id": 186,
+        "offset": 487784,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "It's[SP]like[SP]the[SP]school's[SP]dead...[SP]There's[SP]no[SP]one[NL]around[SP]and[SP]I[SP]don't[SP]hear[SP]any[SP]voices,[SP]either...[NL]Is[SP]this[SP]really[SP]my[SP]Kasugayama[SP]High?",
+        "nom_fr": "Eikichi",
+        "texte_fr": "C'est comme si l'école était morte... Y a personne\net je n'entends aucune voix, non plus...\nC'est vraiment mon lycée Kasu ?"
+    },
+    {
+        "id": 187,
+        "offset": 488066,
+        "data_size": 112,
+        "slot_size": 112,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Lisa",
+        "texte_orig": "Aiyah...[SP]You[SP]want[SP]to[SP]go[SP]into[SP]Smile[SP]Hirasaka?",
+        "nom_fr": "Lisa",
+        "texte_fr": "Aïe... Tu veux aller à Smile Hirasaka ?"
+    },
+    {
+        "id": 188,
+        "offset": 488178,
+        "data_size": 124,
+        "slot_size": 124,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Lisa",
+        "texte_orig": "Let's[SP]skip[SP]this[SP]hole[SP]and[SP]go[SP]somewhere[NL]like[SP]Zodiac!",
+        "nom_fr": "Lisa",
+        "texte_fr": "Zappons ce trou et allons plutôt à Zodiac !"
+    },
+    {
+        "id": 189,
+        "offset": 488302,
+        "data_size": 114,
+        "slot_size": 114,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Aiyah...[SP]You[SP]want[SP]to[SP]go[SP]into[SP]Smile[SP]Hirasaka?",
+        "nom_fr": "Ginko",
+        "texte_fr": "Aïe... Tu veux aller à Smile Hirasaka ?"
+    },
+    {
+        "id": 190,
+        "offset": 488416,
+        "data_size": 126,
+        "slot_size": 126,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Let's[SP]skip[SP]this[SP]hole[SP]and[SP]go[SP]somewhere[NL]like[SP]Zodiac!",
+        "nom_fr": "Ginko",
+        "texte_fr": "Zappons ce trou et allons plutôt à Zodiac !"
+    },
+    {
+        "id": 191,
+        "offset": 488542,
+        "data_size": 222,
+        "slot_size": 222,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Yukino",
+        "texte_orig": "Smile[SP]Hirasaka?[SP]You[SP]really[SP]enjoy[SP]detours,[NL]huh,[SP][1113]?[SP]Weren't[SP]we[SP]supposed[SP]to[SP]be[NL]going[SP]to[SP]Peace[SP]Diner?",
+        "nom_fr": "Yukino",
+        "texte_fr": "Smile Hirasaka ? Tu aimes les détours,\nhein, [1113] ? On ne devait pas\naller au Peace Diner ?"
+    },
+    {
+        "id": 192,
+        "offset": 488764,
+        "data_size": 220,
+        "slot_size": 220,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "I[SP]come[SP]here[SP]with[SP]my[SP]friend[SP]a[SP]lot.[SP]Hm?[SP]Who[SP]am[NL]I[SP]talking[SP]about?[SP]Haha...[SP]I'll[SP]introduce[SP]you[NL]sometime.",
+        "nom_fr": "Maya",
+        "texte_fr": "Je viens souvent ici avec mon amie. Hm ? De qui\nje parle ? Haha... Je te la présenterai bientôt."
+    },
+    {
+        "id": 193,
+        "offset": 488984,
+        "data_size": 116,
+        "slot_size": 116,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Smile[SP]Hirasaka...[1205][U+000F][SP]Is[SP]this[SP]the[SP]target?[NL]Or...?",
+        "nom_fr": "Maya",
+        "texte_fr": "Smile Hirasaka...[1205][U+000F] Est-ce la cible ?\nOu... ?"
+    },
+    {
+        "id": 194,
+        "offset": 489100,
+        "data_size": 154,
+        "slot_size": 154,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "We[SP]can't[SP]overthink[SP]this.[1205][U+000F][SP]Let's[SP]just[SP]hurry[SP]up[NL]and[SP]get[SP]inside.",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Faut pas trop y penser.[1205][U+000F] Dépêchons-nous\nd'entrer."
+    },
+    {
+        "id": 195,
+        "offset": 489254,
+        "data_size": 482,
+        "slot_size": 482,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[1106][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?[NL][1208][U+0002][U+1432][U+0000][U+0000][U+0014]Yeah,[SP]let's[SP]check[SP]it[SP]out.[U+1432][U+0000][U+0000][U+0014][NL][U+1432][U+0000][U+0000][U+0014]No,[SP]this[SP]isn't[SP]the[SP]place.[U+1432][U+0000][U+0000][U+0014][NL][1109][E2][E3][1431][U+0000][U+0000]\"Yukino[NL]Alright.[SP]If[SP]it's[SP]decided,[SP]then[SP]let's[SP]hurry.[NL]We[SP]don't[SP]have[SP]time[SP]to[SP]waste.",
+        "nom_fr": "Maya",
+        "texte_fr": "[1113]-kun ?[1205][U+000F] On devrait chercher par ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, jetons un œil.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas le bon endroit.[1432][NULL][NULL][0014][1106][NL]Ok. Si c'est décidé, dépêchons-nous.\nOn a peu de temps à perdre."
+    },
+    {
+        "id": 196,
+        "offset": 489736,
+        "data_size": 164,
+        "slot_size": 164,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Yukino",
+        "texte_orig": "Then[SP]we[SP]don't[SP]need[SP]to[SP]be[SP]here.[SP]Let's[SP]hurry[NL]to[SP]the[SP]Sakanoue[SP]Building.",
+        "nom_fr": "Yukino",
+        "texte_fr": "Alors on n'a rien à faire ici. Vite,\nallons au Bâtiment Sakanoue."
+    },
+    {
+        "id": 197,
+        "offset": 489900,
+        "data_size": 382,
+        "slot_size": 382,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "This[SP]place[SP]is[SP]safe[SP]and[SP]sound.[NL]Question[SP]is,[SP]where's[SP]the[SP]next[SP]target...?[NL]GOLD[SP]or[SP]Pachinko[SP]Silver?[NL][1106][E2][1431][U+0000][U+0000]\"Maya[NL]It's[SP]up[SP]to[SP]you,[SP][1113]-kun.[SP]But[SP]we[SP]don't[NL]have[SP]much[SP]time,[SP]so[SP]let's[SP]get[SP]moving.",
+        "nom_fr": "Maya",
+        "texte_fr": "Cet endroit est sain et sauf.\nMais où est la prochaine cible... ?\nGOLD ou Pachinko Silver ?[1106][NL]C'est à toi de voir, [1113]-kun. Mais on a\npeu de temps, alors en route."
+    },
+    {
+        "id": 198,
+        "offset": 490282,
+        "data_size": 256,
+        "slot_size": 256,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "How[SP]could[SP]this[SP]happen...?[SP]There[SP]must've[SP]been[NL]so[SP]many[SP]people[SP]still[SP]inside...[SP]The[SP]flames[SP]are[NL]swallowing[SP]lives[SP]again...",
+        "nom_fr": "Maya",
+        "texte_fr": "C'est pas vrai... ? Il devait y avoir tant\nde gens à l'intérieur... Les flammes\nôtent encore des vies..."
+    },
+    {
+        "id": 199,
+        "offset": 490538,
+        "data_size": 254,
+        "slot_size": 254,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "We[SP]have[SP]to[SP]prevent[SP]any[SP]more[SP]casualties![NL]The[SP]next[SP]target[SP]is[SP]either[SP]GOLD[SP]or[SP]Pachinko[NL]Silver...[SP]It's[SP]up[SP]to[SP]you,[SP][1113]-kun!",
+        "nom_fr": "Maya",
+        "texte_fr": "On doit empêcher d'autres victimes !\nLa prochaine cible est GOLD ou Pachinko\nSilver... Ça dépend de toi, [1113]-kun !"
+    },
+    {
+        "id": 200,
+        "offset": 490792,
+        "data_size": 224,
+        "slot_size": 224,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Are[SP]you[SP]angry[SP]I[SP]let[SP]that[SP]Ixquic[SP]girl[SP]go?[NL]I[SP]think[SP]it's[SP]just[SP]my[SP]nature...[SP]I'm[SP]sorry[NL]if[SP]you[SP]were[SP]upset.",
+        "nom_fr": "Maya",
+        "texte_fr": "Fâché que j'aie laissé fuir Ixquic ?\nC'est dans ma nature... Désolée si ça\nt'a contrarié."
+    },
+    {
+        "id": 201,
+        "offset": 491016,
+        "data_size": 248,
+        "slot_size": 248,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "I'm[SP]sure[SP]King[SP]Leo[SP]is[SP]waiting[SP]for[SP]us[SP]at[SP]the[NL]Aerospace[SP]Museum.[SP]I'll[SP]put[SP]an[SP]end[SP]to[SP]this...[NL]For[SP]both[SP]him[SP]and[SP]myself.",
+        "nom_fr": "Maya",
+        "texte_fr": "Le Roi Lion nous attend au Musée de\nl'Aérospatiale. Je vais y mettre fin...\nPour lui comme pour moi."
+    },
+    {
+        "id": 202,
+        "offset": 491264,
+        "data_size": 186,
+        "slot_size": 186,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "This[SP]is[SP]horrible...[SP]Is[SP]this[SP]their[SP]will[SP]too?[NL]If[SP]so...[SP]What[SP]are[SP]we[SP]going[SP]to[SP]do...?",
+        "nom_fr": "Ginko",
+        "texte_fr": "C'est horrible... Est-ce leur volonté aussi ?\nSi oui... Que va-t-on faire... ?"
+    },
+    {
+        "id": 203,
+        "offset": 491450,
+        "data_size": 426,
+        "slot_size": 426,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "It's[SP]not[SP]like[SP]Jun-kun[SP]to[SP]wish[SP]for[SP]something[NL]like[SP]this.[SP]Wait[SP]for[SP]me...[SP]I'm[SP]coming[SP]to[SP]get[NL]you[SP]this[SP]time...[1106][E2][NL][E3][1431][U+0000][U+0000]\"Eikichi[NL]The[SP]Sakanoue[SP]Building?[1205][U+000A][SP]Why[SP]would[SP]we[SP]go[SP]there?[1205][U+000A][NL]C'mon,[SP]let's[SP]go[SP]somewhere[SP]else.",
+        "nom_fr": "Maya",
+        "texte_fr": "Ce n'est pas le genre de Jun-kun de souhaiter\nune telle chose. Attends-moi... Je viens\nte chercher cette fois...[NULL][NULL]\"Eikichi\nLe Bâtiment Sakanoue ?[1205][U+000A] Pourquoi on irait là-bas ?[1205][U+000A]\nAllez, allons ailleurs."
+    },
+    {
+        "id": 204,
+        "offset": 491876,
+        "data_size": 98,
+        "slot_size": 98,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Oh...[SP]It's[SP]closed...[SP]We[SP]can't[SP]get[SP]in.",
+        "nom_fr": "Maya",
+        "texte_fr": "Oh... C'est fermé... On n'entre pas."
+    },
+    {
+        "id": 205,
+        "offset": 491974,
+        "data_size": 132,
+        "slot_size": 132,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "The[SP]Sakanoue[SP]Building...[1205][U+000F][SP]Is[SP]this[SP]the[SP]next[NL]target...?",
+        "nom_fr": "Maya",
+        "texte_fr": "Bâtiment Sakanoue...[1205][U+000F] Est-ce la prochaine\ncible... ?"
+    },
+    {
+        "id": 206,
+        "offset": 492106,
+        "data_size": 182,
+        "slot_size": 182,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Let's[SP]worry[SP]about[SP]that[SP]later.[1205][U+000F][SP]We[SP]gotta[SP]hurry[NL]and[SP]take[SP]care[SP]of[SP]those[SP]bombs!",
+        "nom_fr": "Eikichi",
+        "texte_fr": "On s'en souciera plus tard.[1205][U+000F] Faut se dépêcher\nde s'occuper de ces bombes !"
+    },
+    {
+        "id": 207,
+        "offset": 492288,
+        "data_size": 482,
+        "slot_size": 482,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[1106][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?[NL][1208][U+0002][U+1432][U+0000][U+0000][U+0014]Yeah,[SP]let's[SP]check[SP]it[SP]out.[U+1432][U+0000][U+0000][U+0014][NL][U+1432][U+0000][U+0000][U+0014]No,[SP]this[SP]isn't[SP]the[SP]place.[U+1432][U+0000][U+0000][U+0014][NL][1109][E2][E3][1431][U+0000][U+0000]\"Yukino[NL]Alright.[SP]If[SP]it's[SP]decided,[SP]then[SP]let's[SP]hurry.[NL]We[SP]don't[SP]have[SP]time[SP]to[SP]waste.",
+        "nom_fr": "Maya",
+        "texte_fr": "[1113]-kun ?[1205][U+000F] On devrait chercher par ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, jetons un œil.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas le bon endroit.[1432][NULL][NULL][0014][1106][NL]Ok. Si c'est décidé, dépêchons-nous.\nOn n'a pas de temps à perdre."
+    },
+    {
+        "id": 208,
+        "offset": 492770,
+        "data_size": 90,
+        "slot_size": 90,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "H-Hey,[SP]wait[SP]a[SP]sec![SP]Look[SP]at[SP]that!",
+        "nom_fr": "Ginko",
+        "texte_fr": "Hé, attendez ! Regardez ça !"
+    },
+    {
+        "id": 209,
+        "offset": 492860,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "If[SP]we'd[SP]picked[SP]this[SP]building,[SP]Smile[SP]Hirasaka[NL]would[SP]be[SP]ashes[SP]by[SP]now...[SP]Oof,[SP]just[SP]thinking[NL]about[SP]it[SP]gives[SP]me[SP]the[SP]chills.",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Si on avait choisi ici, Smile Hirasaka\nserait en cendres... Pfiou, y penser\nme donne des frissons."
+    },
+    {
+        "id": 210,
+        "offset": 493126,
+        "data_size": 290,
+        "slot_size": 290,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "It's[SP]all[SP]this[SP]building's[SP]fault![SP]They[SP]shouldn't[NL]have[SP]put[SP]it[SP]in[SP]such[SP]a[SP]misleading[SP]place![SP]I[SP]want[NL]this[SP]thing[SP]outta[SP]my[SP]sight![SP]Let's[SP]go!",
+        "nom_fr": "Eikichi",
+        "texte_fr": "C'est la faute de ce bâtiment ! Ils n'auraient\npas dû le mettre dans un endroit si trompeur !\nJe veux plus le voir ! Allons-y !"
+    },
+    {
+        "id": 211,
+        "offset": 493416,
+        "data_size": 158,
+        "slot_size": 158,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Everyone's[SP]waiting[SP]at[SP]the[SP]detective[SP]agency.[NL]We[SP]should[SP]hurry[SP]there.",
+        "nom_fr": "Ginko",
+        "texte_fr": "Tous attendent à l'agence de\ndétectives. Dépêchons-nous."
+    },
+    {
+        "id": 212,
+        "offset": 493574,
+        "data_size": 182,
+        "slot_size": 182,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Huh?[SP]It's[SP]locked.[SP]Guess[SP]we[SP]can't[SP]get[SP]in.[1205][U+000F][NL]Oh[SP]well,[SP]let's[SP]go[SP]somewhere[SP]else.",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Hein ? C'est fermé, on ne peut pas\nentrer.[1205][U+000F] Tant pis, allons ailleurs."
+    },
+    {
+        "id": 213,
+        "offset": 493756,
+        "data_size": 200,
+        "slot_size": 200,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "There's[SP]nothing[SP]left[SP]for[SP]us[SP]to[SP]do[SP]here,[SP]right?[NL]Let's[SP]go[SP]get[SP]the[SP]rest[SP]of[SP]those[SP]skulls.",
+        "nom_fr": "Eikichi",
+        "texte_fr": "On n'a plus rien à faire ici, non ?\nAllons chercher le reste de ces crânes."
+    },
+    {
+        "id": 214,
+        "offset": 493956,
+        "data_size": 168,
+        "slot_size": 168,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Yukino",
+        "texte_orig": "If[SP]this[SP]isn't[SP]the[SP]place...[SP]then[SP]it's[SP]Smile[NL]Hirasaka.[SP]Let's[SP]move[SP]it,[SP][1113]!",
+        "nom_fr": "Yukino",
+        "texte_fr": "Si ce n'est pas ici... alors c'est Smile\nHirasaka. Bougeons-nous, [1113] !"
+    },
+    {
+        "id": 215,
+        "offset": 494124,
+        "data_size": 80,
+        "slot_size": 80,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "S-Smile[SP]Hirasaka...[1205][U+000F][SP]No...",
+        "nom_fr": "Ginko",
+        "texte_fr": "Smile Hirasaka...[1205][U+000F] Non..."
+    },
+    {
+        "id": 216,
+        "offset": 494204,
+        "data_size": 94,
+        "slot_size": 94,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Holy[SP]shit...[1205][U+000F][SP]We[SP]were[SP]so[SP]close!",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Merde...[1205][U+000F] On y était presque !"
+    },
+    {
+        "id": 217,
+        "offset": 494298,
+        "data_size": 36,
+        "slot_size": 36,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "......",
+        "nom_fr": "Maya",
+        "texte_fr": "....."
+    },
+    {
+        "id": 218,
+        "offset": 494334,
+        "data_size": 550,
+        "slot_size": 550,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Elly's[SP]voice",
+        "texte_orig": "Hello?[1205][U+000F][SP]It's[SP]me,[SP]Elly.[1205][U+000F][SP]I've[SP]narrowed[SP]down[SP]the[NL]next[SP]target.[SP]This[SP]clue's[SP]also[SP]related[SP]to[NL]astrology...[NL][1106][E2][1431][U+0000][U+0000]\"Elly's[SP]voice[NL]It's[SP]most[SP]likely[SP]north-northeast[SP]from[SP]Sevens.[NL]The[SP]only[SP]things[SP]there[SP]are[SP]Pachinko[SP]Silver[SP]and[NL]GOLD[SP]in[SP]Yumezaki.[SP]So[SP]the[SP]next[SP]target[SP]is--",
+        "nom_fr": "Voix d'Elly",
+        "texte_fr": "Allô ?[1205][U+000F] C'est moi, Elly.[1205][U+000F] J'ai réduit la\nprochaine cible. Cet indice est aussi lié à\nl'astrologie...[1106][NL]C'est au nord-nord-est de Seven.\nLes seuls trucs là-bas sont Pachinko Silver\net GOLD à Yumezaki. La prochaine cible est--"
+    },
+    {
+        "id": 219,
+        "offset": 494884,
+        "data_size": 226,
+        "slot_size": 226,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Elly-san,[SP]please![SP]Can[SP]you[SP]be[SP]more[SP]specific[NL]about[SP]the[SP]location?[1205][U+000F][SP]Which[SP]one[SP]is[SP]King[SP]Leo's[NL]next[SP]target?",
+        "nom_fr": "Maya",
+        "texte_fr": "Elly-san ! Sois plus précise\nsur le lieu.[1205][U+000F] Quelle est la\nprochaine cible du Roi Lion ?"
+    },
+    {
+        "id": 220,
+        "offset": 495110,
+        "data_size": 260,
+        "slot_size": 260,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Elly's[SP]voice",
+        "texte_orig": "Then...[1205][U+000F][SP]You...[1205][U+000F][SP]You[SP]couldn't[SP]prevent[SP]the[NL]fire...[1205][U+000F][SP]I-I'm[SP]sorry...[1205][U+000F][SP]There's[SP]not[SP]much[SP]more[NL]I[SP]can[SP]tell[SP]you...",
+        "nom_fr": "Voix d'Elly",
+        "texte_fr": "Alors...[1205][U+000F] Vous...[1205][U+000F] N'avez pas pu stopper\nl'incendie...[1205][U+000F] Désolée...[1205][U+000F] Je ne peux\nvous en dire plus..."
+    },
+    {
+        "id": 221,
+        "offset": 495370,
+        "data_size": 242,
+        "slot_size": 242,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Yukino",
+        "texte_orig": "Thanks,[SP]Eriko.[SP]That's[SP]more[SP]than[SP]enough[SP]to[SP]get[NL]us[SP]started.[SP]Contact[SP]us[SP]again[SP]if[SP]you[SP]figure[SP]out[NL]anything[SP]else.",
+        "nom_fr": "Yukino",
+        "texte_fr": "Merci, Eriko. C'est plus qu'assez pour commencer.\nRecontacte-nous si tu découvres\nautre chose."
+    },
+    {
+        "id": 222,
+        "offset": 495612,
+        "data_size": 676,
+        "slot_size": 676,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Yukino",
+        "texte_orig": "Look[SP]alive,[SP]people![SP]This[SP]is[SP]not[SP]the[SP]time[SP]for[NL]moping![SP]We[SP]have[SP]to[SP]get[SP]a[SP]grip[SP]if[SP]we[SP]want[SP]to[NL]stop[SP]any[SP]more[SP]deaths![NL][1106][E2][1431][U+0000][U+0000]\"Yukino[NL]Hang[SP]in[SP]there![1205][U+000F][SP]Dig[SP]deep![1205][U+000F][SP]The[SP]next[SP]target[SP]is[NL]either[SP]GOLD[SP]or[SP]Pachinko[SP]Silver[SP]in[SP]Yumezaki![NL][1106][E2][1431][U+0000][U+0000]\"Yukino[NL]We[SP]HAVE[SP]to[SP]do[SP]this,[SP]or[SP]there's[SP]no[SP]stopping[SP]the[NL]next[SP]bombing![SP][1113],[SP]don't[SP]steer[SP]us[SP]wrong[NL]this[SP]time!",
+        "nom_fr": "Yukino",
+        "texte_fr": "Réveillez-vous ! Ce n'est pas le moment\nde broyer du noir ! Reprenons-nous si on veut\néviter d'autres morts ![1106][NL]Tenez bon ![1205][U+000F] Courage ![1205][U+000F] La prochaine cible est\nGOLD ou Pachinko Silver à Yumezaki ![1106][NL]Il LE faut, sinon la prochaine\nbombe explosera ! [1113], ne\nnous égare pas !"
+    },
+    {
+        "id": 223,
+        "offset": 496288,
+        "data_size": 208,
+        "slot_size": 208,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Jun",
+        "texte_orig": "We[SP]already[SP]have[SP]the[SP]crystal[SP]skull[SP]that[SP]was[SP]here.[NL]Let's[SP]hurry[SP]and[SP]gather[SP]the[SP]remaining[SP]skulls.",
+        "nom_fr": "Jun",
+        "texte_fr": "On a déjà le crâne en cristal qui était ici.\nDépêchons-nous d'obtenir les autres."
+    },
+    {
+        "id": 224,
+        "offset": 496496,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Jun",
+        "texte_orig": "Some[SP]of[SP]the[SP]Masked[SP]Circle[SP]are[SP]still[SP]fighting[NL]in[SP]there...[SP]If[SP]I[SP]still[SP]had[SP]my[SP]powers[SP]as[SP]Joker,[NL]I[SP]could[SP]stop[SP]it[SP]in[SP]an[SP]instant...",
+        "nom_fr": "Jun",
+        "texte_fr": "Le Cercle se bat encore ici...\nSi j'avais mes pouvoirs de Joker,\nje les arrêterais de suite..."
+    },
+    {
+        "id": 225,
+        "offset": 496766,
+        "data_size": 178,
+        "slot_size": 178,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Ken...[SP]Takeshi...[SP]Shogo...[SP]Don't[SP]worry,[SP]guys.[NL]I'll[SP]get[SP]you[SP]back[SP]to[SP]normal.",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Ken... Takeshi... Shogo... Vous en faites pas.\nJ'vais vous aider."
+    },
+    {
+        "id": 226,
+        "offset": 496944,
+        "data_size": 136,
+        "slot_size": 136,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "C'mon,[SP][U+1114].[SP]There's[SP]stuff[SP]we[SP]gotta[SP]take[NL]care[SP]of.[SP]Right?",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Yo, [1114]. Faut qu'on s'occupe d'autre chose\nlà, nan ?"
+    },
+    {
+        "id": 227,
+        "offset": 497080,
+        "data_size": 274,
+        "slot_size": 274,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Whoa,[SP]hold[SP]your[SP]horses.[SP]We[SP]haven't[SP]gotten[SP]the[NL]skull[SP]at[SP]Leo[SP]Temple[SP]yet,[SP]right?[SP]Let's[SP]take[NL]care[SP]of[SP]that[SP]before[SP]we[SP]jump[SP]in[SP]here.",
+        "nom_fr": "Maya",
+        "texte_fr": "Wah, ralentis. On n'a pas encore acquis le crâne au\ntemple lion, non ? Faisons ça avant de venir ici."
+    },
+    {
+        "id": 228,
+        "offset": 497354,
+        "data_size": 224,
+        "slot_size": 224,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Wait[SP]a[SP]sec,[SP]Chinyan![SP]We[SP]don't[SP]have[SP]the[SP]skull[NL]from[SP]Taurus[SP]Temple[SP]yet.[SP]We[SP]should[SP]stop[SP]by[NL]there[SP]first.",
+        "nom_fr": "Ginko",
+        "texte_fr": "Attends Chinyan ! On n'a pas encore le crâne\ndu temple taureau. On devrait y passer d'abord."
+    }
 ]

--- a/traduction/MMAP02.json
+++ b/traduction/MMAP02.json
@@ -1,5678 +1,4304 @@
 [
-  {
-    "id": 0,
-    "offset": 378826,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Yo,[SP]you[SP]here[SP]to[SP]have[SP]some[SP]fun[SP]too?[1205][U+000F][SP]'Course[SP]you\nare.[SP]Yumezaki's[SP]the[SP]district[SP]for[SP]kids![SP]Wall-to-\nwall[SP]entertainment!",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Yo, tu viens t'amuser aussi ?[1205][U+000F] Bien sûr.\nYumezaki est pour les jeunes !\nDu divertissement partout !"
-  },
-  {
-    "id": 1,
-    "offset": 379092,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Mu,[SP]the[SP]hottest[SP]amusement[SP]center.[1205][U+000F][SP]Giga[SP]Macho,\na[SP]record[SP]store[SP]with[SP]a[SP]recording[SP]studio.[1205][U+000F][SP]Anima\nMundi,[SP]home[SP]of[SP]the[SP]latest[SP]fashions.",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Mu, le meilleur centre de jeux.[1205][U+000F] Giga Macho,\nun disquaire avec studio.[1205][U+000F] Anima Mundi,\nle temple de la mode."
-  },
-  {
-    "id": 2,
-    "offset": 379388,
-    "data_size": 176,
-    "slot_size": 180,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "A[SP]guy[SP]my[SP]age[SP]could[SP]easily[SP]spend[SP]an[SP]entire[SP]day\nhere[SP]and[SP]never[SP]get[SP]bored.[1205][U+000F]",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Un gars de mon âge peut passer toute la\njournée ici sans s'ennuyer.[1205][U+000F]"
-  },
-  {
-    "id": 3,
-    "offset": 379568,
-    "data_size": 102,
-    "slot_size": 106,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "And[SP]the[SP]girls[SP]here...[SP]Whew![SP]Heheheh.",
-    "nom_fr": "Jeune",
-    "texte_fr": "Les filles ici... Ouf ! Heheh."
-  },
-  {
-    "id": 4,
-    "offset": 379674,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Looks[SP]like[SP]there's[SP]a[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High.[1205][U+000F]\nHe's[SP]stronger[SP]than[SP]the[SP]old[SP]Boss,[SP]right?",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "On dirait qu'il y a un nouveau chef à Kakasu.[1205][U+000F]\nPlus fort que l'ancien, non ?"
-  },
-  {
-    "id": 5,
-    "offset": 379882,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Heh,[SP]they're[SP]having[SP]a[SP]masquerade[SP]as[SP]part[SP]of\ntheir[SP]school[SP]festival.[SP]Cuss[SP]High[SP]sure[SP]knows\nhow[SP]to[SP]draw[SP]a[SP]crowd.[1205][U+000F][SP]All[SP]my[SP]friends[SP]are[SP]going.",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Ils font un bal masqué pour leur festival.\nLe lycée Kakasu sait comment attirer la\nfoule.[1205][U+000F] Tous mes potes y vont."
-  },
-  {
-    "id": 6,
-    "offset": 380188,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Ooh,[SP]you[SP]on[SP]your[SP]way[SP]to[SP]Mu?[1205][U+000F][SP]We[SP]might[SP]catch[SP]a\nglimpse[SP]of[SP]the[SP]Muses[SP]live![SP]I[SP]better[SP]get[SP]going.",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Ooh, tu vas à Mu ?[1205][U+000F] On pourrait voir les\nMuses en direct ! Il faut que j'y aille."
-  },
-  {
-    "id": 7,
-    "offset": 380408,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Ugh,[SP]I[SP]was[SP]just[SP]at[SP]Giga[SP]Macho,[SP]and[SP]it[SP]was[SP]packed\nwith[SP]guys[SP]trying[SP]to[SP]scope[SP]out[SP]the[SP]Muses[SP]event.[1205][U+000F]\nBandwagon-hopping[SP]bastards...",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Ugh, j'étais à Giga Macho, c'était rempli de\ngars voulant voir l'événement des Muses.[1205][U+000F]\nBande de moutons..."
-  },
-  {
-    "id": 8,
-    "offset": 380696,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "It's[SP]gonna[SP]suck[SP]if[SP]more[SP]schmoes[SP]like[SP]them[SP]keep\nshowing[SP]up.[1205][U+000F][SP]I've[SP]been[SP]a[SP]fan[SP]of[SP]those[SP]girls\nsince[SP]before[SP]it[SP]was[SP]cool.",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Ça va puer si d'autres nazes se pointent.[1205][U+000F]\nJe suis fan depuis bien avant que ce soit cool."
-  },
-  {
-    "id": 9,
-    "offset": 380964,
-    "data_size": 224,
-    "slot_size": 228,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Dude,[SP]everyone[SP]went[SP]to[SP]go[SP]see[SP]the[SP]concert\nin[SP]Aoba...[1205][U+000F][SP]Am[SP]I[SP]the[SP]only[SP]one[SP]who[SP]didn't[SP]go?[1205][U+000F]\nLame...",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Tous sont allés voir le concert à Aoba...[1205][U+000F]\nJe suis le seul à pas y être allé ?[1205][U+000F] Nul..."
-  },
-  {
-    "id": 10,
-    "offset": 381192,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Hey,[SP]what's[SP]the[SP]Masked[SP]Circle?[1205][U+000F][SP]They're[SP]the[SP]ones\nwho[SP]set[SP]fire[SP]to[SP]the[SP]concert[SP]hall,[SP]right?[SP]That's\nwhat[SP]my[SP]friend's[SP]friend[SP]said.",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Hé, c'est quoi le Cercle masqué ?[1205][U+000F] Ce sont\neux qui ont incendié la salle de concert,\nnon ? C'est ce qu'un pote a dit."
-  },
-  {
-    "id": 11,
-    "offset": 381480,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Even[SP]their[SP]name[SP]sounds[SP]suspicious.[1205][U+000F][SP]If[SP]they're\nactually[SP]starting[SP]shit[SP]like[SP]this,[SP]they[SP]must\nreally[SP]be[SP]dangerous.",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Même leur nom est louche.[1205][U+000F] S'ils font\nvraiment ce genre de trucs, ils doivent\nêtre hyper dangereux."
-  },
-  {
-    "id": 12,
-    "offset": 381738,
-    "data_size": 148,
-    "slot_size": 152,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Hey,[SP]is[SP]it[SP]true[SP]the[SP]terrorists[SP]targeted\nSmile[SP]Hirasaka[SP]too?",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Hé, les terroristes ont aussi ciblé\nSmile Hirasaka ?"
-  },
-  {
-    "id": 13,
-    "offset": 381890,
-    "data_size": 188,
-    "slot_size": 192,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "I-I'm[SP]starting[SP]to[SP]think[SP]this[SP]place[SP]isn't[SP]safe\neither...[1205][U+000F][SP]Are[SP]we[SP]gonna[SP]be[SP]okay?",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "J-Je pense qu'ici non plus c'est pas sûr...[1205][U+000F]\nOn va s'en sortir ?"
-  },
-  {
-    "id": 14,
-    "offset": 382082,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Is[SP]it[SP]true[SP]the[SP]terrorists[SP]bombed[SP]Smile\nHirasaka?[SP]Dude,[SP]seriously...?[1205][U+000A][SP]They[SP]could\nhit[SP]here[SP]next![1205][U+000F][SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]run.",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Ils ont vraiment bombardé Smile Hirasaka ?\nSérieux ?[1205][U+000A] Ils pourraient viser ici !\n[1205][U+000F]Je devrais fuir."
-  },
-  {
-    "id": 15,
-    "offset": 382364,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "What,[SP]they[SP]even[SP]targeted[SP]GOLD!?[1205][U+000F][SP]Does[SP]that[SP]mean\nYumezaki's[SP]not[SP]safe[SP]either!?[SP]When[SP]will[SP]someone\ndo[SP]something[SP]about[SP]this...?",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Quoi, ils ont même ciblé GOLD !?[1205][U+000F] Ça\nveut dire que Yumezaki n'est pas sûr\nnon plus !? Quand vont-ils agir... ?"
-  },
-  {
-    "id": 16,
-    "offset": 382644,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "O-Oh[SP]shit,[SP]they[SP]got[SP]GOLD[SP]too...[1205][U+000F][SP]H-Hey,[SP]where\nare[SP]they[SP]gonna[SP]strike[SP]next!?[1205][U+000F][SP]If[SP]I[SP]don't[SP]know\nthat...[SP]I[SP]don't[SP]know[SP]where[SP]to[SP]run[SP]to...",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "M-Merde, ils ont eu GOLD aussi...[1205][U+000F] H-Hé,\noù vont-ils frapper ensuite !?[1205][U+000F] Si je ne le\nsais pas... je ne sais pas où fuir..."
-  },
-  {
-    "id": 17,
-    "offset": 382944,
-    "data_size": 320,
-    "slot_size": 324,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "They've[SP]posted[SP]composite[SP]sketches[SP]of[SP]the[SP]suspects,\nright?[1205][U+000F][SP]Looks[SP]like[SP]crime[SP]doesn't[SP]pay[SP]after[SP]all.\nBut[SP]wasn't[SP]it[SP]the[SP]Masked[SP]Circle[SP]who[SP]did[SP]this?",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Ils ont publié les portraits-robots des\nsuspects, non ?[1205][U+000F] Le crime ne paie pas.\nMais n'était-ce pas le Cercle masqué ?"
-  },
-  {
-    "id": 18,
-    "offset": 383268,
-    "data_size": 116,
-    "slot_size": 120,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "H-Hey,[SP]I[SP]saw[SP]the[SP]news...[SP]What[SP]do[SP]you[SP]think?",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Hé, j'ai vu les infos... T'en dis quoi ?"
-  },
-  {
-    "id": 19,
-    "offset": 383388,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Are[SP]those[SP]guys[SP]not[SP]the[SP]culprits?[1205][U+000F][SP]Or[SP]are[SP]they\nreally[SP]terrorists[SP]after[SP]all?",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Ils sont innocents ?[1205][U+000F] Ou\nde vrais terroristes ?"
-  },
-  {
-    "id": 20,
-    "offset": 383572,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Dude,[SP]shit[SP]keeps[SP]going[SP]down[SP]right[SP]and[SP]left!\nWhat's[SP]going[SP]on!?[1205][U+000F][SP]Were[SP]those[SP]guys[SP]terrorists\nor[SP]not!?[SP]What[SP]are[SP]they[SP]doing[SP]to[SP]our[SP]city!?",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Mec, c'est le bordel de partout !\nIl se passe quoi !?[1205][U+000F] Ces gars étaient des\nterroristes ou pas !? Ils font quoi ici !?"
-  },
-  {
-    "id": 21,
-    "offset": 383872,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "I[SP]saw[SP]a[SP]guy[SP]wearing[SP]a[SP]skirt[SP]go[SP]into[SP]that\ntemple[SP]just[SP]now.",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Un gars en jupe vient d'entrer au temple."
-  },
-  {
-    "id": 22,
-    "offset": 384020,
-    "data_size": 176,
-    "slot_size": 180,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]man",
-    "texte_orig": "Was[SP]he[SP]a[SP]Cuss[SP]High[SP]student?[SP]He[SP]had[SP]a[SP]really\ncute[SP]girl[SP]with[SP]him,[SP]though...",
-    "nom_fr": "Jeune homme",
-    "texte_fr": "Un élève de Kakasu ? Il était avec\nune fille mignonne..."
-  },
-  {
-    "id": 23,
-    "offset": 384200,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Hm?[SP]Are[SP]you[SP]hitting[SP]on[SP]me?[1205][U+000F][SP]If[SP]you[SP]are,[SP]I[SP]hate\nto[SP]break[SP]it[SP]to[SP]you,[SP]but[SP]I'm[SP]a[SP]little[SP]busy.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Hm ? Tu me dragues ?[1205][U+000F] Si c'est le cas,\ndésolée de te décevoir, mais je suis occupée."
-  },
-  {
-    "id": 24,
-    "offset": 384422,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Oh,[SP]you[SP]weren't?[SP]Haha,[SP]sorry[SP]about[SP]that,[SP]then.[1205][U+000F]\nThat[SP]reminds[SP]me,[SP]do[SP]you[SP]go[SP]to[SP]Cuss[SP]High?",
-    "nom_fr": "Femme active",
-    "texte_fr": "Oh, ce n'était pas ça ? Haha, désolée.[1205][U+000F]\nÇa me rappelle, tu vas au lycée Kakasu ?"
-  },
-  {
-    "id": 25,
-    "offset": 384642,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Because[SP]I[SP]saw[SP]a[SP]group[SP]of[SP]Cuss[SP]High[SP]kids[SP]going\ninto[SP]Zodiac[SP]a[SP]moment[SP]ago.[1205][U+000F][SP]Do[SP]you[SP]know[SP]what\nthey're[SP]up[SP]to[SP]in[SP]there?",
-    "nom_fr": "Femme active",
-    "texte_fr": "J'ai vu un groupe de Kakasu entrer dans\nZodiac.[1205][U+000F] Tu sais ce qu'ils y font ?"
-  },
-  {
-    "id": 26,
-    "offset": 384912,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "That[SP]reminds[SP]me,[SP]rumor[SP]has[SP]it[SP]there's[SP]a[SP]secret\nlounge[SP]deep[SP]inside[SP]Zodiac.[1205][U+000F][SP]I've[SP]never[SP]gone[SP]to\nsee[SP]it,[SP]though...",
-    "nom_fr": "Femme active",
-    "texte_fr": "D'ailleurs, la rumeur dit qu'il y a un salon\nsecret au fond de Zodiac.[1205][U+000F] Je n'y suis\njamais allée, par contre..."
-  },
-  {
-    "id": 27,
-    "offset": 385178,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Someone[SP]from[SP]Cuss[SP]High[SP]came[SP]to[SP]sell[SP]tickets[SP]to\nthe[SP]masquerade[SP]just[SP]now.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Un gars de Kakasu est venu vendre\ndes billets pour le bal."
-  },
-  {
-    "id": 28,
-    "offset": 385362,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "All[SP]the[SP]girls[SP]around[SP]here[SP]rushed[SP]over[SP]and[SP]he\nsold[SP]out[SP]in[SP]a[SP]flash.[1205][U+000F][SP]I[SP]didn't[SP]realize[SP]the\nschool[SP]was[SP]that[SP]popular.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Les filles se sont ruées et il a tout vendu\nvite.[1205][U+000F] Je ne pensais pas cette école si cotée."
-  },
-  {
-    "id": 29,
-    "offset": 385630,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Young[SP]kids[SP]tend[SP]to[SP]gather[SP]here,[SP]so[SP]TV[SP]stations\nsend[SP]reporters[SP]to[SP]interview[SP]them[SP]and[SP]hold\nevents.[1205][U+000F][SP]Aren't[SP]they[SP]having[SP]one[SP]at[SP]Mu[SP]today?",
-    "nom_fr": "Femme active",
-    "texte_fr": "Les jeunes traînent ici, donc la télé\nenvoie des reporters pour les interviewer\net faire des trucs.[1205][U+000F] C'est à Mu aujourd'hui ?"
-  },
-  {
-    "id": 30,
-    "offset": 385940,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Is[SP]Muses[SP]still[SP]keeping[SP]their[SP]third[SP]member[SP]a\nsecret?[1205][U+000F][SP]I[SP]know[SP]it's[SP]a[SP]marketing[SP]strategy,[SP]but\nI[SP]wish[SP]they'd[SP]stop[SP]fanning[SP]the[SP]flames.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Muses garde toujours sa troisième membre\nsecrète ?[1205][U+000F] Je sais que c'est du marketing,\nmais j'aimerais qu'ils arrêtent ce teasing."
-  },
-  {
-    "id": 31,
-    "offset": 386240,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Or[SP]are[SP]they[SP]planning[SP]on[SP]making[SP]an[SP]announcement\nduring[SP]the[SP]recording[SP]today?",
-    "nom_fr": "Femme active",
-    "texte_fr": "Ou comptent-ils faire une annonce\npendant l'enregistrement aujourd'hui ?"
-  },
-  {
-    "id": 32,
-    "offset": 386430,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "They[SP]just[SP]revealed[SP]the[SP]third[SP]member,[SP]and[SP]they're\nalready[SP]giving[SP]a[SP]concert?[1205][U+000F][SP]That's[SP]pretty[SP]sudden.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Ils viennent de révéler la troisième membre\net ils donnent déjà un concert ?[1205][U+000F] Rapide."
-  },
-  {
-    "id": 33,
-    "offset": 386668,
-    "data_size": 172,
-    "slot_size": 176,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Either[SP]that[SP]Ginji[SP]Sasaki[SP]is[SP]extremely[SP]skilled,\nor[SP]extremely[SP]rushed.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Soit ce Ginji Sasaki est très doué,\nsoit il est extrêmement pressé."
-  },
-  {
-    "id": 34,
-    "offset": 386844,
-    "data_size": 238,
-    "slot_size": 242,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "They[SP]say[SP]these[SP]bombings[SP]are[SP]part[SP]of[SP]a[SP]wave\nof[SP]terror.[1205][U+000F][SP]There's[SP]no[SP]knowing[SP]where[SP]they'll\nstrike[SP]next.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Ces attentats sont une vague de terreur.[1205][U+000F]\nImpossible de savoir où ils frapperont."
-  },
-  {
-    "id": 35,
-    "offset": 387086,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "They[SP]won't[SP]attack[SP]here,[SP]right...?[1205][U+000F][SP]I[SP]worry\nabout[SP]that[SP]a[SP]lot.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Ils n'attaqueront pas ici, non... ?[1205][U+000F]\nÇa m'inquiète beaucoup."
-  },
-  {
-    "id": 36,
-    "offset": 387250,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "I'd[SP]evacuate[SP]to[SP]the[SP]countryside[SP]if[SP]I[SP]could.[1205][U+000F]\nUnfortunately,[SP]that's[SP]not[SP]an[SP]option.",
-    "nom_fr": "Femme active",
-    "texte_fr": "J'irais à la campagne si je le pouvais.[1205][U+000F]\nMalheureusement, ce n'est pas possible."
-  },
-  {
-    "id": 37,
-    "offset": 387456,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "I've[SP]got[SP]a[SP]huge[SP]backlog[SP]at[SP]work[SP]and[SP]there's\nno[SP]sign[SP]that[SP]this[SP]place[SP]will[SP]be[SP]bombed.",
-    "nom_fr": "Femme active",
-    "texte_fr": "J'ai une tonne de boulot en retard et\nrien n'indique qu'il y aura une bombe ici."
-  },
-  {
-    "id": 38,
-    "offset": 387664,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "But[SP]I[SP]know[SP]I'll[SP]regret[SP]it[SP]immediately[SP]if[SP]there\nIS[SP]a[SP]bombing[SP]here.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Mais je regretterai s'il y A une bombe ici."
-  },
-  {
-    "id": 39,
-    "offset": 387836,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "I[SP]wonder[SP]if[SP]I'm[SP]just[SP]too[SP]used[SP]to[SP]everything\nbeing[SP]peaceful[SP]that[SP]I[SP]can't[SP]make[SP]up[SP]my[SP]mind.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Je me demande si je suis trop habituée\nà la paix pour pouvoir me décider."
-  },
-  {
-    "id": 40,
-    "offset": 388054,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "[1432][NULL][NULL][0014]If[SP]GOLD[SP]was[SP]the[SP]target,[SP]then[SP]our[SP]building's\nsafe.[1432][NULL][NULL][0014][SP]That's[SP]what[SP]he[SP]thinks,[SP]anyway.",
-    "nom_fr": "Femme active",
-    "texte_fr": "[1432][NULL][NULL][0014]Si GOLD était la cible, notre bâtiment\nest sauf.[1432][NULL][NULL][0014] C'est ce qu'il pense, bref."
-  },
-  {
-    "id": 41,
-    "offset": 388272,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "What[SP]on[SP]Earth[SP]is[SP]my[SP]idiot[SP]boss[SP]thinking!?\nI'm[SP]giving[SP]notice[SP]as[SP]soon[SP]as[SP]I[SP]get[SP]back!",
-    "nom_fr": "Femme active",
-    "texte_fr": "À quoi pense mon idiot de patron !?\nJe démissionne dès que je rentre !"
-  },
-  {
-    "id": 42,
-    "offset": 388478,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "[1432][NULL][NULL][0014]They[SP]went[SP]after[SP]GOLD,[SP]so[SP]our[SP]building's\nsafe[1432][NULL][NULL][0014]!?[SP]Is[SP]he[SP]serious!?",
-    "nom_fr": "Femme active",
-    "texte_fr": "[1432][NULL][NULL][0014]Ils ont visé GOLD, donc on est\nsaufs[1432][NULL][NULL][0014] !? Il est sérieux !?"
-  },
-  {
-    "id": 43,
-    "offset": 388660,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "What[SP]on[SP]Earth[SP]is[SP]my[SP]idiot[SP]boss[SP]thinking!?[1205][U+000F]\nI'm[SP]giving[SP]notice[SP]as[SP]soon[SP]as[SP]I[SP]get[SP]back!",
-    "nom_fr": "Femme active",
-    "texte_fr": "À quoi pense mon idiot de patron !?[1205][U+000F]\nJe démissionne dès que je rentre !"
-  },
-  {
-    "id": 44,
-    "offset": 388870,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Huh.[1205][U+000F][SP]Those[SP]kids[SP]were[SP]soaking[SP]wet[SP]and[SP]said[SP]the\npeople[SP]in[SP]the[SP]news[SP]were[SP]heroes[SP]fighting[SP]the\nMasked[SP]Circle...[1205][0014][SP]Who[SP]do[SP]I[SP]believe?",
-    "nom_fr": "Femme active",
-    "texte_fr": "Huh.[1205][U+000F] Ces jeunes étaient trempés et disaient\nque les gars aux infos étaient des héros\ncontre le Cercle masqué...[1205][0014] Qui croire ?"
-  },
-  {
-    "id": 45,
-    "offset": 389168,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "I[SP]wonder[SP]if[SP]the[SP]stuff[SP]in[SP]the[SP]In[SP]Lak'ech[SP]is\ntrue[SP]after[SP]all.[1205][U+000F][SP]I[SP]heard[SP]even[SP]the[SP]recent[SP]wave\nof[SP]terror[SP]is[SP]mentioned[SP]in[SP]there...",
-    "nom_fr": "Femme active",
-    "texte_fr": "Je me demande si les trucs de l'In Lak'ech\nsont vrais.[1205][U+000F] J'ai entendu dire que la vague\nde terreur y est même mentionnée..."
-  },
-  {
-    "id": 46,
-    "offset": 389458,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "If[SP]they're[SP]here,[SP]then[SP]the[SP]secret[SP]treasure[SP]of\nSumaru[SP]City[SP]must[SP]also[SP]exist.[1205][U+000F][SP]Which[SP]means[SP]that\nOracle[SP]thing[SP]is[SP]true...",
-    "nom_fr": "Femme active",
-    "texte_fr": "S'ils sont là, le trésor secret de Sumaru\ndoit aussi exister.[1205][U+000F] Ce qui signifie que\ncet Oracle dit vrai..."
-  },
-  {
-    "id": 47,
-    "offset": 389730,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "The[SP]next[SP]line[SP]was,[SP][1432][NULL][NULL][0014]The[SP]lion's[SP]roar[SP]echoes[SP]far\nand[SP]wide,[1432][NULL][NULL][0014][SP]right?[1205][U+000F][SP]Wh-What's[SP]that[SP]supposed[SP]to\nmean?[1205][U+000F][SP]I[SP]don't[SP]understand...",
-    "nom_fr": "Femme active",
-    "texte_fr": "La suite c'était : [1432][NULL][NULL][0014]Le rugissement\ndu lion résonne[1432][NULL][NULL][0014] ?[1205][U+000F]\nÇa veut dire quoi ?[1205][U+000F] Je pige pas..."
-  },
-  {
-    "id": 48,
-    "offset": 390030,
-    "data_size": 326,
-    "slot_size": 330,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "D-Did[SP]you[SP]see[SP]those[SP]meteors?[1205][U+000F][SP]One[SP]of[SP]the[SP]Masked\nCircle[SP]said[SP]they[SP]were[SP]the[SP][1432][NULL][NULL][0014]lion's[SP]roar[1432][NULL][NULL][0014]![1205][U+000F][SP]That's\nwhat[SP]that[SP]line[SP]in[SP]the[SP]Oracle[SP]was[SP]about!",
-    "nom_fr": "Femme active",
-    "texte_fr": "T-Tu as vu ces météores ?[1205][U+000F] Quelqu'un du Cercle\na dit que c'était le [1432][NULL][NULL][0014]rugissement du lion[1432][NULL][NULL][0014] ![1205][U+000F]\nC'est de ça que parlait l'Oracle !"
-  },
-  {
-    "id": 49,
-    "offset": 390360,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "A[SP]temple[SP]like[SP]that[SP]one[SP]appeared[SP]in[SP]Hirasaka\nand[SP]Aoba[SP]too,[SP]right?",
-    "nom_fr": "Femme active",
-    "texte_fr": "Un temple est apparu à Hirasaka et Aoba, non ?"
-  },
-  {
-    "id": 50,
-    "offset": 390530,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "What[SP]are[SP]those[SP]things...?[1205][U+000F][SP]The[SP]scorpion[SP]mark\ndrawn[SP]on[SP]it[SP]is[SP]kind[SP]of[SP]disturbing...",
-    "nom_fr": "Femme active",
-    "texte_fr": "C'est quoi... ?[1205][U+000F] La marque de\nscorpion dessus est perturbante..."
-  },
-  {
-    "id": 51,
-    "offset": 390736,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "A[SP]city[SP]for[SP]the[SP]young...[1205][U+000F][SP]That's[SP]what[SP]those\nlayabouts[SP]think.[SP]For[SP]us[SP]men[SP]making[SP]an[SP]honest\nday's[SP]pay,[SP]this[SP]place[SP]is[SP]part[SP]of[SP]society[SP]too.",
-    "nom_fr": "Homme",
-    "texte_fr": "Une ville pour jeunes...[1205][U+000F] C'est ce que\npensent ces fainéants. Pour nous qui bossons,\nça fait partie de la société."
-  },
-  {
-    "id": 52,
-    "offset": 391026,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "By[SP]the[SP]way,[SP]are[SP]you[SP]from[SP]Kasugayama[SP]High?[1205][U+000F]\nThis[SP]place[SP]is[SP]usually[SP]packed[SP]with[SP]Sevens[SP]kids,\nbut[SP]I[SP]rarely[SP]see[SP]them[SP]anymore.",
-    "nom_fr": "Homme",
-    "texte_fr": "Au fait, tu viens du lycée Kakasu ?[1205][U+000F]\nC'est souvent plein de gamins de Seven ici,\nmais je les vois rarement désormais."
-  },
-  {
-    "id": 53,
-    "offset": 391290,
-    "data_size": 194,
-    "slot_size": 198,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "A[SP]secret[SP]lounge?[1205][U+000F][SP]Oh,[SP]you[SP]mean[SP]the[SP]place[SP]you\ncan't[SP]get[SP]into[SP]without[SP]one[SP]of[SP]those[SP]masks?",
-    "nom_fr": "Homme",
-    "texte_fr": "Un salon secret ?[1205][U+000F] Oh, tu parles de l'endroit\noù on ne peut pas entrer sans masque ?"
-  },
-  {
-    "id": 54,
-    "offset": 391488,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "I've[SP]heard[SP]rumors[SP]about[SP]it...[1205][U+000F][SP]But[SP]it[SP]sounds[SP]like\na[SP]pretty[SP]shady[SP]place.",
-    "nom_fr": "Homme",
-    "texte_fr": "J'ai entendu des rumeurs...[1205][U+000F] Ça a l'air louche."
-  },
-  {
-    "id": 55,
-    "offset": 391654,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Guess[SP]all[SP]our[SP]customers[SP]are[SP]off[SP]at[SP]Cuss[SP]High's\nschool[SP]festival...[SP]Oh[SP]well.",
-    "nom_fr": "Homme",
-    "texte_fr": "Nos clients sont au festival de Kakasu... Tant pis."
-  },
-  {
-    "id": 56,
-    "offset": 391824,
-    "data_size": 158,
-    "slot_size": 162,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Festivals[SP]like[SP]that[SP]do[SP]only[SP]come[SP]once[SP]a[SP]year,\nso[SP]I[SP]shouldn't[SP]complain.",
-    "nom_fr": "Homme",
-    "texte_fr": "Ce festival n'a lieu qu'une fois\npar an, je me plains pas."
-  },
-  {
-    "id": 57,
-    "offset": 391986,
-    "data_size": 142,
-    "slot_size": 146,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "I[SP]keep[SP]being[SP]surprised[SP]at[SP]how[SP]popular[SP]that\nnew[SP]group[SP]Muses[SP]is.",
-    "nom_fr": "Homme",
-    "texte_fr": "Je suis surpris du succès de Muses."
-  },
-  {
-    "id": 58,
-    "offset": 392132,
-    "data_size": 74,
-    "slot_size": 78,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Is[SP]their[SP]producer[SP]that[SP]good?",
-    "nom_fr": "Homme",
-    "texte_fr": "Leur prod est si doué ?"
-  },
-  {
-    "id": 59,
-    "offset": 392210,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "A[SP]crowd's[SP]forming[SP]at[SP]Giga[SP]Macho,[SP]but[SP]they're\nnot[SP]interested[SP]in[SP]anything[SP]but[SP]Ginji[SP]Sasaki\nand[SP]the[SP]last[SP]member[SP]of[SP]Muses.",
-    "nom_fr": "Homme",
-    "texte_fr": "Une foule se forme à Giga Macho, mais ils ne\ns'intéressent qu'à Ginji Sasaki et à la\ndernière membre de Muses."
-  },
-  {
-    "id": 60,
-    "offset": 392468,
-    "data_size": 102,
-    "slot_size": 106,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "The[SP]outdoor[SP]concert[SP]hall's[SP]packed[SP]already.",
-    "nom_fr": "Homme",
-    "texte_fr": "La salle en plein air est pleine."
-  },
-  {
-    "id": 61,
-    "offset": 392574,
-    "data_size": 222,
-    "slot_size": 226,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "I[SP]envy[SP]them[SP]their[SP]popularity...[SP]It's[SP]a[SP]tough\nthing[SP]to[SP]see[SP]for[SP]those[SP]of[SP]us[SP]who've[SP]fallen\non[SP]hard[SP]times.",
-    "nom_fr": "Homme",
-    "texte_fr": "J'envie leur succès... C'est dur pour nous\nqui avons traversé des crises."
-  },
-  {
-    "id": 62,
-    "offset": 392800,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Some[SP]people[SP]are[SP]saying[SP]the[SP]Masked[SP]Circle[SP]is[SP]to\nblame[SP]for[SP]the[SP]chaos,[SP]but[SP]are[SP]they[SP]really[SP]the\nculprits[SP]here?[1205][U+000F][SP]Granted,[SP]they're[SP]suspicious...",
-    "nom_fr": "Homme",
-    "texte_fr": "Certains accusent le Cercle masqué pour\nce chaos, mais sont-ils vraiment les\ncoupables ?[1205][U+000F] Certes, ils sont louches..."
-  },
-  {
-    "id": 63,
-    "offset": 393098,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "But[SP]I'm[SP]more[SP]worried[SP]about[SP]those[SP]five[SP]people\nseen[SP]outside[SP]the[SP]concert[SP]hall.[1205][U+000F][SP]I[SP]know[SP]a[SP]lot\nof[SP]folks[SP]who[SP]think[SP]they're[SP]the[SP]real[SP]culprits.",
-    "nom_fr": "Homme",
-    "texte_fr": "Mais ces cinq personnes vues devant la salle\nde concert m'inquiètent plus.[1205][U+000F] Beaucoup\npensent que ce sont les vrais coupables."
-  },
-  {
-    "id": 64,
-    "offset": 393392,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "The[SP]Masked[SP]Circle[SP]and[SP]the[SP]group[SP]of[SP]five...[1205][U+000F]\nThey're[SP]both[SP]suspects[SP]behind[SP]the[SP]terrorist\nattacks,[SP]but[SP]there's[SP]no[SP]proof...",
-    "nom_fr": "Homme",
-    "texte_fr": "Le Cercle masqué et le groupe...[1205][U+000F]\nTous deux sont suspects, mais sans preuves..."
-  },
-  {
-    "id": 65,
-    "offset": 393654,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "That's[SP]a[SP]dangerous[SP]situation.[SP]People[SP]here[SP]in\ntown[SP]want[SP]a[SP]quick[SP]end[SP]to[SP]things[SP]like[SP]this,\nso[SP]they're[SP]eager[SP]to[SP]toss[SP]blame[SP]around...",
-    "nom_fr": "Homme",
-    "texte_fr": "C'est une situation dangereuse. Les gens ici\nveulent que ça se termine vite, alors\nils sont pressés de jeter le blâme..."
-  },
-  {
-    "id": 66,
-    "offset": 393932,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Step[SP]out[SP]of[SP]line[SP]even[SP]a[SP]little,[SP]and[SP]you[SP]might\nfind[SP]yourself[SP]labeled[SP]as[SP]a[SP]suspect[SP]too.[1205][U+000F][SP]It's[SP]a\ndamn[SP]witch[SP]hunt.[SP]These[SP]are[SP]scary[SP]times...",
-    "nom_fr": "Homme",
-    "texte_fr": "Un pas de travers, et tu pourrais être\nétiqueté comme suspect aussi.[1205][U+000F] C'est une\npure chasse aux sorcières. Quelle époque..."
-  },
-  {
-    "id": 67,
-    "offset": 394226,
-    "data_size": 228,
-    "slot_size": 232,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Now[SP]people[SP]are[SP]saying[SP]the[SP]terrorists[SP]behind\nthese[SP]attacks[SP]are[SP]a[SP]special[SP]unit[SP]called[SP]the\nLast[SP]Battalion.[1205][U+000F]",
-    "nom_fr": "Homme",
-    "texte_fr": "On dit que les terroristes sont une unité\nappelée le Bataillon.[1205][U+000F]"
-  },
-  {
-    "id": 68,
-    "offset": 394458,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Sheesh...[SP]When[SP]people[SP]start[SP]panicking,[SP]they'll\nbelieve[SP]any[SP]wild[SP]accusation[SP]they[SP]hear.",
-    "nom_fr": "Homme",
-    "texte_fr": "Quand la panique s'installe, les\ngens croient n'importe quoi."
-  },
-  {
-    "id": 69,
-    "offset": 394648,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "You[SP]should[SP]get[SP]out[SP]of[SP]this[SP]city[SP]before[SP]you're\nbranded[SP]a[SP]culprit[SP]too.[1205][U+000F][SP]People[SP]who[SP]believe\nthey're[SP]victims[SP]are[SP]the[SP]most[SP]dangerous[SP]of[SP]all.",
-    "nom_fr": "Homme",
-    "texte_fr": "Tu devrais quitter cette ville avant d'être\nqualifié de coupable aussi.[1205][U+000F] Les gens qui se\ncroient victimes sont les plus dangereux."
-  },
-  {
-    "id": 70,
-    "offset": 394942,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "I[SP]heard[SP]they[SP]released[SP]the[SP]composite[SP]sketches[SP]of\nthe[SP]suspects,[SP]so[SP]I[SP]went[SP]to[SP]check[SP]'em[SP]out...[1205][U+000F]\nThose[SP]were[SP]some[SP]familiar[SP]faces,[SP]all[SP]right.",
-    "nom_fr": "Homme",
-    "texte_fr": "J'ai entendu dire qu'ils avaient publié\nles portraits-robots, alors je suis allé\nvoir...[1205][U+000F] Des visages familiers, en effet."
-  },
-  {
-    "id": 71,
-    "offset": 395236,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Oh,[SP]no,[SP]I[SP]completely[SP]understand[SP]it's[SP]a[SP]trumped-\nup[SP]charge[SP]and[SP]those[SP]are[SP]just[SP]people[SP]in[SP]the\nwrong[SP]place[SP]at[SP]the[SP]wrong[SP]time.",
-    "nom_fr": "Homme",
-    "texte_fr": "Oh, je comprends que ce sont\nde fausses accusations, juste des gens\nau mauvais endroit."
-  },
-  {
-    "id": 72,
-    "offset": 395500,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "But[SP]you[SP]gotta[SP]understand.[1205][U+000F][SP]No[SP]matter[SP]how[SP]much\npeople[SP]like[SP]to[SP]think[SP]they're[SP]realists,[SP]man\nhasn't[SP]changed[SP]since[SP]the[SP]days[SP]of[SP]show[SP]trials.",
-    "nom_fr": "Homme",
-    "texte_fr": "Mais tu dois comprendre.[1205][U+000F] Peu importe à quel\npoint on se dit réalistes, l'homme n'a pas\nchangé depuis les procès-spectacles."
-  },
-  {
-    "id": 73,
-    "offset": 395792,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "I[SP]hope[SP]they[SP]catch[SP]the[SP]real[SP]culprits[SP]soon,\nand[SP]I'll[SP]be[SP]praying[SP]for[SP]your[SP]safety.",
-    "nom_fr": "Homme",
-    "texte_fr": "J'espère qu'ils les attraperont, je prierai."
-  },
-  {
-    "id": 74,
-    "offset": 395970,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "The[SP]new[SP]rumor[SP]is[SP]that[SP]the[SP]group[SP]of[SP]five[SP]is\nactually[SP]fighting[SP]against[SP]the[SP]Masked[SP]Circle.\nDid[SP]you[SP]guys[SP]spread[SP]that[SP]one?[1205][U+000F][SP]Very[SP]clever.",
-    "nom_fr": "Homme",
-    "texte_fr": "La nouvelle rumeur dit que le groupe de cinq\ncombat en fait le Cercle masqué.\nC'est vous qui l'avez lancée ?[1205][U+000F] Très malin."
-  },
-  {
-    "id": 75,
-    "offset": 396256,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "This[SP]feels[SP]a[SP]lot[SP]like[SP]the[SP]final[SP]push.[1205][U+000F][SP]I[SP]don't\nthink[SP]anyone[SP]doubts[SP]the[SP]In[SP]Lak'ech[SP]anymore.",
-    "nom_fr": "Homme",
-    "texte_fr": "Ça sent la fin.[1205][U+000F] Plus personne ne doute\nde l'In Lak'ech."
-  },
-  {
-    "id": 76,
-    "offset": 396460,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Now[SP]where[SP]did[SP]that[SP]monstrosity[SP]come[SP]from...?[1205][U+000A]\nThe[SP]Masked[SP]Circle[SP]and[SP]the[SP]Last[SP]Battalion[SP]are\nhaving[SP]it[SP]out[SP]in[SP]there[SP]now.",
-    "nom_fr": "Homme",
-    "texte_fr": "D'où sort cette monstruosité... ?[1205][U+000A]\nLe Cercle masqué et le Bataillon se\nbattent là-dedans maintenant."
-  },
-  {
-    "id": 77,
-    "offset": 396720,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Fighting[SP]up[SP]here,[SP]destruction[SP]below...[1205][U+000F]\nDoes[SP]anyone[SP]care[SP]what[SP]happens[SP]down[SP]there\nanymore?",
-    "nom_fr": "Homme",
-    "texte_fr": "Se battre en haut, détruire en bas...[1205][U+000F]\nPlus personne ne se soucie d'ici ?"
-  },
-  {
-    "id": 78,
-    "offset": 396922,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "From[SP]what[SP]I've[SP]heard,[SP]a[SP]meteor[SP]shower[SP]will\nrain[SP]down[SP]on[SP]the[SP]Earth[SP]when[SP]the[SP]Grand[SP]Cross\nhappens.",
-    "nom_fr": "Homme",
-    "texte_fr": "On dit qu'une pluie de météores s'abattra\navec la Croix Cosmique."
-  },
-  {
-    "id": 79,
-    "offset": 397134,
-    "data_size": 182,
-    "slot_size": 186,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "But[SP]there[SP]can't[SP]be[SP]any[SP]truth[SP]to[SP]that.[1205][U+000A][SP]There\nwas[SP]no[SP]such[SP]thing[SP]in[SP]the[SP]In[SP]Lak'ech.",
-    "nom_fr": "Homme",
-    "texte_fr": "Mais ça ne peut pas être vrai.[1205][U+000A] Il n'y\navait rien de tel dans l'In Lak'ech."
-  },
-  {
-    "id": 80,
-    "offset": 397320,
-    "data_size": 242,
-    "slot_size": 246,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "I'm[SP]sure[SP]you[SP]know[SP]already,[SP]but[SP]there[SP]are\nseveral[SP]theories[SP]in[SP]Sumaru[SP]about[SP]how[SP]life\ndown[SP]there[SP]on[SP]Earth[SP]will[SP]end.",
-    "nom_fr": "Homme",
-    "texte_fr": "Tu le sais, mais il y a\nplusieurs théories sur la fin du monde."
-  },
-  {
-    "id": 81,
-    "offset": 397566,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]long[SP]as[SP]there[SP]are[SP]competing[SP]theories,\nit[SP]should[SP]be[SP]fine.[1205][U+000A][SP]It's[SP]when[SP]everyone[SP]starts\nto[SP]agree[SP]that[SP]we're[SP]in[SP]trouble...",
-    "nom_fr": "Homme",
-    "texte_fr": "Tant qu'il y a des théories divergentes,\nça va.[1205][U+000A] C'est quand tous\nsont d'accord que ça craint..."
-  },
-  {
-    "id": 82,
-    "offset": 397830,
-    "data_size": 184,
-    "slot_size": 188,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "*sigh*[SP]More[SP]and[SP]more,[SP]it's[SP]getting[SP]unanimous\nas[SP]to[SP]how[SP]the[SP]Earth[SP]will[SP]meet[SP]its[SP]end.",
-    "nom_fr": "Homme",
-    "texte_fr": "*soupir* De plus en plus, l'unanimité se\nfait sur la façon dont la Terre finira."
-  },
-  {
-    "id": 83,
-    "offset": 398018,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Everyone's[SP]saying[SP]now[SP]that[SP]the[SP]Earth's[SP]rotation\nwill[SP]stop[SP]when[SP]the[SP]Grand[SP]Cross[SP]is[SP]complete...",
-    "nom_fr": "Homme",
-    "texte_fr": "Tout le monde dit maintenant que la rotation\nde la Terre s'arrêtera avec la Croix..."
-  },
-  {
-    "id": 84,
-    "offset": 398226,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "And[SP]there[SP]was[SP]a[SP]line[SP]like[SP]that[SP]in[SP]the\nIn[SP]Lak'ech,[SP]so[SP]I[SP]guess[SP]it's[SP]decided.",
-    "nom_fr": "Homme",
-    "texte_fr": "Une phrase de l'In Lak'ech le dit,\ndonc c'est acté."
-  },
-  {
-    "id": 85,
-    "offset": 398396,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Apparently,[SP]there[SP]are[SP]talking[SP]flowers[SP]in[SP]Aoba\nPark.[SP]It[SP]sounds[SP]romantic[SP]when[SP]you[SP]hear[SP]it...\nBut[SP]then[SP]you[SP]wonder[SP]if[SP]they[SP]have[SP]a[SP]foul[SP]mouth.",
-    "nom_fr": "Homme",
-    "texte_fr": "Apparemment, il y a des fleurs qui parlent\nau parc Aoba. Ça a l'air romantique...\nMais imagine qu'elles soient vulgaires."
-  },
-  {
-    "id": 86,
-    "offset": 398692,
-    "data_size": 242,
-    "slot_size": 246,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Things[SP]are[SP]getting[SP]out[SP]of[SP]hand...[SP]I'm[SP]hearing\nnow[SP]that[SP]the[SP]second[SP]floor[SP]of[SP]Zodiac[SP]has[SP]become\na[SP]gigantic[SP]dungeon.",
-    "nom_fr": "Homme",
-    "texte_fr": "Ça dégénère... J'entends dire maintenant\nque le deuxième étage de Zodiac est devenu\nun gigantesque donjon."
-  },
-  {
-    "id": 87,
-    "offset": 398938,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Rumor[SP]is[SP]that[SP]there's[SP]a[SP]ton[SP]of[SP]great[SP]items[SP]in\nthere,[SP]but[SP]exploring[SP]inside[SP]a[SP]club?[SP]You'd[SP]think\npeople[SP]would[SP]be[SP]shocked,[SP]but[SP]I[SP]guess[SP]not.",
-    "nom_fr": "Homme",
-    "texte_fr": "Y a plein de super objets dedans, mais\nexplorer un club ? Ça ne choque même plus."
-  },
-  {
-    "id": 88,
-    "offset": 399230,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "It[SP]never[SP]rains[SP]but[SP]it[SP]pours...[1205][U+000F][SP]That's[SP]how[SP]the\nsaying[SP]goes,[SP]but[SP]come[SP]on.[1205][U+000F][SP]Hanako[SP]now?[SP]This[SP]has\nbeen[SP]one[SP]unlucky[SP]year[SP]for[SP]Sevens.",
-    "nom_fr": "Homme",
-    "texte_fr": "Un malheur n'arrive jamais seul...[1205][U+000F] Hanako ?\nC'est une année noire pour Seven."
-  },
-  {
-    "id": 89,
-    "offset": 399512,
-    "data_size": 164,
-    "slot_size": 168,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "It[SP]sounds[SP]like[SP]there's[SP]a[SP]ghost[SP]named[SP]Bukimi\nappearing[SP]in[SP]Kasugayama[SP]High.",
-    "nom_fr": "Homme",
-    "texte_fr": "On dirait qu'un fantôme nommé Bukimi\napparaît au lycée Kakasu."
-  },
-  {
-    "id": 90,
-    "offset": 399680,
-    "data_size": 226,
-    "slot_size": 230,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "There's[SP]always[SP]a[SP]backlash[SP]like[SP]this[SP]when\nanything[SP]becomes[SP]popular.[SP]The[SP]ugliest[SP]rumors\ntend[SP]to[SP]crop[SP]up...",
-    "nom_fr": "Homme",
-    "texte_fr": "Il y a toujours un revers au succès. Les\npires rumeurs surgissent..."
-  },
-  {
-    "id": 91,
-    "offset": 399910,
-    "data_size": 142,
-    "slot_size": 146,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "I[SP]doubt[SP]there's[SP]actually[SP]any[SP]such[SP]thing[SP]over\nthere.[1205][U+000F][SP]R-Right?",
-    "nom_fr": "Homme",
-    "texte_fr": "Je doute qu'il y ait ça là-bas.[1205][U+000F] P-Pas vrai ?"
-  },
-  {
-    "id": 92,
-    "offset": 400056,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]the[SP]ghost[SP]of[SP]an[SP]idol[SP]has[SP]been\nseen[SP]at[SP]Aoba[SP]Park...[1205][U+000F][SP]But[SP]if[SP]memory[SP]serves,\nthat[SP]idol[SP]is[SP]still[SP]alive[SP]and[SP]well.",
-    "nom_fr": "Homme",
-    "texte_fr": "On a vu le fantôme d'une idole au parc...[1205][U+000F]\nMais cette idole est bien vivante."
-  },
-  {
-    "id": 93,
-    "offset": 400324,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "There's[SP]been[SP]word[SP]of[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the\nabandoned[SP]factory...[SP]That[SP]place[SP]has[SP]spawned[SP]so\nmany[SP]nasty[SP]rumors,[SP]one[SP]was[SP]bound[SP]to[SP]be[SP]true...",
-    "nom_fr": "Homme",
-    "texte_fr": "On parle d'un Taxi Maudit à l'usine...\nUne des rumeurs devait être vraie..."
-  },
-  {
-    "id": 94,
-    "offset": 400616,
-    "data_size": 92,
-    "slot_size": 96,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "But[SP]I[SP]doubt[SP]it's[SP]this[SP]one.[1205][U+000F][SP]R-Right?",
-    "nom_fr": "Homme",
-    "texte_fr": "Mais j'en doute.[1205][U+000F] Pas vrai ?"
-  },
-  {
-    "id": 95,
-    "offset": 400712,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "*sigh*[SP]First[SP]it[SP]was[SP]a[SP]Cursed[SP]Taxi,[SP]now[SP]it's\na[SP]Cursed[SP]Escort...[SP]Rumors[SP]get[SP]bigger[SP]in[SP]the\ntelling,[SP]but[SP]I[SP]wonder[SP]if[SP]this[SP]one's[SP]genuine.",
-    "nom_fr": "Homme",
-    "texte_fr": "*soupir* D'abord un Taxi Maudit, maintenant\nune Escorte Maudite... Les rumeurs gonflent,\nmais je me demande si celle-ci est vraie."
-  },
-  {
-    "id": 96,
-    "offset": 401000,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "It[SP]sounds[SP]like[SP]the[SP]real[SP]Kuchisake-onna[SP]is[SP]at\nMt.[SP]Iwato.[SP]I'm[SP]surprised[SP]such[SP]an[SP]old[SP]story[SP]is\ngetting[SP]brought[SP]up[SP]again.[SP]It[SP]brings[SP]me[SP]back.",
-    "nom_fr": "Homme",
-    "texte_fr": "Il paraît que la vraie Kuchisake-onna est au\nMt Iwato. Je suis surpris qu'une si vieille\nhistoire refasse surface. Ça me rajeunit."
-  },
-  {
-    "id": 97,
-    "offset": 401294,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Now[SP]they're[SP]saying[SP]Jumping[SP]Geezer[SP]is[SP]a[SP]real\nthing[SP]that[SP]chases[SP]cars[SP]down[SP]mountain[SP]passes.\nIs[SP]there[SP]anything[SP]like[SP]that[SP]at[SP]Mt.[SP]Katatsumuri?",
-    "nom_fr": "Homme",
-    "texte_fr": "Maintenant on dit que le Vieux Sauteur est une\nvraie chose qui poursuit les voitures en\nmontagne. Y a-t-il ça au Mt Katatsumuri ?"
-  },
-  {
-    "id": 98,
-    "offset": 401590,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "M-Most[SP]things[SP]don't[SP]bother[SP]me...[SP]But[SP]this...\nHave[SP]you[SP]heard?[SP]That...[SP]Kudan...[SP]Ugh,[SP]I[SP]wish\nI'd[SP]never[SP]heard[SP]of[SP]it.",
-    "nom_fr": "Homme",
-    "texte_fr": "La plupart des choses m'indiffèrent...\nMais ce... Kudan... Ugh, je\npréférerais l'ignorer."
-  },
-  {
-    "id": 99,
-    "offset": 401838,
-    "data_size": 126,
-    "slot_size": 130,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Apparently[SP]there's[SP]a[SP]special,[SP]secret[SP]CD[SP]at\nGiga[SP]Macho.",
-    "nom_fr": "Homme",
-    "texte_fr": "Apparemment, y a un CD secret chez Giga Macho."
-  },
-  {
-    "id": 100,
-    "offset": 401968,
-    "data_size": 172,
-    "slot_size": 176,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "What[SP]kind[SP]of[SP]music's[SP]on[SP]it?[SP]Well,[SP]you'll[SP]have\nto[SP]find[SP]that[SP]out[SP]for[SP]yourself.",
-    "nom_fr": "Homme",
-    "texte_fr": "Quelle musique dessus ? Tu devras\nle découvrir toi-même."
-  },
-  {
-    "id": 101,
-    "offset": 402144,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "There's[SP]some[SP]creature[SP]called[SP]a[SP]Dresser[SP]Hag[SP]at\nthe[SP]abandoned[SP]factory.[SP]It[SP]yells,[SP][1432][NULL][NULL][0014]Get[SP]in[SP]here![1432][NULL][NULL][0014]\nat[SP]anyone[SP]who[SP]passes[SP]by.[SP]Scary,[SP]huh...?",
-    "nom_fr": "Homme",
-    "texte_fr": "Il y a une créature appelée Mégère à\nCommode à l'usine. Elle crie [1432][NULL][NULL][0014]Viens ici ![1432][NULL][NULL][0014]\naux passants. Effrayant, non... ?"
-  },
-  {
-    "id": 102,
-    "offset": 402446,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Time[SP]Castle[SP]in[SP]Rengedai[SP]apparently[SP]handles\nreal[SP]weapons.",
-    "nom_fr": "Homme",
-    "texte_fr": "Time Castle vendrait de vraies armes."
-  },
-  {
-    "id": 103,
-    "offset": 402580,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "As[SP]I[SP]recall,[SP]word[SP]is[SP]their[SP]quality[SP]and[SP]prices\nare[SP]average.[1205][U+000F][SP]Me,[SP]I[SP]think[SP]it's[SP]an[SP]ingenious\nway[SP]to[SP]do[SP]business.",
-    "nom_fr": "Homme",
-    "texte_fr": "Qualité et prix moyens.[1205][U+000F] Perso, je trouve\nque c'est malin de faire ça."
-  },
-  {
-    "id": 104,
-    "offset": 402824,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Time[SP]Castle[SP]in[SP]Rengedai[SP]apparently[SP]handles\nreal[SP]weapons.",
-    "nom_fr": "Homme",
-    "texte_fr": "Time Castle vendrait de vraies armes."
-  },
-  {
-    "id": 105,
-    "offset": 402958,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "As[SP]I[SP]recall,[SP]word[SP]is[SP]their[SP]quality[SP]is[SP]good,\nbut[SP]their[SP]prices[SP]are[SP]high.[1205][U+000F][SP]Me,[SP]I[SP]think[SP]it's[SP]an\ningenious[SP]way[SP]to[SP]do[SP]business.",
-    "nom_fr": "Homme",
-    "texte_fr": "Qualité bonne, mais cher.[1205][U+000F] Perso, je trouve\nque c'est malin de faire ça."
-  },
-  {
-    "id": 106,
-    "offset": 403226,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Time[SP]Castle[SP]in[SP]Rengedai[SP]apparently[SP]handles\nreal[SP]weapons.",
-    "nom_fr": "Homme",
-    "texte_fr": "Time Castle vendrait de vraies armes."
-  },
-  {
-    "id": 107,
-    "offset": 403360,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "As[SP]I[SP]recall,[SP]word[SP]is[SP]they're[SP]cheap,[SP]but[SP]not\ngreat[SP]quality.[1205][U+000F][SP]Me,[SP]I[SP]think[SP]it's[SP]an[SP]ingenious\nway[SP]to[SP]do[SP]business.",
-    "nom_fr": "Homme",
-    "texte_fr": "Pas cher mais mauvaise qualité.[1205][U+000F] Perso, c'est\ntrès malin."
-  },
-  {
-    "id": 108,
-    "offset": 403604,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]Tony's[SP]Shop[SP]was[SP]selling[SP]weapons[SP]after[SP]all...[1205][U+000F]\nI'd[SP]heard[SP]rumors.[SP]Something[SP]about[SP]his[SP]selection\nbeing[SP]good,[SP]but[SP]having[SP]low[SP]resale[SP]value.",
-    "nom_fr": "Homme",
-    "texte_fr": "Donc la boutique de Tony vendait des armes\nfinalement...[1205][U+000F] J'avais entendu des rumeurs.\nBon choix, mais faible valeur de revente."
-  },
-  {
-    "id": 109,
-    "offset": 403904,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]Tony's[SP]Shop[SP]was[SP]selling[SP]weapons[SP]after[SP]all...[1205][U+000F]\nI'd[SP]heard[SP]rumors.[SP]Something[SP]about[SP]his[SP]stuff\nbeing[SP]cheap,[SP]but[SP]low[SP]quality.",
-    "nom_fr": "Homme",
-    "texte_fr": "La boutique de Tony vendait des armes...[1205][U+000F]\nBon marché, mais mauvaise qualité."
-  },
-  {
-    "id": 110,
-    "offset": 404174,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]Tony's[SP]Shop[SP]was[SP]selling[SP]weapons[SP]after[SP]all...[1205][U+000F]\nI'd[SP]heard[SP]rumors.[SP]Something[SP]about[SP]his[SP]prices\nand[SP]quality[SP]being[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "La boutique de Tony vendait des armes...[1205][U+000F]\nRapport qualité-prix dans la moyenne."
-  },
-  {
-    "id": 111,
-    "offset": 404440,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]Tony's[SP]Shop[SP]was[SP]selling[SP]weapons[SP]after[SP]all...[1205][U+000F]\nI'd[SP]heard[SP]rumors.[SP]Something[SP]about[SP]the[SP]quality\nbeing[SP]good,[SP]but[SP]his[SP]prices[SP]being[SP]high.",
-    "nom_fr": "Homme",
-    "texte_fr": "Donc la boutique de Tony vendait des armes\nfinalement...[1205][U+000F] J'avais entendu des rumeurs.\nDe la bonne qualité, mais à des prix élevés."
-  },
-  {
-    "id": 112,
-    "offset": 404732,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]selection\nis[SP]bad,[SP]but[SP]the[SP]buyback[SP]prices[SP]are[SP]great.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nIls ont des difficultés financières aussi ?[1205][U+000F] Choix\nlimité, mais d'excellents prix de rachat."
-  },
-  {
-    "id": 113,
-    "offset": 405030,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]prices\nare[SP]just[SP]right,[SP]but[SP]the[SP]quality[SP]is[SP]so-so.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nLes prix sont corrects, mais la qualité est moyenne."
-  },
-  {
-    "id": 114,
-    "offset": 405322,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]quality\nis[SP]great,[SP]but[SP]the[SP]prices[SP]are[SP]pretty[SP]high.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nLa qualité est top, mais les prix sont élevés."
-  },
-  {
-    "id": 115,
-    "offset": 405616,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]selection\nis[SP]great,[SP]but[SP]the[SP]buyback[SP]prices[SP]aren't[SP]much.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nIls ont des difficultés financières aussi ?[1205][U+000F] Choix\nexcellent, mais prix de rachat dérisoires."
-  },
-  {
-    "id": 116,
-    "offset": 405922,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]quality\nand[SP]prices[SP]are[SP]average,[SP]I[SP]hear.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nLa qualité et les prix sont moyens, paraît-il."
-  },
-  {
-    "id": 117,
-    "offset": 406196,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.\nThey[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]their[SP]prices\nand[SP]quality[SP]are[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Jolly Roger vend des armes.\nIls s'y mettent tard. Prix et qualité moyens."
-  },
-  {
-    "id": 118,
-    "offset": 406462,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.\nThey[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]their[SP]prices\nare[SP]low,[SP]but[SP]so[SP]is[SP]the[SP]quality.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Jolly Roger vend des armes.\nIls s'y mettent tard. Prix bas, faible qualité."
-  },
-  {
-    "id": 119,
-    "offset": 406742,
-    "data_size": 300,
-    "slot_size": 304,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.\nThey[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]the[SP]buyback\nprices[SP]are[SP]low,[SP]but[SP]their[SP]selection's[SP]great.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Jolly Roger vend des armes.\nLe rachat est bas, mais super sélection."
-  },
-  {
-    "id": 120,
-    "offset": 407046,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.\nThey[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]the[SP]buyback\nprices[SP]are[SP]good,[SP]but[SP]their[SP]selection's[SP]bad.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Jolly Roger vend des armes.\nLe rachat est bon, mais mauvaise sélection."
-  },
-  {
-    "id": 121,
-    "offset": 407348,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.\nThey[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]their[SP]prices\nare[SP]high,[SP]but[SP]you[SP]get[SP]good-quality[SP]stuff.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Jolly Roger vend des armes.\nLes prix sont élevés, mais la qualité est là."
-  },
-  {
-    "id": 122,
-    "offset": 407648,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Huh,[SP]so[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]is[SP]getting[SP]in\non[SP]the[SP]armor[SP]market.[1205][U+000F][SP]It[SP]seems[SP]their[SP]quality\nand[SP]prices[SP]are[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida se lance dans les\narmures.[1205][U+000F] Qualité et prix moyens."
-  },
-  {
-    "id": 123,
-    "offset": 407904,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Huh,[SP]so[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]is[SP]getting[SP]in\non[SP]the[SP]armor[SP]market.[1205][U+000F][SP]It[SP]seems[SP]the[SP]quality\nis[SP]low,[SP]but[SP]it's[SP]cheap,[SP]at[SP]least.",
-    "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida se lance dans les\narmures.[1205][U+000F] Qualité faible, mais c'est pas cher."
-  },
-  {
-    "id": 124,
-    "offset": 408176,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Huh,[SP]so[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]is[SP]getting[SP]in\non[SP]the[SP]armor[SP]market.[1205][U+000F][SP]It[SP]seems[SP]the[SP]quality\nis[SP]great,[SP]but[SP]you[SP]pay[SP]through[SP]the[SP]nose.",
-    "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida se lance dans les\narmures.[1205][U+000F] Qualité top, mais ça coûte un bras."
-  },
-  {
-    "id": 125,
-    "offset": 408460,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][U+000F][SP]I'm\nsurprised,[SP]I[SP]admit.[SP]They[SP]say[SP]their[SP]quality[SP]and\nprices[SP]are[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "Donc Anima Mundi vend des armures...[1205][U+000F]\nJe suis surpris. Qualité et prix moyens."
-  },
-  {
-    "id": 126,
-    "offset": 408710,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][U+000F][SP]I'm\nsurprised,[SP]I[SP]admit.[SP]They[SP]say[SP]their[SP]stuff[SP]is\ncheap,[SP]but[SP]not[SP]very[SP]good.",
-    "nom_fr": "Homme",
-    "texte_fr": "Donc Anima Mundi vend des armures...[1205][U+000F]\nSurpris. C'est pas cher, mais mauvais."
-  },
-  {
-    "id": 127,
-    "offset": 408966,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][U+000F][SP]I'm\nsurprised,[SP]I[SP]admit.[SP]They[SP]say[SP]their[SP]selection[SP]is\nfantastic,[SP]but[SP]their[SP]buyback[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Homme",
-    "texte_fr": "Anima Mundi vend des armures...[1205][U+000F]\nChoix fantastique, mais prix de rachat bas."
-  },
-  {
-    "id": 128,
-    "offset": 409268,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][U+000F][SP]I'm\nsurprised,[SP]I[SP]admit.[SP]They[SP]say[SP]the[SP]quality[SP]is\ngreat,[SP]but[SP]it's[SP]expensive[SP]stuff.",
-    "nom_fr": "Homme",
-    "texte_fr": "Anima Mundi vend des armures...[1205][U+000F]\nQualité super, mais matos hors de prix."
-  },
-  {
-    "id": 129,
-    "offset": 409538,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]selection[SP]is[SP]bad,\nbut[SP]they[SP]have[SP]high[SP]buyback[SP]prices.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Mauvais choix, mais bon rachat."
-  },
-  {
-    "id": 130,
-    "offset": 409802,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]quality[SP]and\nprices[SP]are[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Qualité et prix dans la moyenne."
-  },
-  {
-    "id": 131,
-    "offset": 410024,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]quality[SP]is[SP]great,\nbut[SP]their[SP]prices[SP]are[SP]pretty[SP]high.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Qualité géniale, mais très cher."
-  },
-  {
-    "id": 132,
-    "offset": 410286,
-    "data_size": 238,
-    "slot_size": 242,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]stuff[SP]is[SP]cheap,\nbut[SP]not[SP]the[SP]best[SP]quality.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Pas cher, mais de mauvaise qualité."
-  },
-  {
-    "id": 133,
-    "offset": 410528,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]selection[SP]is[SP]pretty\ngood,[SP]but[SP]they[SP]have[SP]low[SP]buyback[SP]prices.",
-    "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Bon choix, mais rachat bas."
-  },
-  {
-    "id": 134,
-    "offset": 410806,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner\nis[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]the[SP]selection\nis[SP]good,[SP]but[SP]their[SP]buyback[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Homme",
-    "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Bon choix, rachat bas."
-  },
-  {
-    "id": 135,
-    "offset": 411104,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner\nis[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]it's[SP]cheap,\nbut[SP]not[SP]the[SP]greatest[SP]quality.",
-    "nom_fr": "Homme",
-    "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Pas cher, qualité moyenne."
-  },
-  {
-    "id": 136,
-    "offset": 411372,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner\nis[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]it's[SP]high-\nquality[SP]stuff,[SP]but[SP]expensive.",
-    "nom_fr": "Homme",
-    "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Haute qualité, très cher."
-  },
-  {
-    "id": 137,
-    "offset": 411638,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner\nis[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]the[SP]quality\nand[SP]prices[SP]there[SP]are[SP]pretty[SP]average.",
-    "nom_fr": "Homme",
-    "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Qualité et prix moyens."
-  },
-  {
-    "id": 138,
-    "offset": 411920,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner\nis[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]the[SP]selection\nis[SP]bad,[SP]but[SP]their[SP]buyback[SP]prices[SP]are[SP]high.",
-    "nom_fr": "Homme",
-    "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Mauvais choix, bon rachat."
-  },
-  {
-    "id": 139,
-    "offset": 412218,
-    "data_size": 126,
-    "slot_size": 130,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Why[SP]don't[SP]you[SP]enter[SP]the[SP]magazine[SP]sweepstakes\nsometime?",
-    "nom_fr": "Homme",
-    "texte_fr": "Fais les concours\ndes magazines un jour."
-  },
-  {
-    "id": 140,
-    "offset": 412348,
-    "data_size": 238,
-    "slot_size": 242,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Winners[SP]get[SP]real[SP]weapons[SP]and[SP]items.[SP]As[SP]I\nrecall,[SP]it's[SP]hard[SP]to[SP]win,[SP]but[SP]you[SP]can[SP]get\nsome[SP]nice[SP]stuff[SP]if[SP]you[SP]do.",
-    "nom_fr": "Homme",
-    "texte_fr": "On y gagne des armes et objets.\nC'est dur de gagner, mais les prix sont beaux."
-  },
-  {
-    "id": 141,
-    "offset": 412590,
-    "data_size": 126,
-    "slot_size": 130,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Why[SP]don't[SP]you[SP]enter[SP]the[SP]magazine[SP]sweepstakes\nsometime?",
-    "nom_fr": "Homme",
-    "texte_fr": "Fais les concours\ndes magazines un jour."
-  },
-  {
-    "id": 142,
-    "offset": 412720,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Winners[SP]get[SP]real[SP]weapons[SP]and[SP]items.[SP]As[SP]I\nrecall,[SP]you[SP]rarely[SP]win,[SP]but[SP]you[SP]can[SP]get\nsome[SP]rare[SP]stuff[SP]if[SP]you[SP]do.",
-    "nom_fr": "Homme",
-    "texte_fr": "On y gagne des armes et objets.\nC'est rare de gagner, mais c'est du rare."
-  },
-  {
-    "id": 143,
-    "offset": 412958,
-    "data_size": 126,
-    "slot_size": 130,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Why[SP]don't[SP]you[SP]enter[SP]the[SP]magazine[SP]sweepstakes\nsometime?",
-    "nom_fr": "Homme",
-    "texte_fr": "Fais les concours\ndes magazines un jour."
-  },
-  {
-    "id": 144,
-    "offset": 413088,
-    "data_size": 226,
-    "slot_size": 230,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Winners[SP]get[SP]real[SP]weapons[SP]and[SP]items.[SP]As[SP]I\nrecall,[SP]it's[SP]not[SP]hard[SP]to[SP]win,[SP]but[SP]you[SP]won't\nget[SP]anything[SP]good.",
-    "nom_fr": "Homme",
-    "texte_fr": "On y gagne des armes et objets.\nC'est facile de gagner, mais c'est pas ouf."
-  },
-  {
-    "id": 145,
-    "offset": 413318,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Sounds[SP]like[SP]Mu[SP]opened[SP]a[SP]casino.[SP]Well,[SP]no[SP]one\never[SP]went[SP]broke[SP]running[SP]a[SP]gambling[SP]parlor...\nI[SP]hear[SP]it's[SP]easy[SP]to[SP]win[SP]at[SP]poker.",
-    "nom_fr": "Homme",
-    "texte_fr": "Mu a ouvert un casino. Personne n'a\njamais fait faillite avec ça...\nOn gagne facilement au poker."
-  },
-  {
-    "id": 146,
-    "offset": 413588,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Sounds[SP]like[SP]Mu[SP]opened[SP]a[SP]casino.[SP]Well,[SP]no[SP]one\never[SP]went[SP]broke[SP]running[SP]a[SP]gambling[SP]parlor...\nI[SP]hear[SP]it's[SP]easy[SP]to[SP]win[SP]at[SP]the[SP]slots.",
-    "nom_fr": "Homme",
-    "texte_fr": "Mu a ouvert un casino. Personne n'a\njamais fait faillite avec ça...\nOn gagne facilement aux machines."
-  },
-  {
-    "id": 147,
-    "offset": 413866,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Sounds[SP]like[SP]Mu[SP]opened[SP]a[SP]casino.[SP]Well,[SP]no[SP]one\never[SP]went[SP]broke[SP]running[SP]a[SP]gambling[SP]parlor...\nI[SP]hear[SP]it's[SP]easy[SP]to[SP]win[SP]at[SP]blackjack.",
-    "nom_fr": "Homme",
-    "texte_fr": "Mu a ouvert un casino. Personne n'a\njamais fait faillite avec ça...\nOn gagne facilement au blackjack."
-  },
-  {
-    "id": 148,
-    "offset": 414144,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "I[SP]wonder[SP]if[SP]there's[SP]really[SP]any[SP]such[SP]thing[SP]as\na[SP]legendary[SP]weapon.[SP]It's[SP]just[SP]that[SP]I[SP]heard[SP]a\nrumor[SP]they[SP]have[SP]one[SP]at[SP]Shiraishi[SP]Ramen...",
-    "nom_fr": "Homme",
-    "texte_fr": "Une arme légendaire, ça existe vraiment ?\nUne rumeur dit que Shiraishi Ramen en aurait une..."
-  },
-  {
-    "id": 149,
-    "offset": 414430,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Do[SP]you[SP]believe[SP]in[SP]legendary[SP]weapons?[SP]Wanna[SP]go\nsee[SP]one[SP]for[SP]yourself?[SP]Go[SP]check[SP]out[SP]Clair[SP]de\nLune,[SP]I[SP]hear[SP]they[SP]have[SP]one.",
-    "nom_fr": "Homme",
-    "texte_fr": "Tu crois aux armes légendaires ? Tu veux\nen voir une ? Clair de Lune en a une, paraît-il."
-  },
-  {
-    "id": 150,
-    "offset": 414688,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]the[SP]owner[SP]of[SP]Time[SP]Castle[SP]won't\nadmit[SP]he[SP]has[SP]a[SP]legendary[SP]weapon.[SP]They[SP]say[SP]he's\ntrying[SP]to[SP]drive[SP]up[SP]the[SP]price...[SP]Shrewd[SP]man.",
-    "nom_fr": "Homme",
-    "texte_fr": "Le proprio de Time Castle n'admet pas avoir\nune arme légendaire. Il veut faire monter le prix."
-  },
-  {
-    "id": 151,
-    "offset": 414980,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Time[SP]Castle[SP]doesn't[SP]have[SP]its[SP]legendary[SP]weapon\nyet,[SP]I[SP]hear.[SP]The[SP]seller[SP]is[SP]still[SP]waiting[SP]at\nthe[SP]abandoned[SP]factory[SP]for[SP]it[SP]to[SP]be[SP]picked[SP]up.",
-    "nom_fr": "Homme",
-    "texte_fr": "Time Castle n'a pas encore son arme légendaire.\nLe vendeur l'attend à l'usine abandonnée."
-  },
-  {
-    "id": 152,
-    "offset": 415274,
-    "data_size": 242,
-    "slot_size": 246,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Wanna[SP]hear[SP]a[SP]bizarre[SP]rumor?[SP]Demons[SP]stole[SP]the\nlegendary[SP]weapon[SP]at[SP]Time[SP]Castle.[SP]Pretty[SP]hard\nto[SP]swallow,[SP]isn't[SP]it?",
-    "nom_fr": "Homme",
-    "texte_fr": "Rumeur bizarre : des démons ont volé l'arme\nlégendaire de Time Castle. Dur à avaler, non ?"
-  },
-  {
-    "id": 153,
-    "offset": 415520,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "I[SP]hear[SP]Time[SP]Castle[SP]sold[SP]its[SP]legendary[SP]weapon.\nSome[SP]unlucky[SP]woman[SP]bought[SP]it[SP]up...",
-    "nom_fr": "Homme",
-    "texte_fr": "Time Castle a vendu son arme légendaire.\nUne femme malchanceuse l'a achetée..."
-  },
-  {
-    "id": 154,
-    "offset": 415704,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Apparently,[SP]the[SP]owner[SP]of[SP]Time[SP]Castle[SP]gave\nthat[SP]legendary[SP]weapon[SP]away[SP]to[SP]a[SP]lady[SP]with\nshort[SP]hair.",
-    "nom_fr": "Homme",
-    "texte_fr": "Le proprio de Time Castle a donné l'arme\nlégendaire à une dame aux cheveux courts."
-  },
-  {
-    "id": 155,
-    "offset": 415916,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Giving[SP]a[SP]weapon[SP]to[SP]a[SP]lady[SP]as[SP]a[SP]present...[1205][U+000F]\nThese[SP]are[SP]crazy[SP]times[SP]we[SP]live[SP]in.",
-    "nom_fr": "Homme",
-    "texte_fr": "Offrir une arme à une dame...[1205][U+000F]\nQuelle époque folle."
-  },
-  {
-    "id": 156,
-    "offset": 416094,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "If[SP]I'm[SP]gonna[SP]date[SP]someone[SP]new,[SP]I'd[SP]rather[SP]go\nwith[SP]a[SP]Cuss[SP]High[SP]guy.[1205][U+000F][SP]Everyone[SP]at[SP]Sevens[SP]is\nunder[SP]the[SP]principal's[SP]thumb.[SP]Snooooore!",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Quitte à sortir avec un gars, je préfère Kakasu.[1205][U+000F]\nÀ Seven, ils sont tous sous la coupe de Hanya. Nul !"
-  },
-  {
-    "id": 157,
-    "offset": 416392,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]hear[SP]there[SP]are[SP]some[SP]uber-cute[SP]Cuss[SP]High\nguys[SP]in[SP]the[SP]secret[SP]lounge.[1205][U+000F]",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Des beaux gosses de Kakasu\nsont au salon secret, on dit.[1205][U+000F]"
-  },
-  {
-    "id": 158,
-    "offset": 416570,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Oohhhh...[SP]I[SP]wish[SP]I[SP]could[SP]go.[SP]But[SP]I[SP]don't[SP]have\na[SP]mask...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "J'aimerais y aller.\nMais je n'ai pas de masque."
-  },
-  {
-    "id": 159,
-    "offset": 416718,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Yeee![SP]I[SP]did[SP]it,[SP]I[SP]did[SP]it![1205][U+000F][SP]I[SP]got[SP]tickets[SP]to\nthe[SP]masquerade![1205][U+000F][SP]It's[SP]the[SP]perfect[SP]chance[SP]to\nget[SP]a[SP]Cuss[SP]High[SP]boyfriend!",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Yeee ! J'ai eu des billets pour le bal masqué ![1205][U+000F]\nParfait pour trouver un petit ami de Kakasu !"
-  },
-  {
-    "id": 160,
-    "offset": 416988,
-    "data_size": 188,
-    "slot_size": 192,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]gotta[SP]make[SP]sure[SP]to[SP]dress[SP]up.[1205][U+000F][SP]Oh[SP]yeah,[SP]and\nI[SP]should[SP]invite[SP]my[SP]friends[SP]too!",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Faut que je sois bien habillée.[1205][U+000F]\nEt je devrais inviter mes copines !"
-  },
-  {
-    "id": 161,
-    "offset": 417180,
-    "data_size": 134,
-    "slot_size": 138,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "*sigh*[SP]Muses[SP]is[SP]made[SP]up[SP]of[SP]Sevens[SP]students,\nright?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "*soupir* Muses n'a que des filles\nde Seven, non ?"
-  },
-  {
-    "id": 162,
-    "offset": 417318,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "So[SP]they're[SP]all[SP]around[SP]my[SP]age.[1205][U+000F][SP]They're[SP]so[SP]lucky,\ngetting[SP]to[SP]make[SP]their[SP]idol[SP]debuts...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Elles ont mon âge.[1205][U+000F] Trop de chance de\ndébuter comme idoles..."
-  },
-  {
-    "id": 163,
-    "offset": 417528,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Looks[SP]like[SP]Giga[SP]Macho's[SP]already[SP]packed[SP]with\nMuses[SP]fans.[1205][U+000F][SP]*sigh*[SP]I[SP]bet[SP]I[SP]couldn't[SP]get[SP]in\nnow[SP]if[SP]I[SP]went.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Giga Macho est plein de fans de Muses.[1205][U+000F]\n*soupir* Je pourrais même pas y entrer."
-  },
-  {
-    "id": 164,
-    "offset": 417772,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]wonder[SP]what[SP]nationality[SP]that[SP]third[SP]member[SP]is.\nShe[SP]looked[SP]white,[SP]but[SP]her[SP]Japanese[SP]was[SP]really\ngood.[SP]Maybe[SP]she[SP]grew[SP]up[SP]here.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "De quelle nationalité est la 3e membre ?\nElle a l'air blanche, mais parle bien\njaponais. Elle a grandi ici ?"
-  },
-  {
-    "id": 165,
-    "offset": 418056,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]there[SP]was[SP]a[SP]Muses[SP]show[SP]at[SP]the[SP]outdoor\nconcert[SP]hall,[SP]right?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Il y a eu un concert de Muses à la\nsalle en plein air, non ?"
-  },
-  {
-    "id": 166,
-    "offset": 418220,
-    "data_size": 138,
-    "slot_size": 142,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "And[SP]Muses[SP]was[SP]a[SP]trio,[SP]right?[1205][U+000F][SP]Huh...\nThat's[SP]weird...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Et Muses était un trio, non ?[1205][U+000F]\nHuh... Étrange..."
-  },
-  {
-    "id": 167,
-    "offset": 418362,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]know[SP]there[SP]were[SP]two[SP]others,[SP]but[SP]I[SP]only\nremember[SP]that[SP]Lisa[SP]girl...[1205][U+000F][SP]W-Well,[SP]I[SP]guess\nit[SP]doesn't[SP]really[SP]matter.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Il y en avait deux autres, mais je ne me\nsouviens que de Lisa...[1205][U+000F] Bref, c'est pas grave."
-  },
-  {
-    "id": 168,
-    "offset": 418622,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Everyone's[SP]panicking[SP]about[SP]terrorists[SP]and[SP]that\nstuff,[SP]but[SP]why[SP]worry[SP]so[SP]much?[1205][U+000F][SP]I[SP]bet[SP]it'll[SP]all\ntake[SP]care[SP]of[SP]itself.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Tout le monde panique à cause des terroristes.\nMais pourquoi ?[1205][U+000F] Ça va s'arranger tout seul."
-  },
-  {
-    "id": 169,
-    "offset": 418890,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I-I[SP]can't[SP]believe[SP]they[SP]were[SP]going[SP]after\nGOLD...[1205][U+000F][SP]There[SP]has[SP]to[SP]be[SP]some[SP]mistake.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "J-Je n'y crois pas pour GOLD...[1205][U+000F]\nIl doit y avoir une erreur."
-  },
-  {
-    "id": 170,
-    "offset": 419086,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]bet[SP]it's[SP]just[SP]some[SP]TV[SP]show's[SP]hoax,[SP]or[SP]some\nattention-starved[SP]jerk[SP]playing[SP]a[SP]prank...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "C'est sûrement le canular d'une émission,\nou un abruti qui fait une blague..."
-  },
-  {
-    "id": 171,
-    "offset": 419296,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]can't[SP]believe[SP]they[SP]blew[SP]up[SP]GOLD...[1205][U+000F][SP]This\ncan't[SP]be[SP]real.[SP]I[SP]mean,[SP]nothing[SP]bad[SP]ever\nhappened[SP]here[SP]before[SP]now.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Ils ont fait exploser GOLD...[1205][U+000F]\nC'est faux. Rien de mal n'arrive jamais ici."
-  },
-  {
-    "id": 172,
-    "offset": 419552,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "What's[SP]going[SP]to[SP]happen[SP]to[SP]us?[SP]We'll[SP]be[SP]okay,\nwon't[SP]we?[1205][U+000A][SP]They're[SP]gonna[SP]catch[SP]the[SP]terrorists\nand[SP]make[SP]everything[SP]all[SP]right[SP]again,[SP]right?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Qu'est-ce qui va nous arriver ? On va s'en sortir,\nnon ?[1205][U+000A] Ils vont attraper les terroristes\net tout va redevenir comme avant, hein ?"
-  },
-  {
-    "id": 173,
-    "offset": 419860,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Y-You're[SP]right...[SP]I[SP]can't[SP]shut[SP]out[SP]reality\nlike[SP]this.[1205][U+000F][SP]It's[SP]just,[SP]I[SP]never[SP]imagined[SP]such\nhorrible[SP]things[SP]could[SP]happen[SP]this[SP]close.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "T-Tu as raison... Faut pas fuir la réalité.[1205][U+000F]\nJe n'aurais jamais imaginé ça si près."
-  },
-  {
-    "id": 174,
-    "offset": 420156,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "But[SP]I[SP]hear[SP]they[SP]have[SP]a[SP]suspect[SP]already,[SP]so[SP]this\nterrorist[SP]stuff[SP]will[SP]be[SP]over[SP]soon.[1205][U+000F][SP]Right?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Mais ils ont déjà un suspect, alors ce sera\nbientôt fini.[1205][U+000F] N'est-ce pas ?"
-  },
-  {
-    "id": 175,
-    "offset": 420376,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Huh?[SP]The[SP]In[SP]Lak'ech?[1205][U+000F][SP]Yeah...[SP]I[SP]saw[SP]that[SP]on[SP]the\nnews[SP]and[SP]rushed[SP]to[SP]the[SP]bookstore,[SP]but[SP]they\nwere[SP]all[SP]sold[SP]out.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Hein ? L'In Lak'ech ?[1205][U+000F] J'ai vu aux infos\net j'ai couru à la librairie, mais rupture de stock."
-  },
-  {
-    "id": 176,
-    "offset": 420634,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "They[SP]said[SP]they[SP]ran[SP]out[SP]pretty[SP]much[SP]instantly.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Ils ont été dévalisés quasi instantanément."
-  },
-  {
-    "id": 177,
-    "offset": 420762,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Th-Those[SP]soldiers[SP]were[SP]headed[SP]to\nMt.[SP]Katatsumuri...[1205][U+000F][SP]They'll[SP]probably[SP]leave\nus[SP]alone[SP]if[SP]we[SP]don't[SP]get[SP]in[SP]their[SP]way.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "C-Ces soldats allaient au Mt Katatsumuri...[1205][U+000F]\nIls nous laisseront si on ne les gêne pas."
-  },
-  {
-    "id": 178,
-    "offset": 421030,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "The[SP]end[SP]of[SP]the[SP]world's[SP]pretty[SP]harsh,[SP]but[SP]doesn't\nit[SP]feel[SP]nice,[SP]in[SP]a[SP]way?[1205][U+000F][SP]It's[SP]not[SP]like[SP]anything\ngood[SP]happened[SP]down[SP]there[SP]anyway.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "La fin du monde c'est dur, mais ça fait du bien,\nnon ?[1205][U+000F] Rien de bon ne se passe ici, de toute façon."
-  },
-  {
-    "id": 179,
-    "offset": 421328,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "If[SP]we[SP]evolve[SP]and[SP]the[SP]crappy[SP]old[SP]world[SP]is[SP]gone\nfor[SP]good,[SP]I[SP]could[SP]make[SP]a[SP]fresh[SP]start...[SP]Yeah,\nI[SP]bet[SP]that's[SP]exactly[SP]it.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Si ce monde merdique disparaît, on fera un\nnouveau départ... Ouais, c'est sûrement ça."
-  },
-  {
-    "id": 180,
-    "offset": 421598,
-    "data_size": 126,
-    "slot_size": 130,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "*sigh*[1205][U+0008][SP]I[SP]wonder[SP]what'll[SP]happen[SP]down[SP]there...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "*soupir*[1205][U+0008] Que va-t-il se passer ici..."
-  },
-  {
-    "id": 181,
-    "offset": 421728,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]heard[SP]a[SP]rumor[SP]that[SP]when[SP]the[SP]Grand[SP]Cross[SP]is\nfinished,[SP]the[SP]other[SP]planets[SP]are[SP]gonna[SP]block[SP]out\nthe[SP]sun[SP]and[SP]freeze[SP]the[SP]whole[SP]world.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "À la Croix Cosmique, les autres planètes vont\nocculter le soleil et geler le monde entier."
-  },
-  {
-    "id": 182,
-    "offset": 422022,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Will[SP]that[SP]really[SP]kill[SP]everyone[SP]down[SP]there?[1205][U+000A]\nMaybe[SP]they'll[SP]all[SP]just[SP]be[SP]kept[SP]alive,[SP]but\nfrozen[SP]solid.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Ça tuera tout le monde en bas ?[1205][U+000A] Peut-être\nqu'ils seront maintenus en vie, mais gelés."
-  },
-  {
-    "id": 183,
-    "offset": 422260,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]heard[SP]from[SP]someone[SP]else[SP]that[SP]once[SP]the[SP]Grand\nCross[SP]happens,[SP]gas[SP]from[SP]the[SP]other[SP]planets[SP]is\ngonna[SP]cover[SP]the[SP]Earth.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "J'ai entendu dire que quand la Croix\naura lieu, les gaz des autres planètes\nvont recouvrir la Terre."
-  },
-  {
-    "id": 184,
-    "offset": 422524,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Some[SP]planets[SP]are[SP]mostly[SP]made[SP]of[SP]gases,[SP]right?[1205][U+000A]\nThose[SP]gases[SP]are[SP]supposedly[SP]poison[SP]to[SP]humans,\nand[SP]that's[SP]how[SP]everyone[SP]down[SP]there'll[SP]die.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Certaines planètes sont faites de gaz, non ?[1205][U+000A]\nIls sont toxiques, et tout le monde en bas mourra."
-  },
-  {
-    "id": 185,
-    "offset": 422832,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]heard[SP]some[SP]people[SP]around[SP]say[SP]that[SP]when[SP]the\nGrand[SP]Cross[SP]is[SP]complete,[SP]the[SP]balance[SP]of[SP]gravity\nwill[SP]be[SP]thrown[SP]off[SP]and[SP]stop[SP]Earth's[SP]rotation.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Avec la Croix Cosmique, l'équilibre de la gravité\nsera rompu et arrêtera la rotation de la Terre."
-  },
-  {
-    "id": 186,
-    "offset": 423146,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "The[SP]Earth[SP]rotates[SP]really[SP]fast,[SP]doesn't[SP]it?[1205][U+000F]\nIf[SP]that[SP]stops[SP]all[SP]of[SP]a[SP]sudden,[SP]no[SP]wonder[SP]the\nworld[SP]down[SP]there[SP]will[SP]be[SP]a[SP]mess.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "La Terre tourne vite, non ?[1205][U+000F] Si ça s'arrête\nd'un coup, le monde sera un vrai chaos."
-  },
-  {
-    "id": 187,
-    "offset": 423428,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]heard[SP]there[SP]are[SP]talking[SP]flowers[SP]growing[SP]in\nAoba[SP]Park.[SP]It's[SP]like[SP]a[SP]fairy[SP]tale![SP]I[SP]wonder\nif[SP]I[SP]should[SP]go[SP]to[SP]them[SP]for[SP]advice.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Des fleurs parlent au parc Aoba.\nC'est comme un conte de fées !\nJe devrais leur demander conseil."
-  },
-  {
-    "id": 188,
-    "offset": 423712,
-    "data_size": 172,
-    "slot_size": 176,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]you[SP]think[SP]it's[SP]true[SP]that[SP]Zodiac's[SP]second\nfloor[SP]is[SP]a[SP]dungeon[SP]now?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "C'est vrai que le 2e étage de Zodiac\nest devenu un donjon ?"
-  },
-  {
-    "id": 189,
-    "offset": 423888,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "My[SP]friends[SP]rave[SP]about[SP]all[SP]the[SP]items[SP]there...[1205][U+000F]\nBut[SP]it[SP]sucks![SP]Why[SP]a[SP]dungeon!?[SP]My[SP]favorite\nclub's[SP]all[SP]messed[SP]up[SP]now!",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Mes amies adorent les objets là-bas...[1205][U+000F]\nMais c'est nul ! Pourquoi un donjon !? Mon club\nest gâché !"
-  },
-  {
-    "id": 190,
-    "offset": 424154,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]is[SP]it[SP]true[SP]the[SP]ghost[SP]of[SP]Hanako[SP]is\nhaunting[SP]Sevens?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, c'est vrai que le fantôme de Hanako\nhante Seven ?"
-  },
-  {
-    "id": 191,
-    "offset": 424302,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hanako[SP]is[SP]that[SP]girl[SP]they[SP]tell[SP]ghost[SP]stories\nabout[SP]at[SP]school,[SP]right?[1205][U+000F][SP]Wow![SP]I[SP]wanna[SP]see[SP]her!",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Hanako, c'est cette histoire de fantôme\nà l'école, non ?[1205][U+000F] Waouh ! Je veux la voir !"
-  },
-  {
-    "id": 192,
-    "offset": 424522,
-    "data_size": 242,
-    "slot_size": 246,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Do[SP]you[SP]know[SP]about[SP]Bukimi?[SP]I[SP]heard[SP]a[SP]rumor[SP]it's\nbeen[SP]appearing[SP]at[SP]Cuss[SP]High.[SP]Is[SP]she[SP]a[SP]ghost\nlike[SP]Hanako?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Connais-tu Bukimi ? Elle apparaîtrait à Kakasu.\nC'est un fantôme comme Hanako ?"
-  },
-  {
-    "id": 193,
-    "offset": 424768,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Do[SP]you[SP]know[SP]the[SP]story[SP]about[SP]some[SP]girl's[SP]ghost\nin[SP]Aoba[SP]Park?[SP]I[SP]heard[SP]from[SP]a[SP]friend[SP]of[SP]a[SP]friend\nthat[SP]she[SP]was[SP]an[SP]idol[SP]when[SP]she[SP]was[SP]alive.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Tu connais le fantôme du parc Aoba ?\nUne amie d'amie dit qu'elle était une idole."
-  },
-  {
-    "id": 194,
-    "offset": 425076,
-    "data_size": 300,
-    "slot_size": 304,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "My[SP]boyfriend[SP]told[SP]me[SP]there's[SP]a[SP]Cursed[SP]Taxi\nparked[SP]at[SP]the[SP]abandoned[SP]factory.[SP]That[SP]would[SP]be\nso[SP]freaky[SP]if[SP]you[SP]accidentally[SP]got[SP]in[SP]it...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Mon copain m'a dit qu'il y a un Taxi Maudit\ngaré à l'usine abandonnée. Ce serait tellement\nflippant de monter dedans par accident..."
-  },
-  {
-    "id": 195,
-    "offset": 425380,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]I[SP]asked[SP]my[SP]friend,[SP]and[SP]he[SP]said[SP]the[SP]thing\nat[SP]the[SP]abandoned[SP]factory[SP]is[SP]actually[SP]a[SP]Cursed\nEscort.[1205][U+0019][SP]Um...[SP]what's[SP]the[SP]difference?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "On m'a dit que le truc à l'usine est une Escorte\nMaudite.[1205][U+0019] Euh... c'est quoi la différence ?"
-  },
-  {
-    "id": 196,
-    "offset": 425680,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]Kuchisake-onna[SP]is[SP]up[SP]at[SP]Mt.[SP]Iwato,[SP]right?\nI[SP]always[SP]wanted[SP]to[SP]see[SP]if[SP]that[SP]urban[SP]legend\nwas[SP]true...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Kuchisake-onna est au Mt Iwato ?\nJe veux savoir si cette légende est vraie..."
-  },
-  {
-    "id": 197,
-    "offset": 425924,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "So[SP]there[SP]really[SP]was[SP]a[SP]Jumping[SP]Geezer[SP]at\nMt.[SP]Katatsumuri...[1205][U+000F][SP]These[SP]guys[SP]were[SP]talking\nabout[SP]it[SP]on[SP]the[SP]train,[SP]and[SP]it[SP]was[SP]bugging[SP]me.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Il y avait donc vraiment un Vieux Sauteur au\nMt Katatsumuri...[1205][U+000F] Ces types en parlaient\ndans le train, et ça me tracassait."
-  },
-  {
-    "id": 198,
-    "offset": 426224,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Yikes...[SP]I[SP]heard[SP]a[SP]really[SP]scary[SP]story...[SP]I-It\nwas[SP]about[SP]Kudan...[SP]No,[SP]don't[SP]make[SP]me[SP]repeat[SP]it!\nWhat[SP]am[SP]I[SP]gonna[SP]do?[SP]How[SP]am[SP]I[SP]gonna[SP]sleep?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Yikes... J'ai entendu une histoire effrayante...\nSur Kudan... Ne me fais pas la répéter !\nJe vais faire quoi ? Comment je vais dormir ?"
-  },
-  {
-    "id": 199,
-    "offset": 426534,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "So[SP]Giga[SP]Macho[SP]really[SP]did[SP]have[SP]a[SP]secret[SP]CD.\nHuh.[SP]A[SP]friend[SP]of[SP]a[SP]friend[SP]of[SP]mine[SP]has[SP]been\nswearing[SP]up[SP]and[SP]down[SP]it's[SP]true.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Giga Macho a vraiment un CD secret. L'ami\nd'un ami a juré que c'était vrai."
-  },
-  {
-    "id": 200,
-    "offset": 426808,
-    "data_size": 312,
-    "slot_size": 316,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]do[SP]you[SP]know[SP]about[SP]the[SP]Dresser[SP]Hag?[SP]They\nsay[SP]she's[SP]at[SP]the[SP]abandoned[SP]factory.[1205][U+000F][SP]What[SP]is\nthat,[SP]some[SP]kinda[SP]monster?[1205][U+000F][SP]Weird[SP]name[SP]for[SP]one.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Tu connais la Mégère à Commode ? Elle serait à\nl'usine abandonnée.[1205][U+000F] C'est un monstre ?[1205][U+000F]\nDrôle de nom."
-  },
-  {
-    "id": 201,
-    "offset": 427124,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle's[SP]so[SP]cool.[SP]He[SP]sells\nweapons[SP]in[SP]secret,[SP]like[SP]one[SP]of[SP]those[SP]smugglers\nin[SP]spy[SP]movies.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Le boss de Time Castle est trop cool.\nIl vend des armes en secret, comme un\ncontrebandier de film."
-  },
-  {
-    "id": 202,
-    "offset": 427374,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle's[SP]so[SP]cool.[SP]He[SP]sells\nweapons[SP]in[SP]secret,[SP]like[SP]one[SP]of[SP]those[SP]smugglers\nin[SP]spy[SP]movies.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Le boss de Time Castle est trop cool.\nIl vend des armes en secret, comme un\ncontrebandier de film."
-  },
-  {
-    "id": 203,
-    "offset": 427624,
-    "data_size": 182,
-    "slot_size": 186,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Looks[SP]like[SP]his[SP]stuff[SP]is[SP]expensive,[SP]but[SP]nice.\nJust[SP]like[SP]I[SP]thought[SP]it'd[SP]be!",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Ce qu'il a coûte cher, mais c'est bien.\nExactement ce que je pensais !"
-  },
-  {
-    "id": 204,
-    "offset": 427810,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle's[SP]so[SP]cool.[SP]He[SP]sells\nweapons[SP]in[SP]secret,[SP]like[SP]one[SP]of[SP]those[SP]smugglers\nin[SP]spy[SP]movies.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Le boss de Time Castle est trop cool.\nIl vend des armes en secret, comme un\ncontrebandier de film."
-  },
-  {
-    "id": 205,
-    "offset": 428060,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Looks[SP]like[SP]his[SP]stuff[SP]is[SP]cheap[SP]and[SP]crappy.\nThat's[SP]not[SP]really[SP]how[SP]I[SP]thought[SP]it'd[SP]be...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Ses trucs sont pas chers et merdiques.\nJe ne m'y attendais pas..."
-  },
-  {
-    "id": 206,
-    "offset": 428268,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after\nall,[SP]huh?[1205][U+000F][SP]I[SP]knew[SP]it.[1205][U+000F][SP]I[SP]could[SP]tell[SP]in[SP]my\ngut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup."
-  },
-  {
-    "id": 207,
-    "offset": 428534,
-    "data_size": 312,
-    "slot_size": 316,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]hear[SP]his[SP]selection's[SP]good,[SP]but[SP]the[SP]resale\nvalue[SP]sucks.[SP]Like,[SP]he'll[SP]pay[SP]you[SP]barely[SP]anything\nand[SP]make[SP]a[SP]bundle[SP]selling[SP]it.[1205][U+000F][SP]What[SP]a[SP]creep.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Il a du choix, mais paie une misère.\nIl achète rien et se fait un paquet en\nrevendant.[1205][U+000F] Sale type."
-  },
-  {
-    "id": 208,
-    "offset": 428850,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after\nall,[SP]huh?[1205][U+000F][SP]I[SP]knew[SP]it.[1205][U+000F][SP]I[SP]could[SP]tell[SP]in[SP]my\ngut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup."
-  },
-  {
-    "id": 209,
-    "offset": 429116,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]hear[SP]he[SP]sells[SP]basically[SP]junk[SP]for[SP]almost[SP]no\nmoney.[1205][U+000F][SP]That[SP]totally[SP]sounds[SP]like[SP]him.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Il vend des merdes pour presque rien.[1205][U+000F]\nÇa lui ressemble bien."
-  },
-  {
-    "id": 210,
-    "offset": 429322,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after\nall,[SP]huh?[1205][U+000F][SP]I[SP]knew[SP]it.[1205][U+000F][SP]I[SP]could[SP]tell[SP]in[SP]my\ngut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup."
-  },
-  {
-    "id": 211,
-    "offset": 429588,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]hear[SP]his[SP]selection[SP]and[SP]stuff's[SP]all[SP]average.\nIt's[SP]so[SP]weird[SP]he[SP]sells[SP]weapons,[SP]but[SP]they're\nall[SP]ordinary.[1205][U+000F][SP]He[SP]would,[SP]though.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Ses articles sont dans la moyenne. C'est bizarre\nqu'il vende des armes ordinaires.[1205][U+000F]\nC'est tout lui ça."
-  },
-  {
-    "id": 212,
-    "offset": 429874,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after\nall,[SP]huh?[1205][U+000F][SP]I[SP]knew[SP]it.[1205][U+000F][SP]I[SP]could[SP]tell[SP]in[SP]my\ngut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup."
-  },
-  {
-    "id": 213,
-    "offset": 430140,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]hear[SP]he[SP]has[SP]good[SP]stuff,[SP]but[SP]his[SP]prices[SP]are\na[SP]ripoff.[1205][U+000F][SP]That[SP]totally[SP]sounds[SP]like[SP]him.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Il a de bons trucs, mais c'est une arnaque.[1205][U+000F]\nÇa lui ressemble tout à fait."
-  },
-  {
-    "id": 214,
-    "offset": 430352,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?"
-  },
-  {
-    "id": 215,
-    "offset": 430486,
-    "data_size": 226,
-    "slot_size": 230,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]knew[SP]it...[1205][0014][SP]Like,[SP]that[SP]store[SP]was[SP]exactly[SP]the\nkinda[SP]place[SP]you'd[SP]find[SP]Mafia[SP]goons[SP]or[SP]something.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Je le savais...[1205][0014] C'est le genre\nd'endroit où on trouverait des mafieux."
-  },
-  {
-    "id": 216,
-    "offset": 430716,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "But[SP]they[SP]don't[SP]sell[SP]much.[SP]Trade-ins[SP]seem[SP]to[SP]be\ntheir[SP]main[SP]thing.[SP]I[SP]bet[SP]they[SP]ship[SP]the[SP]weapons\nthey[SP]buy[SP]back[SP]to[SP]the[SP]Mafia.[SP]Brrrr...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Mais ils vendent peu. Les échanges sont\nleur truc. Ils envoient les armes à la Mafia. Brrrr..."
-  },
-  {
-    "id": 217,
-    "offset": 431014,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?"
-  },
-  {
-    "id": 218,
-    "offset": 431148,
-    "data_size": 226,
-    "slot_size": 230,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]knew[SP]it...[1205][0014][SP]Like,[SP]that[SP]store[SP]was[SP]exactly[SP]the\nkinda[SP]place[SP]you'd[SP]find[SP]Mafia[SP]goons[SP]or[SP]something.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Je le savais...[1205][0014] C'est le genre\nd'endroit où on trouverait des mafieux."
-  },
-  {
-    "id": 219,
-    "offset": 431378,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]hear[SP]they're[SP]cheap,[SP]but[SP]low[SP]quality.[SP]The[SP]cops\nhave[SP]been[SP]cracking[SP]down,[SP]so[SP]I[SP]bet[SP]they're[SP]selling\nwhatever[SP]they[SP]can[SP]to[SP]raise[SP]money.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Pas cher, mais de mauvaise qualité. Les flics\nsévissent, ils vendent tout pour amasser de l'argent."
-  },
-  {
-    "id": 220,
-    "offset": 431680,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?"
-  },
-  {
-    "id": 221,
-    "offset": 431814,
-    "data_size": 226,
-    "slot_size": 230,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]knew[SP]it...[1205][0014][SP]Like,[SP]that[SP]store[SP]was[SP]exactly[SP]the\nkinda[SP]place[SP]you'd[SP]find[SP]Mafia[SP]goons[SP]or[SP]something.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Je le savais...[1205][0014] C'est le genre\nd'endroit où on trouverait des mafieux."
-  },
-  {
-    "id": 222,
-    "offset": 432044,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]hear[SP]their[SP]quality's[SP]good,[SP]but[SP]it's[SP]really\nexpensive.[SP]Which[SP]means[SP]they'll[SP]sell[SP]anything\nas[SP]long[SP]as[SP]you[SP]have[SP]the[SP]cash.[SP]Brrrr...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Qualité bonne, mais vraiment cher. Ils vendront\nn'importe quoi pour de l'argent. Brrrr..."
-  },
-  {
-    "id": 223,
-    "offset": 432340,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?"
-  },
-  {
-    "id": 224,
-    "offset": 432474,
-    "data_size": 226,
-    "slot_size": 230,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]knew[SP]it...[1205][0014][SP]Like,[SP]that[SP]store[SP]was[SP]exactly[SP]the\nkinda[SP]place[SP]you'd[SP]find[SP]Mafia[SP]goons[SP]or[SP]something.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Je le savais...[1205][0014] C'est le genre\nd'endroit où on trouverait des mafieux."
-  },
-  {
-    "id": 225,
-    "offset": 432704,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "They[SP]focus[SP]on[SP]selling,[SP]so[SP]their[SP]selection[SP]is\ngood,[SP]but[SP]they[SP]don't[SP]pay[SP]much[SP]for[SP]stuff[SP]you\nsell[SP]them.[SP]Pretty[SP]suspicious,[SP]if[SP]you[SP]ask[SP]me.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Leur sélection est bonne, mais ils paient mal.\nC'est louche, à mon avis."
-  },
-  {
-    "id": 226,
-    "offset": 433010,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?"
-  },
-  {
-    "id": 227,
-    "offset": 433144,
-    "data_size": 226,
-    "slot_size": 230,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]knew[SP]it...[1205][0014][SP]Like,[SP]that[SP]store[SP]was[SP]exactly[SP]the\nkinda[SP]place[SP]you'd[SP]find[SP]Mafia[SP]goons[SP]or[SP]something.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Je le savais...[1205][0014] C'est le genre\nd'endroit où on trouverait des mafieux."
-  },
-  {
-    "id": 228,
-    "offset": 433374,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]hear[SP]their[SP]quality[SP]and[SP]prices[SP]are[SP]average.\nWhat's[SP]scary[SP]is[SP]that[SP]even[SP]details[SP]like[SP]that\nare[SP]part[SP]of[SP]the[SP]rumor.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Qualité et prix moyens. Ce qui est effrayant,\nc'est que de tels détails soient dans la rumeur."
-  },
-  {
-    "id": 229,
-    "offset": 433636,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear\nJolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes."
-  },
-  {
-    "id": 230,
-    "offset": 433832,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]Anyway,[SP]his[SP]weapons\nare[SP]supposed[SP]to[SP]be[SP]average[SP]as[SP]far[SP]as[SP]the\nquality[SP]and[SP]price[SP]goes.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "C'est un vrai pirate ? Ses armes sont\nmoyennes en qualité et en prix."
-  },
-  {
-    "id": 231,
-    "offset": 434090,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear\nJolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes."
-  },
-  {
-    "id": 232,
-    "offset": 434286,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]His[SP]weapons[SP]are\nsupposed[SP]to[SP]be[SP]cheap,[SP]but[SP]not[SP]great[SP]quality.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "C'est un vrai pirate ? Ses armes sont\nbon marché, mais de mauvaise qualité."
-  },
-  {
-    "id": 233,
-    "offset": 434494,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear\nJolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes."
-  },
-  {
-    "id": 234,
-    "offset": 434690,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]He's[SP]supposed[SP]to[SP]have\na[SP]great[SP]selection,[SP]but[SP]he[SP]barely[SP]pays[SP]anything\nfor[SP]what[SP]you[SP]sell[SP]him.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "C'est un vrai pirate ? Super sélection,\nmais il paie une misère."
-  },
-  {
-    "id": 235,
-    "offset": 434960,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear\nJolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes."
-  },
-  {
-    "id": 236,
-    "offset": 435156,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]He's[SP]supposed[SP]to[SP]have\na[SP]crappy[SP]selection,[SP]but[SP]he'll[SP]pay[SP]a[SP]lot[SP]for\nwhatever[SP]you[SP]have[SP]to[SP]sell.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "C'est un vrai pirate ? Mauvaise sélection,\nmais il paie beaucoup."
-  },
-  {
-    "id": 237,
-    "offset": 435428,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear\nJolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes."
-  },
-  {
-    "id": 238,
-    "offset": 435624,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]His[SP]weapons[SP]are\nsupposed[SP]to[SP]be[SP]good[SP]quality,[SP]but[SP]really\nexpensive.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "C'est un vrai pirate ? Ses armes sont\nde bonne qualité, mais chères."
-  },
-  {
-    "id": 239,
-    "offset": 435844,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "No[SP]way...[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]actually\nsells[SP]real[SP]armor?[SP]I[SP]wonder[SP]if[SP]that's[SP]gonna\nbe[SP]the[SP]next[SP]trend.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Rosa Candida vend de vraies\narmures ? Ce sera la prochaine tendance."
-  },
-  {
-    "id": 240,
-    "offset": 436092,
-    "data_size": 210,
-    "slot_size": 214,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "The[SP]prices[SP]and[SP]quality[SP]there[SP]are[SP]pretty[SP]average.\nI[SP]wonder[SP]if[SP]I[SP]should[SP]go[SP]check[SP]it[SP]out...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Les prix et la qualité y sont moyens.\nJe devrais aller voir..."
-  },
-  {
-    "id": 241,
-    "offset": 436306,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "No[SP]way...[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]actually\nsells[SP]real[SP]armor?[SP]I[SP]wonder[SP]if[SP]that's[SP]gonna\nbe[SP]the[SP]next[SP]trend.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Rosa Candida vend de vraies\narmures ? Ce sera la prochaine tendance."
-  },
-  {
-    "id": 242,
-    "offset": 436554,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Their[SP]quality's[SP]kinda[SP]sketchy,[SP]but[SP]you[SP]can't\nbeat[SP]those[SP]prices.[SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]go\ncheck[SP]them[SP]out...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Qualité douteuse, mais prix imbattables.\nJe devrais aller voir..."
-  },
-  {
-    "id": 243,
-    "offset": 436802,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "No[SP]way...[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]actually\nsells[SP]real[SP]armor?[SP]I[SP]wonder[SP]if[SP]that's[SP]gonna\nbe[SP]the[SP]next[SP]trend.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Rosa Candida vend de vraies\narmures ? Ce sera la prochaine tendance."
-  },
-  {
-    "id": 244,
-    "offset": 437050,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "It's[SP]on[SP]the[SP]expensive[SP]side,[SP]but[SP]the[SP]quality's\nsupposed[SP]to[SP]be[SP]great.[SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]go\ncheck[SP]them[SP]out...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "C'est cher, mais la qualité est super.\nJe devrais aller voir..."
-  },
-  {
-    "id": 245,
-    "offset": 437306,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Anima[SP]Mundi[SP]sells[SP]armor?[SP]I[SP]go[SP]there[SP]all[SP]the\ntime[SP]and[SP]I[SP]never[SP]knew[SP]that.[SP]Well,[SP]their[SP]stuff\nis[SP]average[SP]quality[SP]for[SP]average[SP]prices.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Anima Mundi vend des armures ? J'y vais tout le\ntemps sans le savoir. Qualité et prix moyens."
-  },
-  {
-    "id": 246,
-    "offset": 437600,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Anima[SP]Mundi[SP]sells[SP]armor?[SP]I[SP]go[SP]there[SP]all[SP]the\ntime[SP]and[SP]I[SP]never[SP]knew[SP]that.[SP]It's[SP]pretty[SP]cheap,\nbut[SP]the[SP]quality's[SP]lousy.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Anima Mundi vend des armures ? J'y vais tout le\ntemps sans le savoir. Pas cher, mais qualité nulle."
-  },
-  {
-    "id": 247,
-    "offset": 437868,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Anima[SP]Mundi[SP]sells[SP]armor?[SP]I[SP]go[SP]there[SP]all[SP]the\ntime[SP]and[SP]I[SP]never[SP]knew[SP]that.[SP]That[SP]store's[SP]got\na[SP]really[SP]great[SP]selection.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Anima Mundi vend des armures ? J'y vais tout le\ntemps et je n'en savais rien. Ce magasin a\nune super sélection."
-  },
-  {
-    "id": 248,
-    "offset": 438134,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Huh?[SP]Their[SP]buyback[SP]prices?[SP]I[SP]dunno...[SP]I[SP]didn't\nhear[SP]much[SP]about[SP]that.[SP]I[SP]wouldn't[SP]get[SP]my[SP]hopes\nup[SP]if[SP]I[SP]were[SP]you,[SP]though.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Quoi ? Les prix de rachat ? J'en sais rien...\nJe ne me ferais pas trop d'illusions."
-  },
-  {
-    "id": 249,
-    "offset": 438408,
-    "data_size": 176,
-    "slot_size": 180,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Anima[SP]Mundi[SP]sells[SP]armor?[SP]I[SP]go[SP]there[SP]all[SP]the\ntime[SP]and[SP]I[SP]never[SP]knew[SP]that.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Anima Mundi vend des armures ? J'y vais\nsouvent sans le savoir."
-  },
-  {
-    "id": 250,
-    "offset": 438588,
-    "data_size": 182,
-    "slot_size": 186,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "That[SP]store's[SP]got[SP]really[SP]great[SP]stuff,[SP]but[SP]it's\nkinda[SP]out[SP]of[SP]my[SP]price[SP]range.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Ce magasin a de superbes trucs, mais c'est\nun peu hors de mon budget."
-  },
-  {
-    "id": 251,
-    "offset": 438774,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they\nsell[SP]real[SP]armor.[SP]Their[SP]selection's[SP]not[SP]great,\nbut[SP]the[SP]buyback[SP]prices[SP]are[SP]the[SP]best.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Mauvais choix, super rachat."
-  },
-  {
-    "id": 252,
-    "offset": 439070,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they\nsell[SP]real[SP]armor.[SP]Their[SP]quality[SP]and[SP]prices[SP]are\naverage,[SP]so[SP]they[SP]say.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Qualité et prix moyens."
-  },
-  {
-    "id": 253,
-    "offset": 439336,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they\nsell[SP]real[SP]armor.[SP]Their[SP]quality's[SP]pretty[SP]good,\nbut[SP]it's[SP]all[SP]really[SP]expensive.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Qualité bonne, mais très cher."
-  },
-  {
-    "id": 254,
-    "offset": 439620,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they\nsell[SP]real[SP]armor.[SP]Supposedly[SP]their[SP]stuff's[SP]super\ncheap,[SP]but[SP]really[SP]low[SP]quality.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Pas cher, mauvaise qualité."
-  },
-  {
-    "id": 255,
-    "offset": 439908,
-    "data_size": 300,
-    "slot_size": 304,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they\nsell[SP]real[SP]armor.[SP]Their[SP]selection's[SP]really[SP]good,\nbut[SP]the[SP]buyback[SP]prices[SP]are[SP]pretty[SP]low.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Super sélection, mauvais rachat."
-  },
-  {
-    "id": 256,
-    "offset": 440212,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Even[SP]London[SP]Clothier[SP]sells[SP]armor[SP]now.[SP]I[SP]guess\nthey[SP]get[SP]special[SP]orders.[SP]Their[SP]selection's\ngreat,[SP]but[SP]the[SP]buyback[SP]price[SP]is[SP]low.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Super choix, rachat bas."
-  },
-  {
-    "id": 257,
-    "offset": 440500,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Even[SP]London[SP]Clothier[SP]sells[SP]armor[SP]now.[SP]I[SP]guess\nthey[SP]get[SP]special[SP]orders.[SP]Their[SP]stuff's[SP]cheap,\nbut[SP]it's[SP]kinda[SP]not[SP]very[SP]good.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Pas cher, qualité bof."
-  },
-  {
-    "id": 258,
-    "offset": 440780,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Even[SP]London[SP]Clothier[SP]sells[SP]armor[SP]now.[SP]I[SP]guess\nthey[SP]get[SP]special[SP]orders.[SP]Their[SP]stuff[SP]is\nhigh[SP]quality,[SP]but[SP]really[SP]expensive.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Super qualité, très cher."
-  },
-  {
-    "id": 259,
-    "offset": 441060,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Even[SP]London[SP]Clothier[SP]sells[SP]armor[SP]now.[SP]I[SP]guess\nthey[SP]get[SP]special[SP]orders.[SP]Their[SP]prices[SP]and\nquality[SP]are[SP]nothing[SP]special.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Prix et qualité moyens."
-  },
-  {
-    "id": 260,
-    "offset": 441330,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Even[SP]London[SP]Clothier[SP]sells[SP]armor[SP]now.[SP]I[SP]guess\nthey[SP]get[SP]special[SP]orders.[SP]Their[SP]selection's\ncrappy,[SP]but[SP]the[SP]buyback[SP]price[SP]is[SP]great.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Mauvais choix, rachat top."
-  },
-  {
-    "id": 261,
-    "offset": 441624,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "That[SP]reminds[SP]me,[SP]a[SP]friend[SP]of[SP]a[SP]friend[SP]won[SP]a\nsweepstakes[SP]and[SP]got[SP]a[SP]real[SP]weapon[SP]in[SP]the[SP]mail.\nI[SP]was[SP]like,[SP]whoa,[SP]is[SP]that[SP]legal!?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "L'ami d'un ami a gagné à une loterie et a reçu une\nvéritable arme par la poste. C'est légal ça !?"
-  },
-  {
-    "id": 262,
-    "offset": 441910,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]think[SP]she[SP]said[SP]it[SP]was[SP]a[SP]magazine[SP]sweepstakes.\nYou[SP]can[SP]win[SP]pretty[SP]good[SP]stuff,[SP]but[SP]you[SP]won't\nwin[SP]too[SP]often.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "C'était un concours de magazine.\nTu peux gagner de bons trucs, mais c'est rare."
-  },
-  {
-    "id": 263,
-    "offset": 442162,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "That[SP]reminds[SP]me,[SP]a[SP]friend[SP]of[SP]a[SP]friend[SP]won[SP]a\nsweepstakes[SP]and[SP]got[SP]a[SP]real[SP]weapon[SP]in[SP]the[SP]mail.\nI[SP]was[SP]like,[SP]whoa,[SP]is[SP]that[SP]legal!?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "L'ami d'un ami a gagné à une loterie et a reçu une\nvéritable arme par la poste. C'est légal ça !?"
-  },
-  {
-    "id": 264,
-    "offset": 442448,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]think[SP]she[SP]said[SP]it[SP]was[SP]a[SP]magazine[SP]sweepstakes.\nYou[SP]hardly[SP]ever[SP]win,[SP]but[SP]when[SP]you[SP]do,[SP]you[SP]can\nget[SP]really[SP]rare[SP]stuff.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "C'était un concours de magazine.\nC'est rare, mais tu peux obtenir des trucs rares."
-  },
-  {
-    "id": 265,
-    "offset": 442718,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "That[SP]reminds[SP]me,[SP]a[SP]friend[SP]of[SP]a[SP]friend[SP]won[SP]a\nsweepstakes[SP]and[SP]got[SP]a[SP]real[SP]weapon[SP]in[SP]the[SP]mail.\nI[SP]was[SP]like,[SP]whoa,[SP]is[SP]that[SP]legal!?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "L'ami d'un ami a gagné à une loterie et a reçu une\nvéritable arme par la poste. C'est légal ça !?"
-  },
-  {
-    "id": 266,
-    "offset": 443004,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]think[SP]she[SP]said[SP]it[SP]was[SP]a[SP]magazine[SP]sweepstakes.\nThere's[SP]lots[SP]of[SP]winners,[SP]but[SP]no[SP]one[SP]ever[SP]gets\nanything[SP]really[SP]good.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "C'était un concours de magazine.\nPlein de gagnants, mais rien de vraiment bien."
-  },
-  {
-    "id": 267,
-    "offset": 443272,
-    "data_size": 120,
-    "slot_size": 124,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]didja[SP]know[SP]there's[SP]a[SP]casino[SP]in[SP]Mu[SP]now?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, tu savais pour le casino dans Mu ?"
-  },
-  {
-    "id": 268,
-    "offset": 443396,
-    "data_size": 152,
-    "slot_size": 156,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]heard[SP]rumors[SP]about[SP]it,[SP]but[SP]I[SP]didn't[SP]think\nthey'd[SP]be[SP]true.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "J'avais entendu des rumeurs, mais c'est vrai."
-  },
-  {
-    "id": 269,
-    "offset": 443552,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Just[SP]between[SP]you[SP]and[SP]me,[SP]poker[SP]seems[SP]like[SP]the\nbest[SP]bet.[SP]Rumor[SP]has[SP]it[SP]you[SP]can[SP]win[SP]big[SP]at\nmachine[SP]#5.[SP]My[SP]gamer[SP]friend[SP]told[SP]me.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Le poker est le meilleur pari. On gagne le gros\nlot à la machine #5. Un ami joueur me l'a dit."
-  },
-  {
-    "id": 270,
-    "offset": 443838,
-    "data_size": 120,
-    "slot_size": 124,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]didja[SP]know[SP]there's[SP]a[SP]casino[SP]in[SP]Mu[SP]now?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, tu savais pour le casino dans Mu ?"
-  },
-  {
-    "id": 271,
-    "offset": 443962,
-    "data_size": 152,
-    "slot_size": 156,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]heard[SP]rumors[SP]about[SP]it,[SP]but[SP]I[SP]didn't[SP]think\nthey'd[SP]be[SP]true.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "J'avais entendu des rumeurs, mais c'est vrai."
-  },
-  {
-    "id": 272,
-    "offset": 444118,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Just[SP]between[SP]you[SP]and[SP]me,[SP]slots[SP]seems[SP]like[SP]the\nbest[SP]bet.[SP]Rumor[SP]has[SP]it[SP]you[SP]can[SP]win[SP]big[SP]at\nmachine[SP]#1.[SP]My[SP]gamer[SP]friend[SP]told[SP]me.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Les machines à sous sont le meilleur pari.\nOn gagne le gros lot à la #1. Un ami me l'a dit."
-  },
-  {
-    "id": 273,
-    "offset": 444404,
-    "data_size": 120,
-    "slot_size": 124,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Hey,[SP]didja[SP]know[SP]there's[SP]a[SP]casino[SP]in[SP]Mu[SP]now?",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, tu savais pour le casino dans Mu ?"
-  },
-  {
-    "id": 274,
-    "offset": 444528,
-    "data_size": 152,
-    "slot_size": 156,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]heard[SP]rumors[SP]about[SP]it,[SP]but[SP]I[SP]didn't[SP]think\nthey'd[SP]be[SP]true.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "J'avais entendu des rumeurs, mais c'est vrai."
-  },
-  {
-    "id": 275,
-    "offset": 444684,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Anyway,[SP]my[SP]gamer[SP]friend[SP]said[SP]you[SP]can[SP]win[SP]big\nat[SP]blackjack.[SP]I[SP]don't[SP]know[SP]how,[SP]though...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Bref, on peut gagner gros au blackjack.\nJe ne sais pas comment, par contre..."
-  },
-  {
-    "id": 276,
-    "offset": 444894,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Huh,[SP]so[SP]Shiraishi[SP]Ramen[SP]in[SP]Hirasaka[SP]has[SP]a\nlegendary[SP]weapon[SP]for[SP]sale.[1205][U+000F][SP]I[SP]wonder[SP]if[SP]she\npicked[SP]it[SP]up[SP]on[SP]one[SP]of[SP]her[SP]spying[SP]missions.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Shiraishi Ramen vend une arme légendaire.[1205][U+000F]\nObtenue lors d'une mission d'espionnage ?"
-  },
-  {
-    "id": 277,
-    "offset": 445192,
-    "data_size": 188,
-    "slot_size": 192,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]wouldn't[SP]be[SP]surprised[SP]if[SP]Clair[SP]de[SP]Lune[SP]had\na[SP]legendary[SP]weapon[SP]lying[SP]around.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Clair de Lune pourrait avoir une arme\nlégendaire."
-  },
-  {
-    "id": 278,
-    "offset": 445384,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "They've[SP]got[SP]moonstones[SP]embedded[SP]in[SP]the[SP]floors\nand[SP]the[SP]whole[SP]store[SP]has[SP]this[SP]mysterious[SP]feel.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Il y a des pierres de lune incrustées, et\nle magasin a une atmosphère mystérieuse."
-  },
-  {
-    "id": 279,
-    "offset": 445602,
-    "data_size": 238,
-    "slot_size": 242,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "But[SP]I[SP]like[SP]the[SP]idea[SP]of[SP]them[SP]selling[SP]weapons.\nI[SP]feel[SP]like[SP]I'll[SP]get[SP]shot[SP]if[SP]I'm[SP]not[SP]careful\naround[SP]them.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Vendre des armes ? Je vais me faire tirer\ndessus si je ne fais pas attention."
-  },
-  {
-    "id": 280,
-    "offset": 445844,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "There's[SP]a[SP]really[SP]nasty[SP]rumor[SP]going[SP]around.[SP]The\nowner[SP]of[SP]Time[SP]Castle's[SP]keeping[SP]his[SP]legendary\nweapon[SP]under[SP]wraps[SP]to[SP]jack[SP]up[SP]the[SP]price.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Une vilaine rumeur court. Le patron de Time Castle\ngarde son arme légendaire pour faire monter les prix."
-  },
-  {
-    "id": 281,
-    "offset": 446144,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "A[SP]cool[SP]guy[SP]like[SP]that[SP]would[SP]never[SP]pull[SP]such\na[SP]jerk[SP]move![SP]Sheesh,[SP]the[SP]people[SP]in[SP]this[SP]city\ndon't[SP]know[SP]him[SP]at[SP]all!",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Un mec cool ne ferait pas ça ! Les gens d'ici\nne le connaissent pas du tout !"
-  },
-  {
-    "id": 282,
-    "offset": 446402,
-    "data_size": 300,
-    "slot_size": 304,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "There's[SP]a[SP]really[SP]nasty[SP]rumor[SP]going[SP]around![1205][U+000F][SP]They\nsay[SP]the[SP]Time[SP]Castle[SP]owner[SP]doesn't[SP]have[SP]his\nlegendary[SP]weapon[SP]'cause[SP]he's[SP]too[SP]chicken.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Vilaine rumeur ![1205][U+000F] Le patron de Time Castle\nn'a pas son arme car il a la trouille."
-  },
-  {
-    "id": 283,
-    "offset": 446706,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Like,[SP]he[SP]won't[SP]go[SP]to[SP]the[SP]abandoned[SP]factory[SP]to\npick[SP]it[SP]up[SP]from[SP]the[SP]seller.[SP]There's[SP]no[SP]way[SP]a\nguy[SP]that[SP]cool[SP]is[SP]a[SP]coward![SP]I-It's[SP]a[SP]mistake!",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Il n'ose pas aller à l'usine pour la récupérer.\nUn mec aussi cool n'est pas lâche ! C'est faux !"
-  },
-  {
-    "id": 284,
-    "offset": 447014,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Did[SP]a[SP]demon[SP]steal[SP]the[SP]legendary[SP]weapon[SP]at\nTime[SP]Castle?[1205][U+000F][SP]That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]but...",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Un démon a volé l'arme de Time Castle ?[1205][U+000F]\nC'est la rumeur, mais..."
-  },
-  {
-    "id": 285,
-    "offset": 447230,
-    "data_size": 164,
-    "slot_size": 168,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Looks[SP]like[SP]some[SP]girl[SP]bought[SP]the[SP]legendary\nweapon[SP]from[SP]Time[SP]Castle.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Une fille a acheté l'arme de Time Castle."
-  },
-  {
-    "id": 286,
-    "offset": 447398,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "I[SP]heard[SP]it[SP]was[SP]this[SP]really[SP]unlucky[SP]woman...\nPeople[SP]like[SP]that[SP]are[SP]capable[SP]of[SP]some[SP]pretty\nscary[SP]stuff.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "C'était une femme très malchanceuse...\nDes gens capables de choses effrayantes."
-  },
-  {
-    "id": 287,
-    "offset": 447636,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "Awww,[SP]I'm[SP]really[SP]bummed...[SP]The[SP]owner[SP]of[SP]Time\nCastle[SP]gave[SP]his[SP]legendary[SP]weapon[SP]to[SP]some[SP]girl.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Je suis dégoûtée... Le patron de Time\nCastle a donné son arme légendaire à une fille."
-  },
-  {
-    "id": 288,
-    "offset": 447854,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Young[SP]woman",
-    "texte_orig": "That[SP]can[SP]only[SP]mean[SP]one[SP]thing,[SP]huh?[SP]I[SP]wonder\nwhat[SP]kind[SP]of[SP]girl[SP]she[SP]is?[SP]All[SP]I[SP]heard[SP]about\nher[SP]is[SP]that[SP]she's[SP]got[SP]short[SP]hair.",
-    "nom_fr": "Jeune femme",
-    "texte_fr": "Ça veut dire quoi ? Elle est comment ?\nTout ce que je sais, c'est qu'elle a les cheveux courts."
-  },
-  {
-    "id": 289,
-    "offset": 448134,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Sevens[SP]High[SP]male[SP]student",
-    "texte_orig": "Oh,[SP]L-Lisa-san![1205][U+000A][SP]I[SP]finally[SP]found[SP]you.[1205][U+000A]\nI-I[SP]saw[SP]the[SP]poster![1205][U+000A][SP]Th-That[SP]silhouette\nis[SP]you,[SP]right?",
-    "nom_fr": "Lycéen de Seven",
-    "texte_fr": "Oh, L-Lisa-san ![1205][U+000A] Enfin trouvée.[1205][U+000A]\nJ-J'ai vu l'affiche ![1205][U+000A] C-Cette silhouette\nc'est toi ?"
-  },
-  {
-    "id": 290,
-    "offset": 448390,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Sevens[SP]High[SP]male[SP]student",
-    "texte_orig": "I-I[SP]had[SP]it[SP]figured[SP]out[SP]as[SP]soon[SP]as[SP]I[SP]saw[SP]it.[1205][U+000A]\nI-I[SP]mean,[SP]since[SP]I've[SP]always[SP]been[SP]watching\nyou[SP]and[SP]all...[1205][U+000A][SP]I'm[SP]right,[SP]aren't[SP]I?",
-    "nom_fr": "Lycéen de Seven",
-    "texte_fr": "J-J'ai tout de suite compris en la voyant.[1205][U+000A]\nE-Enfin, puisque je t'ai toujours\nobservée et tout...[1205][U+000A] J'ai raison, non ?"
-  },
-  {
-    "id": 291,
-    "offset": 448704,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Poster?[1205][U+000F][SP]Silhouette?[1205][U+000F][SP]I,[SP]uh,[SP]have[SP]no[SP]idea[SP]what\nyou're[SP]talking[SP]about.[SP]Whatever[SP]it[SP]is,[SP]it's\nnot[SP]me.[SP]You've[SP]got[SP]the[SP]wrong[SP]girl,[SP]dude.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Affiche ?[1205][U+000F] Silhouette ?[1205][U+000F] Je vois pas de quoi\ntu parles. Ce n'est pas moi. Tu te trompes de fille."
-  },
-  {
-    "id": 292,
-    "offset": 448994,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Sevens[SP]High[SP]male[SP]student",
-    "texte_orig": "C-Congratulations[SP]on[SP]your[SP]debut,[SP]L-Lisa-san.[1205][U+000A]\nI-I[SP]looked[SP]all[SP]over[SP]for[SP]you[SP]to[SP]tell[SP]you[SP]that...",
-    "nom_fr": "Lycéen de Seven",
-    "texte_fr": "F-Félicitations pour tes débuts, L-Lisa-san.[1205][U+000A]\nJ-Je t'ai cherchée partout pour te dire ça..."
-  },
-  {
-    "id": 293,
-    "offset": 449246,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Sevens[SP]High[SP]male[SP]student",
-    "texte_orig": "I-I[SP]think[SP]you'll[SP]make[SP]a[SP]great[SP]idol...[1205][U+000A][SP]I-I[SP]mean,\nyou're[SP]cute...[1205][U+000A][SP]and[SP]beautiful...[1205][U+000A][SP]and[SP]nice...",
-    "nom_fr": "Lycéen de Seven",
-    "texte_fr": "T-Tu ferais une super idole...[1205][U+000A] J-Je veux dire,\ntu es mignonne...[1205][U+000A] belle...[1205][U+000A] et gentille..."
-  },
-  {
-    "id": 294,
-    "offset": 449504,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "T-Toche...[1205][U+000F][SP]But[SP]I[SP]think[SP]this[SP]is[SP]just[SP]a[SP]big\nmisunderstanding.[SP]I-I[SP]never[SP]said[SP]I[SP]was[SP]going\nto[SP]be[SP]debuting.",
-    "nom_fr": "Ginko",
-    "texte_fr": "T-Toche...[1205][U+000F] Mais c'est un grand\nmalentendu. J-Je n'ai jamais dit que j'allais\ndébuter."
-  },
-  {
-    "id": 295,
-    "offset": 449738,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Sevens[SP]High[SP]male[SP]student",
-    "texte_orig": "Oh,[SP]L-Lisa-san,[SP]are[SP]you[SP]going[SP]to[SP]Mu?[1205][U+000A][SP]There's\ngoing[SP]to[SP]be[SP]a[SP]promo[SP]video[SP]shoot[SP]there,[SP]right?[1205][U+000A]\nG-Good[SP]luck.",
-    "nom_fr": "Lycéen de Seven",
-    "texte_fr": "Oh, L-Lisa-san, tu vas à Mu ?[1205][U+000A] Il va y\navoir le tournage d'une vidéo promo, c'est ça ?[1205][U+000A]\nB-Bonne chance."
-  },
-  {
-    "id": 296,
-    "offset": 450016,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Wh-Whoa,[SP]if[SP]you[SP]think[SP]I'm[SP]debuting[SP]because[SP]you\nsaw[SP]some[SP]poster,[SP]you're[SP]way[SP]off[SP]base.[1205][U+000F][SP]I[SP]am[SP]NOT\nbecoming[SP]an[SP]idol.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Wh-Whoa, si tu penses ça à cause d'une\naffiche, tu te plantes.[1205][U+000F] Je ne\ndeviens PAS une idole."
-  },
-  {
-    "id": 297,
-    "offset": 450268,
-    "data_size": 152,
-    "slot_size": 156,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "The[SP]reason[SP]I'm[SP]going[SP]to[SP]Mu[SP]is[SP]to[SP]set[SP]the[SP]record\nstraight[SP]on[SP]that!",
-    "nom_fr": "Ginko",
-    "texte_fr": "Je vais à Mu pour remettre les pendules à l'heure !"
-  },
-  {
-    "id": 298,
-    "offset": 450424,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Sevens[SP]High[SP]male[SP]student",
-    "texte_orig": "Y-You're[SP]the[SP]hero[SP]of[SP]S-Sevens,[SP]Lisa-san...[1205][U+000F]\nPlease[SP]bring[SP]back[SP]S-Sevens'[SP]popularity...[1205][U+000F]\nW-We're[SP]counting[SP]on[SP]you...",
-    "nom_fr": "Lycéen de Seven",
-    "texte_fr": "T-Tu es l'héroïne de S-Seven, Lisa-san...[1205][U+000F]\nS'il te plaît, rends à S-Seven sa popularité...[1205][U+000F]\nO-On compte sur toi..."
-  },
-  {
-    "id": 299,
-    "offset": 450718,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Kehhei![SP]Enough[SP]of[SP]this[SP]bullshit![1205][U+000F][SP]You[SP]don't[SP]know\nwhat[SP]I'm[SP]going[SP]through!",
-    "nom_fr": "Ginko",
-    "texte_fr": "Kehhei ! Assez de ces conneries ![1205][U+000F] Tu ne sais\npas ce que je traverse !"
-  },
-  {
-    "id": 300,
-    "offset": 450890,
-    "data_size": 154,
-    "slot_size": 158,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "I'll[SP]never[SP]debut[SP]as[SP]an[SP]idol,[SP]and[SP]I[SP]don't[SP]give\na[SP]shit[SP]about[SP]Sevens!",
-    "nom_fr": "Ginko",
-    "texte_fr": "Jamais idole, je\nm'en fiche de Seven !"
-  },
-  {
-    "id": 301,
-    "offset": 451048,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Sevens[SP]High[SP]male[SP]student",
-    "texte_orig": "I-I[SP]went[SP]to[SP]th-the[SP]outdoor[SP]concert[SP]hall\na[SP]second[SP]ago.[1205][U+000A][SP]E-Everyone's[SP]so[SP]excited,\nthere[SP]was[SP]a[SP]huge[SP]l-line[SP]at[SP]the[SP]entrance.",
-    "nom_fr": "Lycéen de Seven",
-    "texte_fr": "J-Je suis allé à la salle de concert\nil y a une seconde.[1205][U+000A] T-Tout le monde est excité,\nune énorme f-file d'attente à l'entrée."
-  },
-  {
-    "id": 302,
-    "offset": 451354,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Sevens[SP]High[SP]male[SP]student",
-    "texte_orig": "Y-You're[SP]amazing,[SP]Lisa-san...[1205][U+000A][SP]But[SP][1113]-\nsenpai[SP]is[SP]more[SP]than[SP]just[SP]a[SP]friend[SP]to[SP]you...[1205][U+000A]\nI'm[SP]so[SP]jealous...[1205][U+000A][SP]So[SP]envious...",
-    "nom_fr": "Lycéen de Seven",
-    "texte_fr": "T-Tu es incroyable, Lisa-san...[1205][U+000A] Mais [1113]-\nsenpai est plus qu'un ami pour toi...[1205][U+000A]\nJe suis si jaloux...[1205][U+000A] Tellement envieux..."
-  },
-  {
-    "id": 303,
-    "offset": 451654,
-    "data_size": 320,
-    "slot_size": 324,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Masked[SP]Circle[SP]member",
-    "texte_orig": "Wh...[SP]Why[SP]won't[SP]the[SP]executives[SP]come[SP]back[SP]to\nhelp[SP]us!?[1205][U+000F][SP]There's[SP]no[SP]way[SP]we[SP]can[SP]protect[SP]the\npeople[SP]of[SP]Sumaru[SP]alone![1205][U+000F][SP]S-Someone[SP]help[SP]us!",
-    "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Qu... Pourquoi les cadres ne reviennent pas\naider !?[1205][U+000F] On ne pourra jamais protéger les\nhabitants seuls ![1205][U+000F] Qu-Qu'on nous aide !"
-  },
-  {
-    "id": 304,
-    "offset": 451978,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Last[SP]Battalion",
-    "texte_orig": "We[SP]are[SP]the[SP]mightiest.[SP]We[SP]stand[SP]unrivalled.[1205][U+000F]\nThose[SP]who[SP]dare[SP]stand[SP]in[SP]the[SP]way[SP]of[SP]our[SP]march\nshall[SP]be[SP]crushed[SP]by[SP]the[SP]holy[SP]lance.",
-    "nom_fr": "Bataillon",
-    "texte_fr": "Nous sommes les plus forts, sans égal.[1205][U+000F]\nCeux sur notre chemin seront écrasés par\nla lance sacrée."
-  },
-  {
-    "id": 305,
-    "offset": 452272,
-    "data_size": 238,
-    "slot_size": 242,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Lisa",
-    "texte_orig": "Zodiac's[SP]a[SP]club,[SP]but[SP]you've[SP]never[SP]been[SP]inside,\nhave[SP]you,[SP]Chinyan?[SP]I[SP]haven't[SP]been[SP]around[SP]here\nlately[SP]either...",
-    "nom_fr": "Lisa",
-    "texte_fr": "Zodiac est un club, tu n'y es jamais entré,\nChinyan ? Je ne suis pas venue dans le\ncoin non plus..."
-  },
-  {
-    "id": 306,
-    "offset": 452514,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Lisa",
-    "texte_orig": "You[SP]know[SP]how[SP]guys[SP]from[SP]Sevens[SP]can't[SP]come[SP]here\nanymore[SP]because[SP]of[SP]that[SP]disease?[SP]I[SP]hear[SP]Cuss\nHigh[SP]students[SP]have[SP]stepped[SP]up[SP]instead.",
-    "nom_fr": "Lisa",
-    "texte_fr": "Les gars de Seven ne viennent plus à cause de\nla maladie ? Les élèves de Kakasu les ont\nremplacés, on dirait."
-  },
-  {
-    "id": 307,
-    "offset": 452796,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Zodiac's[SP]a[SP]club,[SP]but[SP]you've[SP]never[SP]been[SP]inside,\nhave[SP]you,[SP]Chinyan?[SP]I[SP]haven't[SP]been[SP]around[SP]here\nlately[SP]either...",
-    "nom_fr": "Ginko",
-    "texte_fr": "Zodiac est un club, tu n'y es jamais entré,\nChinyan ? Je ne suis pas venue dans le\ncoin non plus..."
-  },
-  {
-    "id": 308,
-    "offset": 453040,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Lisa",
-    "texte_orig": "You[SP]know[SP]how[SP]guys[SP]from[SP]Sevens[SP]can't[SP]come[SP]here\nanymore[SP]because[SP]of[SP]that[SP]disease?[SP]I[SP]hear[SP]Cuss\nHigh[SP]students[SP]have[SP]stepped[SP]up[SP]instead.",
-    "nom_fr": "Lisa",
-    "texte_fr": "Les gars de Seven ne viennent plus à cause de\nla maladie ? Les élèves de Kakasu les ont\nremplacés, on dirait."
-  },
-  {
-    "id": 309,
-    "offset": 453322,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "I[SP]don't[SP]think[SP]that's[SP]the[SP]best[SP]idea[SP]after[SP]we\nbusted[SP]heads[SP]in[SP]there.[SP]Let's[SP]go[SP]somewhere[SP]else.",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Mauvaise idée après avoir cassé des têtes\nlà-dedans. Allons ailleurs."
-  },
-  {
-    "id": 310,
-    "offset": 453534,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "What[SP]if[SP]someone[SP]catches[SP]us[SP]wandering[SP]around\nlike[SP]this,[SP][1113]?[SP]We[SP]should[SP]hurry[SP]to[SP]the\ndetective[SP]agency.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Et si on nous voit traîner par ici, [1113] ?\nVite à l'agence de détectives."
-  },
-  {
-    "id": 311,
-    "offset": 453756,
-    "data_size": 156,
-    "slot_size": 160,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "There's[SP]nothing[SP]we[SP]have[SP]to[SP]do[SP]here,[SP]is[SP]there?\nSo[SP]let's[SP]get[SP]going.",
-    "nom_fr": "Eikichi",
-    "texte_fr": "On n'a rien à faire ici, non ?\nAlors on y va."
-  },
-  {
-    "id": 312,
-    "offset": 453916,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "This[SP]is[SP]a[SP]CD[SP]store[SP]called[SP]Giga[SP]Macho.\nThey[SP]have[SP]all[SP]kinds[SP]of[SP]music[SP]here.[SP]I[SP]used\nto[SP]come[SP]here[SP]a[SP]lot[SP]with[SP]Sheba[SP]and[SP]Mee-ho...",
-    "nom_fr": "Ginko",
-    "texte_fr": "C'est un disquaire, Giga Macho.\nToutes sortes de musiques ici. Je venais\nsouvent avec Sheba et Mee-ho..."
-  },
-  {
-    "id": 313,
-    "offset": 454188,
-    "data_size": 106,
-    "slot_size": 110,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "GOLD...?[SP]Dude,[SP]this[SP]is[SP]a[SP]fitness[SP]center.",
-    "nom_fr": "Eikichi",
-    "texte_fr": "GOLD... ? C'est un centre de fitness."
-  },
-  {
-    "id": 314,
-    "offset": 454298,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Ohhh,[SP]I[SP]get[SP]it.[SP]You[SP]think[SP]you[SP]can[SP]compete\nwith[SP]me[SP]there,[SP]huh?[SP]Well,[SP]I[SP]think[SP]you'll\nfind[SP]your[SP]efforts[SP]will[SP]go[SP]to[SP]waste!",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Oh, tu crois que tu peux rivaliser avec\nmoi là-bas ? Tu verras que tes\nefforts ne serviront à rien !"
-  },
-  {
-    "id": 315,
-    "offset": 454564,
-    "data_size": 170,
-    "slot_size": 174,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Haha...[SP]I[SP]wonder[SP]if[SP]she's[SP]still[SP]at[SP]it...\nOh,[SP]sorry,[SP]it's[SP]nothing.[SP]Hahaha...",
-    "nom_fr": "Maya",
-    "texte_fr": "Haha... Je me demande si elle y est encore...\nOh, désolée. Hahaha..."
-  },
-  {
-    "id": 316,
-    "offset": 454738,
-    "data_size": 126,
-    "slot_size": 130,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "GOLD,[SP]huh...?[SP]Could[SP]this[SP]be[SP]the[SP]next[SP]target?\nOr...?[1205][U+000F]",
-    "nom_fr": "Maya",
-    "texte_fr": "GOLD, hein... ? C'est la prochaine cible ?\nOu... ?[1205][U+000F]"
-  },
-  {
-    "id": 317,
-    "offset": 454868,
-    "data_size": 148,
-    "slot_size": 152,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Where[SP]else[SP]could[SP]it[SP]be?[1205][U+000F][SP]Let's[SP]just[SP]hurry[SP]up\nand[SP]get[SP]inside.",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Où d'autre ?[1205][U+000F] Dépêchons-nous\nd'entrer."
-  },
-  {
-    "id": 318,
-    "offset": 455020,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "We[SP]can't[SP]afford[SP]to[SP]make[SP]another[SP]mistake.[1205][U+000F]\nIs[SP]GOLD[SP]where[SP]we[SP]should[SP]go,[SP]or...?",
-    "nom_fr": "Maya",
-    "texte_fr": "On n'a pas le droit à l'erreur.[1205][U+000F]\nC'est GOLD la cible, ou... ?"
-  },
-  {
-    "id": 319,
-    "offset": 455198,
-    "data_size": 146,
-    "slot_size": 150,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Dammit,[SP]which[SP]one[SP]is[SP]it?[1205][U+000F][SP]Choices[SP]like[SP]this[SP]make\nme[SP]queasy.",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Bordel, c'est où ?[1205][U+000F] Choisir me\ndonne la nausée."
-  },
-  {
-    "id": 320,
-    "offset": 455348,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4361,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?\n[1208][0002][1432][NULL][NULL][0014]Yeah,[SP]let's[SP]check[SP]it[SP]out.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]No,[SP]this[SP]isn't[SP]the[SP]place.[1432][NULL][NULL][0014]",
-    "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun ?[1205][U+000F] On fouille ici ?[E1][E2][E3]On fouille ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, allons voir.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas ici.[1432][NULL][NULL][0014]",
-    "question_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?",
-    "choix_orig": [
-      "Yeah,[SP]let's[SP]check[SP]it[SP]out.",
-      "No,[SP]this[SP]isn't[SP]the[SP]place."
-    ],
-    "question_fr": "",
-    "choix_fr": [
-      "",
-      ""
-    ]
-  },
-  {
-    "id": 321,
-    "offset": 455658,
-    "data_size": 210,
-    "slot_size": 214,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Okay,[SP]we'll[SP]trust[SP][1113]'s[SP]instincts.\nThere's[SP]no[SP]use[SP]hemming[SP]and[SP]hawing[SP]over[SP]it\nanymore.[SP]Let's[SP]go!",
-    "nom_fr": "Yukino",
-    "texte_fr": "Ok, on va se fier à l'instinct de [1113].\nInutile d'hésiter plus longtemps.\nOn y va !"
-  },
-  {
-    "id": 322,
-    "offset": 455872,
-    "data_size": 110,
-    "slot_size": 114,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Alright.[SP]Then[SP]let's[SP]get[SP]to[SP]Pachinko[SP]Silver!",
-    "nom_fr": "Yukino",
-    "texte_fr": "D'accord. Direction Pachinko Silver !"
-  },
-  {
-    "id": 323,
-    "offset": 455986,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Wow,[SP]that[SP]Ulala[SP]lady[SP]was[SP]something[SP]else.[SP]She\nscared[SP]even[SP]me[SP]a[SP]little...[SP]But[SP]we[SP]stopped[SP]the\nbombs,[SP]so[SP]I[SP]guess[SP]it[SP]worked[SP]out[SP]in[SP]the[SP]end.",
-    "nom_fr": "Yukino",
-    "texte_fr": "Waouh, cette Ulala c'était quelque chose.\nMais on a arrêté les bombes, donc tout\nest bien qui finit bien."
-  },
-  {
-    "id": 324,
-    "offset": 456282,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Well,[SP]all[SP]that's[SP]left[SP]is[SP]King[SP]Leo[SP]and[SP]the\nAerospace[SP]Museum.[SP]He's[SP]had[SP]us[SP]wrapped[SP]around\nhis[SP]finger[SP]for[SP]so[SP]long,[SP]it's[SP]time[SP]for[SP]payback!",
-    "nom_fr": "Yukino",
-    "texte_fr": "Il ne reste que le Roi Lion et le Musée de\nl'Aérospatiale. Il s'est moqué de nous, c'est\nl'heure de la revanche !"
-  },
-  {
-    "id": 325,
-    "offset": 456576,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Does[SP]King[SP]Leo[SP]think[SP]this[SP]is[SP]all[SP]a[SP]game...!?\nThat[SP]bastard's[SP]dead[SP]when[SP]I[SP]find[SP]him![SP]Let's[SP]go,\n[1113]![SP]To[SP]the[SP]Aerospace[SP]Museum!",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Ce Lion croit jouer !?\nIl est mort quand je l'aurai !\nEn route, [1113] ! Au Musée !"
-  },
-  {
-    "id": 326,
-    "offset": 456842,
-    "data_size": 170,
-    "slot_size": 174,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "I[SP]wonder[SP]if[SP]this[SP]was[SP]their[SP]will,[SP]too...\nBut[SP]they[SP]were[SP]so[SP]kind[SP]back[SP]then...",
-    "nom_fr": "Ginko",
-    "texte_fr": "C'était aussi leur volonté... ?\nMais ils étaient si gentils..."
-  },
-  {
-    "id": 327,
-    "offset": 457016,
-    "data_size": 148,
-    "slot_size": 152,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Yeah...[SP]Jun[SP]would[SP]never[SP]have[SP]done[SP]this.[SP]We[SP]gotta\nstop[SP]him,[SP][1114]!",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Ouais... Jun n'aurait jamais fait ça. Il faut\nl'arrêter, [1114] !"
-  },
-  {
-    "id": 328,
-    "offset": 457168,
-    "data_size": 62,
-    "slot_size": 66,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "PACHINKO[SP]SILVERRRRRR!",
-    "nom_fr": "Maya",
-    "texte_fr": "PACHINKO SILVER !"
-  },
-  {
-    "id": 329,
-    "offset": 457234,
-    "data_size": 132,
-    "slot_size": 136,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "...I[SP]mean,[SP]hold[SP]it,[SP][1113]-kun.[SP]You're[SP]still\na[SP]high[SP]schooler.",
-    "nom_fr": "Maya",
-    "texte_fr": "...Je veux dire, attends, [1113]-kun. T'es encore\nlycéen."
-  },
-  {
-    "id": 330,
-    "offset": 457370,
-    "data_size": 236,
-    "slot_size": 240,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Pachinko[SP]Silver,[SP]huh...?[1205][U+000F][SP]I'd[SP]hate[SP]to[SP]see[SP]this\nplace[SP]go,[SP]that's[SP]for[SP]sure.[SP]But[SP]it[SP]might[SP]not\nbe[SP]the[SP]target...",
-    "nom_fr": "Maya",
-    "texte_fr": "Pachinko Silver... ?[1205][U+000F] Je détesterais voir ça\ndisparaître. Mais c'est peut-être pas la cible..."
-  },
-  {
-    "id": 331,
-    "offset": 457610,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "In[SP]any[SP]case,[SP]we[SP]gotta[SP]move.[1205][U+000F][SP]Let's[SP]stop[SP]second-\nguessing[SP]ourselves[SP]and[SP]get[SP]this[SP]done!",
-    "nom_fr": "Eikichi",
-    "texte_fr": "En tout cas, faut bouger.[1205][U+000F] Arrêtons de\ndouter et finissons-en !"
-  },
-  {
-    "id": 332,
-    "offset": 457812,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "We[SP]can't[SP]make[SP]the[SP]same[SP]mistake[SP]again.[SP]Is[SP]this\nthe[SP]target?[1205][U+000F][SP]It[SP]could[SP]always[SP]be[SP]GOLD...",
-    "nom_fr": "Maya",
-    "texte_fr": "On ne peut pas répéter l'erreur. Est-ce\nla cible ?[1205][U+000F] Ça pourrait être GOLD..."
-  },
-  {
-    "id": 333,
-    "offset": 458008,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "It[SP]could[SP]just[SP]as[SP]likely[SP]be[SP]this[SP]place,[SP]though.[1205][U+000F]\nSheesh,[SP]this[SP]is[SP]a[SP]lot[SP]of[SP]responsibility...",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Mais ça pourrait tout aussi bien être ici.[1205][U+000F]\nPfff, c'est une lourde responsabilité..."
-  },
-  {
-    "id": 334,
-    "offset": 458220,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4361,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?\n[1208][0002][1432][NULL][NULL][0014]Yeah,[SP]let's[SP]check[SP]it[SP]out.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]No,[SP]this[SP]isn't[SP]the[SP]place.[1432][NULL][NULL][0014]",
-    "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun ?[1205][U+000F] On fouille ici ?[E1][E2][E3]On fouille ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, allons voir.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas ici.[1432][NULL][NULL][0014]",
-    "question_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[E1][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?",
-    "choix_orig": [
-      "Yeah,[SP]let's[SP]check[SP]it[SP]out.",
-      "No,[SP]this[SP]isn't[SP]the[SP]place."
-    ],
-    "question_fr": "",
-    "choix_fr": [
-      "",
-      ""
-    ]
-  },
-  {
-    "id": 335,
-    "offset": 458530,
-    "data_size": 98,
-    "slot_size": 102,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Not[SP]here,[SP]then.[SP]Alright,[SP]off[SP]to[SP]GOLD!",
-    "nom_fr": "Yukino",
-    "texte_fr": "Pas ici, alors. En route pour GOLD !"
-  },
-  {
-    "id": 336,
-    "offset": 458632,
-    "data_size": 72,
-    "slot_size": 76,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Okay.[SP]Then[SP]here[SP]we[SP]go...",
-    "nom_fr": "Yukino",
-    "texte_fr": "Ok. C'est parti..."
-  },
-  {
-    "id": 337,
-    "offset": 458708,
-    "data_size": 120,
-    "slot_size": 124,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "???",
-    "texte_orig": "Huh?[SP]Oh,[SP]hey,[SP]Maya![1205][U+000F][SP]You[SP]came[SP]to[SP]play\npachinko[SP]too?",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 338,
-    "offset": 459116,
-    "data_size": 128,
-    "slot_size": 132,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Ulala![1205][U+000F][SP]What're[SP]you[SP]doing[SP]here?[SP]Did[SP]something\nhappen?",
-    "nom_fr": "Maya",
-    "texte_fr": "Ulala ![1205][U+000F] Que fais-tu ici ?\nUn problème ?"
-  },
-  {
-    "id": 339,
-    "offset": 459248,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Ulala",
-    "texte_orig": "Can't[SP]you[SP]tell?[1205][U+000F][SP]I[SP]had[SP]a[SP]feeling[SP]luck[SP]was[SP]on[SP]my\nside[SP]today![SP]And[SP]sure[SP]enough,[SP]I[SP]hit[SP]the[SP]jackpot!",
-    "nom_fr": "Ulala",
-    "texte_fr": "Ça se voit pas ?[1205][U+000F] La chance me souriait !\nEt bingo, j'ai touché le gros lot !"
-  },
-  {
-    "id": 340,
-    "offset": 459464,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ulala",
-    "texte_orig": "I[SP]felt[SP]like[SP]I[SP]could[SP]keep[SP]the[SP]streak[SP]going...\nBut[SP]it's[SP]almost[SP]time[SP]for[SP]my[SP]training.[1205][U+000F][SP]I[SP]decided\nto[SP]be[SP]a[SP]good[SP]girl[SP]and[SP]leave.",
-    "nom_fr": "Ulala",
-    "texte_fr": "Je sentais que je pouvais continuer...\nMais c'est l'heure de mon entraînement.[1205][U+000F]\nJ'ai décidé d'être sage et partir."
-  },
-  {
-    "id": 341,
-    "offset": 459736,
-    "data_size": 102,
-    "slot_size": 106,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Wait[SP]a[SP]sec![1205][U+000F][SP]Your[SP]fitness[SP]club[SP]was[SP]GOLD!",
-    "nom_fr": "Maya",
-    "texte_fr": "Attends ![1205][U+000F] Ton club c'était GOLD !"
-  },
-  {
-    "id": 342,
-    "offset": 459842,
-    "data_size": 58,
-    "slot_size": 62,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ulala",
-    "texte_orig": "Yep![SP]That's[SP]right!",
-    "nom_fr": "Ulala",
-    "texte_fr": "Ouais ! Exact !"
-  },
-  {
-    "id": 343,
-    "offset": 459904,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "If[SP]we'd[SP]searched[SP]this[SP]place,[SP]we[SP]wouldn't[SP]have\nbeen[SP]able[SP]to[SP]stop[SP]GOLD[SP]from[SP]going[SP]down...\nThat's[SP]my[SP]Chinyan!",
-    "nom_fr": "Ginko",
-    "texte_fr": "Si on avait fouillé cet endroit, on n'aurait pas pu\nempêcher l'explosion de GOLD... T'es géniale !"
-  },
-  {
-    "id": 344,
-    "offset": 460142,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Kehhei![SP]If[SP]this[SP]place[SP]didn't[SP]exist,[SP]we[SP]would\nhave[SP]stopped[SP]GOLD[SP]from[SP]going[SP]down!",
-    "nom_fr": "Ginko",
-    "texte_fr": "Kehhei ! Sans ce lieu, on aurait\nempêché la chute de GOLD !"
-  },
-  {
-    "id": 345,
-    "offset": 460326,
-    "data_size": 188,
-    "slot_size": 192,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "We'll[SP]get[SP]caught[SP]if[SP]we[SP]stick[SP]around[SP]here.\nLet's[SP]go[SP]to[SP]the[SP]detective[SP]agency[SP]already.",
-    "nom_fr": "Ginko",
-    "texte_fr": "On va se faire choper ici.\nAllons à l'agence de détectives."
-  },
-  {
-    "id": 346,
-    "offset": 460518,
-    "data_size": 100,
-    "slot_size": 104,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Hey,[SP]this[SP]isn't[SP]the[SP]time[SP]for[SP]gambling.",
-    "nom_fr": "Yukino",
-    "texte_fr": "Hé, ce n'est pas le moment de jouer."
-  },
-  {
-    "id": 347,
-    "offset": 460622,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Awww,[SP]it's[SP]closed.[SP]Though[SP]that's[SP]hardly[SP]a\nsurprise,[SP]given[SP]the[SP]situation...",
-    "nom_fr": "Eikichi",
-    "texte_fr": "C'est fermé. Ce n'est pas une\nsurprise, vu la situation..."
-  },
-  {
-    "id": 348,
-    "offset": 460800,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "We[SP]got[SP]the[SP]crystal[SP]skull[SP]and[SP]we[SP]saved[SP]Miyabi.\nI[SP]don't[SP]think[SP]we[SP]need[SP]to[SP]go[SP]in[SP]there[SP]anymore.",
-    "nom_fr": "Eikichi",
-    "texte_fr": "On a le crâne de cristal et on a sauvé Miyabi.\nPlus besoin d'y retourner."
-  },
-  {
-    "id": 349,
-    "offset": 461012,
-    "data_size": 82,
-    "slot_size": 86,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ulala",
-    "texte_orig": "Noooooo![1205][U+000F][SP]GOOOOOLD![1205][U+000F][SP]My[SP]gym!",
-    "nom_fr": "Ulala",
-    "texte_fr": "Non ![1205][U+000F] GOLD ![1205][U+000F] Ma gym !"
-  },
-  {
-    "id": 350,
-    "offset": 461098,
-    "data_size": 114,
-    "slot_size": 118,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Huh?[SP]Why?[1205][U+000F][SP]Pachinko[SP]Silver[SP]wasn't[SP]the[SP]target?",
-    "nom_fr": "Ginko",
-    "texte_fr": "Hein ?[1205][U+000F] Silver pas visé ?"
-  },
-  {
-    "id": 351,
-    "offset": 461216,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ulala",
-    "texte_orig": "Did[SP]the[SP]terrorists[SP]do[SP]this!?[1205][U+000F][SP]This[SP]isn't[SP]funny!\nI[SP]just[SP]joined[SP]this[SP]place![1205][U+000F][SP]And[SP]I[SP]fully[SP]paid[SP]my\nmembership[SP]in[SP]advance!",
-    "nom_fr": "Ulala",
-    "texte_fr": "Les terroristes ont fait ça !?[1205][U+000F] Pas drôle !\nJe viens de m'inscrire ![1205][U+000F] J'ai payé d'avance !"
-  },
-  {
-    "id": 352,
-    "offset": 461480,
-    "data_size": 44,
-    "slot_size": 48,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Uh--[1205][U+000A]Ulala!",
-    "nom_fr": "Maya",
-    "texte_fr": "Eh-[1205][U+000A]Ulala!"
-  },
-  {
-    "id": 353,
-    "offset": 461528,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Elly's[SP]voice",
-    "texte_orig": "Hello?[SP]Elly[SP]here.[1205][U+000F][SP]I've[SP]figured[SP]out[SP]the[SP]last\ntarget.[1205][U+000F][SP]It's[SP]south-southeast[SP]of[SP]Sevens...",
-    "nom_fr": "Voix d'Elly",
-    "texte_fr": "Allô ? C'est Elly.[1205][U+000F] J'ai découvert la dernière\ncible.[1205][U+000F] C'est au sud-sud-est de Seven..."
-  },
-  {
-    "id": 354,
-    "offset": 461746,
-    "data_size": 224,
-    "slot_size": 228,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Elly's[SP]voice",
-    "texte_orig": "There's[SP]only[SP]one[SP]building[SP]in[SP]that[SP]direction:[1205][U+000F]\nThe[SP]Aerospace[SP]Museum[SP]in[SP]Kounan.[SP]You[SP]must[SP]hurry!",
-    "nom_fr": "Voix d'Elly",
-    "texte_fr": "Un seul bâtiment dans cette direction :[1205][U+000F]\nLe Musée de l'Aérospatiale. Faites vite !"
-  },
-  {
-    "id": 355,
-    "offset": 461974,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "You[SP]hear[SP]that,[SP]guys?[1205][U+000F][SP]We[SP]finally[SP]got[SP]a[SP]concrete\nclue.[SP]The[SP]last[SP]target's[SP]the[SP]Aerospace[SP]Museum!",
-    "nom_fr": "Yukino",
-    "texte_fr": "Vous avez entendu ?[1205][U+000F] On a une piste. La\ndernière cible est le Musée de l'Aérospatiale !"
-  },
-  {
-    "id": 356,
-    "offset": 462190,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "That[SP]King[SP]Leo[SP]bastard[SP]hasn't[SP]shown[SP]himself[SP]since\nthe[SP]concert[SP]hall,[SP]but...[SP]You[SP]really[SP]think[SP]he'll\nstay[SP]that[SP]quiet?",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Ce fumier de Roi Lion ne s'est pas montré\ndepuis la salle de concert... Tu crois qu'il\nva rester tranquille ?"
-  },
-  {
-    "id": 357,
-    "offset": 462446,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "I[SP]agree...[SP]If[SP]the[SP]Aerospace[SP]Museum[SP]is[SP]the[SP]last\ntarget,[SP]you[SP]can[SP]bet[SP]King[SP]Leo[SP]will[SP]be[SP]there.[1205][U+000F]\nLet's[SP]put[SP]an[SP]end[SP]to[SP]this!",
-    "nom_fr": "Maya",
-    "texte_fr": "D'accord... Si le Musée est la dernière\ncible, le Roi Lion y sera.[1205][U+000F] Mettons\nun terme à tout ça !"
-  },
-  {
-    "id": 358,
-    "offset": 462706,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Whoa,[SP]hold[SP]your[SP]horses.[SP]We[SP]haven't[SP]gotten[SP]the\nskull[SP]at[SP]Leo[SP]Temple[SP]yet,[SP]right?[SP]Let's[SP]take\ncare[SP]of[SP]that[SP]before[SP]we[SP]jump[SP]in[SP]here.",
-    "nom_fr": "Maya",
-    "texte_fr": "Whoa, doucement. On n'a pas encore récupéré le crâne\nau Temple du Lion, non ? Occupons-nous de ça\navant de foncer ici."
-  },
-  {
-    "id": 359,
-    "offset": 462980,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Wait[SP]a[SP]sec,[SP]Chinyan![SP]We[SP]don't[SP]have[SP]the[SP]skull\nfrom[SP]Taurus[SP]Temple[SP]yet.[SP]We[SP]should[SP]stop[SP]by\nthere[SP]first.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Attends, Chinyan ! On n'a pas encore le crâne\ndu Temple du Taureau. On devrait commencer par là."
-  },
-  {
-    "id": 360,
-    "offset": 463204,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Jun",
-    "texte_orig": "Hold[SP]on[SP]a[SP]moment.[SP]We're[SP]still[SP]not[SP]done[SP]with\nthe[SP]Aquarius[SP]Temple.",
-    "nom_fr": "Jun",
-    "texte_fr": "Une seconde. On n'en a pas fini avec\nle Temple du Verseau."
-  }
+    {
+        "id": 0,
+        "offset": 378826,
+        "data_size": 848,
+        "slot_size": 848,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "Yo,[SP]you[SP]here[SP]to[SP]have[SP]some[SP]fun[SP]too?[1205][U+000F][SP]'Course[SP]you[NL]are.[SP]Yumezaki's[SP]the[SP]district[SP]for[SP]kids![SP]Wall-to-[NL]wall[SP]entertainment![NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]man[NL]Mu,[SP]the[SP]hottest[SP]amusement[SP]center.[1205][U+000F][SP]Giga[SP]Macho,[NL]a[SP]record[SP]store[SP]with[SP]a[SP]recording[SP]studio.[1205][U+000F][SP]Anima[NL]Mundi,[SP]home[SP]of[SP]the[SP]latest[SP]fashions.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]man[NL]A[SP]guy[SP]my[SP]age[SP]could[SP]easily[SP]spend[SP]an[SP]entire[SP]day[NL]here[SP]and[SP]never[SP]get[SP]bored.[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]man[NL]And[SP]the[SP]girls[SP]here...[SP]Whew![SP]Heheheh.",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Yo, tu viens t'amuser aussi ?[1205][U+000F] Bien sûr.\nYumezaki est pour les jeunes !\nDu divertissement partout ![1106][NL]Mu, le meilleur centre de jeux.[1205][U+000F] Giga Macho,\nun disquaire avec studio.[1205][U+000F] Anima Mundi,\nle temple de la mode.[1106][NL]Un gars de mon âge peut passer toute la\njournée ici sans s'ennuyer.[1205][U+000F][1106][NL]Les filles ici... Ouf ! Heheh."
+    },
+    {
+        "id": 1,
+        "offset": 379674,
+        "data_size": 208,
+        "slot_size": 208,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "Looks[SP]like[SP]there's[SP]a[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High.[1205][U+000F][NL]He's[SP]stronger[SP]than[SP]the[SP]old[SP]Boss,[SP]right?",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "On dirait qu'il y a un nouveau chef à Kakasu.[1205][U+000F]\nPlus fort que l'ancien, non ?"
+    },
+    {
+        "id": 2,
+        "offset": 379882,
+        "data_size": 306,
+        "slot_size": 306,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "Heh,[SP]they're[SP]having[SP]a[SP]masquerade[SP]as[SP]part[SP]of[NL]their[SP]school[SP]festival.[SP]Cuss[SP]High[SP]sure[SP]knows[NL]how[SP]to[SP]draw[SP]a[SP]crowd.[1205][U+000F][SP]All[SP]my[SP]friends[SP]are[SP]going.",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Ils font un bal masqué pour leur festival.\nLe lycée Kakasu sait comment attirer la\nfoule.[1205][U+000F] Tous mes potes y vont."
+    },
+    {
+        "id": 3,
+        "offset": 380188,
+        "data_size": 220,
+        "slot_size": 220,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "Ooh,[SP]you[SP]on[SP]your[SP]way[SP]to[SP]Mu?[1205][U+000F][SP]We[SP]might[SP]catch[SP]a[NL]glimpse[SP]of[SP]the[SP]Muses[SP]live![SP]I[SP]better[SP]get[SP]going.",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Ooh, tu vas à Mu ?[1205][U+000F] On pourrait voir les\nMuses en direct ! Il faut que j'y aille."
+    },
+    {
+        "id": 4,
+        "offset": 380408,
+        "data_size": 556,
+        "slot_size": 556,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "Ugh,[SP]I[SP]was[SP]just[SP]at[SP]Giga[SP]Macho,[SP]and[SP]it[SP]was[SP]packed[NL]with[SP]guys[SP]trying[SP]to[SP]scope[SP]out[SP]the[SP]Muses[SP]event.[1205][U+000F][NL]Bandwagon-hopping[SP]bastards...[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]man[NL]It's[SP]gonna[SP]suck[SP]if[SP]more[SP]schmoes[SP]like[SP]them[SP]keep[NL]showing[SP]up.[1205][U+000F][SP]I've[SP]been[SP]a[SP]fan[SP]of[SP]those[SP]girls[NL]since[SP]before[SP]it[SP]was[SP]cool.",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Ugh, j'étais à Giga Macho, c'était rempli de\ngars voulant voir l'événement des Muses.[1205][U+000F]\nBande de moutons...[1106][NL]Ça va puer si d'autres nazes se pointent.[1205][U+000F]\nJe suis fan depuis bien avant que ce soit cool."
+    },
+    {
+        "id": 5,
+        "offset": 380964,
+        "data_size": 228,
+        "slot_size": 228,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "Dude,[SP]everyone[SP]went[SP]to[SP]go[SP]see[SP]the[SP]concert[NL]in[SP]Aoba...[1205][U+000F][SP]Am[SP]I[SP]the[SP]only[SP]one[SP]who[SP]didn't[SP]go?[1205][U+000F][NL]Lame...",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Tous sont allés voir le concert à Aoba...[1205][U+000F]\nJe suis le seul à pas y être allé ?[1205][U+000F] Nul..."
+    },
+    {
+        "id": 6,
+        "offset": 381192,
+        "data_size": 546,
+        "slot_size": 546,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "Hey,[SP]what's[SP]the[SP]Masked[SP]Circle?[1205][U+000F][SP]They're[SP]the[SP]ones[NL]who[SP]set[SP]fire[SP]to[SP]the[SP]concert[SP]hall,[SP]right?[SP]That's[NL]what[SP]my[SP]friend's[SP]friend[SP]said.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]man[NL]Even[SP]their[SP]name[SP]sounds[SP]suspicious.[1205][U+000F][SP]If[SP]they're[NL]actually[SP]starting[SP]shit[SP]like[SP]this,[SP]they[SP]must[NL]really[SP]be[SP]dangerous.",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Hé, c'est quoi le Cercle masqué ?[1205][U+000F] Ce sont\neux qui ont incendié la salle de concert,\nnon ? C'est ce qu'un pote a dit.[1106][NL]Même leur nom est louche.[1205][U+000F] S'ils font\nvraiment ce genre de trucs, ils doivent\nêtre hyper dangereux."
+    },
+    {
+        "id": 7,
+        "offset": 381738,
+        "data_size": 344,
+        "slot_size": 344,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "Hey,[SP]is[SP]it[SP]true[SP]the[SP]terrorists[SP]targeted[NL]Smile[SP]Hirasaka[SP]too?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]man[NL]I-I'm[SP]starting[SP]to[SP]think[SP]this[SP]place[SP]isn't[SP]safe[NL]either...[1205][U+000F][SP]Are[SP]we[SP]gonna[SP]be[SP]okay?",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Hé, les terroristes ont aussi ciblé\nSmile Hirasaka ?[1106][NL]J-Je pense qu'ici non plus c'est pas sûr...[1205][U+000F]\nOn va s'en sortir ?"
+    },
+    {
+        "id": 8,
+        "offset": 382082,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "Is[SP]it[SP]true[SP]the[SP]terrorists[SP]bombed[SP]Smile[NL]Hirasaka?[SP]Dude,[SP]seriously...?[1205][U+000A][SP]They[SP]could[NL]hit[SP]here[SP]next![1205][U+000F][SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]run.",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Ils ont vraiment bombardé Smile Hirasaka ?\nSérieux ?[1205][U+000A] Ils pourraient viser ici !\n[1205][U+000F]Je devrais fuir."
+    },
+    {
+        "id": 9,
+        "offset": 382364,
+        "data_size": 280,
+        "slot_size": 280,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "What,[SP]they[SP]even[SP]targeted[SP]GOLD!?[1205][U+000F][SP]Does[SP]that[SP]mean[NL]Yumezaki's[SP]not[SP]safe[SP]either!?[SP]When[SP]will[SP]someone[NL]do[SP]something[SP]about[SP]this...?",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Quoi, ils ont même ciblé GOLD !?[1205][U+000F] Ça\nveut dire que Yumezaki n'est pas sûr\nnon plus !? Quand vont-ils agir... ?"
+    },
+    {
+        "id": 10,
+        "offset": 382644,
+        "data_size": 300,
+        "slot_size": 300,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "O-Oh[SP]shit,[SP]they[SP]got[SP]GOLD[SP]too...[1205][U+000F][SP]H-Hey,[SP]where[NL]are[SP]they[SP]gonna[SP]strike[SP]next!?[1205][U+000F][SP]If[SP]I[SP]don't[SP]know[NL]that...[SP]I[SP]don't[SP]know[SP]where[SP]to[SP]run[SP]to...",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "M-Merde, ils ont eu GOLD aussi...[1205][U+000F] H-Hé,\noù vont-ils frapper ensuite !?[1205][U+000F] Si je ne le\nsais pas... je ne sais pas où fuir..."
+    },
+    {
+        "id": 11,
+        "offset": 382944,
+        "data_size": 324,
+        "slot_size": 324,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "They've[SP]posted[SP]composite[SP]sketches[SP]of[SP]the[SP]suspects,[NL]right?[1205][U+000F][SP]Looks[SP]like[SP]crime[SP]doesn't[SP]pay[SP]after[SP]all.[NL]But[SP]wasn't[SP]it[SP]the[SP]Masked[SP]Circle[SP]who[SP]did[SP]this?",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Ils ont publié les portraits-robots des\nsuspects, non ?[1205][U+000F] Le crime ne paie pas.\nMais n'était-ce pas le Cercle masqué ?"
+    },
+    {
+        "id": 12,
+        "offset": 383268,
+        "data_size": 304,
+        "slot_size": 304,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "H-Hey,[SP]I[SP]saw[SP]the[SP]news...[SP]What[SP]do[SP]you[SP]think?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]man[NL]Are[SP]those[SP]guys[SP]not[SP]the[SP]culprits?[1205][U+000F][SP]Or[SP]are[SP]they[NL]really[SP]terrorists[SP]after[SP]all?",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Hé, j'ai vu les infos... T'en dis quoi ?[1106][NL]Ils sont innocents ?[1205][U+000F] Ou\nde vrais terroristes ?"
+    },
+    {
+        "id": 13,
+        "offset": 383572,
+        "data_size": 300,
+        "slot_size": 300,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "Dude,[SP]shit[SP]keeps[SP]going[SP]down[SP]right[SP]and[SP]left![NL]What's[SP]going[SP]on!?[1205][U+000F][SP]Were[SP]those[SP]guys[SP]terrorists[NL]or[SP]not!?[SP]What[SP]are[SP]they[SP]doing[SP]to[SP]our[SP]city!?",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Mec, c'est le bordel de partout !\nIl se passe quoi !?[1205][U+000F] Ces gars étaient des\nterroristes ou pas !? Ils font quoi ici !?"
+    },
+    {
+        "id": 14,
+        "offset": 383872,
+        "data_size": 328,
+        "slot_size": 328,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]man",
+        "texte_orig": "I[SP]saw[SP]a[SP]guy[SP]wearing[SP]a[SP]skirt[SP]go[SP]into[SP]that[NL]temple[SP]just[SP]now.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]man[NL]Was[SP]he[SP]a[SP]Cuss[SP]High[SP]student?[SP]He[SP]had[SP]a[SP]really[NL]cute[SP]girl[SP]with[SP]him,[SP]though...",
+        "nom_fr": "Jeune homme",
+        "texte_fr": "Un gars en jupe vient d'entrer au temple.[1106][NL]Un élève de Kakasu ? Il était avec\nune fille mignonne..."
+    },
+    {
+        "id": 15,
+        "offset": 384200,
+        "data_size": 712,
+        "slot_size": 712,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "Hm?[SP]Are[SP]you[SP]hitting[SP]on[SP]me?[1205][U+000F][SP]If[SP]you[SP]are,[SP]I[SP]hate[NL]to[SP]break[SP]it[SP]to[SP]you,[SP]but[SP]I'm[SP]a[SP]little[SP]busy.[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]Oh,[SP]you[SP]weren't?[SP]Haha,[SP]sorry[SP]about[SP]that,[SP]then.[1205][U+000F][NL]That[SP]reminds[SP]me,[SP]do[SP]you[SP]go[SP]to[SP]Cuss[SP]High?[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]Because[SP]I[SP]saw[SP]a[SP]group[SP]of[SP]Cuss[SP]High[SP]kids[SP]going[NL]into[SP]Zodiac[SP]a[SP]moment[SP]ago.[1205][U+000F][SP]Do[SP]you[SP]know[SP]what[NL]they're[SP]up[SP]to[SP]in[SP]there?",
+        "nom_fr": "Femme active",
+        "texte_fr": "Hm ? Tu me dragues ?[1205][U+000F] Si c'est le cas,\ndésolée de te décevoir, mais je suis occupée.[1106][NL]Oh, ce n'était pas ça ? Haha, désolée.[1205][U+000F]\nÇa me rappelle, tu vas au lycée Kakasu ?[1106][NL]J'ai vu un groupe de Kakasu entrer dans\nZodiac.[1205][U+000F] Tu sais ce qu'ils y font ?"
+    },
+    {
+        "id": 16,
+        "offset": 384912,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "That[SP]reminds[SP]me,[SP]rumor[SP]has[SP]it[SP]there's[SP]a[SP]secret[NL]lounge[SP]deep[SP]inside[SP]Zodiac.[1205][U+000F][SP]I've[SP]never[SP]gone[SP]to[NL]see[SP]it,[SP]though...",
+        "nom_fr": "Femme active",
+        "texte_fr": "D'ailleurs, la rumeur dit qu'il y a un salon\nsecret au fond de Zodiac.[1205][U+000F] Je n'y suis\njamais allée, par contre..."
+    },
+    {
+        "id": 17,
+        "offset": 385178,
+        "data_size": 452,
+        "slot_size": 452,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "Someone[SP]from[SP]Cuss[SP]High[SP]came[SP]to[SP]sell[SP]tickets[SP]to[NL]the[SP]masquerade[SP]just[SP]now.[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]All[SP]the[SP]girls[SP]around[SP]here[SP]rushed[SP]over[SP]and[SP]he[NL]sold[SP]out[SP]in[SP]a[SP]flash.[1205][U+000F][SP]I[SP]didn't[SP]realize[SP]the[NL]school[SP]was[SP]that[SP]popular.",
+        "nom_fr": "Femme active",
+        "texte_fr": "Un gars de Kakasu est venu vendre\ndes billets pour le bal.[1106][NL]Les filles se sont ruées et il a tout vendu\nvite.[1205][U+000F] Je ne pensais pas cette école si cotée."
+    },
+    {
+        "id": 18,
+        "offset": 385630,
+        "data_size": 310,
+        "slot_size": 310,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "Young[SP]kids[SP]tend[SP]to[SP]gather[SP]here,[SP]so[SP]TV[SP]stations[NL]send[SP]reporters[SP]to[SP]interview[SP]them[SP]and[SP]hold[NL]events.[1205][U+000F][SP]Aren't[SP]they[SP]having[SP]one[SP]at[SP]Mu[SP]today?",
+        "nom_fr": "Femme active",
+        "texte_fr": "Les jeunes traînent ici, donc la télé\nenvoie des reporters pour les interviewer\net faire des trucs.[1205][U+000F] C'est à Mu aujourd'hui ?"
+    },
+    {
+        "id": 19,
+        "offset": 385940,
+        "data_size": 490,
+        "slot_size": 490,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "Is[SP]Muses[SP]still[SP]keeping[SP]their[SP]third[SP]member[SP]a[NL]secret?[1205][U+000F][SP]I[SP]know[SP]it's[SP]a[SP]marketing[SP]strategy,[SP]but[NL]I[SP]wish[SP]they'd[SP]stop[SP]fanning[SP]the[SP]flames.[1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]Or[SP]are[SP]they[SP]planning[SP]on[SP]making[SP]an[SP]announcement[NL]during[SP]the[SP]recording[SP]today?",
+        "nom_fr": "Femme active",
+        "texte_fr": "Muses garde toujours sa troisième membre\nsecrète ?[1205][U+000F] Je sais que c'est du marketing,\nmais j'aimerais qu'ils arrêtent ce teasing.[1106][NL]Ou comptent-ils faire une annonce\npendant l'enregistrement aujourd'hui ?"
+    },
+    {
+        "id": 20,
+        "offset": 386430,
+        "data_size": 414,
+        "slot_size": 414,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "They[SP]just[SP]revealed[SP]the[SP]third[SP]member,[SP]and[SP]they're[NL]already[SP]giving[SP]a[SP]concert?[1205][U+000F][SP]That's[SP]pretty[SP]sudden.[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]Either[SP]that[SP]Ginji[SP]Sasaki[SP]is[SP]extremely[SP]skilled,[NL]or[SP]extremely[SP]rushed.",
+        "nom_fr": "Femme active",
+        "texte_fr": "Ils viennent de révéler la troisième membre\net ils donnent déjà un concert ?[1205][U+000F] Rapide.[1106][NL]Soit ce Ginji Sasaki est très doué,\nsoit il est extrêmement pressé."
+    },
+    {
+        "id": 21,
+        "offset": 386844,
+        "data_size": 406,
+        "slot_size": 406,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "They[SP]say[SP]these[SP]bombings[SP]are[SP]part[SP]of[SP]a[SP]wave[NL]of[SP]terror.[1205][U+000F][SP]There's[SP]no[SP]knowing[SP]where[SP]they'll[NL]strike[SP]next.[1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]They[SP]won't[SP]attack[SP]here,[SP]right...?[1205][U+000F][SP]I[SP]worry[NL]about[SP]that[SP]a[SP]lot.",
+        "nom_fr": "Femme active",
+        "texte_fr": "Ces attentats sont une vague de terreur.[1205][U+000F]\nImpossible de savoir où ils frapperont.[1106][NL]Ils n'attaqueront pas ici, non... ?[1205][U+000F]\nÇa m'inquiète beaucoup."
+    },
+    {
+        "id": 22,
+        "offset": 387250,
+        "data_size": 804,
+        "slot_size": 804,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "I'd[SP]evacuate[SP]to[SP]the[SP]countryside[SP]if[SP]I[SP]could.[1205][U+000F][NL]Unfortunately,[SP]that's[SP]not[SP]an[SP]option.[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]I've[SP]got[SP]a[SP]huge[SP]backlog[SP]at[SP]work[SP]and[SP]there's[NL]no[SP]sign[SP]that[SP]this[SP]place[SP]will[SP]be[SP]bombed.[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]But[SP]I[SP]know[SP]I'll[SP]regret[SP]it[SP]immediately[SP]if[SP]there[NL]IS[SP]a[SP]bombing[SP]here.[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]I[SP]wonder[SP]if[SP]I'm[SP]just[SP]too[SP]used[SP]to[SP]everything[NL]being[SP]peaceful[SP]that[SP]I[SP]can't[SP]make[SP]up[SP]my[SP]mind.",
+        "nom_fr": "Femme active",
+        "texte_fr": "J'irais à la campagne si je le pouvais.[1205][U+000F]\nMalheureusement, ce n'est pas possible.[1106][NL]J'ai une tonne de boulot en retard et\nrien n'indique qu'il y aura une bombe ici.[1106][NL]Mais je regretterai s'il y A une bombe ici.[1106][NL]Je me demande si je suis trop habituée\nà la paix pour pouvoir me décider."
+    },
+    {
+        "id": 23,
+        "offset": 388054,
+        "data_size": 424,
+        "slot_size": 424,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "[U+1432][U+0000][U+0000][U+0014]If[SP]GOLD[SP]was[SP]the[SP]target,[SP]then[SP]our[SP]building's[NL]safe.[U+1432][U+0000][U+0000][U+0014][SP]That's[SP]what[SP]he[SP]thinks,[SP]anyway.[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]What[SP]on[SP]Earth[SP]is[SP]my[SP]idiot[SP]boss[SP]thinking!?[NL]I'm[SP]giving[SP]notice[SP]as[SP]soon[SP]as[SP]I[SP]get[SP]back!",
+        "nom_fr": "Femme active",
+        "texte_fr": "[1432][NULL][NULL][0014]Si GOLD était la cible, notre bâtiment\nest sauf.[1432][NULL][NULL][0014] C'est ce qu'il pense, bref.[1106][NL]À quoi pense mon idiot de patron !?\nJe démissionne dès que je rentre !"
+    },
+    {
+        "id": 24,
+        "offset": 388478,
+        "data_size": 392,
+        "slot_size": 392,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "[U+1432][U+0000][U+0000][U+0014]They[SP]went[SP]after[SP]GOLD,[SP]so[SP]our[SP]building's[NL]safe[U+1432][U+0000][U+0000][U+0014]!?[SP]Is[SP]he[SP]serious!?[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]What[SP]on[SP]Earth[SP]is[SP]my[SP]idiot[SP]boss[SP]thinking!?[1205][U+000F][NL]I'm[SP]giving[SP]notice[SP]as[SP]soon[SP]as[SP]I[SP]get[SP]back!",
+        "nom_fr": "Femme active",
+        "texte_fr": "[1432][NULL][NULL][0014]Ils ont visé GOLD, donc on est\nsaufs[1432][NULL][NULL][0014] !? Il est sérieux !?[1106][NL]À quoi pense mon idiot de patron !?[1205][U+000F]\nJe démissionne dès que je rentre !"
+    },
+    {
+        "id": 25,
+        "offset": 388870,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "Huh.[1205][U+000F][SP]Those[SP]kids[SP]were[SP]soaking[SP]wet[SP]and[SP]said[SP]the[NL]people[SP]in[SP]the[SP]news[SP]were[SP]heroes[SP]fighting[SP]the[NL]Masked[SP]Circle...[1205][U+0014][SP]Who[SP]do[SP]I[SP]believe?",
+        "nom_fr": "Femme active",
+        "texte_fr": "Huh.[1205][U+000F] Ces jeunes étaient trempés et disaient\nque les gars aux infos étaient des héros\ncontre le Cercle masqué...[1205][0014] Qui croire ?"
+    },
+    {
+        "id": 26,
+        "offset": 389168,
+        "data_size": 290,
+        "slot_size": 290,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "I[SP]wonder[SP]if[SP]the[SP]stuff[SP]in[SP]the[SP]In[SP]Lak'ech[SP]is[NL]true[SP]after[SP]all.[1205][U+000F][SP]I[SP]heard[SP]even[SP]the[SP]recent[SP]wave[NL]of[SP]terror[SP]is[SP]mentioned[SP]in[SP]there...",
+        "nom_fr": "Femme active",
+        "texte_fr": "Je me demande si les trucs de l'In Lak'ech\nsont vrais.[1205][U+000F] J'ai entendu dire que la vague\nde terreur y est même mentionnée..."
+    },
+    {
+        "id": 27,
+        "offset": 389458,
+        "data_size": 572,
+        "slot_size": 572,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "If[SP]they're[SP]here,[SP]then[SP]the[SP]secret[SP]treasure[SP]of[NL]Sumaru[SP]City[SP]must[SP]also[SP]exist.[1205][U+000F][SP]Which[SP]means[SP]that[NL]Oracle[SP]thing[SP]is[SP]true...[1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]The[SP]next[SP]line[SP]was,[SP][U+1432][U+0000][U+0000][U+0014]The[SP]lion's[SP]roar[SP]echoes[SP]far[NL]and[SP]wide,[U+1432][U+0000][U+0000][U+0014][SP]right?[1205][U+000F][SP]Wh-What's[SP]that[SP]supposed[SP]to[NL]mean?[1205][U+000F][SP]I[SP]don't[SP]understand...",
+        "nom_fr": "Femme active",
+        "texte_fr": "S'ils sont là, le trésor secret de Sumaru\ndoit aussi exister.[1205][U+000F] Ce qui signifie que\ncet Oracle dit vrai...[1106][NL]La suite c'était : [1432][NULL][NULL][0014]Le rugissement\ndu lion résonne[1432][NULL][NULL][0014] ?[1205][U+000F]\nÇa veut dire quoi ?[1205][U+000F] Je pige pas..."
+    },
+    {
+        "id": 28,
+        "offset": 390030,
+        "data_size": 330,
+        "slot_size": 330,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "D-Did[SP]you[SP]see[SP]those[SP]meteors?[1205][U+000F][SP]One[SP]of[SP]the[SP]Masked[NL]Circle[SP]said[SP]they[SP]were[SP]the[SP][U+1432][U+0000][U+0000][U+0014]lion's[SP]roar[U+1432][U+0000][U+0000][U+0014]![1205][U+000F][SP]That's[NL]what[SP]that[SP]line[SP]in[SP]the[SP]Oracle[SP]was[SP]about!",
+        "nom_fr": "Femme active",
+        "texte_fr": "T-Tu as vu ces météores ?[1205][U+000F] Quelqu'un du Cercle\na dit que c'était le [1432][NULL][NULL][0014]rugissement du lion[1432][NULL][NULL][0014] ![1205][U+000F]\nC'est de ça que parlait l'Oracle !"
+    },
+    {
+        "id": 29,
+        "offset": 390360,
+        "data_size": 376,
+        "slot_size": 376,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "A[SP]temple[SP]like[SP]that[SP]one[SP]appeared[SP]in[SP]Hirasaka[NL]and[SP]Aoba[SP]too,[SP]right?[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]What[SP]are[SP]those[SP]things...?[1205][U+000F][SP]The[SP]scorpion[SP]mark[NL]drawn[SP]on[SP]it[SP]is[SP]kind[SP]of[SP]disturbing...",
+        "nom_fr": "Femme active",
+        "texte_fr": "Un temple est apparu à Hirasaka et Aoba, non ?[1106][NL]C'est quoi... ?[1205][U+000F] La marque de\nscorpion dessus est perturbante..."
+    },
+    {
+        "id": 30,
+        "offset": 390736,
+        "data_size": 554,
+        "slot_size": 554,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "A[SP]city[SP]for[SP]the[SP]young...[1205][U+000F][SP]That's[SP]what[SP]those[NL]layabouts[SP]think.[SP]For[SP]us[SP]men[SP]making[SP]an[SP]honest[NL]day's[SP]pay,[SP]this[SP]place[SP]is[SP]part[SP]of[SP]society[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]By[SP]the[SP]way,[SP]are[SP]you[SP]from[SP]Kasugayama[SP]High?[1205][U+000F][NL]This[SP]place[SP]is[SP]usually[SP]packed[SP]with[SP]Sevens[SP]kids,[NL]but[SP]I[SP]rarely[SP]see[SP]them[SP]anymore.",
+        "nom_fr": "Homme",
+        "texte_fr": "Une ville pour jeunes...[1205][U+000F] C'est ce que\npensent ces fainéants. Pour nous qui bossons,\nça fait partie de la société.[1106][NL]Au fait, tu viens du lycée Kakasu ?[1205][U+000F]\nC'est souvent plein de gamins de Seven ici,\nmais je les vois rarement désormais."
+    },
+    {
+        "id": 31,
+        "offset": 391290,
+        "data_size": 364,
+        "slot_size": 364,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "A[SP]secret[SP]lounge?[1205][U+000F][SP]Oh,[SP]you[SP]mean[SP]the[SP]place[SP]you[NL]can't[SP]get[SP]into[SP]without[SP]one[SP]of[SP]those[SP]masks?[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]I've[SP]heard[SP]rumors[SP]about[SP]it...[1205][U+000F][SP]But[SP]it[SP]sounds[SP]like[NL]a[SP]pretty[SP]shady[SP]place.",
+        "nom_fr": "Homme",
+        "texte_fr": "Un salon secret ?[1205][U+000F] Oh, tu parles de l'endroit\noù on ne peut pas entrer sans masque ?[1106][NL]J'ai entendu des rumeurs...[1205][U+000F] Ça a l'air louche."
+    },
+    {
+        "id": 32,
+        "offset": 391654,
+        "data_size": 332,
+        "slot_size": 332,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Guess[SP]all[SP]our[SP]customers[SP]are[SP]off[SP]at[SP]Cuss[SP]High's[NL]school[SP]festival...[SP]Oh[SP]well.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]Festivals[SP]like[SP]that[SP]do[SP]only[SP]come[SP]once[SP]a[SP]year,[NL]so[SP]I[SP]shouldn't[SP]complain.",
+        "nom_fr": "Homme",
+        "texte_fr": "Nos clients sont au festival de Kakasu... Tant pis.[1106][NL]Ce festival n'a lieu qu'une fois\npar an, je me plains pas."
+    },
+    {
+        "id": 33,
+        "offset": 391986,
+        "data_size": 224,
+        "slot_size": 224,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "I[SP]keep[SP]being[SP]surprised[SP]at[SP]how[SP]popular[SP]that[NL]new[SP]group[SP]Muses[SP]is.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]Is[SP]their[SP]producer[SP]that[SP]good?",
+        "nom_fr": "Homme",
+        "texte_fr": "Je suis surpris du succès de Muses.[1106][NL]Leur prod est si doué ?"
+    },
+    {
+        "id": 34,
+        "offset": 392210,
+        "data_size": 258,
+        "slot_size": 258,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "A[SP]crowd's[SP]forming[SP]at[SP]Giga[SP]Macho,[SP]but[SP]they're[NL]not[SP]interested[SP]in[SP]anything[SP]but[SP]Ginji[SP]Sasaki[NL]and[SP]the[SP]last[SP]member[SP]of[SP]Muses.",
+        "nom_fr": "Homme",
+        "texte_fr": "Une foule se forme à Giga Macho, mais ils ne\ns'intéressent qu'à Ginji Sasaki et à la\ndernière membre de Muses."
+    },
+    {
+        "id": 35,
+        "offset": 392468,
+        "data_size": 332,
+        "slot_size": 332,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "The[SP]outdoor[SP]concert[SP]hall's[SP]packed[SP]already.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]I[SP]envy[SP]them[SP]their[SP]popularity...[SP]It's[SP]a[SP]tough[NL]thing[SP]to[SP]see[SP]for[SP]those[SP]of[SP]us[SP]who've[SP]fallen[NL]on[SP]hard[SP]times.",
+        "nom_fr": "Homme",
+        "texte_fr": "La salle en plein air est pleine.[1106][NL]J'envie leur succès... C'est dur pour nous\nqui avons traversé des crises."
+    },
+    {
+        "id": 36,
+        "offset": 392800,
+        "data_size": 592,
+        "slot_size": 592,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Some[SP]people[SP]are[SP]saying[SP]the[SP]Masked[SP]Circle[SP]is[SP]to[NL]blame[SP]for[SP]the[SP]chaos,[SP]but[SP]are[SP]they[SP]really[SP]the[NL]culprits[SP]here?[1205][U+000F][SP]Granted,[SP]they're[SP]suspicious...[1106][E2][1431][U+0000][U+0000]\"Man[NL]But[SP]I'm[SP]more[SP]worried[SP]about[SP]those[SP]five[SP]people[NL]seen[SP]outside[SP]the[SP]concert[SP]hall.[1205][U+000F][SP]I[SP]know[SP]a[SP]lot[NL]of[SP]folks[SP]who[SP]think[SP]they're[SP]the[SP]real[SP]culprits.",
+        "nom_fr": "Homme",
+        "texte_fr": "Certains accusent le Cercle masqué pour\nce chaos, mais sont-ils vraiment les\ncoupables ?[1205][U+000F] Certes, ils sont louches...[1106][NL]Mais ces cinq personnes vues devant la salle\nde concert m'inquiètent plus.[1205][U+000F] Beaucoup\npensent que ce sont les vrais coupables."
+    },
+    {
+        "id": 37,
+        "offset": 393392,
+        "data_size": 834,
+        "slot_size": 834,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "The[SP]Masked[SP]Circle[SP]and[SP]the[SP]group[SP]of[SP]five...[1205][U+000F][NL]They're[SP]both[SP]suspects[SP]behind[SP]the[SP]terrorist[NL]attacks,[SP]but[SP]there's[SP]no[SP]proof...[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]That's[SP]a[SP]dangerous[SP]situation.[SP]People[SP]here[SP]in[NL]town[SP]want[SP]a[SP]quick[SP]end[SP]to[SP]things[SP]like[SP]this,[NL]so[SP]they're[SP]eager[SP]to[SP]toss[SP]blame[SP]around...[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]Step[SP]out[SP]of[SP]line[SP]even[SP]a[SP]little,[SP]and[SP]you[SP]might[NL]find[SP]yourself[SP]labeled[SP]as[SP]a[SP]suspect[SP]too.[1205][U+000F][SP]It's[SP]a[NL]damn[SP]witch[SP]hunt.[SP]These[SP]are[SP]scary[SP]times...",
+        "nom_fr": "Homme",
+        "texte_fr": "Le Cercle masqué et le groupe...[1205][U+000F]\nTous deux sont suspects, mais sans preuves...[1106][NL]C'est une situation dangereuse. Les gens ici\nveulent que ça se termine vite, alors\nils sont pressés de jeter le blâme...[1106][NL]Un pas de travers, et tu pourrais être\nétiqueté comme suspect aussi.[1205][U+000F] C'est une\npure chasse aux sorcières. Quelle époque..."
+    },
+    {
+        "id": 38,
+        "offset": 394226,
+        "data_size": 716,
+        "slot_size": 716,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Now[SP]people[SP]are[SP]saying[SP]the[SP]terrorists[SP]behind[NL]these[SP]attacks[SP]are[SP]a[SP]special[SP]unit[SP]called[SP]the[NL]Last[SP]Battalion.[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]Sheesh...[SP]When[SP]people[SP]start[SP]panicking,[SP]they'll[NL]believe[SP]any[SP]wild[SP]accusation[SP]they[SP]hear.[1106][E2][1431][U+0000][U+0000]\"Man[NL]You[SP]should[SP]get[SP]out[SP]of[SP]this[SP]city[SP]before[SP]you're[NL]branded[SP]a[SP]culprit[SP]too.[1205][U+000F][SP]People[SP]who[SP]believe[NL]they're[SP]victims[SP]are[SP]the[SP]most[SP]dangerous[SP]of[SP]all.",
+        "nom_fr": "Homme",
+        "texte_fr": "On dit que les terroristes sont une unité\nappelée le Bataillon.[1205][U+000F][1106][NL]Quand la panique s'installe, les\ngens croient n'importe quoi.[1106][NL]Tu devrais quitter cette ville avant d'être\nqualifié de coupable aussi.[1205][U+000F] Les gens qui se\ncroient victimes sont les plus dangereux."
+    },
+    {
+        "id": 39,
+        "offset": 394942,
+        "data_size": 1028,
+        "slot_size": 1028,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "I[SP]heard[SP]they[SP]released[SP]the[SP]composite[SP]sketches[SP]of[NL]the[SP]suspects,[SP]so[SP]I[SP]went[SP]to[SP]check[SP]'em[SP]out...[1205][U+000F][NL]Those[SP]were[SP]some[SP]familiar[SP]faces,[SP]all[SP]right.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]Oh,[SP]no,[SP]I[SP]completely[SP]understand[SP]it's[SP]a[SP]trumped-[NL]up[SP]charge[SP]and[SP]those[SP]are[SP]just[SP]people[SP]in[SP]the[NL]wrong[SP]place[SP]at[SP]the[SP]wrong[SP]time.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]But[SP]you[SP]gotta[SP]understand.[1205][U+000F][SP]No[SP]matter[SP]how[SP]much[NL]people[SP]like[SP]to[SP]think[SP]they're[SP]realists,[SP]man[NL]hasn't[SP]changed[SP]since[SP]the[SP]days[SP]of[SP]show[SP]trials.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]I[SP]hope[SP]they[SP]catch[SP]the[SP]real[SP]culprits[SP]soon,[NL]and[SP]I'll[SP]be[SP]praying[SP]for[SP]your[SP]safety.",
+        "nom_fr": "Homme",
+        "texte_fr": "J'ai entendu dire qu'ils avaient publié\nles portraits-robots, alors je suis allé\nvoir...[1205][U+000F] Des visages familiers, en effet.[1106][NL]Oh, je comprends que ce sont\nde fausses accusations, juste des gens\nau mauvais endroit.[1106][NL]Mais tu dois comprendre.[1205][U+000F] Peu importe à quel\npoint on se dit réalistes, l'homme n'a pas\nchangé depuis les procès-spectacles.[1106][NL]J'espère qu'ils les attraperont, je prierai."
+    },
+    {
+        "id": 40,
+        "offset": 395970,
+        "data_size": 286,
+        "slot_size": 286,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "The[SP]new[SP]rumor[SP]is[SP]that[SP]the[SP]group[SP]of[SP]five[SP]is[NL]actually[SP]fighting[SP]against[SP]the[SP]Masked[SP]Circle.[NL]Did[SP]you[SP]guys[SP]spread[SP]that[SP]one?[1205][U+000F][SP]Very[SP]clever.",
+        "nom_fr": "Homme",
+        "texte_fr": "La nouvelle rumeur dit que le groupe de cinq\ncombat en fait le Cercle masqué.\nC'est vous qui l'avez lancée ?[1205][U+000F] Très malin."
+    },
+    {
+        "id": 41,
+        "offset": 396256,
+        "data_size": 204,
+        "slot_size": 204,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "This[SP]feels[SP]a[SP]lot[SP]like[SP]the[SP]final[SP]push.[1205][U+000F][SP]I[SP]don't[NL]think[SP]anyone[SP]doubts[SP]the[SP]In[SP]Lak'ech[SP]anymore.",
+        "nom_fr": "Homme",
+        "texte_fr": "Ça sent la fin.[1205][U+000F] Plus personne ne doute\nde l'In Lak'ech."
+    },
+    {
+        "id": 42,
+        "offset": 396460,
+        "data_size": 462,
+        "slot_size": 462,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Now[SP]where[SP]did[SP]that[SP]monstrosity[SP]come[SP]from...?[1205][U+000A][NL]The[SP]Masked[SP]Circle[SP]and[SP]the[SP]Last[SP]Battalion[SP]are[NL]having[SP]it[SP]out[SP]in[SP]there[SP]now.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]Fighting[SP]up[SP]here,[SP]destruction[SP]below...[1205][U+000F][NL]Does[SP]anyone[SP]care[SP]what[SP]happens[SP]down[SP]there[NL]anymore?",
+        "nom_fr": "Homme",
+        "texte_fr": "D'où sort cette monstruosité... ?[1205][U+000A]\nLe Cercle masqué et le Bataillon se\nbattent là-dedans maintenant.[1106][NL]Se battre en haut, détruire en bas...[1205][U+000F]\nPlus personne ne se soucie d'ici ?"
+    },
+    {
+        "id": 43,
+        "offset": 396922,
+        "data_size": 398,
+        "slot_size": 398,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "From[SP]what[SP]I've[SP]heard,[SP]a[SP]meteor[SP]shower[SP]will[NL]rain[SP]down[SP]on[SP]the[SP]Earth[SP]when[SP]the[SP]Grand[SP]Cross[NL]happens.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]But[SP]there[SP]can't[SP]be[SP]any[SP]truth[SP]to[SP]that.[1205][U+000A][SP]There[NL]was[SP]no[SP]such[SP]thing[SP]in[SP]the[SP]In[SP]Lak'ech.",
+        "nom_fr": "Homme",
+        "texte_fr": "On dit qu'une pluie de météores s'abattra\navec la Croix Cosmique.[1106][NL]Mais ça ne peut pas être vrai.[1205][U+000A] Il n'y\navait rien de tel dans l'In Lak'ech."
+    },
+    {
+        "id": 44,
+        "offset": 397320,
+        "data_size": 510,
+        "slot_size": 510,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "I'm[SP]sure[SP]you[SP]know[SP]already,[SP]but[SP]there[SP]are[NL]several[SP]theories[SP]in[SP]Sumaru[SP]about[SP]how[SP]life[NL]down[SP]there[SP]on[SP]Earth[SP]will[SP]end.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]So[SP]long[SP]as[SP]there[SP]are[SP]competing[SP]theories,[NL]it[SP]should[SP]be[SP]fine.[1205][U+000A][SP]It's[SP]when[SP]everyone[SP]starts[NL]to[SP]agree[SP]that[SP]we're[SP]in[SP]trouble...",
+        "nom_fr": "Homme",
+        "texte_fr": "Tu le sais, mais il y a\nplusieurs théories sur la fin du monde.[1106][NL]Tant qu'il y a des théories divergentes,\nça va.[1205][U+000A] C'est quand tous\nsont d'accord que ça craint..."
+    },
+    {
+        "id": 45,
+        "offset": 397830,
+        "data_size": 566,
+        "slot_size": 566,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "*sigh*[SP]More[SP]and[SP]more,[SP]it's[SP]getting[SP]unanimous[NL]as[SP]to[SP]how[SP]the[SP]Earth[SP]will[SP]meet[SP]its[SP]end.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]Everyone's[SP]saying[SP]now[SP]that[SP]the[SP]Earth's[SP]rotation[NL]will[SP]stop[SP]when[SP]the[SP]Grand[SP]Cross[SP]is[SP]complete...[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]And[SP]there[SP]was[SP]a[SP]line[SP]like[SP]that[SP]in[SP]the[NL]In[SP]Lak'ech,[SP]so[SP]I[SP]guess[SP]it's[SP]decided.",
+        "nom_fr": "Homme",
+        "texte_fr": "*soupir* De plus en plus, l'unanimité se\nfait sur la façon dont la Terre finira.[1106][NL]Tout le monde dit maintenant que la rotation\nde la Terre s'arrêtera avec la Croix...[1106][NL]Une phrase de l'In Lak'ech le dit,\ndonc c'est acté."
+    },
+    {
+        "id": 46,
+        "offset": 398396,
+        "data_size": 296,
+        "slot_size": 296,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Apparently,[SP]there[SP]are[SP]talking[SP]flowers[SP]in[SP]Aoba[NL]Park.[SP]It[SP]sounds[SP]romantic[SP]when[SP]you[SP]hear[SP]it...[NL]But[SP]then[SP]you[SP]wonder[SP]if[SP]they[SP]have[SP]a[SP]foul[SP]mouth.",
+        "nom_fr": "Homme",
+        "texte_fr": "Apparemment, il y a des fleurs qui parlent\nau parc Aoba. Ça a l'air romantique...\nMais imagine qu'elles soient vulgaires."
+    },
+    {
+        "id": 47,
+        "offset": 398692,
+        "data_size": 538,
+        "slot_size": 538,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Things[SP]are[SP]getting[SP]out[SP]of[SP]hand...[SP]I'm[SP]hearing[NL]now[SP]that[SP]the[SP]second[SP]floor[SP]of[SP]Zodiac[SP]has[SP]become[NL]a[SP]gigantic[SP]dungeon.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]Rumor[SP]is[SP]that[SP]there's[SP]a[SP]ton[SP]of[SP]great[SP]items[SP]in[NL]there,[SP]but[SP]exploring[SP]inside[SP]a[SP]club?[SP]You'd[SP]think[NL]people[SP]would[SP]be[SP]shocked,[SP]but[SP]I[SP]guess[SP]not.",
+        "nom_fr": "Homme",
+        "texte_fr": "Ça dégénère... J'entends dire maintenant\nque le deuxième étage de Zodiac est devenu\nun gigantesque donjon.[1106][NL]Y a plein de super objets dedans, mais\nexplorer un club ? Ça ne choque même plus."
+    },
+    {
+        "id": 48,
+        "offset": 399230,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "It[SP]never[SP]rains[SP]but[SP]it[SP]pours...[1205][U+000F][SP]That's[SP]how[SP]the[NL]saying[SP]goes,[SP]but[SP]come[SP]on.[1205][U+000F][SP]Hanako[SP]now?[SP]This[SP]has[NL]been[SP]one[SP]unlucky[SP]year[SP]for[SP]Sevens.",
+        "nom_fr": "Homme",
+        "texte_fr": "Un malheur n'arrive jamais seul...[1205][U+000F] Hanako ?\nC'est une année noire pour Seven."
+    },
+    {
+        "id": 49,
+        "offset": 399512,
+        "data_size": 544,
+        "slot_size": 544,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "It[SP]sounds[SP]like[SP]there's[SP]a[SP]ghost[SP]named[SP]Bukimi[NL]appearing[SP]in[SP]Kasugayama[SP]High.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]There's[SP]always[SP]a[SP]backlash[SP]like[SP]this[SP]when[NL]anything[SP]becomes[SP]popular.[SP]The[SP]ugliest[SP]rumors[NL]tend[SP]to[SP]crop[SP]up...[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]I[SP]doubt[SP]there's[SP]actually[SP]any[SP]such[SP]thing[SP]over[NL]there.[1205][U+000F][SP]R-Right?",
+        "nom_fr": "Homme",
+        "texte_fr": "On dirait qu'un fantôme nommé Bukimi\napparaît au lycée Kakasu.[1106][NL]Il y a toujours un revers au succès. Les\npires rumeurs surgissent...[1106][NL]Je doute qu'il y ait ça là-bas.[1205][U+000F] P-Pas vrai ?"
+    },
+    {
+        "id": 50,
+        "offset": 400056,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Rumor[SP]has[SP]it[SP]the[SP]ghost[SP]of[SP]an[SP]idol[SP]has[SP]been[NL]seen[SP]at[SP]Aoba[SP]Park...[1205][U+000F][SP]But[SP]if[SP]memory[SP]serves,[NL]that[SP]idol[SP]is[SP]still[SP]alive[SP]and[SP]well.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "On a vu le fantôme d'une idole au parc...[1205][U+000F]\nMais cette idole est bien vivante."
+    },
+    {
+        "id": 51,
+        "offset": 400324,
+        "data_size": 388,
+        "slot_size": 388,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "There's[SP]been[SP]word[SP]of[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the[NL]abandoned[SP]factory...[SP]That[SP]place[SP]has[SP]spawned[SP]so[NL]many[SP]nasty[SP]rumors,[SP]one[SP]was[SP]bound[SP]to[SP]be[SP]true...[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]But[SP]I[SP]doubt[SP]it's[SP]this[SP]one.[1205][U+000F][SP]R-Right?",
+        "nom_fr": "Homme",
+        "texte_fr": "On parle d'un Taxi Maudit à l'usine...\nUne des rumeurs devait être vraie...[1106][NL]Mais j'en doute.[1205][U+000F] Pas vrai ?"
+    },
+    {
+        "id": 52,
+        "offset": 400712,
+        "data_size": 288,
+        "slot_size": 288,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "*sigh*[SP]First[SP]it[SP]was[SP]a[SP]Cursed[SP]Taxi,[SP]now[SP]it's[NL]a[SP]Cursed[SP]Escort...[SP]Rumors[SP]get[SP]bigger[SP]in[SP]the[NL]telling,[SP]but[SP]I[SP]wonder[SP]if[SP]this[SP]one's[SP]genuine.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "*soupir* D'abord un Taxi Maudit, maintenant\nune Escorte Maudite... Les rumeurs gonflent,\nmais je me demande si celle-ci est vraie."
+    },
+    {
+        "id": 53,
+        "offset": 401000,
+        "data_size": 294,
+        "slot_size": 294,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "It[SP]sounds[SP]like[SP]the[SP]real[SP]Kuchisake-onna[SP]is[SP]at[NL]Mt.[SP]Iwato.[SP]I'm[SP]surprised[SP]such[SP]an[SP]old[SP]story[SP]is[NL]getting[SP]brought[SP]up[SP]again.[SP]It[SP]brings[SP]me[SP]back.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Il paraît que la vraie Kuchisake-onna est au\nMt Iwato. Je suis surpris qu'une si vieille\nhistoire refasse surface. Ça me rajeunit."
+    },
+    {
+        "id": 54,
+        "offset": 401294,
+        "data_size": 296,
+        "slot_size": 296,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Now[SP]they're[SP]saying[SP]Jumping[SP]Geezer[SP]is[SP]a[SP]real[NL]thing[SP]that[SP]chases[SP]cars[SP]down[SP]mountain[SP]passes.[NL]Is[SP]there[SP]anything[SP]like[SP]that[SP]at[SP]Mt.[SP]Katatsumuri?[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Maintenant on dit que le Vieux Sauteur est une\nvraie chose qui poursuit les voitures en\nmontagne. Y a-t-il ça au Mt Katatsumuri ?"
+    },
+    {
+        "id": 55,
+        "offset": 401590,
+        "data_size": 248,
+        "slot_size": 248,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "M-Most[SP]things[SP]don't[SP]bother[SP]me...[SP]But[SP]this...[NL]Have[SP]you[SP]heard?[SP]That...[SP]Kudan...[SP]Ugh,[SP]I[SP]wish[NL]I'd[SP]never[SP]heard[SP]of[SP]it.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "La plupart des choses m'indiffèrent...\nMais ce... Kudan... Ugh, je\npréférerais l'ignorer."
+    },
+    {
+        "id": 56,
+        "offset": 401838,
+        "data_size": 306,
+        "slot_size": 306,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Apparently[SP]there's[SP]a[SP]special,[SP]secret[SP]CD[SP]at[NL]Giga[SP]Macho.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]What[SP]kind[SP]of[SP]music's[SP]on[SP]it?[SP]Well,[SP]you'll[SP]have[NL]to[SP]find[SP]that[SP]out[SP]for[SP]yourself.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Apparemment, y a un CD secret chez Giga Macho.[1106][NL]Quelle musique dessus ? Tu devras\nle découvrir toi-même."
+    },
+    {
+        "id": 57,
+        "offset": 402144,
+        "data_size": 302,
+        "slot_size": 302,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "There's[SP]some[SP]creature[SP]called[SP]a[SP]Dresser[SP]Hag[SP]at[NL]the[SP]abandoned[SP]factory.[SP]It[SP]yells,[SP][U+1432][U+0000][U+0000][U+0014]Get[SP]in[SP]here![U+1432][U+0000][U+0000][U+0014][NL]at[SP]anyone[SP]who[SP]passes[SP]by.[SP]Scary,[SP]huh...?[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Il y a une créature appelée Mégère à\nCommode à l'usine. Elle crie [1432][NULL][NULL][0014]Viens ici ![1432][NULL][NULL][0014]\naux passants. Effrayant, non... ?"
+    },
+    {
+        "id": 58,
+        "offset": 402446,
+        "data_size": 378,
+        "slot_size": 378,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Time[SP]Castle[SP]in[SP]Rengedai[SP]apparently[SP]handles[NL]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]As[SP]I[SP]recall,[SP]word[SP]is[SP]their[SP]quality[SP]and[SP]prices[NL]are[SP]average.[1205][U+000F][SP]Me,[SP]I[SP]think[SP]it's[SP]an[SP]ingenious[NL]way[SP]to[SP]do[SP]business.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Time Castle vendrait de vraies armes.[1106][NL]Qualité et prix moyens.[1205][U+000F] Perso, je trouve\nque c'est malin de faire ça."
+    },
+    {
+        "id": 59,
+        "offset": 402824,
+        "data_size": 402,
+        "slot_size": 402,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Time[SP]Castle[SP]in[SP]Rengedai[SP]apparently[SP]handles[NL]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]As[SP]I[SP]recall,[SP]word[SP]is[SP]their[SP]quality[SP]is[SP]good,[NL]but[SP]their[SP]prices[SP]are[SP]high.[1205][U+000F][SP]Me,[SP]I[SP]think[SP]it's[SP]an[NL]ingenious[SP]way[SP]to[SP]do[SP]business.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Time Castle vendrait de vraies armes.[1106][NL]Qualité bonne, mais cher.[1205][U+000F] Perso, je trouve\nque c'est malin de faire ça."
+    },
+    {
+        "id": 60,
+        "offset": 403226,
+        "data_size": 378,
+        "slot_size": 378,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Time[SP]Castle[SP]in[SP]Rengedai[SP]apparently[SP]handles[NL]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]As[SP]I[SP]recall,[SP]word[SP]is[SP]they're[SP]cheap,[SP]but[SP]not[NL]great[SP]quality.[1205][U+000F][SP]Me,[SP]I[SP]think[SP]it's[SP]an[SP]ingenious[NL]way[SP]to[SP]do[SP]business.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Time Castle vendrait de vraies armes.[1106][NL]Pas cher mais mauvaise qualité.[1205][U+000F] Perso, c'est\ntrès malin."
+    },
+    {
+        "id": 61,
+        "offset": 403604,
+        "data_size": 300,
+        "slot_size": 300,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "So[SP]Tony's[SP]Shop[SP]was[SP]selling[SP]weapons[SP]after[SP]all...[1205][U+000F][NL]I'd[SP]heard[SP]rumors.[SP]Something[SP]about[SP]his[SP]selection[NL]being[SP]good,[SP]but[SP]having[SP]low[SP]resale[SP]value.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Donc la boutique de Tony vendait des armes\nfinalement...[1205][U+000F] J'avais entendu des rumeurs.\nBon choix, mais faible valeur de revente."
+    },
+    {
+        "id": 62,
+        "offset": 403904,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "So[SP]Tony's[SP]Shop[SP]was[SP]selling[SP]weapons[SP]after[SP]all...[1205][U+000F][NL]I'd[SP]heard[SP]rumors.[SP]Something[SP]about[SP]his[SP]stuff[NL]being[SP]cheap,[SP]but[SP]low[SP]quality.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "La boutique de Tony vendait des armes...[1205][U+000F]\nBon marché, mais mauvaise qualité."
+    },
+    {
+        "id": 63,
+        "offset": 404174,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "So[SP]Tony's[SP]Shop[SP]was[SP]selling[SP]weapons[SP]after[SP]all...[1205][U+000F][NL]I'd[SP]heard[SP]rumors.[SP]Something[SP]about[SP]his[SP]prices[NL]and[SP]quality[SP]being[SP]average.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "La boutique de Tony vendait des armes...[1205][U+000F]\nRapport qualité-prix dans la moyenne."
+    },
+    {
+        "id": 64,
+        "offset": 404440,
+        "data_size": 292,
+        "slot_size": 292,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "So[SP]Tony's[SP]Shop[SP]was[SP]selling[SP]weapons[SP]after[SP]all...[1205][U+000F][NL]I'd[SP]heard[SP]rumors.[SP]Something[SP]about[SP]the[SP]quality[NL]being[SP]good,[SP]but[SP]his[SP]prices[SP]being[SP]high.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Donc la boutique de Tony vendait des armes\nfinalement...[1205][U+000F] J'avais entendu des rumeurs.\nDe la bonne qualité, mais à des prix élevés."
+    },
+    {
+        "id": 65,
+        "offset": 404732,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F][NL]Are[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]selection[NL]is[SP]bad,[SP]but[SP]the[SP]buyback[SP]prices[SP]are[SP]great.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nIls ont des difficultés financières aussi ?[1205][U+000F] Choix\nlimité, mais d'excellents prix de rachat."
+    },
+    {
+        "id": 66,
+        "offset": 405030,
+        "data_size": 292,
+        "slot_size": 292,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F][NL]Are[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]prices[NL]are[SP]just[SP]right,[SP]but[SP]the[SP]quality[SP]is[SP]so-so.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nLes prix sont corrects, mais la qualité est moyenne."
+    },
+    {
+        "id": 67,
+        "offset": 405322,
+        "data_size": 294,
+        "slot_size": 294,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F][NL]Are[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]quality[NL]is[SP]great,[SP]but[SP]the[SP]prices[SP]are[SP]pretty[SP]high.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nLa qualité est top, mais les prix sont élevés."
+    },
+    {
+        "id": 68,
+        "offset": 405616,
+        "data_size": 306,
+        "slot_size": 306,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F][NL]Are[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]selection[NL]is[SP]great,[SP]but[SP]the[SP]buyback[SP]prices[SP]aren't[SP]much.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nIls ont des difficultés financières aussi ?[1205][U+000F] Choix\nexcellent, mais prix de rachat dérisoires."
+    },
+    {
+        "id": 69,
+        "offset": 405922,
+        "data_size": 274,
+        "slot_size": 274,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][U+000F][NL]Are[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][U+000F][SP]Their[SP]quality[NL]and[SP]prices[SP]are[SP]average,[SP]I[SP]hear.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Clair de Lune vend des armes...[1205][U+000F]\nLa qualité et les prix sont moyens, paraît-il."
+    },
+    {
+        "id": 70,
+        "offset": 406196,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.[NL]They[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]their[SP]prices[NL]and[SP]quality[SP]are[SP]average.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Jolly Roger vend des armes.\nIls s'y mettent tard. Prix et qualité moyens."
+    },
+    {
+        "id": 71,
+        "offset": 406462,
+        "data_size": 280,
+        "slot_size": 280,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.[NL]They[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]their[SP]prices[NL]are[SP]low,[SP]but[SP]so[SP]is[SP]the[SP]quality.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Jolly Roger vend des armes.\nIls s'y mettent tard. Prix bas, faible qualité."
+    },
+    {
+        "id": 72,
+        "offset": 406742,
+        "data_size": 304,
+        "slot_size": 304,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.[NL]They[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]the[SP]buyback[NL]prices[SP]are[SP]low,[SP]but[SP]their[SP]selection's[SP]great.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Jolly Roger vend des armes.\nLe rachat est bas, mais super sélection."
+    },
+    {
+        "id": 73,
+        "offset": 407046,
+        "data_size": 302,
+        "slot_size": 302,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.[NL]They[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]the[SP]buyback[NL]prices[SP]are[SP]good,[SP]but[SP]their[SP]selection's[SP]bad.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Jolly Roger vend des armes.\nLe rachat est bon, mais mauvaise sélection."
+    },
+    {
+        "id": 74,
+        "offset": 407348,
+        "data_size": 300,
+        "slot_size": 300,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Ah,[SP]so[SP]even[SP]Jolly[SP]Roger[SP]is[SP]selling[SP]weapons[SP]now.[NL]They[SP]got[SP]a[SP]late[SP]start,[SP]eh?[SP]Rumor[SP]is[SP]their[SP]prices[NL]are[SP]high,[SP]but[SP]you[SP]get[SP]good-quality[SP]stuff.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Jolly Roger vend des armes.\nLes prix sont élevés, mais la qualité est là."
+    },
+    {
+        "id": 75,
+        "offset": 407648,
+        "data_size": 256,
+        "slot_size": 256,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Huh,[SP]so[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]is[SP]getting[SP]in[NL]on[SP]the[SP]armor[SP]market.[1205][U+000F][SP]It[SP]seems[SP]their[SP]quality[NL]and[SP]prices[SP]are[SP]average.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Rosa Candida se lance dans les\narmures.[1205][U+000F] Qualité et prix moyens."
+    },
+    {
+        "id": 76,
+        "offset": 407904,
+        "data_size": 272,
+        "slot_size": 272,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Huh,[SP]so[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]is[SP]getting[SP]in[NL]on[SP]the[SP]armor[SP]market.[1205][U+000F][SP]It[SP]seems[SP]the[SP]quality[NL]is[SP]low,[SP]but[SP]it's[SP]cheap,[SP]at[SP]least.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Rosa Candida se lance dans les\narmures.[1205][U+000F] Qualité faible, mais c'est pas cher."
+    },
+    {
+        "id": 77,
+        "offset": 408176,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Huh,[SP]so[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]is[SP]getting[SP]in[NL]on[SP]the[SP]armor[SP]market.[1205][U+000F][SP]It[SP]seems[SP]the[SP]quality[NL]is[SP]great,[SP]but[SP]you[SP]pay[SP]through[SP]the[SP]nose.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Rosa Candida se lance dans les\narmures.[1205][U+000F] Qualité top, mais ça coûte un bras."
+    },
+    {
+        "id": 78,
+        "offset": 408460,
+        "data_size": 250,
+        "slot_size": 250,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][U+000F][SP]I'm[NL]surprised,[SP]I[SP]admit.[SP]They[SP]say[SP]their[SP]quality[SP]and[NL]prices[SP]are[SP]average.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Donc Anima Mundi vend des armures...[1205][U+000F]\nJe suis surpris. Qualité et prix moyens."
+    },
+    {
+        "id": 79,
+        "offset": 408710,
+        "data_size": 256,
+        "slot_size": 256,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][U+000F][SP]I'm[NL]surprised,[SP]I[SP]admit.[SP]They[SP]say[SP]their[SP]stuff[SP]is[NL]cheap,[SP]but[SP]not[SP]very[SP]good.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Donc Anima Mundi vend des armures...[1205][U+000F]\nSurpris. C'est pas cher, mais mauvais."
+    },
+    {
+        "id": 80,
+        "offset": 408966,
+        "data_size": 302,
+        "slot_size": 302,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][U+000F][SP]I'm[NL]surprised,[SP]I[SP]admit.[SP]They[SP]say[SP]their[SP]selection[SP]is[NL]fantastic,[SP]but[SP]their[SP]buyback[SP]prices[SP]are[SP]low.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Anima Mundi vend des armures...[1205][U+000F]\nChoix fantastique, mais prix de rachat bas."
+    },
+    {
+        "id": 81,
+        "offset": 409268,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][U+000F][SP]I'm[NL]surprised,[SP]I[SP]admit.[SP]They[SP]say[SP]the[SP]quality[SP]is[NL]great,[SP]but[SP]it's[SP]expensive[SP]stuff.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Anima Mundi vend des armures...[1205][U+000F]\nQualité super, mais matos hors de prix."
+    },
+    {
+        "id": 82,
+        "offset": 409538,
+        "data_size": 264,
+        "slot_size": 264,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles[NL]armor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]selection[SP]is[SP]bad,[NL]but[SP]they[SP]have[SP]high[SP]buyback[SP]prices.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Mauvais choix, mais bon rachat."
+    },
+    {
+        "id": 83,
+        "offset": 409802,
+        "data_size": 222,
+        "slot_size": 222,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles[NL]armor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]quality[SP]and[NL]prices[SP]are[SP]average.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Qualité et prix dans la moyenne."
+    },
+    {
+        "id": 84,
+        "offset": 410024,
+        "data_size": 262,
+        "slot_size": 262,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles[NL]armor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]quality[SP]is[SP]great,[NL]but[SP]their[SP]prices[SP]are[SP]pretty[SP]high.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Qualité géniale, mais très cher."
+    },
+    {
+        "id": 85,
+        "offset": 410286,
+        "data_size": 242,
+        "slot_size": 242,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles[NL]armor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]stuff[SP]is[SP]cheap,[NL]but[SP]not[SP]the[SP]best[SP]quality.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Pas cher, mais de mauvaise qualité."
+    },
+    {
+        "id": 86,
+        "offset": 410528,
+        "data_size": 278,
+        "slot_size": 278,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles[NL]armor?[1205][U+000F][SP]I've[SP]heard[SP]their[SP]selection[SP]is[SP]pretty[NL]good,[SP]but[SP]they[SP]have[SP]low[SP]buyback[SP]prices.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][U+000F] Bon choix, mais rachat bas."
+    },
+    {
+        "id": 87,
+        "offset": 410806,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner[NL]is[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]the[SP]selection[NL]is[SP]good,[SP]but[SP]their[SP]buyback[SP]prices[SP]are[SP]low.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Bon choix, rachat bas."
+    },
+    {
+        "id": 88,
+        "offset": 411104,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner[NL]is[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]it's[SP]cheap,[NL]but[SP]not[SP]the[SP]greatest[SP]quality.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Pas cher, qualité moyenne."
+    },
+    {
+        "id": 89,
+        "offset": 411372,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner[NL]is[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]it's[SP]high-[NL]quality[SP]stuff,[SP]but[SP]expensive.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Haute qualité, très cher."
+    },
+    {
+        "id": 90,
+        "offset": 411638,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner[NL]is[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]the[SP]quality[NL]and[SP]prices[SP]there[SP]are[SP]pretty[SP]average.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Qualité et prix moyens."
+    },
+    {
+        "id": 91,
+        "offset": 411920,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Armor[SP]at[SP]London[SP]Clothier,[SP]eh?[SP]Guess[SP]the[SP]owner[NL]is[SP]a[SP]savvy[SP]businessman.[SP]I've[SP]heard[SP]the[SP]selection[NL]is[SP]bad,[SP]but[SP]their[SP]buyback[SP]prices[SP]are[SP]high.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Mauvais choix, bon rachat."
+    },
+    {
+        "id": 92,
+        "offset": 412218,
+        "data_size": 372,
+        "slot_size": 372,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Why[SP]don't[SP]you[SP]enter[SP]the[SP]magazine[SP]sweepstakes[NL]sometime?[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]Winners[SP]get[SP]real[SP]weapons[SP]and[SP]items.[SP]As[SP]I[NL]recall,[SP]it's[SP]hard[SP]to[SP]win,[SP]but[SP]you[SP]can[SP]get[NL]some[SP]nice[SP]stuff[SP]if[SP]you[SP]do.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Fais les concours\ndes magazines un jour.[1106][NL]On y gagne des armes et objets.\nC'est dur de gagner, mais les prix sont beaux."
+    },
+    {
+        "id": 93,
+        "offset": 412590,
+        "data_size": 368,
+        "slot_size": 368,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Why[SP]don't[SP]you[SP]enter[SP]the[SP]magazine[SP]sweepstakes[NL]sometime?[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]Winners[SP]get[SP]real[SP]weapons[SP]and[SP]items.[SP]As[SP]I[NL]recall,[SP]you[SP]rarely[SP]win,[SP]but[SP]you[SP]can[SP]get[NL]some[SP]rare[SP]stuff[SP]if[SP]you[SP]do.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Fais les concours\ndes magazines un jour.[1106][NL]On y gagne des armes et objets.\nC'est rare de gagner, mais c'est du rare."
+    },
+    {
+        "id": 94,
+        "offset": 412958,
+        "data_size": 360,
+        "slot_size": 360,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Why[SP]don't[SP]you[SP]enter[SP]the[SP]magazine[SP]sweepstakes[NL]sometime?[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]Winners[SP]get[SP]real[SP]weapons[SP]and[SP]items.[SP]As[SP]I[NL]recall,[SP]it's[SP]not[SP]hard[SP]to[SP]win,[SP]but[SP]you[SP]won't[NL]get[SP]anything[SP]good.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Fais les concours\ndes magazines un jour.[1106][NL]On y gagne des armes et objets.\nC'est facile de gagner, mais c'est pas ouf."
+    },
+    {
+        "id": 95,
+        "offset": 413318,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Sounds[SP]like[SP]Mu[SP]opened[SP]a[SP]casino.[SP]Well,[SP]no[SP]one[NL]ever[SP]went[SP]broke[SP]running[SP]a[SP]gambling[SP]parlor...[NL]I[SP]hear[SP]it's[SP]easy[SP]to[SP]win[SP]at[SP]poker.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Mu a ouvert un casino. Personne n'a\njamais fait faillite avec ça...\nOn gagne facilement au poker."
+    },
+    {
+        "id": 96,
+        "offset": 413588,
+        "data_size": 278,
+        "slot_size": 278,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Sounds[SP]like[SP]Mu[SP]opened[SP]a[SP]casino.[SP]Well,[SP]no[SP]one[NL]ever[SP]went[SP]broke[SP]running[SP]a[SP]gambling[SP]parlor...[NL]I[SP]hear[SP]it's[SP]easy[SP]to[SP]win[SP]at[SP]the[SP]slots.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Mu a ouvert un casino. Personne n'a\njamais fait faillite avec ça...\nOn gagne facilement aux machines."
+    },
+    {
+        "id": 97,
+        "offset": 413866,
+        "data_size": 278,
+        "slot_size": 278,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Sounds[SP]like[SP]Mu[SP]opened[SP]a[SP]casino.[SP]Well,[SP]no[SP]one[NL]ever[SP]went[SP]broke[SP]running[SP]a[SP]gambling[SP]parlor...[NL]I[SP]hear[SP]it's[SP]easy[SP]to[SP]win[SP]at[SP]blackjack.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Mu a ouvert un casino. Personne n'a\njamais fait faillite avec ça...\nOn gagne facilement au blackjack."
+    },
+    {
+        "id": 98,
+        "offset": 414144,
+        "data_size": 286,
+        "slot_size": 286,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "I[SP]wonder[SP]if[SP]there's[SP]really[SP]any[SP]such[SP]thing[SP]as[NL]a[SP]legendary[SP]weapon.[SP]It's[SP]just[SP]that[SP]I[SP]heard[SP]a[NL]rumor[SP]they[SP]have[SP]one[SP]at[SP]Shiraishi[SP]Ramen...[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Une arme légendaire, ça existe vraiment ?\nUne rumeur dit que Shiraishi Ramen en aurait une..."
+    },
+    {
+        "id": 99,
+        "offset": 414430,
+        "data_size": 258,
+        "slot_size": 258,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Do[SP]you[SP]believe[SP]in[SP]legendary[SP]weapons?[SP]Wanna[SP]go[NL]see[SP]one[SP]for[SP]yourself?[SP]Go[SP]check[SP]out[SP]Clair[SP]de[NL]Lune,[SP]I[SP]hear[SP]they[SP]have[SP]one.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Tu crois aux armes légendaires ? Tu veux\nen voir une ? Clair de Lune en a une, paraît-il."
+    },
+    {
+        "id": 100,
+        "offset": 414688,
+        "data_size": 292,
+        "slot_size": 292,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Rumor[SP]has[SP]it[SP]the[SP]owner[SP]of[SP]Time[SP]Castle[SP]won't[NL]admit[SP]he[SP]has[SP]a[SP]legendary[SP]weapon.[SP]They[SP]say[SP]he's[NL]trying[SP]to[SP]drive[SP]up[SP]the[SP]price...[SP]Shrewd[SP]man.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Le proprio de Time Castle n'admet pas avoir\nune arme légendaire. Il veut faire monter le prix."
+    },
+    {
+        "id": 101,
+        "offset": 414980,
+        "data_size": 294,
+        "slot_size": 294,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Time[SP]Castle[SP]doesn't[SP]have[SP]its[SP]legendary[SP]weapon[NL]yet,[SP]I[SP]hear.[SP]The[SP]seller[SP]is[SP]still[SP]waiting[SP]at[NL]the[SP]abandoned[SP]factory[SP]for[SP]it[SP]to[SP]be[SP]picked[SP]up.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Time Castle n'a pas encore son arme légendaire.\nLe vendeur l'attend à l'usine abandonnée."
+    },
+    {
+        "id": 102,
+        "offset": 415274,
+        "data_size": 246,
+        "slot_size": 246,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Wanna[SP]hear[SP]a[SP]bizarre[SP]rumor?[SP]Demons[SP]stole[SP]the[NL]legendary[SP]weapon[SP]at[SP]Time[SP]Castle.[SP]Pretty[SP]hard[NL]to[SP]swallow,[SP]isn't[SP]it?[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Rumeur bizarre : des démons ont volé l'arme\nlégendaire de Time Castle. Dur à avaler, non ?"
+    },
+    {
+        "id": 103,
+        "offset": 415520,
+        "data_size": 184,
+        "slot_size": 184,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "I[SP]hear[SP]Time[SP]Castle[SP]sold[SP]its[SP]legendary[SP]weapon.[NL]Some[SP]unlucky[SP]woman[SP]bought[SP]it[SP]up...[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Time Castle a vendu son arme légendaire.\nUne femme malchanceuse l'a achetée..."
+    },
+    {
+        "id": 104,
+        "offset": 415704,
+        "data_size": 390,
+        "slot_size": 390,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Apparently,[SP]the[SP]owner[SP]of[SP]Time[SP]Castle[SP]gave[NL]that[SP]legendary[SP]weapon[SP]away[SP]to[SP]a[SP]lady[SP]with[NL]short[SP]hair.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]Giving[SP]a[SP]weapon[SP]to[SP]a[SP]lady[SP]as[SP]a[SP]present...[1205][U+000F][NL]These[SP]are[SP]crazy[SP]times[SP]we[SP]live[SP]in.[NL]",
+        "nom_fr": "Homme",
+        "texte_fr": "Le proprio de Time Castle a donné l'arme\nlégendaire à une dame aux cheveux courts.[1106][NL]Offrir une arme à une dame...[1205][U+000F]\nQuelle époque folle."
+    },
+    {
+        "id": 105,
+        "offset": 416094,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "If[SP]I'm[SP]gonna[SP]date[SP]someone[SP]new,[SP]I'd[SP]rather[SP]go[NL]with[SP]a[SP]Cuss[SP]High[SP]guy.[1205][U+000F][SP]Everyone[SP]at[SP]Sevens[SP]is[NL]under[SP]the[SP]principal's[SP]thumb.[SP]Snooooore!",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Quitte à sortir avec un gars, je préfère Kakasu.[1205][U+000F]\nÀ Seven, ils sont tous sous la coupe de Hanya. Nul !"
+    },
+    {
+        "id": 106,
+        "offset": 416392,
+        "data_size": 326,
+        "slot_size": 326,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "I[SP]hear[SP]there[SP]are[SP]some[SP]uber-cute[SP]Cuss[SP]High[NL]guys[SP]in[SP]the[SP]secret[SP]lounge.[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Oohhhh...[SP]I[SP]wish[SP]I[SP]could[SP]go.[SP]But[SP]I[SP]don't[SP]have[NL]a[SP]mask...",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Des beaux gosses de Kakasu\nsont au salon secret, on dit.[1205][U+000F][1106][NL]J'aimerais y aller.\nMais je n'ai pas de masque."
+    },
+    {
+        "id": 107,
+        "offset": 416718,
+        "data_size": 462,
+        "slot_size": 462,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Yeee![SP]I[SP]did[SP]it,[SP]I[SP]did[SP]it![1205][U+000F][SP]I[SP]got[SP]tickets[SP]to[NL]the[SP]masquerade![1205][U+000F][SP]It's[SP]the[SP]perfect[SP]chance[SP]to[NL]get[SP]a[SP]Cuss[SP]High[SP]boyfriend![NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]gotta[SP]make[SP]sure[SP]to[SP]dress[SP]up.[1205][U+000F][SP]Oh[SP]yeah,[SP]and[NL]I[SP]should[SP]invite[SP]my[SP]friends[SP]too!",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Yeee ! J'ai eu des billets pour le bal masqué ![1205][U+000F]\nParfait pour trouver un petit ami de Kakasu ![1106][NL]Faut que je sois bien habillée.[1205][U+000F]\nEt je devrais inviter mes copines !"
+    },
+    {
+        "id": 108,
+        "offset": 417180,
+        "data_size": 348,
+        "slot_size": 348,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "*sigh*[SP]Muses[SP]is[SP]made[SP]up[SP]of[SP]Sevens[SP]students,[NL]right?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]So[SP]they're[SP]all[SP]around[SP]my[SP]age.[1205][U+000F][SP]They're[SP]so[SP]lucky,[NL]getting[SP]to[SP]make[SP]their[SP]idol[SP]debuts...",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "*soupir* Muses n'a que des filles\nde Seven, non ?[1106][NL]Elles ont mon âge.[1205][U+000F] Trop de chance de\ndébuter comme idoles..."
+    },
+    {
+        "id": 109,
+        "offset": 417528,
+        "data_size": 244,
+        "slot_size": 244,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Looks[SP]like[SP]Giga[SP]Macho's[SP]already[SP]packed[SP]with[NL]Muses[SP]fans.[1205][U+000F][SP]*sigh*[SP]I[SP]bet[SP]I[SP]couldn't[SP]get[SP]in[NL]now[SP]if[SP]I[SP]went.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Giga Macho est plein de fans de Muses.[1205][U+000F]\n*soupir* Je pourrais même pas y entrer."
+    },
+    {
+        "id": 110,
+        "offset": 417772,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "I[SP]wonder[SP]what[SP]nationality[SP]that[SP]third[SP]member[SP]is.[NL]She[SP]looked[SP]white,[SP]but[SP]her[SP]Japanese[SP]was[SP]really[NL]good.[SP]Maybe[SP]she[SP]grew[SP]up[SP]here.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "De quelle nationalité est la 3e membre ?\nElle a l'air blanche, mais parle bien\njaponais. Elle a grandi ici ?"
+    },
+    {
+        "id": 111,
+        "offset": 418056,
+        "data_size": 566,
+        "slot_size": 566,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]there[SP]was[SP]a[SP]Muses[SP]show[SP]at[SP]the[SP]outdoor[NL]concert[SP]hall,[SP]right?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]And[SP]Muses[SP]was[SP]a[SP]trio,[SP]right?[1205][U+000F][SP]Huh...[NL]That's[SP]weird...[1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]know[SP]there[SP]were[SP]two[SP]others,[SP]but[SP]I[SP]only[NL]remember[SP]that[SP]Lisa[SP]girl...[1205][U+000F][SP]W-Well,[SP]I[SP]guess[NL]it[SP]doesn't[SP]really[SP]matter.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Il y a eu un concert de Muses à la\nsalle en plein air, non ?[1106][NL]Et Muses était un trio, non ?[1205][U+000F]\nHuh... Étrange...[1106][NL]Il y en avait deux autres, mais je ne me\nsouviens que de Lisa...[1205][U+000F] Bref, c'est pas grave."
+    },
+    {
+        "id": 112,
+        "offset": 418622,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Everyone's[SP]panicking[SP]about[SP]terrorists[SP]and[SP]that[NL]stuff,[SP]but[SP]why[SP]worry[SP]so[SP]much?[1205][U+000F][SP]I[SP]bet[SP]it'll[SP]all[NL]take[SP]care[SP]of[SP]itself.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Tout le monde panique à cause des terroristes.\nMais pourquoi ?[1205][U+000F] Ça va s'arranger tout seul."
+    },
+    {
+        "id": 113,
+        "offset": 418890,
+        "data_size": 406,
+        "slot_size": 406,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "I-I[SP]can't[SP]believe[SP]they[SP]were[SP]going[SP]after[NL]GOLD...[1205][U+000F][SP]There[SP]has[SP]to[SP]be[SP]some[SP]mistake.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]bet[SP]it's[SP]just[SP]some[SP]TV[SP]show's[SP]hoax,[SP]or[SP]some[NL]attention-starved[SP]jerk[SP]playing[SP]a[SP]prank...",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "J-Je n'y crois pas pour GOLD...[1205][U+000F]\nIl doit y avoir une erreur.[1106][NL]C'est sûrement le canular d'une émission,\nou un abruti qui fait une blague..."
+    },
+    {
+        "id": 114,
+        "offset": 419296,
+        "data_size": 564,
+        "slot_size": 564,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "I[SP]can't[SP]believe[SP]they[SP]blew[SP]up[SP]GOLD...[1205][U+000F][SP]This[NL]can't[SP]be[SP]real.[SP]I[SP]mean,[SP]nothing[SP]bad[SP]ever[NL]happened[SP]here[SP]before[SP]now.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]What's[SP]going[SP]to[SP]happen[SP]to[SP]us?[SP]We'll[SP]be[SP]okay,[NL]won't[SP]we?[1205][U+000A][SP]They're[SP]gonna[SP]catch[SP]the[SP]terrorists[NL]and[SP]make[SP]everything[SP]all[SP]right[SP]again,[SP]right?",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Ils ont fait exploser GOLD...[1205][U+000F]\nC'est faux. Rien de mal n'arrive jamais ici.[1106][NL]Qu'est-ce qui va nous arriver ? On va s'en sortir,\nnon ?[1205][U+000A] Ils vont attraper les terroristes\net tout va redevenir comme avant, hein ?"
+    },
+    {
+        "id": 115,
+        "offset": 419860,
+        "data_size": 516,
+        "slot_size": 516,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Y-You're[SP]right...[SP]I[SP]can't[SP]shut[SP]out[SP]reality[NL]like[SP]this.[1205][U+000F][SP]It's[SP]just,[SP]I[SP]never[SP]imagined[SP]such[NL]horrible[SP]things[SP]could[SP]happen[SP]this[SP]close.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]But[SP]I[SP]hear[SP]they[SP]have[SP]a[SP]suspect[SP]already,[SP]so[SP]this[NL]terrorist[SP]stuff[SP]will[SP]be[SP]over[SP]soon.[1205][U+000F][SP]Right?",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "T-Tu as raison... Faut pas fuir la réalité.[1205][U+000F]\nJe n'aurais jamais imaginé ça si près.[1106][NL]Mais ils ont déjà un suspect, alors ce sera\nbientôt fini.[1205][U+000F] N'est-ce pas ?"
+    },
+    {
+        "id": 116,
+        "offset": 420376,
+        "data_size": 386,
+        "slot_size": 386,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Huh?[SP]The[SP]In[SP]Lak'ech?[1205][U+000F][SP]Yeah...[SP]I[SP]saw[SP]that[SP]on[SP]the[NL]news[SP]and[SP]rushed[SP]to[SP]the[SP]bookstore,[SP]but[SP]they[NL]were[SP]all[SP]sold[SP]out.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]They[SP]said[SP]they[SP]ran[SP]out[SP]pretty[SP]much[SP]instantly.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Hein ? L'In Lak'ech ?[1205][U+000F] J'ai vu aux infos\net j'ai couru à la librairie, mais rupture de stock.[1106][NL]Ils ont été dévalisés quasi instantanément."
+    },
+    {
+        "id": 117,
+        "offset": 420762,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Th-Those[SP]soldiers[SP]were[SP]headed[SP]to[NL]Mt.[SP]Katatsumuri...[1205][U+000F][SP]They'll[SP]probably[SP]leave[NL]us[SP]alone[SP]if[SP]we[SP]don't[SP]get[SP]in[SP]their[SP]way.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "C-Ces soldats allaient au Mt Katatsumuri...[1205][U+000F]\nIls nous laisseront si on ne les gêne pas."
+    },
+    {
+        "id": 118,
+        "offset": 421030,
+        "data_size": 698,
+        "slot_size": 698,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "The[SP]end[SP]of[SP]the[SP]world's[SP]pretty[SP]harsh,[SP]but[SP]doesn't[NL]it[SP]feel[SP]nice,[SP]in[SP]a[SP]way?[1205][U+000F][SP]It's[SP]not[SP]like[SP]anything[NL]good[SP]happened[SP]down[SP]there[SP]anyway.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]If[SP]we[SP]evolve[SP]and[SP]the[SP]crappy[SP]old[SP]world[SP]is[SP]gone[NL]for[SP]good,[SP]I[SP]could[SP]make[SP]a[SP]fresh[SP]start...[SP]Yeah,[NL]I[SP]bet[SP]that's[SP]exactly[SP]it.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]*sigh*[1205][U+0008][SP]I[SP]wonder[SP]what'll[SP]happen[SP]down[SP]there...",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "La fin du monde c'est dur, mais ça fait du bien,\nnon ?[1205][U+000F] Rien de bon ne se passe ici, de toute façon.[1106][NL]Si ce monde merdique disparaît, on fera un\nnouveau départ... Ouais, c'est sûrement ça.[1106][NL]*soupir*[1205][U+0008] Que va-t-il se passer ici..."
+    },
+    {
+        "id": 119,
+        "offset": 421728,
+        "data_size": 532,
+        "slot_size": 532,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "I[SP]heard[SP]a[SP]rumor[SP]that[SP]when[SP]the[SP]Grand[SP]Cross[SP]is[NL]finished,[SP]the[SP]other[SP]planets[SP]are[SP]gonna[SP]block[SP]out[NL]the[SP]sun[SP]and[SP]freeze[SP]the[SP]whole[SP]world.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Will[SP]that[SP]really[SP]kill[SP]everyone[SP]down[SP]there?[1205][U+000A][NL]Maybe[SP]they'll[SP]all[SP]just[SP]be[SP]kept[SP]alive,[SP]but[NL]frozen[SP]solid.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "À la Croix Cosmique, les autres planètes vont\nocculter le soleil et geler le monde entier.[1106][NL]Ça tuera tout le monde en bas ?[1205][U+000A] Peut-être\nqu'ils seront maintenus en vie, mais gelés."
+    },
+    {
+        "id": 120,
+        "offset": 422260,
+        "data_size": 572,
+        "slot_size": 572,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "I[SP]heard[SP]from[SP]someone[SP]else[SP]that[SP]once[SP]the[SP]Grand[NL]Cross[SP]happens,[SP]gas[SP]from[SP]the[SP]other[SP]planets[SP]is[NL]gonna[SP]cover[SP]the[SP]Earth.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Some[SP]planets[SP]are[SP]mostly[SP]made[SP]of[SP]gases,[SP]right?[1205][U+000A][NL]Those[SP]gases[SP]are[SP]supposedly[SP]poison[SP]to[SP]humans,[NL]and[SP]that's[SP]how[SP]everyone[SP]down[SP]there'll[SP]die.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "J'ai entendu dire que quand la Croix\naura lieu, les gaz des autres planètes\nvont recouvrir la Terre.[1106][NL]Certaines planètes sont faites de gaz, non ?[1205][U+000A]\nIls sont toxiques, et tout le monde en bas mourra."
+    },
+    {
+        "id": 121,
+        "offset": 422832,
+        "data_size": 596,
+        "slot_size": 596,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "I[SP]heard[SP]some[SP]people[SP]around[SP]say[SP]that[SP]when[SP]the[NL]Grand[SP]Cross[SP]is[SP]complete,[SP]the[SP]balance[SP]of[SP]gravity[NL]will[SP]be[SP]thrown[SP]off[SP]and[SP]stop[SP]Earth's[SP]rotation.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]The[SP]Earth[SP]rotates[SP]really[SP]fast,[SP]doesn't[SP]it?[1205][U+000F][NL]If[SP]that[SP]stops[SP]all[SP]of[SP]a[SP]sudden,[SP]no[SP]wonder[SP]the[NL]world[SP]down[SP]there[SP]will[SP]be[SP]a[SP]mess.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Avec la Croix Cosmique, l'équilibre de la gravité\nsera rompu et arrêtera la rotation de la Terre.[1106][NL]La Terre tourne vite, non ?[1205][U+000F] Si ça s'arrête\nd'un coup, le monde sera un vrai chaos."
+    },
+    {
+        "id": 122,
+        "offset": 423428,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "I[SP]heard[SP]there[SP]are[SP]talking[SP]flowers[SP]growing[SP]in[NL]Aoba[SP]Park.[SP]It's[SP]like[SP]a[SP]fairy[SP]tale![SP]I[SP]wonder[NL]if[SP]I[SP]should[SP]go[SP]to[SP]them[SP]for[SP]advice.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Des fleurs parlent au parc Aoba.\nC'est comme un conte de fées !\nJe devrais leur demander conseil."
+    },
+    {
+        "id": 123,
+        "offset": 423712,
+        "data_size": 442,
+        "slot_size": 442,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]you[SP]think[SP]it's[SP]true[SP]that[SP]Zodiac's[SP]second[NL]floor[SP]is[SP]a[SP]dungeon[SP]now?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]My[SP]friends[SP]rave[SP]about[SP]all[SP]the[SP]items[SP]there...[1205][U+000F][NL]But[SP]it[SP]sucks![SP]Why[SP]a[SP]dungeon!?[SP]My[SP]favorite[NL]club's[SP]all[SP]messed[SP]up[SP]now!",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "C'est vrai que le 2e étage de Zodiac\nest devenu un donjon ?[1106][NL]Mes amies adorent les objets là-bas...[1205][U+000F]\nMais c'est nul ! Pourquoi un donjon !? Mon club\nest gâché !"
+    },
+    {
+        "id": 124,
+        "offset": 424154,
+        "data_size": 368,
+        "slot_size": 368,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]is[SP]it[SP]true[SP]the[SP]ghost[SP]of[SP]Hanako[SP]is[NL]haunting[SP]Sevens?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Hanako[SP]is[SP]that[SP]girl[SP]they[SP]tell[SP]ghost[SP]stories[NL]about[SP]at[SP]school,[SP]right?[1205][U+000F][SP]Wow![SP]I[SP]wanna[SP]see[SP]her!",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Hé, c'est vrai que le fantôme de Hanako\nhante Seven ?[1106][NL]Hanako, c'est cette histoire de fantôme\nà l'école, non ?[1205][U+000F] Waouh ! Je veux la voir !"
+    },
+    {
+        "id": 125,
+        "offset": 424522,
+        "data_size": 246,
+        "slot_size": 246,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Do[SP]you[SP]know[SP]about[SP]Bukimi?[SP]I[SP]heard[SP]a[SP]rumor[SP]it's[NL]been[SP]appearing[SP]at[SP]Cuss[SP]High.[SP]Is[SP]she[SP]a[SP]ghost[NL]like[SP]Hanako?[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Connais-tu Bukimi ? Elle apparaîtrait à Kakasu.\nC'est un fantôme comme Hanako ?"
+    },
+    {
+        "id": 126,
+        "offset": 424768,
+        "data_size": 308,
+        "slot_size": 308,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Do[SP]you[SP]know[SP]the[SP]story[SP]about[SP]some[SP]girl's[SP]ghost[NL]in[SP]Aoba[SP]Park?[SP]I[SP]heard[SP]from[SP]a[SP]friend[SP]of[SP]a[SP]friend[NL]that[SP]she[SP]was[SP]an[SP]idol[SP]when[SP]she[SP]was[SP]alive.[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Tu connais le fantôme du parc Aoba ?\nUne amie d'amie dit qu'elle était une idole."
+    },
+    {
+        "id": 127,
+        "offset": 425076,
+        "data_size": 304,
+        "slot_size": 304,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "My[SP]boyfriend[SP]told[SP]me[SP]there's[SP]a[SP]Cursed[SP]Taxi[NL]parked[SP]at[SP]the[SP]abandoned[SP]factory.[SP]That[SP]would[SP]be[NL]so[SP]freaky[SP]if[SP]you[SP]accidentally[SP]got[SP]in[SP]it...[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Mon copain m'a dit qu'il y a un Taxi Maudit\ngaré à l'usine abandonnée. Ce serait tellement\nflippant de monter dedans par accident..."
+    },
+    {
+        "id": 128,
+        "offset": 425380,
+        "data_size": 300,
+        "slot_size": 300,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]I[SP]asked[SP]my[SP]friend,[SP]and[SP]he[SP]said[SP]the[SP]thing[NL]at[SP]the[SP]abandoned[SP]factory[SP]is[SP]actually[SP]a[SP]Cursed[NL]Escort.[1205][U+0019][SP]Um...[SP]what's[SP]the[SP]difference?[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "On m'a dit que le truc à l'usine est une Escorte\nMaudite.[1205][U+0019] Euh... c'est quoi la différence ?"
+    },
+    {
+        "id": 129,
+        "offset": 425680,
+        "data_size": 244,
+        "slot_size": 244,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]Kuchisake-onna[SP]is[SP]up[SP]at[SP]Mt.[SP]Iwato,[SP]right?[NL]I[SP]always[SP]wanted[SP]to[SP]see[SP]if[SP]that[SP]urban[SP]legend[NL]was[SP]true...[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Kuchisake-onna est au Mt Iwato ?\nJe veux savoir si cette légende est vraie..."
+    },
+    {
+        "id": 130,
+        "offset": 425924,
+        "data_size": 300,
+        "slot_size": 300,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "So[SP]there[SP]really[SP]was[SP]a[SP]Jumping[SP]Geezer[SP]at[NL]Mt.[SP]Katatsumuri...[1205][U+000F][SP]These[SP]guys[SP]were[SP]talking[NL]about[SP]it[SP]on[SP]the[SP]train,[SP]and[SP]it[SP]was[SP]bugging[SP]me.[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Il y avait donc vraiment un Vieux Sauteur au\nMt Katatsumuri...[1205][U+000F] Ces types en parlaient\ndans le train, et ça me tracassait."
+    },
+    {
+        "id": 131,
+        "offset": 426224,
+        "data_size": 310,
+        "slot_size": 310,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Yikes...[SP]I[SP]heard[SP]a[SP]really[SP]scary[SP]story...[SP]I-It[NL]was[SP]about[SP]Kudan...[SP]No,[SP]don't[SP]make[SP]me[SP]repeat[SP]it![NL]What[SP]am[SP]I[SP]gonna[SP]do?[SP]How[SP]am[SP]I[SP]gonna[SP]sleep?[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Yikes... J'ai entendu une histoire effrayante...\nSur Kudan... Ne me fais pas la répéter !\nJe vais faire quoi ? Comment je vais dormir ?"
+    },
+    {
+        "id": 132,
+        "offset": 426534,
+        "data_size": 274,
+        "slot_size": 274,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "So[SP]Giga[SP]Macho[SP]really[SP]did[SP]have[SP]a[SP]secret[SP]CD.[NL]Huh.[SP]A[SP]friend[SP]of[SP]a[SP]friend[SP]of[SP]mine[SP]has[SP]been[NL]swearing[SP]up[SP]and[SP]down[SP]it's[SP]true.[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Giga Macho a vraiment un CD secret. L'ami\nd'un ami a juré que c'était vrai."
+    },
+    {
+        "id": 133,
+        "offset": 426808,
+        "data_size": 316,
+        "slot_size": 316,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]do[SP]you[SP]know[SP]about[SP]the[SP]Dresser[SP]Hag?[SP]They[NL]say[SP]she's[SP]at[SP]the[SP]abandoned[SP]factory.[1205][U+000F][SP]What[SP]is[NL]that,[SP]some[SP]kinda[SP]monster?[1205][U+000F][SP]Weird[SP]name[SP]for[SP]one.[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Tu connais la Mégère à Commode ? Elle serait à\nl'usine abandonnée.[1205][U+000F] C'est un monstre ?[1205][U+000F]\nDrôle de nom."
+    },
+    {
+        "id": 134,
+        "offset": 427124,
+        "data_size": 250,
+        "slot_size": 250,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle's[SP]so[SP]cool.[SP]He[SP]sells[NL]weapons[SP]in[SP]secret,[SP]like[SP]one[SP]of[SP]those[SP]smugglers[NL]in[SP]spy[SP]movies.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Le boss de Time Castle est trop cool.\nIl vend des armes en secret, comme un\ncontrebandier de film."
+    },
+    {
+        "id": 135,
+        "offset": 427374,
+        "data_size": 436,
+        "slot_size": 436,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle's[SP]so[SP]cool.[SP]He[SP]sells[NL]weapons[SP]in[SP]secret,[SP]like[SP]one[SP]of[SP]those[SP]smugglers[NL]in[SP]spy[SP]movies.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Looks[SP]like[SP]his[SP]stuff[SP]is[SP]expensive,[SP]but[SP]nice.[NL]Just[SP]like[SP]I[SP]thought[SP]it'd[SP]be![NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Le boss de Time Castle est trop cool.\nIl vend des armes en secret, comme un\ncontrebandier de film.[1106][NL]Ce qu'il a coûte cher, mais c'est bien.\nExactement ce que je pensais !"
+    },
+    {
+        "id": 136,
+        "offset": 427810,
+        "data_size": 458,
+        "slot_size": 458,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle's[SP]so[SP]cool.[SP]He[SP]sells[NL]weapons[SP]in[SP]secret,[SP]like[SP]one[SP]of[SP]those[SP]smugglers[NL]in[SP]spy[SP]movies.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Looks[SP]like[SP]his[SP]stuff[SP]is[SP]cheap[SP]and[SP]crappy.[NL]That's[SP]not[SP]really[SP]how[SP]I[SP]thought[SP]it'd[SP]be...[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Le boss de Time Castle est trop cool.\nIl vend des armes en secret, comme un\ncontrebandier de film.[1106][NL]Ses trucs sont pas chers et merdiques.\nJe ne m'y attendais pas..."
+    },
+    {
+        "id": 137,
+        "offset": 428268,
+        "data_size": 582,
+        "slot_size": 582,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after[NL]all,[SP]huh?[1205][U+000F][SP]I[SP]knew[SP]it.[1205][U+000F][SP]I[SP]could[SP]tell[SP]in[SP]my[NL]gut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]hear[SP]his[SP]selection's[SP]good,[SP]but[SP]the[SP]resale[NL]value[SP]sucks.[SP]Like,[SP]he'll[SP]pay[SP]you[SP]barely[SP]anything[NL]and[SP]make[SP]a[SP]bundle[SP]selling[SP]it.[1205][U+000F][SP]What[SP]a[SP]creep.[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup.[1106][NL]Il a du choix, mais paie une misère.\nIl achète rien et se fait un paquet en\nrevendant.[1205][U+000F] Sale type."
+    },
+    {
+        "id": 138,
+        "offset": 428850,
+        "data_size": 472,
+        "slot_size": 472,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after[NL]all,[SP]huh?[1205][U+000F][SP]I[SP]knew[SP]it.[1205][U+000F][SP]I[SP]could[SP]tell[SP]in[SP]my[NL]gut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]hear[SP]he[SP]sells[SP]basically[SP]junk[SP]for[SP]almost[SP]no[NL]money.[1205][U+000F][SP]That[SP]totally[SP]sounds[SP]like[SP]him.[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup.[1106][NL]Il vend des merdes pour presque rien.[1205][U+000F]\nÇa lui ressemble bien."
+    },
+    {
+        "id": 139,
+        "offset": 429322,
+        "data_size": 552,
+        "slot_size": 552,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after[NL]all,[SP]huh?[1205][U+000F][SP]I[SP]knew[SP]it.[1205][U+000F][SP]I[SP]could[SP]tell[SP]in[SP]my[NL]gut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]hear[SP]his[SP]selection[SP]and[SP]stuff's[SP]all[SP]average.[NL]It's[SP]so[SP]weird[SP]he[SP]sells[SP]weapons,[SP]but[SP]they're[NL]all[SP]ordinary.[1205][U+000F][SP]He[SP]would,[SP]though.[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup.[1106][NL]Ses articles sont dans la moyenne. C'est bizarre\nqu'il vende des armes ordinaires.[1205][U+000F]\nC'est tout lui ça."
+    },
+    {
+        "id": 140,
+        "offset": 429874,
+        "data_size": 478,
+        "slot_size": 478,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after[NL]all,[SP]huh?[1205][U+000F][SP]I[SP]knew[SP]it.[1205][U+000F][SP]I[SP]could[SP]tell[SP]in[SP]my[NL]gut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]hear[SP]he[SP]has[SP]good[SP]stuff,[SP]but[SP]his[SP]prices[SP]are[NL]a[SP]ripoff.[1205][U+000F][SP]That[SP]totally[SP]sounds[SP]like[SP]him.[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup.[1106][NL]Il a de bons trucs, mais c'est une arnaque.[1205][U+000F]\nÇa lui ressemble tout à fait."
+    },
+    {
+        "id": 141,
+        "offset": 430352,
+        "data_size": 662,
+        "slot_size": 662,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,[NL]right?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]knew[SP]it...[1205][U+0014][SP]Like,[SP]that[SP]store[SP]was[SP]exactly[SP]the[NL]kinda[SP]place[SP]you'd[SP]find[SP]Mafia[SP]goons[SP]or[SP]something.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]But[SP]they[SP]don't[SP]sell[SP]much.[SP]Trade-ins[SP]seem[SP]to[SP]be[NL]their[SP]main[SP]thing.[SP]I[SP]bet[SP]they[SP]ship[SP]the[SP]weapons[NL]they[SP]buy[SP]back[SP]to[SP]the[SP]Mafia.[SP]Brrrr...[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[1106][NL]Je le savais...[1205][0014] C'est le genre\nd'endroit où on trouverait des mafieux.[1106][NL]Mais ils vendent peu. Les échanges sont\nleur truc. Ils envoient les armes à la Mafia. Brrrr..."
+    },
+    {
+        "id": 142,
+        "offset": 431014,
+        "data_size": 666,
+        "slot_size": 666,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,[NL]right?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]knew[SP]it...[1205][U+0014][SP]Like,[SP]that[SP]store[SP]was[SP]exactly[SP]the[NL]kinda[SP]place[SP]you'd[SP]find[SP]Mafia[SP]goons[SP]or[SP]something.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]hear[SP]they're[SP]cheap,[SP]but[SP]low[SP]quality.[SP]The[SP]cops[NL]have[SP]been[SP]cracking[SP]down,[SP]so[SP]I[SP]bet[SP]they're[SP]selling[NL]whatever[SP]they[SP]can[SP]to[SP]raise[SP]money.[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[1106][NL]Je le savais...[1205][0014] C'est le genre\nd'endroit où on trouverait des mafieux.[1106][NL]Pas cher, mais de mauvaise qualité. Les flics\nsévissent, ils vendent tout pour amasser de l'argent."
+    },
+    {
+        "id": 143,
+        "offset": 431680,
+        "data_size": 660,
+        "slot_size": 660,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,[NL]right?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]knew[SP]it...[1205][U+0014][SP]Like,[SP]that[SP]store[SP]was[SP]exactly[SP]the[NL]kinda[SP]place[SP]you'd[SP]find[SP]Mafia[SP]goons[SP]or[SP]something.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]hear[SP]their[SP]quality's[SP]good,[SP]but[SP]it's[SP]really[NL]expensive.[SP]Which[SP]means[SP]they'll[SP]sell[SP]anything[NL]as[SP]long[SP]as[SP]you[SP]have[SP]the[SP]cash.[SP]Brrrr...[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[1106][NL]Je le savais...[1205][0014] C'est le genre\nd'endroit où on trouverait des mafieux.[1106][NL]Qualité bonne, mais vraiment cher. Ils vendront\nn'importe quoi pour de l'argent. Brrrr..."
+    },
+    {
+        "id": 144,
+        "offset": 432340,
+        "data_size": 670,
+        "slot_size": 670,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,[NL]right?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]knew[SP]it...[1205][U+0014][SP]Like,[SP]that[SP]store[SP]was[SP]exactly[SP]the[NL]kinda[SP]place[SP]you'd[SP]find[SP]Mafia[SP]goons[SP]or[SP]something.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]They[SP]focus[SP]on[SP]selling,[SP]so[SP]their[SP]selection[SP]is[NL]good,[SP]but[SP]they[SP]don't[SP]pay[SP]much[SP]for[SP]stuff[SP]you[NL]sell[SP]them.[SP]Pretty[SP]suspicious,[SP]if[SP]you[SP]ask[SP]me.[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[1106][NL]Je le savais...[1205][0014] C'est le genre\nd'endroit où on trouverait des mafieux.[1106][NL]Leur sélection est bonne, mais ils paient mal.\nC'est louche, à mon avis."
+    },
+    {
+        "id": 145,
+        "offset": 433010,
+        "data_size": 626,
+        "slot_size": 626,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,[NL]right?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]knew[SP]it...[1205][U+0014][SP]Like,[SP]that[SP]store[SP]was[SP]exactly[SP]the[NL]kinda[SP]place[SP]you'd[SP]find[SP]Mafia[SP]goons[SP]or[SP]something.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]hear[SP]their[SP]quality[SP]and[SP]prices[SP]are[SP]average.[NL]What's[SP]scary[SP]is[SP]that[SP]even[SP]details[SP]like[SP]that[NL]are[SP]part[SP]of[SP]the[SP]rumor.[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[1106][NL]Je le savais...[1205][0014] C'est le genre\nd'endroit où on trouverait des mafieux.[1106][NL]Qualité et prix moyens. Ce qui est effrayant,\nc'est que de tels détails soient dans la rumeur."
+    },
+    {
+        "id": 146,
+        "offset": 433636,
+        "data_size": 454,
+        "slot_size": 454,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear[NL]Jolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]Anyway,[SP]his[SP]weapons[NL]are[SP]supposed[SP]to[SP]be[SP]average[SP]as[SP]far[SP]as[SP]the[NL]quality[SP]and[SP]price[SP]goes.[NL]",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes.[1106][NL]C'est un vrai pirate ? Ses armes sont\nmoyennes en qualité et en prix."
+    },
+    {
+        "id": 147,
+        "offset": 434090,
+        "data_size": 404,
+        "slot_size": 404,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear[NL]Jolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]His[SP]weapons[SP]are[NL]supposed[SP]to[SP]be[SP]cheap,[SP]but[SP]not[SP]great[SP]quality.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes.[1106][NL]C'est un vrai pirate ? Ses armes sont\nbon marché, mais de mauvaise qualité."
+    },
+    {
+        "id": 148,
+        "offset": 434494,
+        "data_size": 466,
+        "slot_size": 466,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear[NL]Jolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]He's[SP]supposed[SP]to[SP]have[NL]a[SP]great[SP]selection,[SP]but[SP]he[SP]barely[SP]pays[SP]anything[NL]for[SP]what[SP]you[SP]sell[SP]him.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes.[1106][NL]C'est un vrai pirate ? Super sélection,\nmais il paie une misère."
+    },
+    {
+        "id": 149,
+        "offset": 434960,
+        "data_size": 468,
+        "slot_size": 468,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear[NL]Jolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]He's[SP]supposed[SP]to[SP]have[NL]a[SP]crappy[SP]selection,[SP]but[SP]he'll[SP]pay[SP]a[SP]lot[SP]for[NL]whatever[SP]you[SP]have[SP]to[SP]sell.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes.[1106][NL]C'est un vrai pirate ? Mauvaise sélection,\nmais il paie beaucoup."
+    },
+    {
+        "id": 150,
+        "offset": 435428,
+        "data_size": 416,
+        "slot_size": 416,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Yikes...[SP]Wanna[SP]know[SP]something[SP]scary?[SP]I[SP]hear[NL]Jolly[SP]Roger[SP]sells[SP]real[SP]weapons[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Is[SP]he[SP]actually[SP]a[SP]pirate?[SP]His[SP]weapons[SP]are[NL]supposed[SP]to[SP]be[SP]good[SP]quality,[SP]but[SP]really[NL]expensive.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Yikes... Tu veux avoir peur ? On dit\nque Jolly Roger vend des armes.[1106][NL]C'est un vrai pirate ? Ses armes sont\nde bonne qualité, mais chères."
+    },
+    {
+        "id": 151,
+        "offset": 435844,
+        "data_size": 462,
+        "slot_size": 462,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "No[SP]way...[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]actually[NL]sells[SP]real[SP]armor?[SP]I[SP]wonder[SP]if[SP]that's[SP]gonna[NL]be[SP]the[SP]next[SP]trend.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]The[SP]prices[SP]and[SP]quality[SP]there[SP]are[SP]pretty[SP]average.[NL]I[SP]wonder[SP]if[SP]I[SP]should[SP]go[SP]check[SP]it[SP]out...",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Rosa Candida vend de vraies\narmures ? Ce sera la prochaine tendance.[1106][NL]Les prix et la qualité y sont moyens.\nJe devrais aller voir..."
+    },
+    {
+        "id": 152,
+        "offset": 436306,
+        "data_size": 496,
+        "slot_size": 496,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "No[SP]way...[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]actually[NL]sells[SP]real[SP]armor?[SP]I[SP]wonder[SP]if[SP]that's[SP]gonna[NL]be[SP]the[SP]next[SP]trend.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Their[SP]quality's[SP]kinda[SP]sketchy,[SP]but[SP]you[SP]can't[NL]beat[SP]those[SP]prices.[SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]go[NL]check[SP]them[SP]out...",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Rosa Candida vend de vraies\narmures ? Ce sera la prochaine tendance.[1106][NL]Qualité douteuse, mais prix imbattables.\nJe devrais aller voir..."
+    },
+    {
+        "id": 153,
+        "offset": 436802,
+        "data_size": 504,
+        "slot_size": 504,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "No[SP]way...[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]actually[NL]sells[SP]real[SP]armor?[SP]I[SP]wonder[SP]if[SP]that's[SP]gonna[NL]be[SP]the[SP]next[SP]trend.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]It's[SP]on[SP]the[SP]expensive[SP]side,[SP]but[SP]the[SP]quality's[NL]supposed[SP]to[SP]be[SP]great.[SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]go[NL]check[SP]them[SP]out...",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Rosa Candida vend de vraies\narmures ? Ce sera la prochaine tendance.[1106][NL]C'est cher, mais la qualité est super.\nJe devrais aller voir..."
+    },
+    {
+        "id": 154,
+        "offset": 437306,
+        "data_size": 294,
+        "slot_size": 294,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Anima[SP]Mundi[SP]sells[SP]armor?[SP]I[SP]go[SP]there[SP]all[SP]the[NL]time[SP]and[SP]I[SP]never[SP]knew[SP]that.[SP]Well,[SP]their[SP]stuff[NL]is[SP]average[SP]quality[SP]for[SP]average[SP]prices.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Anima Mundi vend des armures ? J'y vais tout le\ntemps sans le savoir. Qualité et prix moyens."
+    },
+    {
+        "id": 155,
+        "offset": 437600,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Anima[SP]Mundi[SP]sells[SP]armor?[SP]I[SP]go[SP]there[SP]all[SP]the[NL]time[SP]and[SP]I[SP]never[SP]knew[SP]that.[SP]It's[SP]pretty[SP]cheap,[NL]but[SP]the[SP]quality's[SP]lousy.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Anima Mundi vend des armures ? J'y vais tout le\ntemps sans le savoir. Pas cher, mais qualité nulle."
+    },
+    {
+        "id": 156,
+        "offset": 437868,
+        "data_size": 540,
+        "slot_size": 540,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Anima[SP]Mundi[SP]sells[SP]armor?[SP]I[SP]go[SP]there[SP]all[SP]the[NL]time[SP]and[SP]I[SP]never[SP]knew[SP]that.[SP]That[SP]store's[SP]got[NL]a[SP]really[SP]great[SP]selection.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Huh?[SP]Their[SP]buyback[SP]prices?[SP]I[SP]dunno...[SP]I[SP]didn't[NL]hear[SP]much[SP]about[SP]that.[SP]I[SP]wouldn't[SP]get[SP]my[SP]hopes[NL]up[SP]if[SP]I[SP]were[SP]you,[SP]though.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Anima Mundi vend des armures ? J'y vais tout le\ntemps et je n'en savais rien. Ce magasin a\nune super sélection.[1106][NL]Quoi ? Les prix de rachat ? J'en sais rien...\nJe ne me ferais pas trop d'illusions."
+    },
+    {
+        "id": 157,
+        "offset": 438408,
+        "data_size": 366,
+        "slot_size": 366,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Anima[SP]Mundi[SP]sells[SP]armor?[SP]I[SP]go[SP]there[SP]all[SP]the[NL]time[SP]and[SP]I[SP]never[SP]knew[SP]that.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]That[SP]store's[SP]got[SP]really[SP]great[SP]stuff,[SP]but[SP]it's[NL]kinda[SP]out[SP]of[SP]my[SP]price[SP]range.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Anima Mundi vend des armures ? J'y vais\nsouvent sans le savoir.[1106][NL]Ce magasin a de superbes trucs, mais c'est\nun peu hors de mon budget."
+    },
+    {
+        "id": 158,
+        "offset": 438774,
+        "data_size": 296,
+        "slot_size": 296,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they[NL]sell[SP]real[SP]armor.[SP]Their[SP]selection's[SP]not[SP]great,[NL]but[SP]the[SP]buyback[SP]prices[SP]are[SP]the[SP]best.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Mauvais choix, super rachat."
+    },
+    {
+        "id": 159,
+        "offset": 439070,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they[NL]sell[SP]real[SP]armor.[SP]Their[SP]quality[SP]and[SP]prices[SP]are[NL]average,[SP]so[SP]they[SP]say.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Qualité et prix moyens."
+    },
+    {
+        "id": 160,
+        "offset": 439336,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they[NL]sell[SP]real[SP]armor.[SP]Their[SP]quality's[SP]pretty[SP]good,[NL]but[SP]it's[SP]all[SP]really[SP]expensive.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Qualité bonne, mais très cher."
+    },
+    {
+        "id": 161,
+        "offset": 439620,
+        "data_size": 288,
+        "slot_size": 288,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they[NL]sell[SP]real[SP]armor.[SP]Supposedly[SP]their[SP]stuff's[SP]super[NL]cheap,[SP]but[SP]really[SP]low[SP]quality.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Pas cher, mauvaise qualité."
+    },
+    {
+        "id": 162,
+        "offset": 439908,
+        "data_size": 304,
+        "slot_size": 304,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Ever[SP]been[SP]to[SP]Rosa[SP]Candida[SP]in[SP]Aoba?[SP]I[SP]hear[SP]they[NL]sell[SP]real[SP]armor.[SP]Their[SP]selection's[SP]really[SP]good,[NL]but[SP]the[SP]buyback[SP]prices[SP]are[SP]pretty[SP]low.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Super sélection, mauvais rachat."
+    },
+    {
+        "id": 163,
+        "offset": 440212,
+        "data_size": 288,
+        "slot_size": 288,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Even[SP]London[SP]Clothier[SP]sells[SP]armor[SP]now.[SP]I[SP]guess[NL]they[SP]get[SP]special[SP]orders.[SP]Their[SP]selection's[NL]great,[SP]but[SP]the[SP]buyback[SP]price[SP]is[SP]low.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Super choix, rachat bas."
+    },
+    {
+        "id": 164,
+        "offset": 440500,
+        "data_size": 280,
+        "slot_size": 280,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Even[SP]London[SP]Clothier[SP]sells[SP]armor[SP]now.[SP]I[SP]guess[NL]they[SP]get[SP]special[SP]orders.[SP]Their[SP]stuff's[SP]cheap,[NL]but[SP]it's[SP]kinda[SP]not[SP]very[SP]good.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Pas cher, qualité bof."
+    },
+    {
+        "id": 165,
+        "offset": 440780,
+        "data_size": 280,
+        "slot_size": 280,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Even[SP]London[SP]Clothier[SP]sells[SP]armor[SP]now.[SP]I[SP]guess[NL]they[SP]get[SP]special[SP]orders.[SP]Their[SP]stuff[SP]is[NL]high[SP]quality,[SP]but[SP]really[SP]expensive.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Super qualité, très cher."
+    },
+    {
+        "id": 166,
+        "offset": 441060,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Even[SP]London[SP]Clothier[SP]sells[SP]armor[SP]now.[SP]I[SP]guess[NL]they[SP]get[SP]special[SP]orders.[SP]Their[SP]prices[SP]and[NL]quality[SP]are[SP]nothing[SP]special.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Prix et qualité moyens."
+    },
+    {
+        "id": 167,
+        "offset": 441330,
+        "data_size": 294,
+        "slot_size": 294,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Even[SP]London[SP]Clothier[SP]sells[SP]armor[SP]now.[SP]I[SP]guess[NL]they[SP]get[SP]special[SP]orders.[SP]Their[SP]selection's[NL]crappy,[SP]but[SP]the[SP]buyback[SP]price[SP]is[SP]great.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Mauvais choix, rachat top."
+    },
+    {
+        "id": 168,
+        "offset": 441624,
+        "data_size": 538,
+        "slot_size": 538,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "That[SP]reminds[SP]me,[SP]a[SP]friend[SP]of[SP]a[SP]friend[SP]won[SP]a[NL]sweepstakes[SP]and[SP]got[SP]a[SP]real[SP]weapon[SP]in[SP]the[SP]mail.[NL]I[SP]was[SP]like,[SP]whoa,[SP]is[SP]that[SP]legal!?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]think[SP]she[SP]said[SP]it[SP]was[SP]a[SP]magazine[SP]sweepstakes.[NL]You[SP]can[SP]win[SP]pretty[SP]good[SP]stuff,[SP]but[SP]you[SP]won't[NL]win[SP]too[SP]often.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "L'ami d'un ami a gagné à une loterie et a reçu une\nvéritable arme par la poste. C'est légal ça !?[1106][NL]C'était un concours de magazine.\nTu peux gagner de bons trucs, mais c'est rare."
+    },
+    {
+        "id": 169,
+        "offset": 442162,
+        "data_size": 556,
+        "slot_size": 556,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "That[SP]reminds[SP]me,[SP]a[SP]friend[SP]of[SP]a[SP]friend[SP]won[SP]a[NL]sweepstakes[SP]and[SP]got[SP]a[SP]real[SP]weapon[SP]in[SP]the[SP]mail.[NL]I[SP]was[SP]like,[SP]whoa,[SP]is[SP]that[SP]legal!?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]think[SP]she[SP]said[SP]it[SP]was[SP]a[SP]magazine[SP]sweepstakes.[NL]You[SP]hardly[SP]ever[SP]win,[SP]but[SP]when[SP]you[SP]do,[SP]you[SP]can[NL]get[SP]really[SP]rare[SP]stuff.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "L'ami d'un ami a gagné à une loterie et a reçu une\nvéritable arme par la poste. C'est légal ça !?[1106][NL]C'était un concours de magazine.\nC'est rare, mais tu peux obtenir des trucs rares."
+    },
+    {
+        "id": 170,
+        "offset": 442718,
+        "data_size": 554,
+        "slot_size": 554,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "That[SP]reminds[SP]me,[SP]a[SP]friend[SP]of[SP]a[SP]friend[SP]won[SP]a[NL]sweepstakes[SP]and[SP]got[SP]a[SP]real[SP]weapon[SP]in[SP]the[SP]mail.[NL]I[SP]was[SP]like,[SP]whoa,[SP]is[SP]that[SP]legal!?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]think[SP]she[SP]said[SP]it[SP]was[SP]a[SP]magazine[SP]sweepstakes.[NL]There's[SP]lots[SP]of[SP]winners,[SP]but[SP]no[SP]one[SP]ever[SP]gets[NL]anything[SP]really[SP]good.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "L'ami d'un ami a gagné à une loterie et a reçu une\nvéritable arme par la poste. C'est légal ça !?[1106][NL]C'était un concours de magazine.\nPlein de gagnants, mais rien de vraiment bien."
+    },
+    {
+        "id": 171,
+        "offset": 443272,
+        "data_size": 566,
+        "slot_size": 566,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]didja[SP]know[SP]there's[SP]a[SP]casino[SP]in[SP]Mu[SP]now?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]heard[SP]rumors[SP]about[SP]it,[SP]but[SP]I[SP]didn't[SP]think[NL]they'd[SP]be[SP]true.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Just[SP]between[SP]you[SP]and[SP]me,[SP]poker[SP]seems[SP]like[SP]the[NL]best[SP]bet.[SP]Rumor[SP]has[SP]it[SP]you[SP]can[SP]win[SP]big[SP]at[NL]machine[SP]#5.[SP]My[SP]gamer[SP]friend[SP]told[SP]me.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Hé, tu savais pour le casino dans Mu ?[1106][NL]J'avais entendu des rumeurs, mais c'est vrai.[1106][NL]Le poker est le meilleur pari. On gagne le gros\nlot à la machine #5. Un ami joueur me l'a dit."
+    },
+    {
+        "id": 172,
+        "offset": 443838,
+        "data_size": 566,
+        "slot_size": 566,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]didja[SP]know[SP]there's[SP]a[SP]casino[SP]in[SP]Mu[SP]now?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]heard[SP]rumors[SP]about[SP]it,[SP]but[SP]I[SP]didn't[SP]think[NL]they'd[SP]be[SP]true.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Just[SP]between[SP]you[SP]and[SP]me,[SP]slots[SP]seems[SP]like[SP]the[NL]best[SP]bet.[SP]Rumor[SP]has[SP]it[SP]you[SP]can[SP]win[SP]big[SP]at[NL]machine[SP]#1.[SP]My[SP]gamer[SP]friend[SP]told[SP]me.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Hé, tu savais pour le casino dans Mu ?[1106][NL]J'avais entendu des rumeurs, mais c'est vrai.[1106][NL]Les machines à sous sont le meilleur pari.\nOn gagne le gros lot à la #1. Un ami me l'a dit."
+    },
+    {
+        "id": 173,
+        "offset": 444404,
+        "data_size": 490,
+        "slot_size": 490,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Hey,[SP]didja[SP]know[SP]there's[SP]a[SP]casino[SP]in[SP]Mu[SP]now?[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]heard[SP]rumors[SP]about[SP]it,[SP]but[SP]I[SP]didn't[SP]think[NL]they'd[SP]be[SP]true.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Anyway,[SP]my[SP]gamer[SP]friend[SP]said[SP]you[SP]can[SP]win[SP]big[NL]at[SP]blackjack.[SP]I[SP]don't[SP]know[SP]how,[SP]though...",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Hé, tu savais pour le casino dans Mu ?[1106][NL]J'avais entendu des rumeurs, mais c'est vrai.[1106][NL]Bref, on peut gagner gros au blackjack.\nJe ne sais pas comment, par contre..."
+    },
+    {
+        "id": 174,
+        "offset": 444894,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Huh,[SP]so[SP]Shiraishi[SP]Ramen[SP]in[SP]Hirasaka[SP]has[SP]a[NL]legendary[SP]weapon[SP]for[SP]sale.[1205][U+000F][SP]I[SP]wonder[SP]if[SP]she[NL]picked[SP]it[SP]up[SP]on[SP]one[SP]of[SP]her[SP]spying[SP]missions.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Shiraishi Ramen vend une arme légendaire.[1205][U+000F]\nObtenue lors d'une mission d'espionnage ?"
+    },
+    {
+        "id": 175,
+        "offset": 445192,
+        "data_size": 652,
+        "slot_size": 652,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "I[SP]wouldn't[SP]be[SP]surprised[SP]if[SP]Clair[SP]de[SP]Lune[SP]had[NL]a[SP]legendary[SP]weapon[SP]lying[SP]around.[NL][1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]They've[SP]got[SP]moonstones[SP]embedded[SP]in[SP]the[SP]floors[NL]and[SP]the[SP]whole[SP]store[SP]has[SP]this[SP]mysterious[SP]feel.[1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]But[SP]I[SP]like[SP]the[SP]idea[SP]of[SP]them[SP]selling[SP]weapons.[NL]I[SP]feel[SP]like[SP]I'll[SP]get[SP]shot[SP]if[SP]I'm[SP]not[SP]careful[NL]around[SP]them.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Clair de Lune pourrait avoir une arme\nlégendaire.[1106][NL]Il y a des pierres de lune incrustées, et\nle magasin a une atmosphère mystérieuse.[1106][NL]Vendre des armes ? Je vais me faire tirer\ndessus si je ne fais pas attention."
+    },
+    {
+        "id": 176,
+        "offset": 445844,
+        "data_size": 558,
+        "slot_size": 558,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "There's[SP]a[SP]really[SP]nasty[SP]rumor[SP]going[SP]around.[SP]The[NL]owner[SP]of[SP]Time[SP]Castle's[SP]keeping[SP]his[SP]legendary[NL]weapon[SP]under[SP]wraps[SP]to[SP]jack[SP]up[SP]the[SP]price.[1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]A[SP]cool[SP]guy[SP]like[SP]that[SP]would[SP]never[SP]pull[SP]such[NL]a[SP]jerk[SP]move![SP]Sheesh,[SP]the[SP]people[SP]in[SP]this[SP]city[NL]don't[SP]know[SP]him[SP]at[SP]all!",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Une vilaine rumeur court. Le patron de Time Castle\ngarde son arme légendaire pour faire monter les prix.[1106][NL]Un mec cool ne ferait pas ça ! Les gens d'ici\nne le connaissent pas du tout !"
+    },
+    {
+        "id": 177,
+        "offset": 446402,
+        "data_size": 612,
+        "slot_size": 612,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "There's[SP]a[SP]really[SP]nasty[SP]rumor[SP]going[SP]around![1205][U+000F][SP]They[NL]say[SP]the[SP]Time[SP]Castle[SP]owner[SP]doesn't[SP]have[SP]his[NL]legendary[SP]weapon[SP]'cause[SP]he's[SP]too[SP]chicken.[1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]Like,[SP]he[SP]won't[SP]go[SP]to[SP]the[SP]abandoned[SP]factory[SP]to[NL]pick[SP]it[SP]up[SP]from[SP]the[SP]seller.[SP]There's[SP]no[SP]way[SP]a[NL]guy[SP]that[SP]cool[SP]is[SP]a[SP]coward![SP]I-It's[SP]a[SP]mistake!",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Vilaine rumeur ![1205][U+000F] Le patron de Time Castle\nn'a pas son arme car il a la trouille.[1106][NL]Il n'ose pas aller à l'usine pour la récupérer.\nUn mec aussi cool n'est pas lâche ! C'est faux !"
+    },
+    {
+        "id": 178,
+        "offset": 447014,
+        "data_size": 216,
+        "slot_size": 216,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Did[SP]a[SP]demon[SP]steal[SP]the[SP]legendary[SP]weapon[SP]at[NL]Time[SP]Castle?[1205][U+000F][SP]That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]but...",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Un démon a volé l'arme de Time Castle ?[1205][U+000F]\nC'est la rumeur, mais..."
+    },
+    {
+        "id": 179,
+        "offset": 447230,
+        "data_size": 406,
+        "slot_size": 406,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Looks[SP]like[SP]some[SP]girl[SP]bought[SP]the[SP]legendary[NL]weapon[SP]from[SP]Time[SP]Castle.[1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]I[SP]heard[SP]it[SP]was[SP]this[SP]really[SP]unlucky[SP]woman...[NL]People[SP]like[SP]that[SP]are[SP]capable[SP]of[SP]some[SP]pretty[NL]scary[SP]stuff.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Une fille a acheté l'arme de Time Castle.[1106][NL]C'était une femme très malchanceuse...\nDes gens capables de choses effrayantes."
+    },
+    {
+        "id": 180,
+        "offset": 447636,
+        "data_size": 498,
+        "slot_size": 498,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Young[SP]woman",
+        "texte_orig": "Awww,[SP]I'm[SP]really[SP]bummed...[SP]The[SP]owner[SP]of[SP]Time[NL]Castle[SP]gave[SP]his[SP]legendary[SP]weapon[SP]to[SP]some[SP]girl.[1106][E2][1431][U+0000][U+0000]\"Young[SP]woman[NL]That[SP]can[SP]only[SP]mean[SP]one[SP]thing,[SP]huh?[SP]I[SP]wonder[NL]what[SP]kind[SP]of[SP]girl[SP]she[SP]is?[SP]All[SP]I[SP]heard[SP]about[NL]her[SP]is[SP]that[SP]she's[SP]got[SP]short[SP]hair.",
+        "nom_fr": "Jeune femme",
+        "texte_fr": "Je suis dégoûtée... Le patron de Time\nCastle a donné son arme légendaire à une fille.[1106][NL]Ça veut dire quoi ? Elle est comment ?\nTout ce que je sais, c'est qu'elle a les cheveux courts."
+    },
+    {
+        "id": 181,
+        "offset": 448134,
+        "data_size": 570,
+        "slot_size": 570,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Sevens[SP]High[SP]male[SP]student",
+        "texte_orig": "Oh,[SP]L-Lisa-san![1205][U+000A][SP]I[SP]finally[SP]found[SP]you.[1205][U+000A][NL]I-I[SP]saw[SP]the[SP]poster![1205][U+000A][SP]Th-That[SP]silhouette[NL]is[SP]you,[SP]right?[NL][1106][E2][1431][U+0000][U+0000]\"Sevens[SP]High[SP]male[SP]student[NL]I-I[SP]had[SP]it[SP]figured[SP]out[SP]as[SP]soon[SP]as[SP]I[SP]saw[SP]it.[1205][U+000A][NL]I-I[SP]mean,[SP]since[SP]I've[SP]always[SP]been[SP]watching[NL]you[SP]and[SP]all...[1205][U+000A][SP]I'm[SP]right,[SP]aren't[SP]I?",
+        "nom_fr": "Lycéen de Seven",
+        "texte_fr": "Oh, L-Lisa-san ![1205][U+000A] Enfin trouvée.[1205][U+000A]\nJ-J'ai vu l'affiche ![1205][U+000A] C-Cette silhouette\nc'est toi ?[1106][NL]J-J'ai tout de suite compris en la voyant.[1205][U+000A]\nE-Enfin, puisque je t'ai toujours\nobservée et tout...[1205][U+000A] J'ai raison, non ?"
+    },
+    {
+        "id": 182,
+        "offset": 448704,
+        "data_size": 290,
+        "slot_size": 290,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Poster?[1205][U+000F][SP]Silhouette?[1205][U+000F][SP]I,[SP]uh,[SP]have[SP]no[SP]idea[SP]what[NL]you're[SP]talking[SP]about.[SP]Whatever[SP]it[SP]is,[SP]it's[NL]not[SP]me.[SP]You've[SP]got[SP]the[SP]wrong[SP]girl,[SP]dude.",
+        "nom_fr": "Ginko",
+        "texte_fr": "Affiche ?[1205][U+000F] Silhouette ?[1205][U+000F] Je vois pas de quoi\ntu parles. Ce n'est pas moi. Tu te trompes de fille."
+    },
+    {
+        "id": 183,
+        "offset": 448994,
+        "data_size": 510,
+        "slot_size": 510,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Sevens[SP]High[SP]male[SP]student",
+        "texte_orig": "C-Congratulations[SP]on[SP]your[SP]debut,[SP]L-Lisa-san.[1205][U+000A][NL]I-I[SP]looked[SP]all[SP]over[SP]for[SP]you[SP]to[SP]tell[SP]you[SP]that...[NL][1106][E2][1431][U+0000][U+0000]\"Sevens[SP]High[SP]male[SP]student[NL]I-I[SP]think[SP]you'll[SP]make[SP]a[SP]great[SP]idol...[1205][U+000A][SP]I-I[SP]mean,[NL]you're[SP]cute...[1205][U+000A][SP]and[SP]beautiful...[1205][U+000A][SP]and[SP]nice...",
+        "nom_fr": "Lycéen de Seven",
+        "texte_fr": "F-Félicitations pour tes débuts, L-Lisa-san.[1205][U+000A]\nJ-Je t'ai cherchée partout pour te dire ça...[1106][NL]T-Tu ferais une super idole...[1205][U+000A] J-Je veux dire,\ntu es mignonne...[1205][U+000A] belle...[1205][U+000A] et gentille..."
+    },
+    {
+        "id": 184,
+        "offset": 449504,
+        "data_size": 234,
+        "slot_size": 234,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "T-Toche...[1205][U+000F][SP]But[SP]I[SP]think[SP]this[SP]is[SP]just[SP]a[SP]big[NL]misunderstanding.[SP]I-I[SP]never[SP]said[SP]I[SP]was[SP]going[NL]to[SP]be[SP]debuting.",
+        "nom_fr": "Ginko",
+        "texte_fr": "T-Toche...[1205][U+000F] Mais c'est un grand\nmalentendu. J-Je n'ai jamais dit que j'allais\ndébuter."
+    },
+    {
+        "id": 185,
+        "offset": 449738,
+        "data_size": 278,
+        "slot_size": 278,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Sevens[SP]High[SP]male[SP]student",
+        "texte_orig": "Oh,[SP]L-Lisa-san,[SP]are[SP]you[SP]going[SP]to[SP]Mu?[1205][U+000A][SP]There's[NL]going[SP]to[SP]be[SP]a[SP]promo[SP]video[SP]shoot[SP]there,[SP]right?[1205][U+000A][NL]G-Good[SP]luck.",
+        "nom_fr": "Lycéen de Seven",
+        "texte_fr": "Oh, L-Lisa-san, tu vas à Mu ?[1205][U+000A] Il va y\navoir le tournage d'une vidéo promo, c'est ça ?[1205][U+000A]\nB-Bonne chance."
+    },
+    {
+        "id": 186,
+        "offset": 450016,
+        "data_size": 408,
+        "slot_size": 408,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Wh-Whoa,[SP]if[SP]you[SP]think[SP]I'm[SP]debuting[SP]because[SP]you[NL]saw[SP]some[SP]poster,[SP]you're[SP]way[SP]off[SP]base.[1205][U+000F][SP]I[SP]am[SP]NOT[NL]becoming[SP]an[SP]idol.[NL][1106][E2][1431][U+0000][U+0000]\"Ginko[NL]The[SP]reason[SP]I'm[SP]going[SP]to[SP]Mu[SP]is[SP]to[SP]set[SP]the[SP]record[NL]straight[SP]on[SP]that!",
+        "nom_fr": "Ginko",
+        "texte_fr": "Wh-Whoa, si tu penses ça à cause d'une\naffiche, tu te plantes.[1205][U+000F] Je ne\ndeviens PAS une idole.[1106][NL]Je vais à Mu pour remettre les pendules à l'heure !"
+    },
+    {
+        "id": 187,
+        "offset": 450424,
+        "data_size": 294,
+        "slot_size": 294,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Sevens[SP]High[SP]male[SP]student",
+        "texte_orig": "Y-You're[SP]the[SP]hero[SP]of[SP]S-Sevens,[SP]Lisa-san...[1205][U+000F][NL]Please[SP]bring[SP]back[SP]S-Sevens'[SP]popularity...[1205][U+000F][NL]W-We're[SP]counting[SP]on[SP]you...",
+        "nom_fr": "Lycéen de Seven",
+        "texte_fr": "T-Tu es l'héroïne de S-Seven, Lisa-san...[1205][U+000F]\nS'il te plaît, rends à S-Seven sa popularité...[1205][U+000F]\nO-On compte sur toi..."
+    },
+    {
+        "id": 188,
+        "offset": 450718,
+        "data_size": 330,
+        "slot_size": 330,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Kehhei![SP]Enough[SP]of[SP]this[SP]bullshit![1205][U+000F][SP]You[SP]don't[SP]know[NL]what[SP]I'm[SP]going[SP]through![NL][1106][E2][1431][U+0000][U+0000]\"Ginko[NL]I'll[SP]never[SP]debut[SP]as[SP]an[SP]idol,[SP]and[SP]I[SP]don't[SP]give[NL]a[SP]shit[SP]about[SP]Sevens!",
+        "nom_fr": "Ginko",
+        "texte_fr": "Kehhei ! Assez de ces conneries ![1205][U+000F] Tu ne sais\npas ce que je traverse ![1106][NL]Jamais idole, je\nm'en fiche de Seven !"
+    },
+    {
+        "id": 189,
+        "offset": 451048,
+        "data_size": 606,
+        "slot_size": 606,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Sevens[SP]High[SP]male[SP]student",
+        "texte_orig": "I-I[SP]went[SP]to[SP]th-the[SP]outdoor[SP]concert[SP]hall[NL]a[SP]second[SP]ago.[1205][U+000A][SP]E-Everyone's[SP]so[SP]excited,[NL]there[SP]was[SP]a[SP]huge[SP]l-line[SP]at[SP]the[SP]entrance.[NL][1106][E2][1431][U+0000][U+0000]\"Sevens[SP]High[SP]male[SP]student[NL]Y-You're[SP]amazing,[SP]Lisa-san...[1205][U+000A][SP]But[SP][1113]-[NL]senpai[SP]is[SP]more[SP]than[SP]just[SP]a[SP]friend[SP]to[SP]you...[1205][U+000A][NL]I'm[SP]so[SP]jealous...[1205][U+000A][SP]So[SP]envious...",
+        "nom_fr": "Lycéen de Seven",
+        "texte_fr": "J-Je suis allé à la salle de concert\nil y a une seconde.[1205][U+000A] T-Tout le monde est excité,\nune énorme f-file d'attente à l'entrée.[1106][NL]T-Tu es incroyable, Lisa-san...[1205][U+000A] Mais [1113]-\nsenpai est plus qu'un ami pour toi...[1205][U+000A]\nJe suis si jaloux...[1205][U+000A] Tellement envieux..."
+    },
+    {
+        "id": 190,
+        "offset": 451654,
+        "data_size": 324,
+        "slot_size": 324,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Masked[SP]Circle[SP]member",
+        "texte_orig": "Wh...[SP]Why[SP]won't[SP]the[SP]executives[SP]come[SP]back[SP]to[NL]help[SP]us!?[1205][U+000F][SP]There's[SP]no[SP]way[SP]we[SP]can[SP]protect[SP]the[NL]people[SP]of[SP]Sumaru[SP]alone![1205][U+000F][SP]S-Someone[SP]help[SP]us!",
+        "nom_fr": "Membre du Cercle masqué",
+        "texte_fr": "Qu... Pourquoi les cadres ne reviennent pas\naider !?[1205][U+000F] On ne pourra jamais protéger les\nhabitants seuls ![1205][U+000F] Qu-Qu'on nous aide !"
+    },
+    {
+        "id": 191,
+        "offset": 451978,
+        "data_size": 294,
+        "slot_size": 294,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Last[SP]Battalion",
+        "texte_orig": "We[SP]are[SP]the[SP]mightiest.[SP]We[SP]stand[SP]unrivalled.[1205][U+000F][NL]Those[SP]who[SP]dare[SP]stand[SP]in[SP]the[SP]way[SP]of[SP]our[SP]march[NL]shall[SP]be[SP]crushed[SP]by[SP]the[SP]holy[SP]lance.",
+        "nom_fr": "Bataillon",
+        "texte_fr": "Nous sommes les plus forts, sans égal.[1205][U+000F]\nCeux sur notre chemin seront écrasés par\nla lance sacrée."
+    },
+    {
+        "id": 192,
+        "offset": 452272,
+        "data_size": 524,
+        "slot_size": 524,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Lisa",
+        "texte_orig": "Zodiac's[SP]a[SP]club,[SP]but[SP]you've[SP]never[SP]been[SP]inside,[NL]have[SP]you,[SP]Chinyan?[SP]I[SP]haven't[SP]been[SP]around[SP]here[NL]lately[SP]either...[NL][1106][E2][1431][U+0000][U+0000]\"Lisa[NL]You[SP]know[SP]how[SP]guys[SP]from[SP]Sevens[SP]can't[SP]come[SP]here[NL]anymore[SP]because[SP]of[SP]that[SP]disease?[SP]I[SP]hear[SP]Cuss[NL]High[SP]students[SP]have[SP]stepped[SP]up[SP]instead.",
+        "nom_fr": "Lisa",
+        "texte_fr": "Zodiac est un club, tu n'y es jamais entré,\nChinyan ? Je ne suis pas venue dans le\ncoin non plus...[1106][NL]Les gars de Seven ne viennent plus à cause de\nla maladie ? Les élèves de Kakasu les ont\nremplacés, on dirait."
+    },
+    {
+        "id": 193,
+        "offset": 452796,
+        "data_size": 526,
+        "slot_size": 526,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Zodiac's[SP]a[SP]club,[SP]but[SP]you've[SP]never[SP]been[SP]inside,[NL]have[SP]you,[SP]Chinyan?[SP]I[SP]haven't[SP]been[SP]around[SP]here[NL]lately[SP]either...[NL][1106][E2][1431][U+0000][U+0000]\"Lisa[NL]You[SP]know[SP]how[SP]guys[SP]from[SP]Sevens[SP]can't[SP]come[SP]here[NL]anymore[SP]because[SP]of[SP]that[SP]disease?[SP]I[SP]hear[SP]Cuss[NL]High[SP]students[SP]have[SP]stepped[SP]up[SP]instead.",
+        "nom_fr": "Ginko",
+        "texte_fr": "Zodiac est un club, tu n'y es jamais entré,\nChinyan ? Je ne suis pas venue dans le\ncoin non plus...[1106][NL]Les gars de Seven ne viennent plus à cause de\nla maladie ? Les élèves de Kakasu les ont\nremplacés, on dirait."
+    },
+    {
+        "id": 194,
+        "offset": 453322,
+        "data_size": 212,
+        "slot_size": 212,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "I[SP]don't[SP]think[SP]that's[SP]the[SP]best[SP]idea[SP]after[SP]we[NL]busted[SP]heads[SP]in[SP]there.[SP]Let's[SP]go[SP]somewhere[SP]else.",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Mauvaise idée après avoir cassé des têtes\nlà-dedans. Allons ailleurs."
+    },
+    {
+        "id": 195,
+        "offset": 453534,
+        "data_size": 222,
+        "slot_size": 222,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "What[SP]if[SP]someone[SP]catches[SP]us[SP]wandering[SP]around[NL]like[SP]this,[SP][1113]?[SP]We[SP]should[SP]hurry[SP]to[SP]the[NL]detective[SP]agency.",
+        "nom_fr": "Ginko",
+        "texte_fr": "Et si on nous voit traîner par ici, [1113] ?\nVite à l'agence de détectives."
+    },
+    {
+        "id": 196,
+        "offset": 453756,
+        "data_size": 160,
+        "slot_size": 160,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "There's[SP]nothing[SP]we[SP]have[SP]to[SP]do[SP]here,[SP]is[SP]there?[NL]So[SP]let's[SP]get[SP]going.",
+        "nom_fr": "Eikichi",
+        "texte_fr": "On n'a rien à faire ici, non ?\nAlors on y va."
+    },
+    {
+        "id": 197,
+        "offset": 453916,
+        "data_size": 272,
+        "slot_size": 272,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "This[SP]is[SP]a[SP]CD[SP]store[SP]called[SP]Giga[SP]Macho.[NL]They[SP]have[SP]all[SP]kinds[SP]of[SP]music[SP]here.[SP]I[SP]used[NL]to[SP]come[SP]here[SP]a[SP]lot[SP]with[SP]Sheba[SP]and[SP]Mee-ho...",
+        "nom_fr": "Ginko",
+        "texte_fr": "C'est un disquaire, Giga Macho.\nToutes sortes de musiques ici. Je venais\nsouvent avec Sheba et Mee-ho..."
+    },
+    {
+        "id": 198,
+        "offset": 454188,
+        "data_size": 110,
+        "slot_size": 110,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "GOLD...?[SP]Dude,[SP]this[SP]is[SP]a[SP]fitness[SP]center.",
+        "nom_fr": "Eikichi",
+        "texte_fr": "GOLD... ? C'est un centre de fitness."
+    },
+    {
+        "id": 199,
+        "offset": 454298,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Ohhh,[SP]I[SP]get[SP]it.[SP]You[SP]think[SP]you[SP]can[SP]compete[NL]with[SP]me[SP]there,[SP]huh?[SP]Well,[SP]I[SP]think[SP]you'll[NL]find[SP]your[SP]efforts[SP]will[SP]go[SP]to[SP]waste!",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Oh, tu crois que tu peux rivaliser avec\nmoi là-bas ? Tu verras que tes\nefforts ne serviront à rien !"
+    },
+    {
+        "id": 200,
+        "offset": 454564,
+        "data_size": 174,
+        "slot_size": 174,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Haha...[SP]I[SP]wonder[SP]if[SP]she's[SP]still[SP]at[SP]it...[NL]Oh,[SP]sorry,[SP]it's[SP]nothing.[SP]Hahaha...",
+        "nom_fr": "Maya",
+        "texte_fr": "Haha... Je me demande si elle y est encore...\nOh, désolée. Hahaha..."
+    },
+    {
+        "id": 201,
+        "offset": 454738,
+        "data_size": 130,
+        "slot_size": 130,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "GOLD,[SP]huh...?[SP]Could[SP]this[SP]be[SP]the[SP]next[SP]target?[NL]Or...?[1205][U+000F]",
+        "nom_fr": "Maya",
+        "texte_fr": "GOLD, hein... ? C'est la prochaine cible ?\nOu... ?[1205][U+000F]"
+    },
+    {
+        "id": 202,
+        "offset": 454868,
+        "data_size": 152,
+        "slot_size": 152,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Where[SP]else[SP]could[SP]it[SP]be?[1205][U+000F][SP]Let's[SP]just[SP]hurry[SP]up[NL]and[SP]get[SP]inside.",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Où d'autre ?[1205][U+000F] Dépêchons-nous\nd'entrer."
+    },
+    {
+        "id": 203,
+        "offset": 455020,
+        "data_size": 178,
+        "slot_size": 178,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "We[SP]can't[SP]afford[SP]to[SP]make[SP]another[SP]mistake.[1205][U+000F][NL]Is[SP]GOLD[SP]where[SP]we[SP]should[SP]go,[SP]or...?",
+        "nom_fr": "Maya",
+        "texte_fr": "On n'a pas le droit à l'erreur.[1205][U+000F]\nC'est GOLD la cible, ou... ?"
+    },
+    {
+        "id": 204,
+        "offset": 455198,
+        "data_size": 150,
+        "slot_size": 150,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Dammit,[SP]which[SP]one[SP]is[SP]it?[1205][U+000F][SP]Choices[SP]like[SP]this[SP]make[NL]me[SP]queasy.",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Bordel, c'est où ?[1205][U+000F] Choisir me\ndonne la nausée."
+    },
+    {
+        "id": 205,
+        "offset": 455348,
+        "data_size": 524,
+        "slot_size": 524,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[1106][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?[NL][1208][U+0002][U+1432][U+0000][U+0000][U+0014]Yeah,[SP]let's[SP]check[SP]it[SP]out.[U+1432][U+0000][U+0000][U+0014][NL][U+1432][U+0000][U+0000][U+0014]No,[SP]this[SP]isn't[SP]the[SP]place.[U+1432][U+0000][U+0000][U+0014][NL][1109][E2][E3][1431][U+0000][U+0000]\"Yukino[NL]Okay,[SP]we'll[SP]trust[SP][1113]'s[SP]instincts.[NL]There's[SP]no[SP]use[SP]hemming[SP]and[SP]hawing[SP]over[SP]it[NL]anymore.[SP]Let's[SP]go!",
+        "nom_fr": "Maya",
+        "texte_fr": "[1113]-kun ?[1205][U+000F] On fouille ici ?[E1][E2][E3]On fouille ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, allons voir.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas ici.[1432][NULL][NULL][0014][1106][NL]Ok, on va se fier à l'instinct de [1113].\nInutile d'hésiter plus longtemps.\nOn y va !"
+    },
+    {
+        "id": 206,
+        "offset": 455872,
+        "data_size": 114,
+        "slot_size": 114,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Yukino",
+        "texte_orig": "Alright.[SP]Then[SP]let's[SP]get[SP]to[SP]Pachinko[SP]Silver!",
+        "nom_fr": "Yukino",
+        "texte_fr": "D'accord. Direction Pachinko Silver !"
+    },
+    {
+        "id": 207,
+        "offset": 455986,
+        "data_size": 590,
+        "slot_size": 590,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Yukino",
+        "texte_orig": "Wow,[SP]that[SP]Ulala[SP]lady[SP]was[SP]something[SP]else.[SP]She[NL]scared[SP]even[SP]me[SP]a[SP]little...[SP]But[SP]we[SP]stopped[SP]the[NL]bombs,[SP]so[SP]I[SP]guess[SP]it[SP]worked[SP]out[SP]in[SP]the[SP]end.[NL][1106][E2][1431][U+0000][U+0000]\"Yukino[NL]Well,[SP]all[SP]that's[SP]left[SP]is[SP]King[SP]Leo[SP]and[SP]the[NL]Aerospace[SP]Museum.[SP]He's[SP]had[SP]us[SP]wrapped[SP]around[NL]his[SP]finger[SP]for[SP]so[SP]long,[SP]it's[SP]time[SP]for[SP]payback!",
+        "nom_fr": "Yukino",
+        "texte_fr": "Waouh, cette Ulala c'était quelque chose.\nMais on a arrêté les bombes, donc tout\nest bien qui finit bien.[1106][NL]Il ne reste que le Roi Lion et le Musée de\nl'Aérospatiale. Il s'est moqué de nous, c'est\nl'heure de la revanche !"
+    },
+    {
+        "id": 208,
+        "offset": 456576,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Does[SP]King[SP]Leo[SP]think[SP]this[SP]is[SP]all[SP]a[SP]game...!?[NL]That[SP]bastard's[SP]dead[SP]when[SP]I[SP]find[SP]him![SP]Let's[SP]go,[NL][1113]![SP]To[SP]the[SP]Aerospace[SP]Museum!",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Ce Lion croit jouer !?\nIl est mort quand je l'aurai !\nEn route, [1113] ! Au Musée !"
+    },
+    {
+        "id": 209,
+        "offset": 456842,
+        "data_size": 174,
+        "slot_size": 174,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "I[SP]wonder[SP]if[SP]this[SP]was[SP]their[SP]will,[SP]too...[NL]But[SP]they[SP]were[SP]so[SP]kind[SP]back[SP]then...",
+        "nom_fr": "Ginko",
+        "texte_fr": "C'était aussi leur volonté... ?\nMais ils étaient si gentils..."
+    },
+    {
+        "id": 210,
+        "offset": 457016,
+        "data_size": 152,
+        "slot_size": 152,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Yeah...[SP]Jun[SP]would[SP]never[SP]have[SP]done[SP]this.[SP]We[SP]gotta[NL]stop[SP]him,[SP][U+1114]!",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Ouais... Jun n'aurait jamais fait ça. Il faut\nl'arrêter, [1114] !"
+    },
+    {
+        "id": 211,
+        "offset": 457168,
+        "data_size": 66,
+        "slot_size": 66,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "PACHINKO[SP]SILVERRRRRR!",
+        "nom_fr": "Maya",
+        "texte_fr": "PACHINKO SILVER !"
+    },
+    {
+        "id": 212,
+        "offset": 457234,
+        "data_size": 136,
+        "slot_size": 136,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "...I[SP]mean,[SP]hold[SP]it,[SP][1113]-kun.[SP]You're[SP]still[NL]a[SP]high[SP]schooler.",
+        "nom_fr": "Maya",
+        "texte_fr": "...Je veux dire, attends, [1113]-kun. T'es encore\nlycéen."
+    },
+    {
+        "id": 213,
+        "offset": 457370,
+        "data_size": 240,
+        "slot_size": 240,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Pachinko[SP]Silver,[SP]huh...?[1205][U+000F][SP]I'd[SP]hate[SP]to[SP]see[SP]this[NL]place[SP]go,[SP]that's[SP]for[SP]sure.[SP]But[SP]it[SP]might[SP]not[NL]be[SP]the[SP]target...",
+        "nom_fr": "Maya",
+        "texte_fr": "Pachinko Silver... ?[1205][U+000F] Je détesterais voir ça\ndisparaître. Mais c'est peut-être pas la cible..."
+    },
+    {
+        "id": 214,
+        "offset": 457610,
+        "data_size": 202,
+        "slot_size": 202,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "In[SP]any[SP]case,[SP]we[SP]gotta[SP]move.[1205][U+000F][SP]Let's[SP]stop[SP]second-[NL]guessing[SP]ourselves[SP]and[SP]get[SP]this[SP]done!",
+        "nom_fr": "Eikichi",
+        "texte_fr": "En tout cas, faut bouger.[1205][U+000F] Arrêtons de\ndouter et finissons-en !"
+    },
+    {
+        "id": 215,
+        "offset": 457812,
+        "data_size": 196,
+        "slot_size": 196,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "We[SP]can't[SP]make[SP]the[SP]same[SP]mistake[SP]again.[SP]Is[SP]this[NL]the[SP]target?[1205][U+000F][SP]It[SP]could[SP]always[SP]be[SP]GOLD...",
+        "nom_fr": "Maya",
+        "texte_fr": "On ne peut pas répéter l'erreur. Est-ce\nla cible ?[1205][U+000F] Ça pourrait être GOLD..."
+    },
+    {
+        "id": 216,
+        "offset": 458008,
+        "data_size": 212,
+        "slot_size": 212,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "It[SP]could[SP]just[SP]as[SP]likely[SP]be[SP]this[SP]place,[SP]though.[1205][U+000F][NL]Sheesh,[SP]this[SP]is[SP]a[SP]lot[SP]of[SP]responsibility...",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Mais ça pourrait tout aussi bien être ici.[1205][U+000F]\nPfff, c'est une lourde responsabilité..."
+    },
+    {
+        "id": 217,
+        "offset": 458220,
+        "data_size": 412,
+        "slot_size": 412,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "[1113]-kun?[1205][U+000F][SP]Should[SP]we[SP]search[SP]through[SP]here?[1106][E2][E3]Should[SP]we[SP]search[SP]through[SP]here?[NL][1208][U+0002][U+1432][U+0000][U+0000][U+0014]Yeah,[SP]let's[SP]check[SP]it[SP]out.[U+1432][U+0000][U+0000][U+0014][NL][U+1432][U+0000][U+0000][U+0014]No,[SP]this[SP]isn't[SP]the[SP]place.[U+1432][U+0000][U+0000][U+0014][NL][1109][E2][E3][1431][U+0000][U+0000]\"Yukino[NL]Not[SP]here,[SP]then.[SP]Alright,[SP]off[SP]to[SP]GOLD!",
+        "nom_fr": "Maya",
+        "texte_fr": "[1113]-kun ?[1205][U+000F] On fouille ici ?[E1][E2][E3]On fouille ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, allons voir.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas ici.[1432][NULL][NULL][0014][1106][NL]Pas ici, alors. En route pour GOLD !"
+    },
+    {
+        "id": 218,
+        "offset": 458632,
+        "data_size": 76,
+        "slot_size": 76,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Yukino",
+        "texte_orig": "Okay.[SP]Then[SP]here[SP]we[SP]go...",
+        "nom_fr": "Yukino",
+        "texte_fr": "Ok. C'est parti..."
+    },
+    {
+        "id": 219,
+        "offset": 459116,
+        "data_size": 132,
+        "slot_size": 132,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Ulala![1205][U+000F][SP]What're[SP]you[SP]doing[SP]here?[SP]Did[SP]something[NL]happen?",
+        "nom_fr": "Maya",
+        "texte_fr": "Ulala ![1205][U+000F] Que fais-tu ici ?\nUn problème ?"
+    },
+    {
+        "id": 220,
+        "offset": 459248,
+        "data_size": 488,
+        "slot_size": 488,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ulala",
+        "texte_orig": "Can't[SP]you[SP]tell?[1205][U+000F][SP]I[SP]had[SP]a[SP]feeling[SP]luck[SP]was[SP]on[SP]my[NL]side[SP]today![SP]And[SP]sure[SP]enough,[SP]I[SP]hit[SP]the[SP]jackpot![1106][E2][1431][U+0000][U+0000]\"Ulala[NL]I[SP]felt[SP]like[SP]I[SP]could[SP]keep[SP]the[SP]streak[SP]going...[NL]But[SP]it's[SP]almost[SP]time[SP]for[SP]my[SP]training.[1205][U+000F][SP]I[SP]decided[NL]to[SP]be[SP]a[SP]good[SP]girl[SP]and[SP]leave.",
+        "nom_fr": "Ulala",
+        "texte_fr": "Ça se voit pas ?[1205][U+000F] La chance me souriait !\nEt bingo, j'ai touché le gros lot ![1106][NL]Je sentais que je pouvais continuer...\nMais c'est l'heure de mon entraînement.[1205][U+000F]\nJ'ai décidé d'être sage et partir."
+    },
+    {
+        "id": 221,
+        "offset": 459736,
+        "data_size": 106,
+        "slot_size": 106,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Wait[SP]a[SP]sec![1205][U+000F][SP]Your[SP]fitness[SP]club[SP]was[SP]GOLD!",
+        "nom_fr": "Maya",
+        "texte_fr": "Attends ![1205][U+000F] Ton club c'était GOLD !"
+    },
+    {
+        "id": 222,
+        "offset": 459842,
+        "data_size": 62,
+        "slot_size": 62,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ulala",
+        "texte_orig": "Yep![SP]That's[SP]right!",
+        "nom_fr": "Ulala",
+        "texte_fr": "Ouais ! Exact !"
+    },
+    {
+        "id": 223,
+        "offset": 459904,
+        "data_size": 238,
+        "slot_size": 238,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "If[SP]we'd[SP]searched[SP]this[SP]place,[SP]we[SP]wouldn't[SP]have[NL]been[SP]able[SP]to[SP]stop[SP]GOLD[SP]from[SP]going[SP]down...[NL]That's[SP]my[SP]Chinyan!",
+        "nom_fr": "Ginko",
+        "texte_fr": "Si on avait fouillé cet endroit, on n'aurait pas pu\nempêcher l'explosion de GOLD... T'es géniale !"
+    },
+    {
+        "id": 224,
+        "offset": 460142,
+        "data_size": 184,
+        "slot_size": 184,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Kehhei![SP]If[SP]this[SP]place[SP]didn't[SP]exist,[SP]we[SP]would[NL]have[SP]stopped[SP]GOLD[SP]from[SP]going[SP]down!",
+        "nom_fr": "Ginko",
+        "texte_fr": "Kehhei ! Sans ce lieu, on aurait\nempêché la chute de GOLD !"
+    },
+    {
+        "id": 225,
+        "offset": 460326,
+        "data_size": 192,
+        "slot_size": 192,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "We'll[SP]get[SP]caught[SP]if[SP]we[SP]stick[SP]around[SP]here.[NL]Let's[SP]go[SP]to[SP]the[SP]detective[SP]agency[SP]already.",
+        "nom_fr": "Ginko",
+        "texte_fr": "On va se faire choper ici.\nAllons à l'agence de détectives."
+    },
+    {
+        "id": 226,
+        "offset": 460518,
+        "data_size": 104,
+        "slot_size": 104,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Yukino",
+        "texte_orig": "Hey,[SP]this[SP]isn't[SP]the[SP]time[SP]for[SP]gambling.",
+        "nom_fr": "Yukino",
+        "texte_fr": "Hé, ce n'est pas le moment de jouer."
+    },
+    {
+        "id": 227,
+        "offset": 460622,
+        "data_size": 178,
+        "slot_size": 178,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Awww,[SP]it's[SP]closed.[SP]Though[SP]that's[SP]hardly[SP]a[NL]surprise,[SP]given[SP]the[SP]situation...",
+        "nom_fr": "Eikichi",
+        "texte_fr": "C'est fermé. Ce n'est pas une\nsurprise, vu la situation..."
+    },
+    {
+        "id": 228,
+        "offset": 460800,
+        "data_size": 212,
+        "slot_size": 212,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "We[SP]got[SP]the[SP]crystal[SP]skull[SP]and[SP]we[SP]saved[SP]Miyabi.[NL]I[SP]don't[SP]think[SP]we[SP]need[SP]to[SP]go[SP]in[SP]there[SP]anymore.",
+        "nom_fr": "Eikichi",
+        "texte_fr": "On a le crâne de cristal et on a sauvé Miyabi.\nPlus besoin d'y retourner."
+    },
+    {
+        "id": 229,
+        "offset": 461012,
+        "data_size": 86,
+        "slot_size": 86,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ulala",
+        "texte_orig": "Noooooo![1205][U+000F][SP]GOOOOOLD![1205][U+000F][SP]My[SP]gym!",
+        "nom_fr": "Ulala",
+        "texte_fr": "Non ![1205][U+000F] GOLD ![1205][U+000F] Ma gym !"
+    },
+    {
+        "id": 230,
+        "offset": 461098,
+        "data_size": 118,
+        "slot_size": 118,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Huh?[SP]Why?[1205][U+000F][SP]Pachinko[SP]Silver[SP]wasn't[SP]the[SP]target?",
+        "nom_fr": "Ginko",
+        "texte_fr": "Hein ?[1205][U+000F] Silver pas visé ?"
+    },
+    {
+        "id": 231,
+        "offset": 461216,
+        "data_size": 264,
+        "slot_size": 264,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ulala",
+        "texte_orig": "Did[SP]the[SP]terrorists[SP]do[SP]this!?[1205][U+000F][SP]This[SP]isn't[SP]funny![NL]I[SP]just[SP]joined[SP]this[SP]place![1205][U+000F][SP]And[SP]I[SP]fully[SP]paid[SP]my[NL]membership[SP]in[SP]advance!",
+        "nom_fr": "Ulala",
+        "texte_fr": "Les terroristes ont fait ça !?[1205][U+000F] Pas drôle !\nJe viens de m'inscrire ![1205][U+000F] J'ai payé d'avance !"
+    },
+    {
+        "id": 232,
+        "offset": 461480,
+        "data_size": 48,
+        "slot_size": 48,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Uh--[1205][U+000A]Ulala!",
+        "nom_fr": "Maya",
+        "texte_fr": "Eh-[1205][U+000A]Ulala!"
+    },
+    {
+        "id": 233,
+        "offset": 461528,
+        "data_size": 446,
+        "slot_size": 446,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Elly's[SP]voice",
+        "texte_orig": "Hello?[SP]Elly[SP]here.[1205][U+000F][SP]I've[SP]figured[SP]out[SP]the[SP]last[NL]target.[1205][U+000F][SP]It's[SP]south-southeast[SP]of[SP]Sevens...[NL][1106][E2][1431][U+0000][U+0000]\"Elly's[SP]voice[NL]There's[SP]only[SP]one[SP]building[SP]in[SP]that[SP]direction:[1205][U+000F][NL]The[SP]Aerospace[SP]Museum[SP]in[SP]Kounan.[SP]You[SP]must[SP]hurry!",
+        "nom_fr": "Voix d'Elly",
+        "texte_fr": "Allô ? C'est Elly.[1205][U+000F] J'ai découvert la dernière\ncible.[1205][U+000F] C'est au sud-sud-est de Seven...[1106][NL]Un seul bâtiment dans cette direction :[1205][U+000F]\nLe Musée de l'Aérospatiale. Faites vite !"
+    },
+    {
+        "id": 234,
+        "offset": 461974,
+        "data_size": 216,
+        "slot_size": 216,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Yukino",
+        "texte_orig": "You[SP]hear[SP]that,[SP]guys?[1205][U+000F][SP]We[SP]finally[SP]got[SP]a[SP]concrete[NL]clue.[SP]The[SP]last[SP]target's[SP]the[SP]Aerospace[SP]Museum!",
+        "nom_fr": "Yukino",
+        "texte_fr": "Vous avez entendu ?[1205][U+000F] On a une piste. La\ndernière cible est le Musée de l'Aérospatiale !"
+    },
+    {
+        "id": 235,
+        "offset": 462190,
+        "data_size": 256,
+        "slot_size": 256,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "That[SP]King[SP]Leo[SP]bastard[SP]hasn't[SP]shown[SP]himself[SP]since[NL]the[SP]concert[SP]hall,[SP]but...[SP]You[SP]really[SP]think[SP]he'll[NL]stay[SP]that[SP]quiet?",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Ce fumier de Roi Lion ne s'est pas montré\ndepuis la salle de concert... Tu crois qu'il\nva rester tranquille ?"
+    },
+    {
+        "id": 236,
+        "offset": 462446,
+        "data_size": 260,
+        "slot_size": 260,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "I[SP]agree...[SP]If[SP]the[SP]Aerospace[SP]Museum[SP]is[SP]the[SP]last[NL]target,[SP]you[SP]can[SP]bet[SP]King[SP]Leo[SP]will[SP]be[SP]there.[1205][U+000F][NL]Let's[SP]put[SP]an[SP]end[SP]to[SP]this!",
+        "nom_fr": "Maya",
+        "texte_fr": "D'accord... Si le Musée est la dernière\ncible, le Roi Lion y sera.[1205][U+000F] Mettons\nun terme à tout ça !"
+    },
+    {
+        "id": 237,
+        "offset": 462706,
+        "data_size": 274,
+        "slot_size": 274,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Whoa,[SP]hold[SP]your[SP]horses.[SP]We[SP]haven't[SP]gotten[SP]the[NL]skull[SP]at[SP]Leo[SP]Temple[SP]yet,[SP]right?[SP]Let's[SP]take[NL]care[SP]of[SP]that[SP]before[SP]we[SP]jump[SP]in[SP]here.",
+        "nom_fr": "Maya",
+        "texte_fr": "Whoa, doucement. On n'a pas encore récupéré le crâne\nau Temple du Lion, non ? Occupons-nous de ça\navant de foncer ici."
+    },
+    {
+        "id": 238,
+        "offset": 462980,
+        "data_size": 224,
+        "slot_size": 224,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Wait[SP]a[SP]sec,[SP]Chinyan![SP]We[SP]don't[SP]have[SP]the[SP]skull[NL]from[SP]Taurus[SP]Temple[SP]yet.[SP]We[SP]should[SP]stop[SP]by[NL]there[SP]first.",
+        "nom_fr": "Ginko",
+        "texte_fr": "Attends, Chinyan ! On n'a pas encore le crâne\ndu Temple du Taureau. On devrait commencer par là.[1106][NL]Une seconde. On n'en a pas fini avec\nle Temple du Verseau."
+    }
 ]

--- a/traduction/MMAP03.json
+++ b/traduction/MMAP03.json
@@ -1,4476 +1,3044 @@
 [
-  {
-    "id": 0,
-    "offset": 276502,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Hm?[SP]The[SP]outdoor[SP]concert[SP]hall?[SP]Oh,[SP]it's[SP]over[SP]in\nAoba[SP]Park.[SP]Are[SP]you[SP]going[SP]to[SP]see[SP]the[SP]show?",
-    "nom_fr": "Employé",
-    "texte_fr": "La salle de concert ? Dans le parc d'Aoba.\nTu vas voir le spectacle ?"
-  },
-  {
-    "id": 1,
-    "offset": 276718,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "The[SP]Muses[SP]sure[SP]got[SP]popular[SP]fast.[SP]I[SP]was[SP]curious,\nbut[SP]the[SP]tickets[SP]are[SP]all[SP]sold[SP]out.[SP]I[SP]guess[SP]it\nwasn't[SP]meant[SP]to[SP]be.",
-    "nom_fr": "Employé",
-    "texte_fr": "Les Muses sont devenues populaires vite.\nJ'étais curieux, mais complet. Pas pour moi."
-  },
-  {
-    "id": 2,
-    "offset": 276984,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "I...[SP]I[SP]can't[SP]believe[SP]the[SP]concert[SP]hall[SP]burned\ndown...[1205][U+000F][SP]Wh-What[SP]happened[SP]in[SP]there?[SP]Is[SP]the\naudience[SP]okay?",
-    "nom_fr": "Employé",
-    "texte_fr": "Je... La salle a brûlé...[1205][U+000F]\nQue s'est-il passé ? Le public va bien ?"
-  },
-  {
-    "id": 3,
-    "offset": 277232,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]from[SP]a[SP]friend[SP]that[SP]Smile[SP]Hirasaka[SP]and\nGOLD[SP]were[SP]targeted[SP]by[SP]terrorists[SP]too.[1205][U+000F][SP]Luckily,\nboth[SP]attacks[SP]were[SP]thwarted...",
-    "nom_fr": "Employé",
-    "texte_fr": "Un ami m'a dit que Smile Hirasaka et GOLD ont aussi été visés.[1205][U+000F]\nHeureusement, les deux ont été évités..."
-  },
-  {
-    "id": 4,
-    "offset": 277520,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "But[SP]they[SP]were[SP]both[SP]packed[SP]with[SP]people.[1205][U+000F]\nWho'd[SP]want[SP]to[SP]bomb[SP]someplace[SP]like[SP]that?\nThe[SP]culprit[SP]is[SP]inhuman...!",
-    "nom_fr": "Employé",
-    "texte_fr": "Mais ils étaient bondés.[1205][U+000F]\nQui voudrait bombarder ça ? Le coupable est inhumain !"
-  },
-  {
-    "id": 5,
-    "offset": 277776,
-    "data_size": 250,
-    "slot_size": 254,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "My[SP]friend[SP]told[SP]me[SP]that[SP]the[SP]terrorists[SP]even[SP]blew\nup[SP]Smile[SP]Hirasaka.[1205][U+000F][SP]I[SP]hear[SP]the[SP]death[SP]toll[SP]was\ntremendous.",
-    "nom_fr": "Employé",
-    "texte_fr": "Mon ami dit que les terroristes ont fait sauter Smile Hirasaka.[1205][U+000F]\nDe nombreux morts."
-  },
-  {
-    "id": 6,
-    "offset": 278030,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "There[SP]were[SP]lots[SP]of[SP]people[SP]at[SP]that[SP]concert[SP]hall,\ntoo...[1205][U+000F][SP]Who'd[SP]want[SP]to[SP]blow[SP]up[SP]someplace[SP]like\nthat?[SP]The[SP]culprit[SP]is[SP]inhuman...!",
-    "nom_fr": "Employé",
-    "texte_fr": "Beaucoup de monde aussi...[1205][U+000F]\nPourquoi bombarder ça ? Inhumain !"
-  },
-  {
-    "id": 7,
-    "offset": 278324,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "My[SP]friend[SP]told[SP]me[SP]that[SP]the[SP]terrorists[SP]even[SP]blew\nup[SP]GOLD[SP]in[SP]Yumezaki.[1205][U+000F][SP]I[SP]hear[SP]the[SP]death[SP]toll[SP]was\ntremendous.",
-    "nom_fr": "Employé",
-    "texte_fr": "Mon ami dit qu'ils ont fait sauter GOLD à Yumezaki.[1205][U+000F]\nBeaucoup de morts."
-  },
-  {
-    "id": 8,
-    "offset": 278580,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "There[SP]were[SP]lots[SP]of[SP]people[SP]at[SP]that[SP]concert[SP]hall,\ntoo...[1205][U+000F][SP]Who'd[SP]want[SP]to[SP]blow[SP]up[SP]someplace[SP]like\nthat?[SP]The[SP]culprit[SP]is[SP]inhuman...!",
-    "nom_fr": "Employé",
-    "texte_fr": "Beaucoup de monde aussi...[1205][U+000F]\nPourquoi bombarder ça ? Inhumain !"
-  },
-  {
-    "id": 9,
-    "offset": 278874,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]from[SP]a[SP]friend[SP]that[SP]terrorists[SP]struck\nat[SP]both[SP]Smile[SP]Hirasaka[SP]and[SP]GOLD.[1205][U+000F][SP]So[SP]many\npeople[SP]died...",
-    "nom_fr": "Employé",
-    "texte_fr": "Un ami m'a dit que les terroristes ont frappé\n Smile Hirasaka et GOLD.[1205][U+000F] Tant de morts..."
-  },
-  {
-    "id": 10,
-    "offset": 279118,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "They[SP]were[SP]both[SP]packed[SP]with[SP]people.[SP]Who'd[SP]want[1205][U+000F]\nto[SP]bomb[SP]someplace[SP]like[SP]that?[SP]The[SP]culprit[SP]is\ninhuman...!",
-    "nom_fr": "Employé",
-    "texte_fr": "Bondés. Qui voudrait[1205][U+000F]\nbombarder ça ? Inhumain !"
-  },
-  {
-    "id": 11,
-    "offset": 279366,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Even[SP]the[SP]Aerospace[SP]Museum[SP]was[SP]bombed...[1205][U+000F]\nThat's[SP]already[SP]six[SP]attacks[SP]in[SP]total.[1205][U+000F]",
-    "nom_fr": "Employé",
-    "texte_fr": "Même le musée aérospatial a été bombardé...[1205][U+000F]\nSix attaques au total.[1205][U+000F]"
-  },
-  {
-    "id": 12,
-    "offset": 279568,
-    "data_size": 156,
-    "slot_size": 160,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "How[SP]many[SP]deaths[SP]will[SP]it[SP]take[SP]to[SP]satisfy[SP]that\ngang[SP]of[SP]five!?",
-    "nom_fr": "Employé",
-    "texte_fr": "Combien de morts pour cette bande de cinq !?"
-  },
-  {
-    "id": 13,
-    "offset": 279728,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "The[SP]paper's[SP]reporting[SP]now[SP]that[SP]the[SP]Masked\nCircle[SP]and[SP]the[SP]Last[SP]Battalion[SP]are[SP]fighting\nover[SP]the[SP]secret[SP]treasure[SP]of[SP]Sumaru.",
-    "nom_fr": "Employé",
-    "texte_fr": "Le journal dit que le Cercle Masqué\n et le Dernier Bataillon se battent\n pour le trésor secret de Sumaru."
-  },
-  {
-    "id": 14,
-    "offset": 280008,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Looks[SP]like[SP]that[SP]was[SP]the[SP]reason[SP]for[SP]the[SP]terror\nwave,[SP]too.[1205][U+000F][SP]Honestly,[SP]one[SP]of[SP]them[SP]should[SP]just\ntake[SP]it[SP]and[SP]go.[SP]We[SP]don't[SP]need[SP]them[SP]here!",
-    "nom_fr": "Employé",
-    "texte_fr": "C'était la raison de la vague de terreur aussi.[1205][U+000F]\nQu'ils le prennent et s'en aillent. On n'en a pas besoin !"
-  },
-  {
-    "id": 15,
-    "offset": 280316,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Th-That[SP]mark...![1205][U+000F][SP]Why[SP]are[SP]soldiers[SP]with[SP]that\ninsignia[SP]coming[SP]to[SP]Sumaru[SP]now!?[SP]It[SP]makes\nno[SP]sense!",
-    "nom_fr": "Employé",
-    "texte_fr": "Ce symbole...![1205][U+000F]\nPourquoi ces soldats viennent à Sumaru ? Insensé !"
-  },
-  {
-    "id": 16,
-    "offset": 280550,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "D-Did[SP]the[SP]Masked[SP]Circle[SP]and[SP]the[SP]Last[SP]Battalion\ncause[SP]those[SP]temples[SP]to[SP]appear,[SP]too?",
-    "nom_fr": "Employé",
-    "texte_fr": "Le Cercle Masqué et le Dernier Bataillon\n ont-ils aussi fait apparaître ces temples ?"
-  },
-  {
-    "id": 17,
-    "offset": 280756,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Because[SP]I[SP]mean,[SP]once[SP]those[SP]things[SP]showed[SP]up,\nthey[SP]all[SP]rushed[SP]inside.",
-    "nom_fr": "Employé",
-    "texte_fr": "Une fois apparus,\n ils se sont tous précipités à l'intérieur."
-  },
-  {
-    "id": 18,
-    "offset": 280934,
-    "data_size": 210,
-    "slot_size": 214,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Ugh...[SP]This[SP]is[SP]too[SP]much...[1205][U+000F][SP]I[SP]feel[SP]like[SP]I'm\ngoing[SP]to[SP]go[SP]insane[SP]before[SP]I[SP]can[SP]evolve...",
-    "nom_fr": "Employé",
-    "texte_fr": "Ugh... C'en est trop...[1205][U+000F]\nJe deviendrai fou avant d'évoluer..."
-  },
-  {
-    "id": 19,
-    "offset": 281148,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Aoba[SP]is[SP]famous[SP]for[SP]its[SP]outdoor[SP]concert[SP]hall,\nbut[SP]that's[SP]not[SP]the[SP]only[SP]thing[SP]we're[SP]known[SP]for.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Aoba est célèbre pour sa salle de concert,\n mais ce n'est pas notre seule fierté."
-  },
-  {
-    "id": 20,
-    "offset": 281372,
-    "data_size": 184,
-    "slot_size": 188,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Kismet[SP]Publishing,[SP]publishers[SP]of[SP]Coolest,\nand[SP]Sumaru[SP]TV[SP]are[SP]in[SP]this[SP]ward.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Kismet Publishing (Coolest) et Sumaru TV\n sont dans ce quartier."
-  },
-  {
-    "id": 21,
-    "offset": 281560,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "It[SP]may[SP]not[SP]have[SP]Yumezaki's[SP]pizazz,[SP]but[SP]I[SP]think\nthis[SP]ward[SP]is[SP]the[SP]beating[SP]heart[SP]that[SP]feeds\ninformation[SP]across[SP]Sumaru[SP]City.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Ça n'a pas le peps de Yumezaki,\n mais ce quartier est le cœur\n qui alimente Sumaru en infos."
-  },
-  {
-    "id": 22,
-    "offset": 281842,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "I[SP]just[SP]saw[SP]a[SP]Masked[SP]Circle[SP]member[SP]in[SP]a[SP]store.[1205][U+000F]\nHe[SP]was[SP]saying[SP]some[SP]scary[SP]stuff...",
-    "nom_fr": "Femme active",
-    "texte_fr": "Je viens de voir un membre du Cercle Masqué.[1205][U+000F]\nIl disait des trucs effrayants..."
-  },
-  {
-    "id": 23,
-    "offset": 282046,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "There's[SP]no[SP]doubt[SP]that[SP]it[SP]was[SP]them[SP]who[SP]set[SP]fire\nto[SP]the[SP]outdoor[SP]concert[SP]hall.[SP]They're[SP]a[SP]menace,\njust[SP]like[SP]the[SP]rumors[SP]said.",
-    "nom_fr": "Femme active",
-    "texte_fr": "Nul doute que c'est eux qui ont incendié la salle.\nUne menace, comme les rumeurs le disaient."
-  },
-  {
-    "id": 24,
-    "offset": 282328,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Some[SP]kids[SP]came[SP]by[SP]just[SP]now[SP]and[SP]said[SP]the[SP]five\nsuspects[SP]are[SP]actually[SP]heroes[SP]fighting[SP]against\nthe[SP]Masked[SP]Circle...",
-    "nom_fr": "Femme active",
-    "texte_fr": "Des gamins ont dit que les cinq suspects sont\n des héros qui combattent le Cercle Masqué..."
-  },
-  {
-    "id": 25,
-    "offset": 282592,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "I-I[SP]knew[SP]all[SP]along.[SP]The[SP]culprits[SP]were[SP]the\nMasked[SP]Circle,[SP]of[SP]course![1205][U+000F][SP]But[SP]I[SP]didn't[SP]know\nthose[SP]five[SP]were[SP]fighting[SP]against[SP]them...",
-    "nom_fr": "Femme active",
-    "texte_fr": "Je le savais. Les coupables sont le Cercle Masqué ![1205][U+000F]\nMais j'ignorais que ces cinq les combattaient..."
-  },
-  {
-    "id": 26,
-    "offset": 282890,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "I-I[SP]heard[SP]the[SP]Oracle[SP]in[SP]the[SP]In[SP]Lak'ech[SP]talks\nabout[SP]everything[SP]that's[SP]happened[SP]lately,\nbut[SP]that's[SP]just[SP]a[SP]marketing[SP]angle.",
-    "nom_fr": "Femme active",
-    "texte_fr": "L'Oracle dans l'In Lak'ech parle de tout,\n mais ce n'est qu'un argument marketing."
-  },
-  {
-    "id": 27,
-    "offset": 283170,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "I[SP]mean,[SP]it's[SP]not[SP]like[SP]it's[SP]some[SP]grand[SP]prophecy.\nThat[SP]would[SP]just[SP]be[SP]ridiculous...",
-    "nom_fr": "Femme active",
-    "texte_fr": "Ce n'est pas une grande prophétie.\nCe serait ridicule..."
-  },
-  {
-    "id": 28,
-    "offset": 283372,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "D-Don't[SP]you[SP]think[SP]so?[1205][U+000F][SP]I-I'm[SP]right,[SP]aren't[SP]I?",
-    "nom_fr": "Femme active",
-    "texte_fr": "Tu ne crois pas ?[1205][U+000F]\nJ'ai raison, non ?"
-  },
-  {
-    "id": 29,
-    "offset": 283506,
-    "data_size": 318,
-    "slot_size": 322,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Why[SP]are[SP]soldiers[SP]raining[SP]from[SP]the[SP]sky!?[SP]Is[SP]this\nthing[SP]saying[SP]there's[SP]some[SP]secret[SP]treasure[SP]here\nin[SP]Sumaru!?[1205][U+000F][SP]I-I[SP]refuse[SP]to[SP]believe[SP]that![SP]No!",
-    "nom_fr": "Femme active",
-    "texte_fr": "Pourquoi les soldats pleuvent du ciel !?\nCe truc dit qu'il y a un trésor secret à Sumaru !?[1205][U+000F]\nJe refuse de le croire ! Non !"
-  },
-  {
-    "id": 30,
-    "offset": 283828,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Working[SP]woman",
-    "texte_orig": "Huh!?[1205][U+000A][SP]Didn't[SP]you[SP]just[SP]go[SP]into[SP]that[SP]temple?[1205][U+000F]\nYeah,[SP]carrying[SP]this[SP]weird[SP]skull...[1205][U+000F][SP]A-Am[SP]I\nseeing[SP]things...?",
-    "nom_fr": "Femme active",
-    "texte_fr": "Hein ?[1205][U+000A] Tu n'es pas entré dans ce temple ?[1205][U+000F]\nOui, avec ce drôle de crâne...[1205][U+000F]\nJ'ai des hallucinations ?"
-  },
-  {
-    "id": 31,
-    "offset": 284086,
-    "data_size": 326,
-    "slot_size": 330,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Ever[SP]hear[SP]the[SP]rumor[SP]that[SP]Rosa[SP]Candida[SP]sells\nreal[SP]armor?[1205][U+000F][SP]An[SP]office[SP]mate[SP]of[SP]mine[SP]told[SP]me\nabout[SP]it,[SP]and[SP]I've[SP]been[SP]curious[SP]ever[SP]since.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tu as entendu que Rosa Candida vend de vraies armures ?[1205][U+000F]\nUn collègue m'en a parlé, je suis curieux."
-  },
-  {
-    "id": 32,
-    "offset": 284416,
-    "data_size": 148,
-    "slot_size": 152,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "It[SP]seems[SP]he[SP]got[SP]the[SP]story[SP]online[SP]somewhere.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Il a dû voir ça sur Internet."
-  },
-  {
-    "id": 33,
-    "offset": 284568,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "If[SP]you[SP]go[SP]to[SP]Double[SP]Slash,[SP]you[SP]can[SP]use[SP]their\nPCs[SP]to[SP]browse[SP]the[SP]Internet.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Au Double Slash, on peut utiliser leurs PC\n pour surfer sur Internet."
-  },
-  {
-    "id": 34,
-    "offset": 284778,
-    "data_size": 322,
-    "slot_size": 326,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Even[SP]an[SP]old[SP]man[SP]like[SP]me[SP]could[SP]look[SP]it[SP]up[SP]there\nif[SP]I[SP]wanted...[1205][U+000F][SP]But[SP]I'm[SP]no[SP]good[SP]with[SP]computers.[1205][U+000F]\nJust[SP]one[SP]of[SP]my[SP]hangups,[SP]I[SP]guess.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Même un vieux comme moi pourrait chercher,[1205][U+000F]\nmais je suis nul en informatique.[1205][U+000F]\nUn de mes travers."
-  },
-  {
-    "id": 35,
-    "offset": 285104,
-    "data_size": 338,
-    "slot_size": 342,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]the[SP]Masked[SP]Circle[SP]did[SP]this,[SP]but[SP]I\nalso[SP]hear[SP]there[SP]was[SP]a[SP]group[SP]of[SP]five[SP]suspicious\npeople[SP]seen[SP]around[SP]the[SP]outdoor[SP]concert[SP]hall.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "On dit que c'est le Cercle Masqué,\n mais j'ai aussi entendu qu'un groupe de cinq suspects\n a été vu près de la salle de concert."
-  },
-  {
-    "id": 36,
-    "offset": 285446,
-    "data_size": 136,
-    "slot_size": 140,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Shouldn't[SP]those[SP]guys[SP]be[SP]suspects[SP]too?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Ils ne devraient pas être suspects aussi ?"
-  },
-  {
-    "id": 37,
-    "offset": 285586,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "I[SP]can't[SP]believe[SP]such[SP]a[SP]terrible[SP]tragedy\nhappened...[1205][U+000F][SP]But[SP]if[SP]sketches[SP]of[SP]the[SP]culprits[SP]are\nout,[SP]it[SP]won't[SP]be[SP]long[SP]before[SP]they're[SP]arrested.",
-    "nom_fr": "Homme",
-    "texte_fr": "Je n'arrive pas à croire qu'une telle tragédie soit arrivée.[1205][U+000F]\nMais avec les portraits-robots, ils seront bientôt arrêtés."
-  },
-  {
-    "id": 38,
-    "offset": 285880,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "My[SP]entire[SP]office[SP]is[SP]buzzing[SP]about[SP]whether[SP]or\nnot[SP]the[SP]In[SP]Lak'ech[SP]is[SP]true.[1205][U+000F][SP]All[SP]the[SP]younger\nemployees[SP]seem[SP]to[SP]believe[SP]in[SP]it.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tout le bureau parle de si l'In Lak'ech est vrai.[1205][U+000F]\nLes jeunes y croient."
-  },
-  {
-    "id": 39,
-    "offset": 286192,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Most[SP]of[SP]those[SP]soldiers[SP]were[SP]heading[SP]to\nMt.[SP]Katatsumuri.[1205][U+000F][SP]But[SP]why[SP]would[SP]they[SP]go[SP]there?\nI[SP]don't[SP]understand.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "La plupart des soldats allaient au mont Katatsumuri.[1205][U+000F]\nPourquoi ? Je ne comprends pas."
-  },
-  {
-    "id": 40,
-    "offset": 286470,
-    "data_size": 316,
-    "slot_size": 320,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "How[SP]can[SP]such[SP]nonsensical[SP]things[SP]be[SP]happening?[1205][U+000A]\nW-Well,[SP]I've[SP]seen[SP]it[SP]for[SP]myself...[1205][U+000A][SP]I[SP]don't\nhave[SP]a[SP]choice[SP]but[SP]to[SP]believe[SP]it...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Comment de telles absurdités arrivent ?[1205][U+000A]\nJe l'ai vu de mes yeux...[1205][U+000A]\nJe n'ai pas le choix, je dois y croire..."
-  },
-  {
-    "id": 41,
-    "offset": 286790,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "But[SP]in[SP]that[SP]case,[SP]this[SP]talk[SP]about[SP]the[SP]Earth\nbeing[SP]annihilated[SP]must[SP]be[SP]true,[SP]too...[1205][U+000F][SP]What\nexactly[SP]is[SP]going[SP]to[SP]happen?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Alors cette histoire de Terre anéantie doit être vraie aussi...[1205][U+000F]\nQue va-t-il exactement se passer ?"
-  },
-  {
-    "id": 42,
-    "offset": 287090,
-    "data_size": 348,
-    "slot_size": 352,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "My[SP]men[SP]say[SP]that[SP]the[SP]Grand[SP]Cross[SP]will[SP]cause[SP]the\nmantle's[SP]temperature[SP]to[SP]rise,[SP]making[SP]the[SP]Earth\na[SP]scorching[SP]hell...[1205][U+000F][SP]Is[SP]that[SP]how[SP]the[SP]world[SP]ends?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Mes collègues disent que la Grande Croix fera monter\n la température, transformant la Terre en enfer...[1205][U+000F]\nC'est ainsi que le monde finit ?"
-  },
-  {
-    "id": 43,
-    "offset": 287442,
-    "data_size": 316,
-    "slot_size": 320,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "A[SP]colleague[SP]of[SP]mine[SP]says[SP]the[SP]Grand[SP]Cross[SP]will\nresult[SP]in[SP]the[SP]gravitational[SP]pull[SP]of[SP]the[SP]other\nplanets[SP]causing[SP]a[SP]gigantic[SP]tsunami.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un collègue dit que la Grande Croix provoquera\n l'attraction des autres planètes,\n causant un tsunami géant."
-  },
-  {
-    "id": 44,
-    "offset": 287762,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]don't[SP]know[SP]much[SP]about[SP]science...[1205][U+000F][SP]Is[SP]that\neven[SP]possible?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Je ne connais pas bien la science...[1205][U+000F]\nEst-ce seulement possible ?"
-  },
-  {
-    "id": 45,
-    "offset": 287946,
-    "data_size": 318,
-    "slot_size": 322,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "That[SP]was[SP]strange.[1205][U+000A][SP]My[SP]men[SP]had[SP]all[SP]been[SP]arguing\nover[SP]how[SP]the[SP]world[SP]down[SP]there[SP]would[SP]end,[SP]when\nsuddenly[SP]they[SP]settled[SP]on[SP]one[SP]idea.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "C'était étrange.[1205][U+000A]\nIls discutaient de la fin du monde en bas,\n quand soudain ils se sont mis d'accord sur une idée."
-  },
-  {
-    "id": 46,
-    "offset": 288268,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "They[SP]think[SP]the[SP]Grand[SP]Cross[SP]will[SP]cause[SP]the\nEarth[SP]to[SP]stop[SP]rotating.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Ils pensent que la Grande Croix\n arrêtera la rotation de la Terre."
-  },
-  {
-    "id": 47,
-    "offset": 288464,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]couldn't[SP]follow[SP]their[SP]explanations,[SP]but[SP]the\nupshot[SP]was[SP]that[SP]everything[SP]on[SP]Earth[SP]will[SP]be\nblasted[SP]away[SP]at[SP]high[SP]speed,[SP]right?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Je n'ai pas suivi,\n mais tout sur Terre sera emporté à grande vitesse ?"
-  },
-  {
-    "id": 48,
-    "offset": 288778,
-    "data_size": 334,
-    "slot_size": 338,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "So[SP]there[SP]are[SP]talking[SP]flowers[SP]in[SP]Aoba[SP]Park...\nWhen[SP]I[SP]first[SP]heard,[SP]I[SP]thought[SP]it[SP]was[SP]a[SP]joke.[1205][U+000F]\nI'm[SP]curious[SP]to[SP]know[SP]what[SP]plants[SP]think[SP]about.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Des fleurs qui parlent dans le parc d'Aoba...\nJ'ai d'abord cru à une blague.[1205][U+000F]\nCurieux de savoir à quoi pensent les plantes."
-  },
-  {
-    "id": 49,
-    "offset": 289116,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "It[SP]seems[SP]Zodiac's[SP]second[SP]floor[SP]has[SP]become[SP]a\ngiant[SP]dungeon.[1205][U+000F][SP]The[SP]rumor[SP]is[SP]that[SP]there's[SP]tons\nof[SP]great[SP]items[SP]there...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Il paraît que le deuxième étage de Zodiac est devenu\n un immense donjon.[1205][U+000F] Beaucoup de bons objets..."
-  },
-  {
-    "id": 50,
-    "offset": 289412,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]this[SP]some[SP]new[SP]marketing[SP]stunt?[SP]What[SP]do\nyou[SP]think?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un nouveau coup de pub ? Qu'en pensez-vous ?"
-  },
-  {
-    "id": 51,
-    "offset": 289582,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]the[SP]ghost[SP]of[SP]an[SP]idol[SP]has[SP]been[SP]seen\nin[SP]Aoba[SP]Park.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "On a vu le fantôme d'une idole dans le parc d'Aoba."
-  },
-  {
-    "id": 52,
-    "offset": 289760,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "If[SP]enough[SP]people[SP]say[SP]so,[SP]it[SP]must[SP]be[SP]true...[1205][U+000F]\nBrrr![SP]I[SP]just[SP]felt[SP]a[SP]chill[SP]down[SP]my[SP]spine.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Si assez de gens le disent, ça doit être vrai...[1205][U+000F]\nBrrr ! J'ai eu un frisson."
-  },
-  {
-    "id": 53,
-    "offset": 289998,
-    "data_size": 330,
-    "slot_size": 334,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]there[SP]something[SP]called[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the\nabandoned[SP]factory?[1205][U+000F][SP]Yikes,[SP]now[SP]I[SP]can't[SP]even[SP]take\na[SP]taxi[SP]ride[SP]without[SP]worrying[SP]anymore.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un Taxi Maudit à l'usine abandonnée ?[1205][U+000F]\nOuf, je ne peux même plus prendre un taxi sans m'inquiéter."
-  },
-  {
-    "id": 54,
-    "offset": 290332,
-    "data_size": 182,
-    "slot_size": 186,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]there's[SP]some[SP]Cursed[SP]Escort[SP]at[SP]the\nabandoned[SP]factory.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "J'ai entendu qu'il y a une Escorte Maudite\n à l'usine abandonnée."
-  },
-  {
-    "id": 55,
-    "offset": 290518,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "A[SP]taxi[SP]driver[SP]told[SP]me[SP]about[SP]it.[1205][U+000F][SP]He[SP]said[SP]he's\nhaving[SP]trouble[SP]getting[SP]customers[SP]because\nof[SP]that[SP]thing.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un chauffeur de taxi m'en a parlé.[1205][U+000F]\nIl a du mal à trouver des clients à cause de ça."
-  },
-  {
-    "id": 56,
-    "offset": 290788,
-    "data_size": 316,
-    "slot_size": 320,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "It[SP]seems[SP]the[SP]real[SP]Kuchisake-onna[SP]has[SP]shown[SP]up\nat[SP]Mt.[SP]Iwato.[SP]First[SP]terrorists,[SP]now[SP]Kuchisake-\nonna...[SP]This[SP]city's[SP]falling[SP]apart.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "La vraie Kuchisake-onna est apparue au mont Iwato.\nD'abord les terroristes, maintenant elle...\nCette ville s'écroule."
-  },
-  {
-    "id": 57,
-    "offset": 291108,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "There's[SP]a[SP]Jumping[SP]Geezer[SP]at[SP]Mt.[SP]Katatsumuri?\nIsn't[SP]that[SP]just[SP]one[SP]of[SP]those[SP]Last[SP]Battalion\nguys?[1205][U+000F][SP]Yeah,[SP]I[SP]bet[SP]that's[SP]all[SP]it[SP]is.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un Sauteur Vieux au mont Katatsumuri ?\nC'est juste un gars du Dernier Bataillon, non ?[1205][U+000F]\nOuais, ça doit être ça."
-  },
-  {
-    "id": 58,
-    "offset": 291426,
-    "data_size": 344,
-    "slot_size": 348,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]can't[SP]believe[SP]they[SP]still[SP]tell[SP]that[SP]story...\nKudan,[SP]huh...?[1205][U+000F][SP]Even[SP]at[SP]my[SP]age,[SP]I'm[SP]afraid[SP]of\nthat[SP]thing...[1205][U+000F][SP]Brrr![SP]Still[SP]gives[SP]me[SP]the[SP]creeps.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Je n'arrive pas à croire qu'on raconte encore ça...\nKudan...[1205][U+000F] Même à mon âge, j'en ai peur.[1205][U+000F]\nBrrr ! Ça me donne toujours des frissons."
-  },
-  {
-    "id": 59,
-    "offset": 291774,
-    "data_size": 332,
-    "slot_size": 336,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "There's[SP]a[SP]secret[SP]CD[SP]at[SP]Giga[SP]Macho?[SP]Stores[SP]have\nbeen[SP]coming[SP]up[SP]with[SP]odd[SP]promotional[SP]stunts\nlately.[1205][U+000F][SP]Though[SP]it[SP]does[SP]pique[SP]my[SP]interest...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un CD secret chez Giga Macho ?\nLes magasins ont des promotions bizarres.[1205][U+000F]\nCela pique ma curiosité..."
-  },
-  {
-    "id": 60,
-    "offset": 292110,
-    "data_size": 324,
-    "slot_size": 328,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Do[SP]you[SP]know[SP]the[SP]Dresser[SP]Hag?[1205][U+000F][SP]There's[SP]a[SP]creature\ncalled[SP]that[SP]at[SP]the[SP]abandoned[SP]factory.[1205][U+000F][SP]Does[SP]that\nmean[SP]it[SP]lives[SP]inside[SP]a[SP]dresser?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tu connais la Sorcière du Buffet ?[1205][U+000F]\nElle serait à l'usine abandonnée.[1205][U+000F]\nElle vit dans un buffet ?"
-  },
-  {
-    "id": 61,
-    "offset": 292438,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]it[SP]true[SP]Time[SP]Castle[SP]sells[SP]real[SP]weapons?\nI[SP]heard[SP]my[SP]coworkers[SP]say[SP]their[SP]quality[SP]and\nprices[SP]were[SP]average...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Time Castle vend de vraies armes ?\nDes collègues disent qualité et prix moyens..."
-  },
-  {
-    "id": 62,
-    "offset": 292720,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]it[SP]true[SP]Time[SP]Castle[SP]sells[SP]real[SP]weapons?\nI[SP]heard[SP]my[SP]coworkers[SP]say[SP]their[SP]quality[SP]was\ngood,[SP]but[SP]they[SP]were[SP]expensive...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Time Castle vend de vraies armes ?\nBonne qualité mais chères, disent mes collègues."
-  },
-  {
-    "id": 63,
-    "offset": 293022,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]it[SP]true[SP]Time[SP]Castle[SP]sells[SP]real[SP]weapons?\nI[SP]heard[SP]my[SP]coworkers[SP]say[SP]their[SP]prices[SP]were\nlow,[SP]but[SP]so[SP]was[SP]the[SP]quality...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Time Castle vend de vraies armes ?\nPrix bas, qualité basse aussi."
-  },
-  {
-    "id": 64,
-    "offset": 293320,
-    "data_size": 328,
-    "slot_size": 332,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells\nweapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]his[SP]selection's\ngreat,[SP]but[SP]his[SP]resale[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tony, le vendeur à Yumezaki, vend des armes à la sauvette.\nBon choix, reprises basses."
-  },
-  {
-    "id": 65,
-    "offset": 293652,
-    "data_size": 334,
-    "slot_size": 338,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells\nweapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]his[SP]prices[SP]are\ngood,[SP]but[SP]the[SP]quality[SP]of[SP]his[SP]stock[SP]isn't.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tony vend des armes à la sauvette.\nPrix corrects, qualité médiocre."
-  },
-  {
-    "id": 66,
-    "offset": 293990,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells\nweapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]his[SP]stock's\nof[SP]average[SP]quality[SP]and[SP]price.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tony vend des armes en plein rue.\nQualité et prix moyens."
-  },
-  {
-    "id": 67,
-    "offset": 294298,
-    "data_size": 332,
-    "slot_size": 336,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells\nweapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]he[SP]keeps[SP]his\nquality[SP]high,[SP]but[SP]his[SP]prices[SP]are[SP]high[SP]too.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tony : armes de qualité, prix élevés."
-  },
-  {
-    "id": 68,
-    "offset": 294634,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Clair de Lune... J'y suis allé avec un associé.\nIls vendent des armes ?"
-  },
-  {
-    "id": 69,
-    "offset": 294886,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]their[SP]selection[SP]isn't[SP]great,\nbut[SP]they[SP]offer[SP]good[SP]resale[SP]prices.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Peu de choix, mais bonnes reprises."
-  },
-  {
-    "id": 70,
-    "offset": 295104,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Clair de Lune... J'y suis allé avec un associé.\nIls vendent des armes ?"
-  },
-  {
-    "id": 71,
-    "offset": 295356,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]their[SP]prices[SP]are[SP]affordable,\nbut[SP]their[SP]stuff's[SP]low[SP]quality.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Prix abordables, qualité basse."
-  },
-  {
-    "id": 72,
-    "offset": 295566,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Clair de Lune... J'y suis allé avec un associé.\nIls vendent des armes ?"
-  },
-  {
-    "id": 73,
-    "offset": 295818,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]their[SP]stuff[SP]is[SP]top-tier,\nbut[SP]it's[SP]not[SP]exactly[SP]affordable.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qualité premium, mais cher."
-  },
-  {
-    "id": 74,
-    "offset": 296024,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Clair de Lune... J'y suis allé avec un associé.\nIls vendent des armes ?"
-  },
-  {
-    "id": 75,
-    "offset": 296276,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]their[SP]selection[SP]is[SP]great,\nbut[SP]they[SP]offer[SP]low[SP]resale[SP]prices.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Grand choix, reprises basses."
-  },
-  {
-    "id": 76,
-    "offset": 296486,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business\npartner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Clair de Lune... J'y suis allé avec un associé.\nIls vendent des armes ?"
-  },
-  {
-    "id": 77,
-    "offset": 296738,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]their[SP]prices[SP]and[SP]quality\nare[SP]average.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qualité et prix moyens."
-  },
-  {
-    "id": 78,
-    "offset": 296904,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Average[SP]quality[SP]and[SP]prices,[SP]huh...?[1205][U+000F][SP]I'd[SP]never\nhave[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real[SP]weapons.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qualité et prix moyens ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes."
-  },
-  {
-    "id": 79,
-    "offset": 297152,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qu'est-il arrivé à cette ville ?"
-  },
-  {
-    "id": 80,
-    "offset": 297296,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Low[SP]prices,[SP]but[SP]low[SP]quality,[SP]huh...?[1205][U+000F][SP]I'd[SP]never\nhave[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real[SP]weapons.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Prix bas, qualité basse ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes."
-  },
-  {
-    "id": 81,
-    "offset": 297546,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qu'est-il arrivé à cette ville ?"
-  },
-  {
-    "id": 82,
-    "offset": 297690,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Great[SP]selection,[SP]but[SP]low[SP]resale[SP]prices,[SP]huh...?[1205][U+000F]\nI'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real\nweapons.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Bon choix, reprises basses ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes."
-  },
-  {
-    "id": 83,
-    "offset": 297962,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qu'est-il arrivé à cette ville ?"
-  },
-  {
-    "id": 84,
-    "offset": 298106,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Poor[SP]selection,[SP]but[SP]great[SP]resale[SP]prices,[SP]eh...?[1205][U+000F]\nI'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real\nweapons.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Peu de choix, bonnes reprises ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes."
-  },
-  {
-    "id": 85,
-    "offset": 298378,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qu'est-il arrivé à cette ville ?"
-  },
-  {
-    "id": 86,
-    "offset": 298522,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Great[SP]quality,[SP]but[SP]high[SP]prices,[SP]huh...?[1205][U+000F]\nI'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold\nreal[SP]weapons.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Bonne qualité, prix élevés ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes."
-  },
-  {
-    "id": 87,
-    "offset": 298778,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qu'est-il arrivé à cette ville ?"
-  },
-  {
-    "id": 88,
-    "offset": 298922,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor\nas[SP]well[SP]as[SP]clothes?[1205][U+000F][SP]I[SP]heard[SP]their[SP]quality[SP]and\nprices[SP]are[SP]average.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "La boutique de Rengedai vend armures et vêtements ?\nQualité et prix moyens."
-  },
-  {
-    "id": 89,
-    "offset": 299218,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "*sigh*[SP]Does[SP]that[SP]mean[SP]it[SP]isn't[SP]enough[SP]just\nto[SP]sell[SP]clothes[SP]in[SP]this[SP]economy?[SP]Now[SP]that's\nscary...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur..."
-  },
-  {
-    "id": 90,
-    "offset": 299474,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor\nas[SP]well[SP]as[SP]clothes?[1205][U+000F][SP]I[SP]heard[SP]their[SP]prices[SP]are\nlow,[SP]but[SP]so[SP]is[SP]the[SP]quality.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Boutique de Rengedai : armures.\nPrix bas, qualité basse."
-  },
-  {
-    "id": 91,
-    "offset": 299784,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "*sigh*[SP]Does[SP]that[SP]mean[SP]it[SP]isn't[SP]enough[SP]just\nto[SP]sell[SP]clothes[SP]in[SP]this[SP]economy?[SP]Now[SP]that's\nscary...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur..."
-  },
-  {
-    "id": 92,
-    "offset": 300040,
-    "data_size": 312,
-    "slot_size": 316,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor\nas[SP]well[SP]as[SP]clothes?[1205][U+000F][SP]I[SP]heard[SP]their[SP]quality[SP]is\nhigh,[SP]but[SP]so[SP]are[SP]their[SP]prices.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Boutique de Rengedai : armures.\nHaute qualité, prix élevés."
-  },
-  {
-    "id": 93,
-    "offset": 300356,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "*sigh*[SP]Does[SP]that[SP]mean[SP]it[SP]isn't[SP]enough[SP]just\nto[SP]sell[SP]clothes[SP]in[SP]this[SP]economy?[SP]Now[SP]that's\nscary...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur..."
-  },
-  {
-    "id": 94,
-    "offset": 300612,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that\nthe[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]quality\nand[SP]prices[SP]are[SP]average.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Anima Mundi vend des armures. Nouvelle mode ?\nQualité et prix moyens."
-  },
-  {
-    "id": 95,
-    "offset": 300896,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that\nthe[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]goods[SP]are\ncheap,[SP]but[SP]low[SP]in[SP]quality.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Anima Mundi vend des armures.\nBon marché, qualité basse."
-  },
-  {
-    "id": 96,
-    "offset": 301190,
-    "data_size": 322,
-    "slot_size": 326,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that\nthe[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]selection\nis[SP]great,[SP]but[SP]their[SP]resale[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Anima Mundi : grand choix, reprises basses."
-  },
-  {
-    "id": 97,
-    "offset": 301516,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that\nthe[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]quality[SP]is\nhigh,[SP]but[SP]they're[SP]very[SP]expensive.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Anima Mundi : haute qualité, très cher."
-  },
-  {
-    "id": 98,
-    "offset": 301826,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nThey[SP]don't[SP]have[SP]a[SP]great[SP]selection,[SP]but[SP]their\nresale[SP]prices[SP]are[SP]worth[SP]it.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba vend des armures.\nPeu de choix, reprises intéressantes."
-  },
-  {
-    "id": 99,
-    "offset": 302126,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
-  },
-  {
-    "id": 100,
-    "offset": 302394,
-    "data_size": 228,
-    "slot_size": 232,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nTheir[SP]quality[SP]and[SP]prices[SP]seem[SP]average.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba : armures,\nqualité et prix moyens."
-  },
-  {
-    "id": 101,
-    "offset": 302626,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
-  },
-  {
-    "id": 102,
-    "offset": 302894,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nTheir[SP]quality[SP]is[SP]great,[SP]but[SP]I[SP]hear[SP]they're\nexpensive.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba :\nbonne qualité, cher."
-  },
-  {
-    "id": 103,
-    "offset": 303156,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
-  },
-  {
-    "id": 104,
-    "offset": 303424,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nTheir[SP]prices[SP]are[SP]certainly[SP]right,[SP]but[SP]there's\na[SP]certain[SP]lack[SP]of[SP]quality[SP]there.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba : prix corrects,\nmais qualité insuffisante."
-  },
-  {
-    "id": 105,
-    "offset": 303736,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
-  },
-  {
-    "id": 106,
-    "offset": 304004,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nThey[SP]have[SP]a[SP]great[SP]selection,[SP]but[SP]their[SP]resale\nprices[SP]seem[SP]low.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba :\ngrand choix, reprises basses."
-  },
-  {
-    "id": 107,
-    "offset": 304284,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants\nthat[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can\nthis[SP]city[SP]get?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
-  },
-  {
-    "id": 108,
-    "offset": 304552,
-    "data_size": 334,
-    "slot_size": 338,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]selection\nis[SP]great[SP]there,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "J'ai fait faire ce manteau chez London Clothier.\nIls vendent aussi des armures ! Bon choix,\nmais reprises basses."
-  },
-  {
-    "id": 109,
-    "offset": 304890,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]Their[SP]prices\nare[SP]low,[SP]but[SP]so[SP]is[SP]the[SP]quality.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "London Clothier fait aussi des armures.\nPrix bas, qualité basse."
-  },
-  {
-    "id": 110,
-    "offset": 305196,
-    "data_size": 320,
-    "slot_size": 324,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]quality[SP]is\nfantastic,[SP]but[SP]the[SP]prices[SP]are[SP]so[SP]high.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "London Clothier : ils vendent des armures.\nQualité fantastique, prix très élevés."
-  },
-  {
-    "id": 111,
-    "offset": 305520,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]quality\nand[SP]prices[SP]of[SP]their[SP]goods[SP]are[SP]average.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "London Clothier vend des armures.\nQualité et prix moyens."
-  },
-  {
-    "id": 112,
-    "offset": 305838,
-    "data_size": 334,
-    "slot_size": 338,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.\nWho[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]selection\nis[SP]poor[SP]there,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]good.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "London Clothier : peu de choix,\nmais bonnes reprises."
-  },
-  {
-    "id": 113,
-    "offset": 306176,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][U+000F][SP]But[SP]I\nhear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll\nget[SP]real[SP]weapons[SP]and[SP]items.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Je n'ai jamais gagné de concours.[1205][U+000F]\nMais gagner donne de vraies armes et objets."
-  },
-  {
-    "id": 114,
-    "offset": 306490,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]it's[SP]hard[SP]to[SP]win,[SP]but[SP]you[SP]get\nnice[SP]prizes[SP]if[SP]you[SP]do.[SP]I[SP]wonder[SP]if[SP]I[SP]should\ngive[SP]it[SP]another[SP]try.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Difficile à gagner, mais lots sympas.\nJe devrais peut-être réessayer."
-  },
-  {
-    "id": 115,
-    "offset": 306770,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][U+000F][SP]But[SP]I\nhear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll\nget[SP]real[SP]weapons[SP]and[SP]items.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais gagné de concours.[1205][U+000F]\nMais gagner donne de vraies armes et objets."
-  },
-  {
-    "id": 116,
-    "offset": 307084,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]it's[SP]very[SP]rare[SP]for[SP]anyone[SP]to[SP]win,\nbut[SP]you[SP]get[SP]amazing[SP]prizes[SP]if[SP]you[SP]do.[SP]I[SP]wonder\nif[SP]I[SP]should[SP]give[SP]it[SP]another[SP]try.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Très rare de gagner, lots incroyables.\nJe devrais réessayer."
-  },
-  {
-    "id": 117,
-    "offset": 307402,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][U+000F][SP]But[SP]I\nhear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll\nget[SP]real[SP]weapons[SP]and[SP]items.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais gagné de concours.[1205][U+000F]\nMais gagner donne de vraies armes et objets."
-  },
-  {
-    "id": 118,
-    "offset": 307716,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Rumor[SP]has[SP]it[SP]it's[SP]easy[SP]to[SP]win,[SP]but[SP]you[SP]get\njunk[SP]for[SP]prizes.[SP]And[SP]I've[SP]still[SP]never[SP]won...\nI[SP]must[SP]have[SP]the[SP]worst[SP]luck.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Facile à gagner, prix pourris.\nJe n'ai jamais gagné. J'ai la pire chance."
-  },
-  {
-    "id": 119,
-    "offset": 308012,
-    "data_size": 328,
-    "slot_size": 332,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it\nseems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][U+000F][SP]I[SP]get[SP]a[SP]tingle[SP]of\nexcitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][U+000F]\nL'idée de jouer m'excite..."
-  },
-  {
-    "id": 120,
-    "offset": 308344,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "A[SP]friend[SP]of[SP]mine[SP]went...[1205][U+000F][SP]He[SP]said[SP]you[SP]can[SP]win\nbig[SP]at[SP]the[SP]#5[SP]poker[SP]machine.[SP]Unfortunately,\nI[SP]don't[SP]know[SP]how[SP]to[SP]play[SP]poker.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un ami y est allé.[1205][U+000F] On peut gagner gros\nà la machine de poker n°5.\nJe ne sais pas jouer au poker."
-  },
-  {
-    "id": 121,
-    "offset": 308654,
-    "data_size": 328,
-    "slot_size": 332,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it\nseems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][U+000F][SP]I[SP]get[SP]a[SP]tingle[SP]of\nexcitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][U+000F]\nL'idée de jouer m'excite..."
-  },
-  {
-    "id": 122,
-    "offset": 308986,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "A[SP]friend[SP]of[SP]mine[SP]went...[1205][U+000F][SP]He[SP]said[SP]you[SP]can[SP]win\nbig[SP]at[SP]the[SP]slot[SP]machine[SP]at[SP]the[SP]end.[SP]I[SP]wonder,\ndid[SP]he[SP]mean[SP]the[SP]#1[SP]or[SP]#8[SP]machine?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un ami y est allé.[1205][U+000F] On peut gagner gros\nà la machine à sous du fond.\n#1 ou #8 ?"
-  },
-  {
-    "id": 123,
-    "offset": 309304,
-    "data_size": 328,
-    "slot_size": 332,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it\nseems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][U+000F][SP]I[SP]get[SP]a[SP]tingle[SP]of\nexcitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][U+000F]\nL'idée de jouer m'excite..."
-  },
-  {
-    "id": 124,
-    "offset": 309636,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "A[SP]friend[SP]of[SP]mine[SP]went...[SP]He[SP]said[SP]you[SP]can[SP]win\nbig[SP]at[SP]blackjack.[1205][U+000F][SP]Then[SP]again,[SP]it[SP]would[SP]be[SP]bad\nif[SP]my[SP]wife[SP]found[SP]out...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un ami y est allé. On peut gagner gros\nau blackjack.[1205][U+000F]\nMais ce serait mal si ma femme le savait..."
-  },
-  {
-    "id": 125,
-    "offset": 309934,
-    "data_size": 336,
-    "slot_size": 340,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]may[SP]not[SP]look[SP]it,[SP]but[SP]I[SP]love[SP]antiques.[SP]I[SP]used\nto[SP]frequent[SP]places[SP]like[SP]Time[SP]Castle.[1205][U+000F][SP]By[SP]the\nway,[SP]do[SP]you[SP]know[SP]what[SP]a[SP]legendary[SP]weapon[SP]is?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "J'adore les antiquités. Je fréquentais Time Castle.[1205][U+000F]\nAu fait, savez-vous ce qu'est une arme légendaire ?"
-  },
-  {
-    "id": 126,
-    "offset": 310274,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I[SP]heard[SP]Shiraishi[SP]Ramen[SP]has[SP]one.[SP]If[SP]it's[SP]true,\nI'd[SP]love[SP]to[SP]at[SP]least[SP]get[SP]a[SP]glimpse...",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Shiraishi Ramen en aurait une.\nJ'aimerais au moins la voir."
-  },
-  {
-    "id": 127,
-    "offset": 310508,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "It[SP]seems[SP]there's[SP]a[SP]legendary[SP]weapon[SP]at\nClair[SP]de[SP]Lune.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Une arme légendaire au Clair de Lune."
-  },
-  {
-    "id": 128,
-    "offset": 310680,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "I'm[SP]quite[SP]fond[SP]of[SP]antiques,[SP]so[SP]I[SP]hope[SP]to[SP]at\nleast[SP]get[SP]a[SP]glimpse[SP]of[SP]what[SP]it[SP]looks[SP]like.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "J'aime les antiquités.\nJ'espère au moins la voir."
-  },
-  {
-    "id": 129,
-    "offset": 310918,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "It[SP]seems[SP]there's[SP]a[SP]legendary[SP]weapon[SP]at[SP]Time\nCastle,[SP]but[SP]the[SP]owner[SP]is[SP]playing[SP]dumb[SP]to[SP]jack\nup[SP]the[SP]price.[SP]What[SP]a[SP]miser!",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Une arme légendaire à Time Castle.\nLe propriétaire fait le sourd pour faire monter le prix.\nQuel avare !"
-  },
-  {
-    "id": 130,
-    "offset": 311218,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "No[SP]wonder[SP]there's[SP]nothing[SP]like[SP]a[SP]legendary\nweapon[SP]at[SP]Time[SP]Castle.[SP]Apparently,[SP]it[SP]hasn't\nbeen[SP]delivered[SP]yet.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Pas étonnant qu'il n'y ait pas d'arme légendaire.\nElle n'a pas encore été livrée."
-  },
-  {
-    "id": 131,
-    "offset": 311498,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "The[SP]seller[SP]is[SP]waiting[SP]at[SP]the[SP]abandoned\nfactory,[SP]but[SP]the[SP]owner's[SP]afraid[SP]of[SP]monsters\nand[SP]won't[SP]go[SP]meet[SP]him.[SP]What[SP]a[SP]coward!",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Le vendeur attend à l'usine abandonnée,\nmais le propriétaire a peur des monstres.\nQuel lâche !"
-  },
-  {
-    "id": 132,
-    "offset": 311804,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Hmmm...[SP]I[SP]heard[SP]a[SP]rumor[SP]that[SP]demons[SP]stole[SP]the\nlegendary[SP]weapon[SP]from[SP]Time[SP]Castle.[SP]Is[SP]it[SP]true?",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "J'ai entendu que des démons ont volé l'arme légendaire.\nC'est vrai ?"
-  },
-  {
-    "id": 133,
-    "offset": 312054,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Augh,[SP]I[SP]was[SP]too[SP]late...[SP]Apparently[SP]a[SP]terribly\nunlucky[SP]woman[SP]bought[SP]Time[SP]Castle's[SP]legendary\nweapon[SP]before[SP]I[SP]could[SP]see[SP]it.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Trop tard. Une femme malchanceuse a acheté\nl'arme légendaire avant que je puisse la voir."
-  },
-  {
-    "id": 134,
-    "offset": 312360,
-    "data_size": 312,
-    "slot_size": 316,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Must[SP]have[SP]been[SP]a[SP]fellow[SP]antique[SP]lover.[SP]If[SP]only\nI[SP]had[SP]made[SP]up[SP]my[SP]mind[SP]earlier,[SP]I[SP]could[SP]have\ngotten[SP]there[SP]first...[SP]What[SP]a[SP]pity.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un autre amateur d'antiquités.\nSi j'avais décidé plus tôt, j'aurais été premier.\nQuel dommage."
-  },
-  {
-    "id": 135,
-    "offset": 312676,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "Honestly,[SP]of[SP]all[SP]the[SP]luck.[SP]It[SP]seems[SP]the[SP]owner\nof[SP]Time[SP]Castle[SP]gave[SP]away[SP]that[SP]legendary[SP]weapon.",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Quelle malchance. Le propriétaire a donné\nl'arme légendaire."
-  },
-  {
-    "id": 136,
-    "offset": 312928,
-    "data_size": 318,
-    "slot_size": 322,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Middle-aged[SP]office[SP]worker",
-    "texte_orig": "To[SP]some[SP]girl[SP]with[SP]short[SP]hair,[SP]supposedly...\nBut[SP]that's[SP]too[SP]vague[SP]a[SP]hint[SP]to[SP]go[SP]on.[SP]*sigh*\nIf[SP]only[SP]I[SP]bought[SP]it[SP]before[SP]it[SP]was[SP]gone!",
-    "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "À une fille aux cheveux courts, dit-on.\nIndice trop vague. *soupir*\nSi seulement je l'avais achetée !"
-  },
-  {
-    "id": 137,
-    "offset": 313250,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Have[SP]you[SP]heard[SP]the[SP]rumor[SP]that[SP]a[SP]woman's[SP]ghost\nis[SP]appearing[SP]in[SP]Aoba[SP]Park?[1205][U+000F]",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu as entendu ? Le fantôme d'une femme\n apparaît dans le parc d'Aoba.[1205][U+000F]"
-  },
-  {
-    "id": 138,
-    "offset": 313440,
-    "data_size": 176,
-    "slot_size": 180,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Do[SP]you[SP]think[SP]it's[SP]true?[1205][U+000F][SP]If[SP]it[SP]is,[SP]I[SP]ought[SP]to\nchange[SP]my[SP]daily[SP]route.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu crois que c'est vrai ?[1205][U+000F]\nJe devrais changer mon itinéraire."
-  },
-  {
-    "id": 139,
-    "offset": 313620,
-    "data_size": 176,
-    "slot_size": 180,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Wh-What[SP]are[SP]we[SP]going[SP]to[SP]do...?[SP]Even[SP]the[SP]fire\ndepartment[SP]was[SP]bombed...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qu'allons-nous faire... ?\nMême les pompiers ont été bombardés..."
-  },
-  {
-    "id": 140,
-    "offset": 313800,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "There's[SP]no[SP]one[SP]left[SP]to[SP]put[SP]out[SP]the[SP]flames[SP]in\ncase[SP]of[SP]another[SP]attack!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Personne pour éteindre les flammes\n en cas de nouvelle attaque !"
-  },
-  {
-    "id": 141,
-    "offset": 313978,
-    "data_size": 312,
-    "slot_size": 316,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Do[SP]you[SP]know[SP]what[SP]this[SP]Last[SP]Battalion[SP]thing[SP]is?[1205][U+000F]\nI[SP]hear[SP]they're[SP]the[SP]terrorists[SP]responsible[SP]for\nthe[SP]attacks,[SP]but[SP]I've[SP]never[SP]heard[SP]of[SP]them.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu sais ce qu'est le Dernier Bataillon ?[1205][U+000F]\nOn dit qu'ils sont les terroristes responsables,\nmais je n'en ai jamais entendu parler."
-  },
-  {
-    "id": 142,
-    "offset": 314294,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Are[SP]the[SP]Masked[SP]Circle[SP]not[SP]the[SP]only[SP]guys[SP]like\nthat[SP]walking[SP]around?[1205][U+000F][SP]If[SP]so,[SP]why[SP]are[SP]they\nattacking[SP]the[SP]city!?[SP]I[SP]don't[SP]know[SP]what[SP]to[SP]do!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le Cercle Masqué n'est pas le seul groupe ?[1205][U+000F]\nPourquoi attaquent-ils la ville !?\nJe ne sais pas quoi faire !"
-  },
-  {
-    "id": 143,
-    "offset": 314602,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]heard[SP]they[SP]posted[SP]composite[SP]sketches[SP]of[SP]the\nsuspects.[SP]So[SP]are[SP]they[SP]Masked[SP]Circle?[1205][U+000F][SP]Or[SP]Last\nBattalion?[1205][U+000F][SP]I'm[SP]just[SP]so[SP]confused.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils ont affiché des portraits-robots.\nIls sont du Cercle Masqué ?[1205][U+000F] Ou du Dernier Bataillon ?[1205][U+000F]\nJe suis perdue."
-  },
-  {
-    "id": 144,
-    "offset": 314898,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Geez![SP]I[SP]wish[SP]they'd[SP]be[SP]more[SP]specific[SP]with[SP]the\nnews[SP]broadcasts.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Dommage qu'ils ne soient pas plus précis\naux infos."
-  },
-  {
-    "id": 145,
-    "offset": 315064,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "They're[SP]just[SP]going[SP]to[SP]end[SP]up[SP]confusing[SP]more\npeople[SP]about[SP]who[SP]the[SP]terrorists[SP]are!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils ne font que semer plus de confusion\n sur les terroristes !"
-  },
-  {
-    "id": 146,
-    "offset": 315266,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]wonder[SP]if[SP]it's[SP]safe[SP]to[SP]be[SP]out[SP]like[SP]this.[1205][U+000F]\nB-But[SP]where[SP]would[SP]I[SP]hide?[SP]We[SP]can't[SP]rely[SP]on\nthe[SP]police[SP]anymore,[SP]after[SP]all...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Est-ce sûr d'être dehors ?[1205][U+000F]\nMais où me cacher ? On ne peut plus compter\n sur la police..."
-  },
-  {
-    "id": 147,
-    "offset": 315548,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Whew...[1205][U+000A][SP]Now[SP]that[SP]we're[SP]in[SP]the[SP]sky,[SP]my[SP]options\nfor[SP]walking[SP]are[SP]limited.[1205][U+000F][SP]Huh?[SP]Now's[SP]not[SP]the\ntime[SP]for[SP]that?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ouf...[1205][U+000A] Dans le ciel, mes options de marche sont limitées.[1205][U+000F]\nHein ? Ce n'est pas le moment ?"
-  },
-  {
-    "id": 148,
-    "offset": 315806,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "But[SP]there's[SP]no[SP]use[SP]panicking[SP]if[SP]things[SP]have\ngotten[SP]this[SP]bad.[1205][U+000F][SP]I[SP]don't[SP]care[SP]anymore[SP]if[SP]we\nevolve[SP]or[SP]all[SP]die[SP]off.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Inutile de paniquer. Ça a déjà trop empiré.[1205][U+000F]\nJe m'en fiche qu'on évolue ou qu'on meure."
-  },
-  {
-    "id": 149,
-    "offset": 316072,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Have[SP]you[SP]heard?[1205][U+000F][SP]There[SP]are[SP]countless[SP]rumors\nflying[SP]around[SP]about[SP]what[SP]kind[SP]of[SP]end[SP]the\npeople[SP]below[SP]will[SP]face.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu as entendu ?[1205][U+000F]\nDes rumeurs sur la fin des gens d'en bas."
-  },
-  {
-    "id": 150,
-    "offset": 316332,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]latest[SP]is[SP]that[SP]when[SP]the[SP]Grand[SP]Cross[SP]is\ncomplete,[SP]an[SP]intense[SP]magnetic[SP]storm[SP]will[SP]arise\nand[SP]scorch[SP]the[SP]Earth's[SP]surface.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "La dernière : la Grande Croix provoquera\n une tempête magnétique brûlant la Terre."
-  },
-  {
-    "id": 151,
-    "offset": 316616,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]did[SP]you[SP]hear?[1205][U+000A][SP]When[SP]the[SP]Grand[SP]Cross[SP]is\ncomplete,[SP]a[SP]plasma[SP]vortex[SP]will[SP]form[SP]and[SP]the\nwhole[SP]Earth[SP]will[SP]look[SP]like[SP]those[SP]crop[SP]circles.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Hé, tu as entendu ?[1205][U+000A]\nLa Grande Croix créera un vortex de plasma,\n la Terre ressemblera à des crop circles."
-  },
-  {
-    "id": 152,
-    "offset": 316928,
-    "data_size": 322,
-    "slot_size": 326,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]seems[SP]like[SP]when[SP]the[SP]Grand[SP]Cross[SP]is[SP]over,[SP]the\nbalance[SP]of[SP]gravity[SP]will[SP]crumble[SP]and[SP]the[SP]Earth's\nrotation[SP]will[SP]stop.[1205][U+000F][SP]Then[SP]the[SP]world[SP]will[SP]end.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Après la Grande Croix, la gravité s'effondrera,\n la Terre s'arrêtera.[1205][U+000F]\nAlors le monde finira."
-  },
-  {
-    "id": 153,
-    "offset": 317254,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]have[SP]you[SP]heard[SP]about[SP]Zodiac?[SP]Their[SP]second\nfloor[SP]is[SP]a[SP]huge[SP]dungeon[SP]now,[SP]filled[SP]with[SP]items.[1205][U+000F]\nWhat[SP]a[SP]weird[SP]club.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu as entendu parler de Zodiac ?\nLeur deuxième étage est devenu un donjon rempli d'objets.[1205][U+000F]\nBizarre."
-  },
-  {
-    "id": 154,
-    "offset": 317526,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]talking[SP]flowers[SP]in[SP]Aoba\nPark?[SP]How[SP]gossipy[SP]would[SP]they[SP]be...?[SP]Guess[SP]you\ncan't[SP]try[SP]anything[SP]funny[SP]there[SP]after[SP]all.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu connais les fleurs qui parlent à Aoba ?\nComme elles seraient bavardes...\nOn ne peut rien tenter de drôle là-bas."
-  },
-  {
-    "id": 155,
-    "offset": 317834,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "H-Hey,[SP]the[SP]rumor[SP]about[SP]that[SP]idol's[SP]ghost[SP]in\nAoba[SP]Park[SP]was[SP]real,[SP]wasn't[SP]it?[1205][U+000F][SP]I[SP]heard[SP]people\nin[SP]the[SP]city[SP]talking[SP]about[SP]it[SP]too!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Hé, le fantôme de l'idole à Aoba était réel ?[1205][U+000F]\nJ'ai entendu des gens en parler !"
-  },
-  {
-    "id": 156,
-    "offset": 318126,
-    "data_size": 210,
-    "slot_size": 214,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Ugh,[SP]what[SP]should[SP]I[SP]do...?[1205][U+000F][SP]This[SP]has[SP]always[SP]been\npart[SP]of[SP]the[SP]route[SP]I[SP]take[SP]on[SP]my[SP]walks.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qu'est-ce que je fais ?[1205][U+000F]\nCela a toujours fait partie de mon itinéraire."
-  },
-  {
-    "id": 157,
-    "offset": 318340,
-    "data_size": 238,
-    "slot_size": 242,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]don't[SP]want[SP]to[SP]get[SP]possessed[SP]by[SP]some[SP]evil\nspirit...[1205][U+000F][SP]I-I'm[SP]gonna[SP]stop[SP]passing[SP]by[SP]here\nfrom[SP]now[SP]on.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je ne veux pas me faire posséder.[1205][U+000F]\nJe vais éviter de passer par ici désormais."
-  },
-  {
-    "id": 158,
-    "offset": 318582,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Did[SP]you[SP]know[SP]there's[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the\nabandoned[SP]factory?[SP]I[SP]heard[SP]it[SP]goes[SP]into[SP]the\ncity[SP]at[SP]night[SP]to[SP]kill.[SP]Scary...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Un Taxi Maudit à l'usine abandonnée ?\nIl tue la nuit en ville. Effrayant..."
-  },
-  {
-    "id": 159,
-    "offset": 318858,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Huh?[1205][U+000F][SP]It[SP]wasn't[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the[SP]abandoned\nfactory,[SP]it[SP]was[SP]a[SP]Cursed[SP]Escort?[1205][U+000F][SP]But[SP]don't[SP]they\nwork[SP]pretty[SP]much[SP]the[SP]same[SP]way?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Hein ?[1205][U+000F] C'est une Escorte Maudite, pas un Taxi ?[1205][U+000F]\nMais ça revient au même, non ?"
-  },
-  {
-    "id": 160,
-    "offset": 319156,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]does[SP]Kuchisake-onna[SP]really[SP]exist?[SP]I[SP]heard\nshe's[SP]shown[SP]up[SP]at[SP]Mt.[SP]Iwato![1205][U+000F][SP]Now[SP]I[SP]can't[SP]go\nwalking[SP]there[SP]anymore[SP]either...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Kuchisake-onna existe ?\nElle serait au mont Iwato ![1205][U+000F]\nJe ne peux plus y aller non plus..."
-  },
-  {
-    "id": 161,
-    "offset": 319446,
-    "data_size": 250,
-    "slot_size": 254,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]what's[SP]a[SP]Jumping[SP]Geezer?[1205][U+000F][SP]Because[SP]I[SP]heard\na[SP]rumor[SP]there's[SP]a[SP]creature[SP]called[SP]that[SP]at\nMt.[SP]Katatsumuri.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "C'est quoi un Sauteur Vieux ?[1205][U+000F]\nIl y en aurait un au mont Katatsumuri."
-  },
-  {
-    "id": 162,
-    "offset": 319700,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Well,[SP]with[SP]the[SP]soldiers[SP]patrolling[SP]there,\nI[SP]wasn't[SP]going[SP]near[SP]that[SP]mountain[SP]to[SP]begin\nwith.[1205][U+000F][SP]It's[SP]just[SP]one[SP]thing[SP]after[SP]another...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Avec les soldats, je ne m'approchais déjà pas.\nC'est une chose après l'autre..."
-  },
-  {
-    "id": 163,
-    "offset": 320000,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]am[SP]I[SP]going[SP]to[SP]do!?[1205][U+000F][SP]I[SP]can't[SP]sleep[SP]alone\nafter[SP]hearing[SP]a[SP]story[SP]like[SP]that![SP]I[SP]need[SP]to\ntry[SP]and[SP]put[SP]Kudan[SP]out[SP]of[SP]my[SP]mind...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je vais faire quoi !?[1205][U+000F]\nJe ne peux plus dormir seule après ça !\nIl faut que je chasse Kudan de mon esprit..."
-  },
-  {
-    "id": 164,
-    "offset": 320290,
-    "data_size": 136,
-    "slot_size": 140,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Giga[SP]Macho[SP]carries[SP]a\nsecret[SP]CD?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Giga Macho a un CD secret."
-  },
-  {
-    "id": 165,
-    "offset": 320430,
-    "data_size": 172,
-    "slot_size": 176,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]special[SP]track[SP]on[SP]it[SP]you\ncan't[SP]hear[SP]any[SP]other[SP]way.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Il contient un morceau spécial\nqu'on n'entend nulle part ailleurs."
-  },
-  {
-    "id": 166,
-    "offset": 320606,
-    "data_size": 194,
-    "slot_size": 198,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]Dresser[SP]Hag's[SP]that[SP]monster[SP]that's[SP]an[SP]old\nwoman[SP]living[SP]in[SP]a[SP]dresser,[SP]right?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "La Sorcière du Buffet, c'est la vieille femme\nqui vit dans un buffet, c'est ça ?"
-  },
-  {
-    "id": 167,
-    "offset": 320804,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Why[SP]would[SP]something[SP]like[SP]that[SP]be[SP]at[SP]the\nabandoned[SP]factory...?[1205][U+000F][SP]Well,[SP]guess[SP]I'm[SP]not\ngoing[SP]near[SP]there[SP]anymore.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Pourquoi à l'usine abandonnée ?[1205][U+000F]\nJe ne m'en approcherai plus."
-  },
-  {
-    "id": 168,
-    "offset": 321064,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][U+000F][SP]I[SP]mean,\nan[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rengedai doit être effrayant.[1205][U+000F]\nUne boutique d'antiquités qui vend des armes ?"
-  },
-  {
-    "id": 169,
-    "offset": 321274,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "People[SP]say[SP]their[SP]quality[SP]and[SP]prices[SP]are\njust[SP]average.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qualité et prix moyens."
-  },
-  {
-    "id": 170,
-    "offset": 321422,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][U+000F][SP]I[SP]mean,\nan[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rengedai doit être effrayant.[1205][U+000F]\nUne boutique d'antiquités qui vend des armes ?"
-  },
-  {
-    "id": 171,
-    "offset": 321632,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "People[SP]say[SP]their[SP]quality's[SP]great,[SP]but[SP]it's\nexpensive.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qualité excellente, cher."
-  },
-  {
-    "id": 172,
-    "offset": 321780,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][U+000F][SP]I[SP]mean,\nan[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rengedai doit être effrayant.[1205][U+000F]\nUne boutique d'antiquités qui vend des armes ?"
-  },
-  {
-    "id": 173,
-    "offset": 321990,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "People[SP]say[SP]their[SP]quality's[SP]not[SP]great,[SP]but[SP]at\nleast[SP]they're[SP]cheap.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qualité moyenne, mais bon marché."
-  },
-  {
-    "id": 174,
-    "offset": 322162,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off\nthe[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]the[SP]selection's\ngood,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Effrayant d'acheter des armes en pleine rue à Yumezaki.\nBon choix, reprises basses."
-  },
-  {
-    "id": 175,
-    "offset": 322462,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what\nare[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the\ncity[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ceux qui les utilisent sont en faute, mais à quoi pensent les commerçants ?\nLa ville devient de plus en plus dangereuse."
-  },
-  {
-    "id": 176,
-    "offset": 322764,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off\nthe[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]their[SP]quality's\nnot[SP]much,[SP]but[SP]the[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Effrayant d'acheter des armes en rue à Yumezaki.\nQualité médiocre, prix bas."
-  },
-  {
-    "id": 177,
-    "offset": 323058,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what\nare[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the\ncity[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ceux qui les utilisent sont en faute, mais à quoi pensent les commerçants ?\nLa ville devient de plus en plus dangereuse."
-  },
-  {
-    "id": 178,
-    "offset": 323360,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off\nthe[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]their[SP]quality\nand[SP]prices[SP]are[SP]average.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Effrayant d'acheter des armes en rue à Yumezaki.\nQualité et prix moyens."
-  },
-  {
-    "id": 179,
-    "offset": 323630,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what\nare[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the\ncity[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ceux qui les utilisent sont en faute, mais à quoi pensent les commerçants ?\nLa ville devient de plus en plus dangereuse."
-  },
-  {
-    "id": 180,
-    "offset": 323932,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off\nthe[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]they're[SP]pretty\nexpensive,[SP]but[SP]very[SP]high[SP]quality.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Effrayant d'acheter des armes en rue à Yumezaki.\nChères, mais très haute qualité."
-  },
-  {
-    "id": 181,
-    "offset": 324224,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what\nare[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the\ncity[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ceux qui les utilisent sont en faute, mais à quoi pensent les commerçants ?\nLa ville devient de plus en plus dangereuse."
-  },
-  {
-    "id": 182,
-    "offset": 324526,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Clair de Lune, le restau français ?"
-  },
-  {
-    "id": 183,
-    "offset": 324654,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]their[SP]selection[SP]is[SP]slim,[SP]but[SP]their\nresale[SP]prices[SP]are[SP]great.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils vendent des armes ?[1205][U+000F]\nPeu de choix, reprises excellentes."
-  },
-  {
-    "id": 184,
-    "offset": 324914,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
-  },
-  {
-    "id": 185,
-    "offset": 325148,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Clair de Lune, le restau français ?"
-  },
-  {
-    "id": 186,
-    "offset": 325276,
-    "data_size": 222,
-    "slot_size": 226,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]they're[SP]cheap,[SP]but[SP]sell[SP]low-quality\ngoods.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils vendent des armes ?[1205][U+000F]\nBon marché, mais basse qualité."
-  },
-  {
-    "id": 187,
-    "offset": 325502,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
-  },
-  {
-    "id": 188,
-    "offset": 325736,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Clair de Lune, le restau français ?"
-  },
-  {
-    "id": 189,
-    "offset": 325864,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]their[SP]quality's[SP]great,[SP]but[SP]expensive,\njust[SP]like[SP]the[SP]food[SP]they[SP]serve.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils vendent des armes ?[1205][U+000F]\nQualité excellente, cher, comme leur nourriture."
-  },
-  {
-    "id": 190,
-    "offset": 326142,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
-  },
-  {
-    "id": 191,
-    "offset": 326376,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Clair de Lune, le restau français ?"
-  },
-  {
-    "id": 192,
-    "offset": 326504,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]their[SP]selection[SP]is[SP]great,[SP]but[SP]their\nresale[SP]prices[SP]are[SP]pretty[SP]low.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils vendent des armes ?[1205][U+000F]\nGrand choix, reprises assez basses."
-  },
-  {
-    "id": 193,
-    "offset": 326776,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
-  },
-  {
-    "id": 194,
-    "offset": 327010,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Clair de Lune, le restau français ?"
-  },
-  {
-    "id": 195,
-    "offset": 327138,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F]\nI[SP]heard[SP]their[SP]quality[SP]and[SP]prices[SP]are[SP]average.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ils vendent des armes ?[1205][U+000F]\nQualité et prix moyens."
-  },
-  {
-    "id": 196,
-    "offset": 327354,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?\nHowever[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up\nrestaurant...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
-  },
-  {
-    "id": 197,
-    "offset": 327588,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]I[SP]hear[SP]the[SP]quality\nand[SP]prices[SP]are[SP]average,[SP]though.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\nQualité et prix moyens."
-  },
-  {
-    "id": 198,
-    "offset": 327886,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]I[SP]hear[SP]they're\ncheap,[SP]but[SP]low[SP]quality.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\nBon marché, basse qualité."
-  },
-  {
-    "id": 199,
-    "offset": 328160,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]His[SP]selection[SP]is\ngreat,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\nGrand choix, reprises basses."
-  },
-  {
-    "id": 200,
-    "offset": 328466,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]His[SP]selection[SP]is\nskimpy,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]great.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\nPeu de choix, reprises excellentes."
-  },
-  {
-    "id": 201,
-    "offset": 328778,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]I[SP]hear[SP]the[SP]quality\nis[SP]great,[SP]but[SP]his[SP]stuff[SP]is[SP]expensive.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\nQualité excellente, cher."
-  },
-  {
-    "id": 202,
-    "offset": 329088,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Rengedai\nsells[SP]real[SP]armor.[SP]Their[SP]quality[SP]and[SP]prices\nseem[SP]to[SP]be[SP]average.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le Rosa Candida de Rengedai vend des armures.\nQualité et prix moyens."
-  },
-  {
-    "id": 203,
-    "offset": 329346,
-    "data_size": 236,
-    "slot_size": 240,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]don't[SP]know[SP]how[SP]much[SP]of[SP]that[SP]is[SP]true,\nbut[SP]I'm[SP]thinking[SP]of[SP]checking[SP]it[SP]out.\nIt[SP]sounds[SP]interesting.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je ne sais si c'est vrai,\nmais je vais vérifier. Intéressant."
-  },
-  {
-    "id": 204,
-    "offset": 329586,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Rengedai\nsells[SP]real[SP]armor.[SP]Their[SP]quality[SP]seems[SP]low,\nbut[SP]at[SP]least[SP]their[SP]prices[SP]are[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida vend des armures.\nQualité basse, prix bas."
-  },
-  {
-    "id": 205,
-    "offset": 329874,
-    "data_size": 236,
-    "slot_size": 240,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]don't[SP]know[SP]how[SP]much[SP]of[SP]that[SP]is[SP]true,\nbut[SP]I'm[SP]thinking[SP]of[SP]checking[SP]it[SP]out.\nIt[SP]sounds[SP]interesting.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je ne sais si c'est vrai,\nmais je vais vérifier. Intéressant."
-  },
-  {
-    "id": 206,
-    "offset": 330114,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Rengedai\nsells[SP]real[SP]armor.[SP]They're[SP]expensive,[SP]but[SP]the\nquality[SP]is[SP]amazing.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida vend des armures.\nCher, mais qualité incroyable."
-  },
-  {
-    "id": 207,
-    "offset": 330376,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]don't[SP]know[SP]how[SP]much[SP]of[SP]that[SP]is[SP]true,\nbut[SP]I'm[SP]thinking[SP]of[SP]checking[SP]it[SP]out.\nIt[SP]sounds[SP]interesting.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je ne sais si c'est vrai,\nmais je vais vérifier. Intéressant."
-  },
-  {
-    "id": 208,
-    "offset": 330614,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They\nsell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]their\nquality[SP]and[SP]prices[SP]are[SP]average.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ma fille va souvent chez Anima Mundi.\nIls vendent des armures ? Qualité et prix moyens."
-  },
-  {
-    "id": 209,
-    "offset": 330886,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything\nweird...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "J'espère qu'elle n'achète rien de bizarre..."
-  },
-  {
-    "id": 210,
-    "offset": 331030,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They\nsell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]their\nquality's[SP]not[SP]great,[SP]but[SP]they're[SP]cheap.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ma fille va chez Anima Mundi.\nArmures : qualité moyenne, bon marché."
-  },
-  {
-    "id": 211,
-    "offset": 331318,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything\nweird...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "J'espère qu'elle n'achète rien de bizarre..."
-  },
-  {
-    "id": 212,
-    "offset": 331462,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They\nsell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]their[SP]resale\nprices[SP]are[SP]low,[SP]but[SP]the[SP]selection's[SP]great.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ma fille va chez Anima Mundi.\nArmures : reprises basses, mais grand choix."
-  },
-  {
-    "id": 213,
-    "offset": 331770,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything\nweird...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "J'espère qu'elle n'achète rien de bizarre..."
-  },
-  {
-    "id": 214,
-    "offset": 331914,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They\nsell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]they're\nexpensive,[SP]but[SP]the[SP]quality's[SP]amazing.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Ma fille va chez Anima Mundi.\nArmures : chères, qualité incroyable."
-  },
-  {
-    "id": 215,
-    "offset": 332202,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything\nweird...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "J'espère qu'elle n'achète rien de bizarre..."
-  },
-  {
-    "id": 216,
-    "offset": 332346,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida ici vend aussi des armures."
-  },
-  {
-    "id": 217,
-    "offset": 332494,
-    "data_size": 236,
-    "slot_size": 240,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their\nselection's[SP]not[SP]great,[SP]but[SP]their[SP]resale\nprices[SP]seem[SP]high.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Peu de choix, reprises élevées."
-  },
-  {
-    "id": 218,
-    "offset": 332734,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida ici vend aussi des armures."
-  },
-  {
-    "id": 219,
-    "offset": 332882,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their\nquality[SP]and[SP]prices[SP]seem[SP]average.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qualité et prix moyens."
-  },
-  {
-    "id": 220,
-    "offset": 333072,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida ici vend aussi des armures."
-  },
-  {
-    "id": 221,
-    "offset": 333220,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their\nquality's[SP]great,[SP]but[SP]they[SP]seem[SP]expensive.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Qualité excellente, cher."
-  },
-  {
-    "id": 222,
-    "offset": 333428,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida ici vend aussi des armures."
-  },
-  {
-    "id": 223,
-    "offset": 333576,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]They're\ncheap,[SP]but[SP]their[SP]goods[SP]seem[SP]rather[SP]low[SP]quality.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Bon marché, qualité plutôt basse."
-  },
-  {
-    "id": 224,
-    "offset": 333800,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real\narmor,[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida ici vend aussi des armures."
-  },
-  {
-    "id": 225,
-    "offset": 333948,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their\nselection's[SP]great,[SP]but[SP]their[SP]resale[SP]prices\nseem[SP]to[SP]be[SP]on[SP]the[SP]low[SP]side.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Grand choix, reprises basses."
-  },
-  {
-    "id": 226,
-    "offset": 334214,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?"
-  },
-  {
-    "id": 227,
-    "offset": 334480,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]know[SP]their[SP]selection's[SP]great,[SP]but[SP]I[SP]don't\nsee[SP]why[SP]they[SP]need[SP]to[SP]sell[SP]armor[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nPourquoi vendre aussi des armures ?"
-  },
-  {
-    "id": 228,
-    "offset": 334772,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?"
-  },
-  {
-    "id": 229,
-    "offset": 335038,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]know[SP]it'll[SP]be[SP]cheap,[SP]but[SP]I[SP]can't[SP]go[SP]to[SP]work\nwearing[SP]a[SP]suit[SP]of[SP]armor!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nBon marché, mais je ne peux pas travailler en armure !"
-  },
-  {
-    "id": 230,
-    "offset": 335310,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?"
-  },
-  {
-    "id": 231,
-    "offset": 335576,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]know[SP]the[SP]quality[SP]will[SP]be[SP]great,[SP]but[SP]that\nwon't[SP]do[SP]me[SP]any[SP]good[SP]if[SP]it[SP]bankrupts[SP]me!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nQualité excellente, mais si ça me ruine, à quoi bon !"
-  },
-  {
-    "id": 232,
-    "offset": 335874,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?"
-  },
-  {
-    "id": 233,
-    "offset": 336140,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]hear[SP]their[SP]quality[SP]and[SP]prices[SP]are[SP]both\nreasonable,[SP]but[SP]that's[SP]not[SP]the[SP]problem.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nQualité et prix raisonnables, mais ce n'est pas le problème."
-  },
-  {
-    "id": 234,
-    "offset": 336432,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?"
-  },
-  {
-    "id": 235,
-    "offset": 336698,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F]\nI[SP]know[SP]their[SP]resale[SP]prices[SP]are[SP]great,[SP]but[SP]I\nstill[SP]can't[SP]get[SP]a[SP]full[SP]refund,[SP]right?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nBonnes reprises, mais pas de remboursement intégral, si ?"
-  },
-  {
-    "id": 236,
-    "offset": 336992,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][U+000F]\nI[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu connais les concours de magazines ?[1205][U+000F]\nOn peut gagner de vraies armes."
-  },
-  {
-    "id": 237,
-    "offset": 337210,
-    "data_size": 118,
-    "slot_size": 122,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]sounds[SP]interesting,[SP]and[SP]exciting[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Intéressant et excitant."
-  },
-  {
-    "id": 238,
-    "offset": 337332,
-    "data_size": 242,
-    "slot_size": 246,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hear[SP]you[SP]don't[SP]win[SP]often,[SP]but[SP]they[SP]send[SP]you\nnice[SP]things[SP]when[SP]you[SP]do.[1205][U+000F][SP]Why[SP]don't[SP]you[SP]give\nit[SP]a[SP]shot?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "On gagne rarement, mais beaux lots.[1205][U+000F]\nPourquoi ne pas essayer ?"
-  },
-  {
-    "id": 239,
-    "offset": 337578,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][U+000F]\nI[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu connais les concours de magazines ?[1205][U+000F]\nOn peut gagner de vraies armes."
-  },
-  {
-    "id": 240,
-    "offset": 337796,
-    "data_size": 118,
-    "slot_size": 122,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]sounds[SP]interesting,[SP]and[SP]exciting[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Intéressant et excitant."
-  },
-  {
-    "id": 241,
-    "offset": 337918,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hear[SP]you[SP]very[SP]rarely[SP]win,[SP]but[SP]they[SP]send[SP]you\nincredible[SP]things[SP]when[SP]you[SP]do.[1205][U+000F][SP]Why[SP]don't[SP]you\ngive[SP]it[SP]a[SP]shot?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Très rare de gagner, lots incroyables.[1205][U+000F]\nPourquoi ne pas essayer ?"
-  },
-  {
-    "id": 242,
-    "offset": 338176,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][U+000F]\nI[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Tu connais les concours de magazines ?[1205][U+000F]\nOn peut gagner de vraies armes."
-  },
-  {
-    "id": 243,
-    "offset": 338394,
-    "data_size": 118,
-    "slot_size": 122,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "It[SP]sounds[SP]interesting,[SP]and[SP]exciting[SP]too.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Intéressant et excitant."
-  },
-  {
-    "id": 244,
-    "offset": 338516,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]hear[SP]you[SP]can[SP]win[SP]quite[SP]easily,[SP]but[SP]the[SP]things\nthey[SP]send[SP]you[SP]as[SP]prizes[SP]aren't[SP]very[SP]good.[1205][U+000F]\nWell,[SP]why[SP]not[SP]give[SP]it[SP]a[SP]shot[SP]anyway?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Facile à gagner, lots moyens.[1205][U+000F]\nPourquoi ne pas essayer quand même ?"
-  },
-  {
-    "id": 245,
-    "offset": 338814,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the\narcade?[1205][U+000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was\nhorrified[SP]to[SP]hear[SP]about[SP]it!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Un casino dans la salle d'arcade ?[1205][U+000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible !"
-  },
-  {
-    "id": 246,
-    "offset": 339084,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "[1432][NULL][NULL][0014]You[SP]can[SP]win[SP]big[SP]at[SP]poker![1432][NULL][NULL][0014][SP]That's[SP]not[SP]an\nappropriate[SP]conversation[SP]for[SP]high[SP]schoolers[SP]to\nbe[SP]having![SP]I[SP]should[SP]report[SP]this[SP]to[SP]the[SP]PTA!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "[1432][NULL][NULL][0014]On peut gagner gros au poker ![1432][NULL][NULL][0014]\nPas une conversation pour des lycéens !\nJe devrais le signaler à l'association de parents d'élèves !"
-  },
-  {
-    "id": 247,
-    "offset": 339402,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the\narcade?[1205][U+000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was\nhorrified[SP]to[SP]hear[SP]about[SP]it!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Un casino dans la salle d'arcade ?[1205][U+000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible !"
-  },
-  {
-    "id": 248,
-    "offset": 339672,
-    "data_size": 320,
-    "slot_size": 324,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "[1432][NULL][NULL][0014]You[SP]can[SP]win[SP]big[SP]at[SP]slots[SP]#1![1432][NULL][NULL][0014][SP]That's[SP]not[SP]an\nappropriate[SP]conversation[SP]for[SP]high[SP]schoolers[SP]to\nbe[SP]having![SP]I[SP]should[SP]report[SP]this[SP]to[SP]the[SP]PTA!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "[1432][NULL][NULL][0014]Gros lots aux machines n°1 ![1432][NULL][NULL][0014]\nPas pour des lycéens !\nÀ signaler à l'association de parents d'élèves !"
-  },
-  {
-    "id": 249,
-    "offset": 339996,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the\narcade?[1205][U+000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was\nhorrified[SP]to[SP]hear[SP]about[SP]it!",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Un casino dans la salle d'arcade ?[1205][U+000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible !"
-  },
-  {
-    "id": 250,
-    "offset": 340266,
-    "data_size": 250,
-    "slot_size": 254,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Where[SP]did[SP]I[SP]hear[SP]this?[SP]There[SP]was[SP]a[SP]young[SP]man\nbragging[SP]about[SP]winning[SP]big[SP]at[SP]blackjack[SP]while\nwalking[SP]around.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Où ai-je entendu ça ? Un jeune homme se vantait\nd'avoir gagné gros au blackjack."
-  },
-  {
-    "id": 251,
-    "offset": 340520,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]wonder[SP]what[SP]this[SP]legendary[SP]weapon[SP]at\nShiraishi[SP]Ramen[SP]is[SP]all[SP]about.[SP]I[SP]bet[SP]it's\ndangerous...[SP]But[SP]I'm[SP]still[SP]a[SP]little[SP]curious.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "L'arme légendaire du Shiraishi Ramen ?\nDangereuse, mais je suis curieuse."
-  },
-  {
-    "id": 252,
-    "offset": 340810,
-    "data_size": 190,
-    "slot_size": 194,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Did[SP]you[SP]hear?[SP]There's[SP]a[SP]legendary[SP]weapon[SP]at\nClair[SP]de[SP]Lune.[SP]Have[SP]you[SP]seen[SP]it?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Une arme légendaire au Clair de Lune.\nTu l'as vue ?"
-  },
-  {
-    "id": 253,
-    "offset": 341004,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Hey,[SP]have[SP]you[SP]heard?[SP]The[SP]owner[SP]of[SP]Time[SP]Castle\nis[SP]supposedly[SP]hiding[SP]his[SP]legendary[SP]weapon[SP]so\nhe[SP]can[SP]inflate[SP]the[SP]price.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio de Time Castle cache son arme légendaire\n pour faire monter le prix."
-  },
-  {
-    "id": 254,
-    "offset": 341276,
-    "data_size": 78,
-    "slot_size": 82,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "What[SP]a[SP]terrible[SP]man.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Quel homme terrible."
-  },
-  {
-    "id": 255,
-    "offset": 341358,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "From[SP]what[SP]I've[SP]heard,[SP]the[SP]seller[SP]with[SP]Time\nCastle's[SP]legendary[SP]weapon[SP]is[SP]waiting[SP]at[SP]the\nabandoned[SP]factory,[SP]but[SP]the[SP]owner[SP]won't[SP]come.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le vendeur de l'arme légendaire attend à l'usine,\nmais le proprio ne vient pas."
-  },
-  {
-    "id": 256,
-    "offset": 341660,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "I[SP]think[SP]that's[SP]smart[SP]of[SP]him.[SP]They[SP]say[SP]that\nabandoned[SP]factory[SP]is[SP]teeming[SP]with[SP]monsters\nand[SP]demons...[SP]It[SP]sounds[SP]dangerous,[SP]anyway.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "C'est malin. L'usine grouille de monstres.\nDangereux, de toute façon."
-  },
-  {
-    "id": 257,
-    "offset": 341958,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Oh,[SP]did[SP]you[SP]hear?[SP]A[SP]demon[SP]stole[SP]that[SP]legendary\nweapon[SP]at[SP]Time[SP]Castle.[SP]Not[SP]long[SP]ago,[SP]I'd[SP]never\nhave[SP]believed[SP]it...",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Un démon a volé l'arme légendaire de Time Castle.\nJe ne l'aurais jamais cru avant."
-  },
-  {
-    "id": 258,
-    "offset": 342226,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "But[SP]look[SP]at[SP]us.[SP]We're[SP]standing[SP]on[SP]top[SP]of[SP]a\nfloating[SP]city![SP]I[SP]bet[SP]demons[SP]exist,[SP]too!\nBrrr...[SP]That's[SP]really[SP]scary.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Mais regarde-nous : on est sur une ville flottante !\nLes démons existent forcément. Brrr... Effrayant."
-  },
-  {
-    "id": 259,
-    "offset": 342490,
-    "data_size": 222,
-    "slot_size": 226,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle[SP]was[SP]sold.\nPeople[SP]keep[SP]asking[SP]me,[SP][1432][NULL][NULL][0014]Did[SP]you[SP]buy[SP]it?[1432][NULL][NULL][0014]",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "L'arme légendaire a été vendue.\nOn me demande sans cesse : [1432][NULL][NULL][0014]C'est toi qui l'as achetée ?[1432][NULL][NULL][0014]"
-  },
-  {
-    "id": 260,
-    "offset": 342716,
-    "data_size": 190,
-    "slot_size": 194,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "But[SP]no,[SP]some[SP]unlucky[SP]woman[SP]bought[SP]it...[1205][U+000F]\nI[SP]don't[SP]look[SP]that[SP]desperate,[SP]do[SP]I?",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Non, une femme l'a achetée.[1205][U+000F]\nJe n'ai pas l'air si désespérée, si ?"
-  },
-  {
-    "id": 261,
-    "offset": 342910,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle[SP]gave[SP]away[SP]that\nlegendary[SP]weapon[SP]to[SP]a[SP]girl[SP]with[SP]short[SP]hair.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio a donné l'arme à une fille aux cheveux courts."
-  },
-  {
-    "id": 262,
-    "offset": 343116,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Walking[SP]woman",
-    "texte_orig": "Leaving[SP]aside[SP]that[SP]it's[SP]a[SP]weapon...[SP]That's[SP]a\nnice[SP]gesture.[SP]I[SP]wish[SP]I[SP]got[SP]presents[SP]sometimes.\nMy[SP]husband[SP]barely[SP]knows[SP]I'm[SP]alive.",
-    "nom_fr": "Promeneuse",
-    "texte_fr": "C'est un joli geste, malgré tout.\nJ'aimerais recevoir des cadeaux parfois.\nMon mari sait à peine que j'existe."
-  },
-  {
-    "id": 263,
-    "offset": 343410,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "Would[SP]you[SP]believe[SP]me[SP]if[SP]I[SP]said[SP][E4][NULL][NULL][U+0006]flowers[SP]can\ntalk[E4][NULL][NULL][0002]?[1205][U+000F][SP]Most[SP]people[SP]wouldn't.[SP]But[SP]there[SP]is\nsomeone[SP]in[SP]this[SP]park[SP]who[SP]speaks[SP]to[SP]flowers.",
-    "nom_fr": "Homme",
-    "texte_fr": "Croirais-tu que [E4][NULL][NULL][U+0006]les fleurs peuvent parler[E4][NULL][NULL][0002] ?[1205][U+000F]\nLa plupart non. Mais quelqu'un ici parle aux fleurs."
-  },
-  {
-    "id": 264,
-    "offset": 343706,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "He[SP]takes[SP]care[SP]of[SP]the[SP]flowers[SP]here,[SP]and[SP]whenever\nI[SP]see[SP]him,[SP]he's[SP]talking[SP]to[SP]them.[1205][U+000F][SP]Rumor[SP]has[SP]it\nthat[SP]the[SP]flowers[SP]in[SP]Aoba[SP]Park[SP]talk[SP]back.",
-    "nom_fr": "Homme",
-    "texte_fr": "Il s'occupe des fleurs et leur parle.[1205][U+000F]\nOn dit qu'elles lui répondent."
-  },
-  {
-    "id": 265,
-    "offset": 344000,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Man",
-    "texte_orig": "In[SP]the[SP]end,[SP]you[SP]decide[SP]what's[SP]real[SP]and[SP]what's\na[SP]dream.[1205][U+000F][SP]If[SP]you're[SP]tired[SP]of[SP]this[SP]dreary\nreality...[SP]try[SP]talking[SP]with[SP]the[SP]flowers.",
-    "nom_fr": "Homme",
-    "texte_fr": "Au final, c'est toi qui décides du réel.[1205][U+000F]\nSi tu es fatigué de cette triste réalité,\nparle aux fleurs."
-  },
-  {
-    "id": 266,
-    "offset": 344278,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Masked[SP]Circle[SP]member",
-    "texte_orig": "Dammit,[SP]that[SP]Joker[SP]ran[SP]off[SP]to[SP]Caracol[SP]along\nwith[SP]the[SP]executives![1205][U+000F][SP]He's[SP]left[SP]us[SP]holding[SP]the\nbag[SP]here!",
-    "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Joker s'est enfui à Caracol avec les cadres ![1205][U+000F]\nIl nous a laissés dans la merde !"
-  },
-  {
-    "id": 267,
-    "offset": 344534,
-    "data_size": 312,
-    "slot_size": 316,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Masked[SP]Circle[SP]member",
-    "texte_orig": "Having[SP]our[SP]ideals[SP]granted[SP]will[SP]make[SP]us[SP]happy?\nBullshit![SP]All[SP]he[SP]wanted[SP]was[SP]to[SP]suck[SP]away[SP]our\nIdeal[SP]Energy[SP]to[SP]realize[SP]his[SP]own[SP]dreams!",
-    "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Nos idéaux exaucés ? N'importe quoi !\nIl a juste aspiré notre Énergie Idéale\n pour ses propres rêves !"
-  },
-  {
-    "id": 268,
-    "offset": 344850,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Last[SP]Battalion",
-    "texte_orig": "The[SP]holy[SP]lance[SP]is[SP]the[SP]emblem[SP]of[SP]our[SP]strength.\nIt[SP]shall[SP]crush[SP]all[SP]hindrances,[SP]along[SP]with[SP]the\nother[SP]self[SP]that[SP]lies[SP]within...",
-    "nom_fr": "Dernier Bataillon",
-    "texte_fr": "La lance sacrée, emblème de notre force,\n écrasera tout obstacle et l'autre soi\n qui sommeille en nous."
-  },
-  {
-    "id": 269,
-    "offset": 345138,
-    "data_size": 172,
-    "slot_size": 176,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "To[SP]hell[SP]with[SP]that[SP]King[SP]Leo[SP]asshole!\nHe's[SP]through[SP]doing[SP]whatever[SP]he[SP]wants!",
-    "nom_fr": "Michel",
-    "texte_fr": "Au diable cet enculé de Roi Lion !\nIl en a fini de faire ce qu'il veut !"
-  },
-  {
-    "id": 270,
-    "offset": 345314,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Uh-oh,[SP][1113].[SP]If[SP]we[SP]keep[SP]standing[SP]around\nlike[SP]this,[SP]people[SP]will[SP]get[SP]more[SP]suspicious.\nLet's[SP]get[SP]to[SP]the[SP]detective[SP]agency.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Uh-oh, [1113]. Si on traîne, les gens vont se méfier.\nAllons à l'agence de détectives."
-  },
-  {
-    "id": 271,
-    "offset": 345570,
-    "data_size": 88,
-    "slot_size": 92,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Huh?[SP]It[SP]says,[SP][1432][NULL][NULL][0014]No[SP]entry.[1432][NULL][NULL][0014]",
-    "nom_fr": "Michel",
-    "texte_fr": "Hein ?[SP][1432][NULL][NULL][0014]Entrée interdite.[1432][NULL][NULL][0014]"
-  },
-  {
-    "id": 272,
-    "offset": 345662,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "The[SP]fire[SP]department[SP]burned[SP]down...[SP]Don't[SP]tell\nme[SP]King[SP]Leo[SP]planned[SP]ahead![SP]No...!",
-    "nom_fr": "Maya",
-    "texte_fr": "Les pompiers ont brûlé... Dis-moi que non.\nLe Roi Lion a tout planifié ? Non... !"
-  },
-  {
-    "id": 273,
-    "offset": 345844,
-    "data_size": 232,
-    "slot_size": 236,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukiko",
-    "texte_orig": "He[SP]did[SP]this[SP]to[SP]prevent[SP]anyone[SP]from[SP]stopping\nhis[SP]plan...[SP]Now[SP]there's[SP]no[SP]one[SP]but[SP]us[SP]left\nto[SP]deal[SP]with[SP]him.",
-    "nom_fr": "Yukiko",
-    "texte_fr": "Il a fait ça pour qu'on ne l'arrête pas.\nIl ne reste plus que nous."
-  },
-  {
-    "id": 274,
-    "offset": 346080,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Yeah,[SP]that's[SP]been[SP]the[SP]plan[SP]all[SP]along![SP]You[SP]can\nbet[SP]we're[SP]taking[SP]down[SP]that[SP]bastard[SP]ourselves!",
-    "nom_fr": "Michel",
-    "texte_fr": "Oui, c'était le plan depuis le début !\nOn va abattre ce salaud nous-mêmes !"
-  },
-  {
-    "id": 275,
-    "offset": 346292,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "King[SP]Leo[SP]will[SP]stop[SP]at[SP]nothing[SP]to[SP]fulfill[SP]the\nOracle.[SP]If[SP]we[SP]don't[SP]take[SP]him[SP]down[SP]now,[SP]there\nwill[SP]only[SP]be[SP]more[SP]casualties...",
-    "nom_fr": "Maya",
-    "texte_fr": "Roi Lion ne reculera devant rien.\nSi on ne l'arrête pas, il y aura plus de victimes..."
-  },
-  {
-    "id": 276,
-    "offset": 346558,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "We[SP]couldn't[SP]stop[SP]any[SP]of[SP]them[SP]from[SP]burning\ndown...[SP]I'm[SP]so[SP]mad[SP]at[SP]myself...",
-    "nom_fr": "Ginko",
-    "texte_fr": "On a pu empêcher aucun incendie...\nJe suis tellement en colère contre moi..."
-  },
-  {
-    "id": 277,
-    "offset": 346730,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "I[SP]understand[SP]how[SP]you[SP]feel,[SP][1113],[SP]but\nwe're[SP]fugitives[SP]now.[SP]We[SP]shouldn't[SP]stay[SP]in\none[SP]place[SP]too[SP]long.",
-    "nom_fr": "Yukino",
-    "texte_fr": "Je comprends, [1113], mais nous sommes fugitifs.\nNe restons pas trop longtemps au même endroit."
-  },
-  {
-    "id": 278,
-    "offset": 346948,
-    "data_size": 118,
-    "slot_size": 122,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "There's[SP]no[SP]point[SP]being[SP]here[SP]anymore.\nLet's[SP]go.",
-    "nom_fr": "Michel",
-    "texte_fr": "Cela ne sert plus à rien d'être ici.\nAllons-y."
-  },
-  {
-    "id": 279,
-    "offset": 347070,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "We've[SP]already[SP]got[SP]the[SP]crystal[SP]skull[SP]here.\nLet's[SP]hurry[SP]and[SP]find[SP]the[SP]others.",
-    "nom_fr": "Maya",
-    "texte_fr": "Nous avons déjà le crâne de cristal.\nTrouvons les autres."
-  },
-  {
-    "id": 280,
-    "offset": 347242,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "I[SP]can[SP]hear[SP]voices...[SP]The[SP]fighting's[SP]still\ngoing[SP]on[SP]inside.[SP]We[SP]need[SP]to[SP]hurry[SP]and[SP]put\na[SP]stop[SP]to[SP]it.",
-    "nom_fr": "Maya",
-    "texte_fr": "J'entends des voix. Le combat continue.\nIl faut y mettre fin."
-  },
-  {
-    "id": 281,
-    "offset": 347460,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "[1113],[SP]now's[SP]not[SP]the[SP]time[SP]for[SP]detours.\nEveryone's[SP]waiting...[SP]We[SP]have[SP]to[SP]go[SP]to[SP]the\ndetective[SP]agency.",
-    "nom_fr": "Ginko",
-    "texte_fr": "[1113], pas de détours.\nTout le monde attend. Allons à l'agence."
-  },
-  {
-    "id": 282,
-    "offset": 347676,
-    "data_size": 170,
-    "slot_size": 174,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Huh?[SP]It's[SP]closed.[SP]I[SP]wonder[SP]what's[SP]up...\nOh[SP]well,[SP]let's[SP]go[SP]somewhere[SP]else.",
-    "nom_fr": "Ginko",
-    "texte_fr": "C'est fermé. Je me demande pourquoi...\nBon, allons ailleurs."
-  },
-  {
-    "id": 283,
-    "offset": 347850,
-    "data_size": 232,
-    "slot_size": 236,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "[1113],[SP]I[SP]kinda[SP]feel[SP]bad[SP]making[SP]everyone\nwait[SP]while[SP]we[SP]wander[SP]around.[SP]We[SP]should[SP]hurry\nto[SP]the[SP]detective[SP]agency.",
-    "nom_fr": "Ginko",
-    "texte_fr": "[1113], je me sens mal de faire attendre tout le monde.\nDépêchons-nous d'aller à l'agence."
-  },
-  {
-    "id": 284,
-    "offset": 348086,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Wait[SP]a[SP]sec,[SP]Chinyan![SP]We[SP]don't[SP]have[SP]the[SP]skull\nfrom[SP]Taurus[SP]Temple[SP]yet.[SP]We[SP]should[SP]stop[SP]by\nthere[SP]first.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Attends, Chinyan ! On n'a pas encore le crâne\ndu temple du Taureau. Allons-y d'abord."
-  },
-  {
-    "id": 285,
-    "offset": 348310,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "H-Hold[SP]the[SP]phone,[SP]man.[1205][U+000F][SP]We're[SP]still[SP]not[SP]done\nwith[SP]Scorpio[SP]Temple.[1205][U+000F][SP]Let's[SP]go[SP]grab[SP]the[SP]skull\nfrom[SP]there[SP]first.",
-    "nom_fr": "Michel",
-    "texte_fr": "A-Attends, mec.[1205][U+000F] On n'a pas fini avec\ntemple du Scorpion.[1205][U+000F] Prenons ce crâne d'abord."
-  },
-  {
-    "id": 286,
-    "offset": 348560,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Jun",
-    "texte_orig": "Hold[SP]on[SP]a[SP]moment.[SP]We're[SP]still[SP]not[SP]done[SP]with\nthe[SP]Aquarius[SP]Temple.",
-    "nom_fr": "Jun",
-    "texte_fr": "Attends. On n'a pas fini avec\nle temple du Verseau."
-  }
+    {
+        "id": 0,
+        "offset": 276502,
+        "data_size": 482,
+        "slot_size": 482,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "Hm?[SP]The[SP]outdoor[SP]concert[SP]hall?[SP]Oh,[SP]it's[SP]over[SP]in[NL]Aoba[SP]Park.[SP]Are[SP]you[SP]going[SP]to[SP]see[SP]the[SP]show?[1106][E2][1431][U+0000][U+0000]\"Office[SP]worker[NL]The[SP]Muses[SP]sure[SP]got[SP]popular[SP]fast.[SP]I[SP]was[SP]curious,[NL]but[SP]the[SP]tickets[SP]are[SP]all[SP]sold[SP]out.[SP]I[SP]guess[SP]it[NL]wasn't[SP]meant[SP]to[SP]be.",
+        "nom_fr": "Employé",
+        "texte_fr": "La salle de concert ? Dans le parc d'Aoba.\nTu vas voir le spectacle ?[1106][NL]Les Muses sont devenues populaires vite.\nJ'étais curieux, mais complet. Pas pour moi."
+    },
+    {
+        "id": 1,
+        "offset": 276984,
+        "data_size": 248,
+        "slot_size": 248,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "I...[SP]I[SP]can't[SP]believe[SP]the[SP]concert[SP]hall[SP]burned[NL]down...[1205][U+000F][SP]Wh-What[SP]happened[SP]in[SP]there?[SP]Is[SP]the[NL]audience[SP]okay?",
+        "nom_fr": "Employé",
+        "texte_fr": "Je... La salle a brûlé...[1205][U+000F]\nQue s'est-il passé ? Le public va bien ?"
+    },
+    {
+        "id": 2,
+        "offset": 277232,
+        "data_size": 544,
+        "slot_size": 544,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "I[SP]heard[SP]from[SP]a[SP]friend[SP]that[SP]Smile[SP]Hirasaka[SP]and[NL]GOLD[SP]were[SP]targeted[SP]by[SP]terrorists[SP]too.[1205][U+000F][SP]Luckily,[NL]both[SP]attacks[SP]were[SP]thwarted...[1106][E2][1431][U+0000][U+0000]\"Office[SP]worker[NL]But[SP]they[SP]were[SP]both[SP]packed[SP]with[SP]people.[1205][U+000F][NL]Who'd[SP]want[SP]to[SP]bomb[SP]someplace[SP]like[SP]that?[NL]The[SP]culprit[SP]is[SP]inhuman...!",
+        "nom_fr": "Employé",
+        "texte_fr": "Un ami m'a dit que Smile Hirasaka et GOLD ont aussi été visés.[1205][U+000F]\nHeureusement, les deux ont été évités...[1106][NL]Mais ils étaient bondés.[1205][U+000F]\nQui voudrait bombarder ça ? Le coupable est inhumain !"
+    },
+    {
+        "id": 3,
+        "offset": 277776,
+        "data_size": 548,
+        "slot_size": 548,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "My[SP]friend[SP]told[SP]me[SP]that[SP]the[SP]terrorists[SP]even[SP]blew[NL]up[SP]Smile[SP]Hirasaka.[1205][U+000F][SP]I[SP]hear[SP]the[SP]death[SP]toll[SP]was[NL]tremendous.[NL][1106][E2][1431][U+0000][U+0000]\"Office[SP]worker[NL]There[SP]were[SP]lots[SP]of[SP]people[SP]at[SP]that[SP]concert[SP]hall,[NL]too...[1205][U+000F][SP]Who'd[SP]want[SP]to[SP]blow[SP]up[SP]someplace[SP]like[NL]that?[SP]The[SP]culprit[SP]is[SP]inhuman...!",
+        "nom_fr": "Employé",
+        "texte_fr": "Mon ami dit que les terroristes ont fait sauter Smile Hirasaka.[1205][U+000F]\nDe nombreux morts.[1106][NL]Beaucoup de monde aussi...[1205][U+000F]\nPourquoi bombarder ça ? Inhumain !"
+    },
+    {
+        "id": 4,
+        "offset": 278324,
+        "data_size": 550,
+        "slot_size": 550,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "My[SP]friend[SP]told[SP]me[SP]that[SP]the[SP]terrorists[SP]even[SP]blew[NL]up[SP]GOLD[SP]in[SP]Yumezaki.[1205][U+000F][SP]I[SP]hear[SP]the[SP]death[SP]toll[SP]was[NL]tremendous.[1106][E2][1431][U+0000][U+0000]\"Office[SP]worker[NL]There[SP]were[SP]lots[SP]of[SP]people[SP]at[SP]that[SP]concert[SP]hall,[NL]too...[1205][U+000F][SP]Who'd[SP]want[SP]to[SP]blow[SP]up[SP]someplace[SP]like[NL]that?[SP]The[SP]culprit[SP]is[SP]inhuman...!",
+        "nom_fr": "Employé",
+        "texte_fr": "Mon ami dit qu'ils ont fait sauter GOLD à Yumezaki.[1205][U+000F]\nBeaucoup de morts.[1106][NL]Beaucoup de monde aussi...[1205][U+000F]\nPourquoi bombarder ça ? Inhumain !"
+    },
+    {
+        "id": 5,
+        "offset": 278874,
+        "data_size": 492,
+        "slot_size": 492,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "I[SP]heard[SP]from[SP]a[SP]friend[SP]that[SP]terrorists[SP]struck[NL]at[SP]both[SP]Smile[SP]Hirasaka[SP]and[SP]GOLD.[1205][U+000F][SP]So[SP]many[NL]people[SP]died...[1106][E2][1431][U+0000][U+0000]\"Office[SP]worker[NL]They[SP]were[SP]both[SP]packed[SP]with[SP]people.[SP]Who'd[SP]want[1205][U+000F][NL]to[SP]bomb[SP]someplace[SP]like[SP]that?[SP]The[SP]culprit[SP]is[NL]inhuman...!",
+        "nom_fr": "Employé",
+        "texte_fr": "Un ami m'a dit que les terroristes ont frappé\n Smile Hirasaka et GOLD.[1205][U+000F] Tant de morts...[1106][NL]Bondés. Qui voudrait[1205][U+000F]\nbombarder ça ? Inhumain !"
+    },
+    {
+        "id": 6,
+        "offset": 279366,
+        "data_size": 362,
+        "slot_size": 362,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "Even[SP]the[SP]Aerospace[SP]Museum[SP]was[SP]bombed...[1205][U+000F][NL]That's[SP]already[SP]six[SP]attacks[SP]in[SP]total.[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Office[SP]worker[NL]How[SP]many[SP]deaths[SP]will[SP]it[SP]take[SP]to[SP]satisfy[SP]that[NL]gang[SP]of[SP]five!?",
+        "nom_fr": "Employé",
+        "texte_fr": "Même le musée aérospatial a été bombardé...[1205][U+000F]\nSix attaques au total.[1205][U+000F][1106][NL]Combien de morts pour cette bande de cinq !?"
+    },
+    {
+        "id": 7,
+        "offset": 279728,
+        "data_size": 588,
+        "slot_size": 588,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "The[SP]paper's[SP]reporting[SP]now[SP]that[SP]the[SP]Masked[NL]Circle[SP]and[SP]the[SP]Last[SP]Battalion[SP]are[SP]fighting[NL]over[SP]the[SP]secret[SP]treasure[SP]of[SP]Sumaru.[1106][E2][1431][U+0000][U+0000]\"Office[SP]worker[NL]Looks[SP]like[SP]that[SP]was[SP]the[SP]reason[SP]for[SP]the[SP]terror[NL]wave,[SP]too.[1205][U+000F][SP]Honestly,[SP]one[SP]of[SP]them[SP]should[SP]just[NL]take[SP]it[SP]and[SP]go.[SP]We[SP]don't[SP]need[SP]them[SP]here!",
+        "nom_fr": "Employé",
+        "texte_fr": "Le journal dit que le Cercle Masqué\n et le Dernier Bataillon se battent\n pour le trésor secret de Sumaru.[1106][NL]C'était la raison de la vague de terreur aussi.[1205][U+000F]\nQu'ils le prennent et s'en aillent. On n'en a pas besoin !"
+    },
+    {
+        "id": 8,
+        "offset": 280316,
+        "data_size": 234,
+        "slot_size": 234,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "Th-That[SP]mark...![1205][U+000F][SP]Why[SP]are[SP]soldiers[SP]with[SP]that[NL]insignia[SP]coming[SP]to[SP]Sumaru[SP]now!?[SP]It[SP]makes[NL]no[SP]sense!",
+        "nom_fr": "Employé",
+        "texte_fr": "Ce symbole...![1205][U+000F]\nPourquoi ces soldats viennent à Sumaru ? Insensé !"
+    },
+    {
+        "id": 9,
+        "offset": 280550,
+        "data_size": 598,
+        "slot_size": 598,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "D-Did[SP]the[SP]Masked[SP]Circle[SP]and[SP]the[SP]Last[SP]Battalion[NL]cause[SP]those[SP]temples[SP]to[SP]appear,[SP]too?[NL][1106][E2][1431][U+0000][U+0000]\"Office[SP]worker[NL]Because[SP]I[SP]mean,[SP]once[SP]those[SP]things[SP]showed[SP]up,[NL]they[SP]all[SP]rushed[SP]inside.[NL][1106][E2][1431][U+0000][U+0000]\"Office[SP]worker[NL]Ugh...[SP]This[SP]is[SP]too[SP]much...[1205][U+000F][SP]I[SP]feel[SP]like[SP]I'm[NL]going[SP]to[SP]go[SP]insane[SP]before[SP]I[SP]can[SP]evolve...",
+        "nom_fr": "Employé",
+        "texte_fr": "Le Cercle Masqué et le Dernier Bataillon\n ont-ils aussi fait apparaître ces temples ?[1106][NL]Une fois apparus,\n ils se sont tous précipités à l'intérieur.[1106][NL]Ugh... C'en est trop...[1205][U+000F]\nJe deviendrai fou avant d'évoluer..."
+    },
+    {
+        "id": 10,
+        "offset": 281148,
+        "data_size": 694,
+        "slot_size": 694,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "Aoba[SP]is[SP]famous[SP]for[SP]its[SP]outdoor[SP]concert[SP]hall,[NL]but[SP]that's[SP]not[SP]the[SP]only[SP]thing[SP]we're[SP]known[SP]for.[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]Kismet[SP]Publishing,[SP]publishers[SP]of[SP]Coolest,[NL]and[SP]Sumaru[SP]TV[SP]are[SP]in[SP]this[SP]ward.[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]It[SP]may[SP]not[SP]have[SP]Yumezaki's[SP]pizazz,[SP]but[SP]I[SP]think[NL]this[SP]ward[SP]is[SP]the[SP]beating[SP]heart[SP]that[SP]feeds[NL]information[SP]across[SP]Sumaru[SP]City.",
+        "nom_fr": "Femme active",
+        "texte_fr": "Aoba est célèbre pour sa salle de concert,\n mais ce n'est pas notre seule fierté.[1106][NL]Kismet Publishing (Coolest) et Sumaru TV\n sont dans ce quartier.[1106][NL]Ça n'a pas le peps de Yumezaki,\n mais ce quartier est le cœur\n qui alimente Sumaru en infos."
+    },
+    {
+        "id": 11,
+        "offset": 281842,
+        "data_size": 486,
+        "slot_size": 486,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "I[SP]just[SP]saw[SP]a[SP]Masked[SP]Circle[SP]member[SP]in[SP]a[SP]store.[1205][U+000F][NL]He[SP]was[SP]saying[SP]some[SP]scary[SP]stuff...[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]There's[SP]no[SP]doubt[SP]that[SP]it[SP]was[SP]them[SP]who[SP]set[SP]fire[NL]to[SP]the[SP]outdoor[SP]concert[SP]hall.[SP]They're[SP]a[SP]menace,[NL]just[SP]like[SP]the[SP]rumors[SP]said.",
+        "nom_fr": "Femme active",
+        "texte_fr": "Je viens de voir un membre du Cercle Masqué.[1205][U+000F]\nIl disait des trucs effrayants...[1106][NL]Nul doute que c'est eux qui ont incendié la salle.\nUne menace, comme les rumeurs le disaient."
+    },
+    {
+        "id": 12,
+        "offset": 282328,
+        "data_size": 562,
+        "slot_size": 562,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "Some[SP]kids[SP]came[SP]by[SP]just[SP]now[SP]and[SP]said[SP]the[SP]five[NL]suspects[SP]are[SP]actually[SP]heroes[SP]fighting[SP]against[NL]the[SP]Masked[SP]Circle...[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]I-I[SP]knew[SP]all[SP]along.[SP]The[SP]culprits[SP]were[SP]the[NL]Masked[SP]Circle,[SP]of[SP]course![1205][U+000F][SP]But[SP]I[SP]didn't[SP]know[NL]those[SP]five[SP]were[SP]fighting[SP]against[SP]them...",
+        "nom_fr": "Femme active",
+        "texte_fr": "Des gamins ont dit que les cinq suspects sont\n des héros qui combattent le Cercle Masqué...[1106][NL]Je le savais. Les coupables sont le Cercle Masqué ![1205][U+000F]\nMais j'ignorais que ces cinq les combattaient..."
+    },
+    {
+        "id": 13,
+        "offset": 282890,
+        "data_size": 616,
+        "slot_size": 616,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "I-I[SP]heard[SP]the[SP]Oracle[SP]in[SP]the[SP]In[SP]Lak'ech[SP]talks[NL]about[SP]everything[SP]that's[SP]happened[SP]lately,[NL]but[SP]that's[SP]just[SP]a[SP]marketing[SP]angle.[1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]I[SP]mean,[SP]it's[SP]not[SP]like[SP]it's[SP]some[SP]grand[SP]prophecy.[NL]That[SP]would[SP]just[SP]be[SP]ridiculous...[NL][1106][E2][1431][U+0000][U+0000]\"Working[SP]woman[NL]D-Don't[SP]you[SP]think[SP]so?[1205][U+000F][SP]I-I'm[SP]right,[SP]aren't[SP]I?",
+        "nom_fr": "Femme active",
+        "texte_fr": "L'Oracle dans l'In Lak'ech parle de tout,\n mais ce n'est qu'un argument marketing.[1106][NL]Ce n'est pas une grande prophétie.\nCe serait ridicule...[1106][NL]Tu ne crois pas ?[1205][U+000F]\nJ'ai raison, non ?"
+    },
+    {
+        "id": 14,
+        "offset": 283506,
+        "data_size": 322,
+        "slot_size": 322,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "Why[SP]are[SP]soldiers[SP]raining[SP]from[SP]the[SP]sky!?[SP]Is[SP]this[NL]thing[SP]saying[SP]there's[SP]some[SP]secret[SP]treasure[SP]here[NL]in[SP]Sumaru!?[1205][U+000F][SP]I-I[SP]refuse[SP]to[SP]believe[SP]that![SP]No!",
+        "nom_fr": "Femme active",
+        "texte_fr": "Pourquoi les soldats pleuvent du ciel !?\nCe truc dit qu'il y a un trésor secret à Sumaru !?[1205][U+000F]\nJe refuse de le croire ! Non !"
+    },
+    {
+        "id": 15,
+        "offset": 283828,
+        "data_size": 258,
+        "slot_size": 258,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Working[SP]woman",
+        "texte_orig": "Huh!?[1205][U+000A][SP]Didn't[SP]you[SP]just[SP]go[SP]into[SP]that[SP]temple?[1205][U+000F][NL]Yeah,[SP]carrying[SP]this[SP]weird[SP]skull...[1205][U+000F][SP]A-Am[SP]I[NL]seeing[SP]things...?",
+        "nom_fr": "Femme active",
+        "texte_fr": "Hein ?[1205][U+000A] Tu n'es pas entré dans ce temple ?[1205][U+000F]\nOui, avec ce drôle de crâne...[1205][U+000F]\nJ'ai des hallucinations ?"
+    },
+    {
+        "id": 16,
+        "offset": 284086,
+        "data_size": 1018,
+        "slot_size": 1018,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Ever[SP]hear[SP]the[SP]rumor[SP]that[SP]Rosa[SP]Candida[SP]sells[NL]real[SP]armor?[1205][U+000F][SP]An[SP]office[SP]mate[SP]of[SP]mine[SP]told[SP]me[NL]about[SP]it,[SP]and[SP]I've[SP]been[SP]curious[SP]ever[SP]since.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]It[SP]seems[SP]he[SP]got[SP]the[SP]story[SP]online[SP]somewhere.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]If[SP]you[SP]go[SP]to[SP]Double[SP]Slash,[SP]you[SP]can[SP]use[SP]their[NL]PCs[SP]to[SP]browse[SP]the[SP]Internet.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Even[SP]an[SP]old[SP]man[SP]like[SP]me[SP]could[SP]look[SP]it[SP]up[SP]there[NL]if[SP]I[SP]wanted...[1205][U+000F][SP]But[SP]I'm[SP]no[SP]good[SP]with[SP]computers.[1205][U+000F][NL]Just[SP]one[SP]of[SP]my[SP]hangups,[SP]I[SP]guess.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Tu as entendu que Rosa Candida vend de vraies armures ?[1205][U+000F]\nUn collègue m'en a parlé, je suis curieux.[1106][NL]Il a dû voir ça sur Internet.[1106][NL]Au Double Slash, on peut utiliser leurs PC\n pour surfer sur Internet.[1106][NL]Même un vieux comme moi pourrait chercher,[1205][U+000F]\nmais je suis nul en informatique.[1205][U+000F]\nUn de mes travers."
+    },
+    {
+        "id": 17,
+        "offset": 285104,
+        "data_size": 482,
+        "slot_size": 482,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Rumor[SP]has[SP]it[SP]the[SP]Masked[SP]Circle[SP]did[SP]this,[SP]but[SP]I[NL]also[SP]hear[SP]there[SP]was[SP]a[SP]group[SP]of[SP]five[SP]suspicious[NL]people[SP]seen[SP]around[SP]the[SP]outdoor[SP]concert[SP]hall.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Shouldn't[SP]those[SP]guys[SP]be[SP]suspects[SP]too?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "On dit que c'est le Cercle Masqué,\n mais j'ai aussi entendu qu'un groupe de cinq suspects\n a été vu près de la salle de concert.[1106][NL]Ils ne devraient pas être suspects aussi ?"
+    },
+    {
+        "id": 18,
+        "offset": 285586,
+        "data_size": 294,
+        "slot_size": 294,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "I[SP]can't[SP]believe[SP]such[SP]a[SP]terrible[SP]tragedy[NL]happened...[1205][U+000F][SP]But[SP]if[SP]sketches[SP]of[SP]the[SP]culprits[SP]are[NL]out,[SP]it[SP]won't[SP]be[SP]long[SP]before[SP]they're[SP]arrested.",
+        "nom_fr": "Homme",
+        "texte_fr": "Je n'arrive pas à croire qu'une telle tragédie soit arrivée.[1205][U+000F]\nMais avec les portraits-robots, ils seront bientôt arrêtés."
+    },
+    {
+        "id": 19,
+        "offset": 285880,
+        "data_size": 312,
+        "slot_size": 312,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "My[SP]entire[SP]office[SP]is[SP]buzzing[SP]about[SP]whether[SP]or[NL]not[SP]the[SP]In[SP]Lak'ech[SP]is[SP]true.[1205][U+000F][SP]All[SP]the[SP]younger[NL]employees[SP]seem[SP]to[SP]believe[SP]in[SP]it.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Tout le bureau parle de si l'In Lak'ech est vrai.[1205][U+000F]\nLes jeunes y croient."
+    },
+    {
+        "id": 20,
+        "offset": 286192,
+        "data_size": 278,
+        "slot_size": 278,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Most[SP]of[SP]those[SP]soldiers[SP]were[SP]heading[SP]to[NL]Mt.[SP]Katatsumuri.[1205][U+000F][SP]But[SP]why[SP]would[SP]they[SP]go[SP]there?[NL]I[SP]don't[SP]understand.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "La plupart des soldats allaient au mont Katatsumuri.[1205][U+000F]\nPourquoi ? Je ne comprends pas."
+    },
+    {
+        "id": 21,
+        "offset": 286470,
+        "data_size": 620,
+        "slot_size": 620,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "How[SP]can[SP]such[SP]nonsensical[SP]things[SP]be[SP]happening?[1205][U+000A][NL]W-Well,[SP]I've[SP]seen[SP]it[SP]for[SP]myself...[1205][U+000A][SP]I[SP]don't[NL]have[SP]a[SP]choice[SP]but[SP]to[SP]believe[SP]it...[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]But[SP]in[SP]that[SP]case,[SP]this[SP]talk[SP]about[SP]the[SP]Earth[NL]being[SP]annihilated[SP]must[SP]be[SP]true,[SP]too...[1205][U+000F][SP]What[NL]exactly[SP]is[SP]going[SP]to[SP]happen?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Comment de telles absurdités arrivent ?[1205][U+000A]\nJe l'ai vu de mes yeux...[1205][U+000A]\nJe n'ai pas le choix, je dois y croire...[1106][NL]Alors cette histoire de Terre anéantie doit être vraie aussi...[1205][U+000F]\nQue va-t-il exactement se passer ?"
+    },
+    {
+        "id": 22,
+        "offset": 287090,
+        "data_size": 352,
+        "slot_size": 352,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "My[SP]men[SP]say[SP]that[SP]the[SP]Grand[SP]Cross[SP]will[SP]cause[SP]the[NL]mantle's[SP]temperature[SP]to[SP]rise,[SP]making[SP]the[SP]Earth[NL]a[SP]scorching[SP]hell...[1205][U+000F][SP]Is[SP]that[SP]how[SP]the[SP]world[SP]ends?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Mes collègues disent que la Grande Croix fera monter\n la température, transformant la Terre en enfer...[1205][U+000F]\nC'est ainsi que le monde finit ?"
+    },
+    {
+        "id": 23,
+        "offset": 287442,
+        "data_size": 504,
+        "slot_size": 504,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "A[SP]colleague[SP]of[SP]mine[SP]says[SP]the[SP]Grand[SP]Cross[SP]will[NL]result[SP]in[SP]the[SP]gravitational[SP]pull[SP]of[SP]the[SP]other[NL]planets[SP]causing[SP]a[SP]gigantic[SP]tsunami.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]I[SP]don't[SP]know[SP]much[SP]about[SP]science...[1205][U+000F][SP]Is[SP]that[NL]even[SP]possible?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Un collègue dit que la Grande Croix provoquera\n l'attraction des autres planètes,\n causant un tsunami géant.[1106][NL]Je ne connais pas bien la science...[1205][U+000F]\nEst-ce seulement possible ?"
+    },
+    {
+        "id": 24,
+        "offset": 287946,
+        "data_size": 832,
+        "slot_size": 832,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "That[SP]was[SP]strange.[1205][U+000A][SP]My[SP]men[SP]had[SP]all[SP]been[SP]arguing[NL]over[SP]how[SP]the[SP]world[SP]down[SP]there[SP]would[SP]end,[SP]when[NL]suddenly[SP]they[SP]settled[SP]on[SP]one[SP]idea.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]They[SP]think[SP]the[SP]Grand[SP]Cross[SP]will[SP]cause[SP]the[NL]Earth[SP]to[SP]stop[SP]rotating.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]I[SP]couldn't[SP]follow[SP]their[SP]explanations,[SP]but[SP]the[NL]upshot[SP]was[SP]that[SP]everything[SP]on[SP]Earth[SP]will[SP]be[NL]blasted[SP]away[SP]at[SP]high[SP]speed,[SP]right?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "C'était étrange.[1205][U+000A]\nIls discutaient de la fin du monde en bas,\n quand soudain ils se sont mis d'accord sur une idée.[1106][NL]Ils pensent que la Grande Croix\n arrêtera la rotation de la Terre.[1106][NL]Je n'ai pas suivi,\n mais tout sur Terre sera emporté à grande vitesse ?"
+    },
+    {
+        "id": 25,
+        "offset": 288778,
+        "data_size": 338,
+        "slot_size": 338,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "So[SP]there[SP]are[SP]talking[SP]flowers[SP]in[SP]Aoba[SP]Park...[NL]When[SP]I[SP]first[SP]heard,[SP]I[SP]thought[SP]it[SP]was[SP]a[SP]joke.[1205][U+000F][NL]I'm[SP]curious[SP]to[SP]know[SP]what[SP]plants[SP]think[SP]about.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Des fleurs qui parlent dans le parc d'Aoba...\nJ'ai d'abord cru à une blague.[1205][U+000F]\nCurieux de savoir à quoi pensent les plantes."
+    },
+    {
+        "id": 26,
+        "offset": 289116,
+        "data_size": 466,
+        "slot_size": 466,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "It[SP]seems[SP]Zodiac's[SP]second[SP]floor[SP]has[SP]become[SP]a[NL]giant[SP]dungeon.[1205][U+000F][SP]The[SP]rumor[SP]is[SP]that[SP]there's[SP]tons[NL]of[SP]great[SP]items[SP]there...[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Is[SP]this[SP]some[SP]new[SP]marketing[SP]stunt?[SP]What[SP]do[NL]you[SP]think?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Il paraît que le deuxième étage de Zodiac est devenu\n un immense donjon.[1205][U+000F] Beaucoup de bons objets...[1106][NL]Un nouveau coup de pub ? Qu'en pensez-vous ?"
+    },
+    {
+        "id": 27,
+        "offset": 289582,
+        "data_size": 416,
+        "slot_size": 416,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I[SP]heard[SP]the[SP]ghost[SP]of[SP]an[SP]idol[SP]has[SP]been[SP]seen[NL]in[SP]Aoba[SP]Park.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]If[SP]enough[SP]people[SP]say[SP]so,[SP]it[SP]must[SP]be[SP]true...[1205][U+000F][NL]Brrr![SP]I[SP]just[SP]felt[SP]a[SP]chill[SP]down[SP]my[SP]spine.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "On a vu le fantôme d'une idole dans le parc d'Aoba.[1106][NL]Si assez de gens le disent, ça doit être vrai...[1205][U+000F]\nBrrr ! J'ai eu un frisson."
+    },
+    {
+        "id": 28,
+        "offset": 289998,
+        "data_size": 334,
+        "slot_size": 334,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Is[SP]there[SP]something[SP]called[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the[NL]abandoned[SP]factory?[1205][U+000F][SP]Yikes,[SP]now[SP]I[SP]can't[SP]even[SP]take[NL]a[SP]taxi[SP]ride[SP]without[SP]worrying[SP]anymore.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Un Taxi Maudit à l'usine abandonnée ?[1205][U+000F]\nOuf, je ne peux même plus prendre un taxi sans m'inquiéter."
+    },
+    {
+        "id": 29,
+        "offset": 290332,
+        "data_size": 456,
+        "slot_size": 456,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I[SP]heard[SP]there's[SP]some[SP]Cursed[SP]Escort[SP]at[SP]the[NL]abandoned[SP]factory.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]A[SP]taxi[SP]driver[SP]told[SP]me[SP]about[SP]it.[1205][U+000F][SP]He[SP]said[SP]he's[NL]having[SP]trouble[SP]getting[SP]customers[SP]because[NL]of[SP]that[SP]thing.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "J'ai entendu qu'il y a une Escorte Maudite\n à l'usine abandonnée.[1106][NL]Un chauffeur de taxi m'en a parlé.[1205][U+000F]\nIl a du mal à trouver des clients à cause de ça."
+    },
+    {
+        "id": 30,
+        "offset": 290788,
+        "data_size": 320,
+        "slot_size": 320,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "It[SP]seems[SP]the[SP]real[SP]Kuchisake-onna[SP]has[SP]shown[SP]up[NL]at[SP]Mt.[SP]Iwato.[SP]First[SP]terrorists,[SP]now[SP]Kuchisake-[NL]onna...[SP]This[SP]city's[SP]falling[SP]apart.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "La vraie Kuchisake-onna est apparue au mont Iwato.\nD'abord les terroristes, maintenant elle...\nCette ville s'écroule."
+    },
+    {
+        "id": 31,
+        "offset": 291108,
+        "data_size": 318,
+        "slot_size": 318,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "There's[SP]a[SP]Jumping[SP]Geezer[SP]at[SP]Mt.[SP]Katatsumuri?[NL]Isn't[SP]that[SP]just[SP]one[SP]of[SP]those[SP]Last[SP]Battalion[NL]guys?[1205][U+000F][SP]Yeah,[SP]I[SP]bet[SP]that's[SP]all[SP]it[SP]is.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Un Sauteur Vieux au mont Katatsumuri ?\nC'est juste un gars du Dernier Bataillon, non ?[1205][U+000F]\nOuais, ça doit être ça."
+    },
+    {
+        "id": 32,
+        "offset": 291426,
+        "data_size": 348,
+        "slot_size": 348,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I[SP]can't[SP]believe[SP]they[SP]still[SP]tell[SP]that[SP]story...[NL]Kudan,[SP]huh...?[1205][U+000F][SP]Even[SP]at[SP]my[SP]age,[SP]I'm[SP]afraid[SP]of[NL]that[SP]thing...[1205][U+000F][SP]Brrr![SP]Still[SP]gives[SP]me[SP]the[SP]creeps.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Je n'arrive pas à croire qu'on raconte encore ça...\nKudan...[1205][U+000F] Même à mon âge, j'en ai peur.[1205][U+000F]\nBrrr ! Ça me donne toujours des frissons."
+    },
+    {
+        "id": 33,
+        "offset": 291774,
+        "data_size": 336,
+        "slot_size": 336,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "There's[SP]a[SP]secret[SP]CD[SP]at[SP]Giga[SP]Macho?[SP]Stores[SP]have[NL]been[SP]coming[SP]up[SP]with[SP]odd[SP]promotional[SP]stunts[NL]lately.[1205][U+000F][SP]Though[SP]it[SP]does[SP]pique[SP]my[SP]interest...",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Un CD secret chez Giga Macho ?\nLes magasins ont des promotions bizarres.[1205][U+000F]\nCela pique ma curiosité..."
+    },
+    {
+        "id": 34,
+        "offset": 292110,
+        "data_size": 328,
+        "slot_size": 328,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Do[SP]you[SP]know[SP]the[SP]Dresser[SP]Hag?[1205][U+000F][SP]There's[SP]a[SP]creature[NL]called[SP]that[SP]at[SP]the[SP]abandoned[SP]factory.[1205][U+000F][SP]Does[SP]that[NL]mean[SP]it[SP]lives[SP]inside[SP]a[SP]dresser?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Tu connais la Sorcière du Buffet ?[1205][U+000F]\nElle serait à l'usine abandonnée.[1205][U+000F]\nElle vit dans un buffet ?"
+    },
+    {
+        "id": 35,
+        "offset": 292438,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Is[SP]it[SP]true[SP]Time[SP]Castle[SP]sells[SP]real[SP]weapons?[NL]I[SP]heard[SP]my[SP]coworkers[SP]say[SP]their[SP]quality[SP]and[NL]prices[SP]were[SP]average...",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Time Castle vend de vraies armes ?\nDes collègues disent qualité et prix moyens..."
+    },
+    {
+        "id": 36,
+        "offset": 292720,
+        "data_size": 302,
+        "slot_size": 302,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Is[SP]it[SP]true[SP]Time[SP]Castle[SP]sells[SP]real[SP]weapons?[NL]I[SP]heard[SP]my[SP]coworkers[SP]say[SP]their[SP]quality[SP]was[NL]good,[SP]but[SP]they[SP]were[SP]expensive...",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Time Castle vend de vraies armes ?\nBonne qualité mais chères, disent mes collègues."
+    },
+    {
+        "id": 37,
+        "offset": 293022,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Is[SP]it[SP]true[SP]Time[SP]Castle[SP]sells[SP]real[SP]weapons?[NL]I[SP]heard[SP]my[SP]coworkers[SP]say[SP]their[SP]prices[SP]were[NL]low,[SP]but[SP]so[SP]was[SP]the[SP]quality...",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Time Castle vend de vraies armes ?\nPrix bas, qualité basse aussi."
+    },
+    {
+        "id": 38,
+        "offset": 293320,
+        "data_size": 332,
+        "slot_size": 332,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells[NL]weapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]his[SP]selection's[NL]great,[SP]but[SP]his[SP]resale[SP]prices[SP]are[SP]low.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Tony, le vendeur à Yumezaki, vend des armes à la sauvette.\nBon choix, reprises basses."
+    },
+    {
+        "id": 39,
+        "offset": 293652,
+        "data_size": 338,
+        "slot_size": 338,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells[NL]weapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]his[SP]prices[SP]are[NL]good,[SP]but[SP]the[SP]quality[SP]of[SP]his[SP]stock[SP]isn't.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Tony vend des armes à la sauvette.\nPrix corrects, qualité médiocre."
+    },
+    {
+        "id": 40,
+        "offset": 293990,
+        "data_size": 308,
+        "slot_size": 308,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells[NL]weapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]his[SP]stock's[NL]of[SP]average[SP]quality[SP]and[SP]price.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Tony vend des armes en plein rue.\nQualité et prix moyens."
+    },
+    {
+        "id": 41,
+        "offset": 294298,
+        "data_size": 336,
+        "slot_size": 336,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "That[SP]street[SP]vendor[SP]Tony[SP]in[SP]Yumezaki...[SP]He[SP]sells[NL]weapons[SP]out[SP]in[SP]the[SP]open?[SP]I[SP]hear[SP]he[SP]keeps[SP]his[NL]quality[SP]high,[SP]but[SP]his[SP]prices[SP]are[SP]high[SP]too.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Tony : armes de qualité, prix élevés."
+    },
+    {
+        "id": 42,
+        "offset": 294634,
+        "data_size": 470,
+        "slot_size": 470,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business[NL]partner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Rumor[SP]has[SP]it[SP]their[SP]selection[SP]isn't[SP]great,[NL]but[SP]they[SP]offer[SP]good[SP]resale[SP]prices.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Clair de Lune... J'y suis allé avec un associé.\nIls vendent des armes ?[1106][NL]Peu de choix, mais bonnes reprises."
+    },
+    {
+        "id": 43,
+        "offset": 295104,
+        "data_size": 462,
+        "slot_size": 462,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business[NL]partner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Rumor[SP]has[SP]it[SP]their[SP]prices[SP]are[SP]affordable,[NL]but[SP]their[SP]stuff's[SP]low[SP]quality.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Clair de Lune... J'y suis allé avec un associé.\nIls vendent des armes ?[1106][NL]Prix abordables, qualité basse."
+    },
+    {
+        "id": 44,
+        "offset": 295566,
+        "data_size": 458,
+        "slot_size": 458,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business[NL]partner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Rumor[SP]has[SP]it[SP]their[SP]stuff[SP]is[SP]top-tier,[NL]but[SP]it's[SP]not[SP]exactly[SP]affordable.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Clair de Lune... J'y suis allé avec un associé.\nIls vendent des armes ?[1106][NL]Qualité premium, mais cher."
+    },
+    {
+        "id": 45,
+        "offset": 296024,
+        "data_size": 462,
+        "slot_size": 462,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business[NL]partner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Rumor[SP]has[SP]it[SP]their[SP]selection[SP]is[SP]great,[NL]but[SP]they[SP]offer[SP]low[SP]resale[SP]prices.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Clair de Lune... J'y suis allé avec un associé.\nIls vendent des armes ?[1106][NL]Grand choix, reprises basses."
+    },
+    {
+        "id": 46,
+        "offset": 296486,
+        "data_size": 418,
+        "slot_size": 418,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Clair[SP]de[SP]Lune...[SP]I[SP]went[SP]there[SP]with[SP]a[SP]business[NL]partner[SP]the[SP]other[SP]day.[SP]They[SP]sell[SP]weapons[SP]there?[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Rumor[SP]has[SP]it[SP]their[SP]prices[SP]and[SP]quality[NL]are[SP]average.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Clair de Lune... J'y suis allé avec un associé.\nIls vendent des armes ?[1106][NL]Qualité et prix moyens."
+    },
+    {
+        "id": 47,
+        "offset": 296904,
+        "data_size": 392,
+        "slot_size": 392,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Average[SP]quality[SP]and[SP]prices,[SP]huh...?[1205][U+000F][SP]I'd[SP]never[NL]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Qualité et prix moyens ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes.[1106][NL]Qu'est-il arrivé à cette ville ?"
+    },
+    {
+        "id": 48,
+        "offset": 297296,
+        "data_size": 394,
+        "slot_size": 394,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Low[SP]prices,[SP]but[SP]low[SP]quality,[SP]huh...?[1205][U+000F][SP]I'd[SP]never[NL]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Prix bas, qualité basse ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes.[1106][NL]Qu'est-il arrivé à cette ville ?"
+    },
+    {
+        "id": 49,
+        "offset": 297690,
+        "data_size": 416,
+        "slot_size": 416,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Great[SP]selection,[SP]but[SP]low[SP]resale[SP]prices,[SP]huh...?[1205][U+000F][NL]I'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real[NL]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Bon choix, reprises basses ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes.[1106][NL]Qu'est-il arrivé à cette ville ?"
+    },
+    {
+        "id": 50,
+        "offset": 298106,
+        "data_size": 416,
+        "slot_size": 416,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Poor[SP]selection,[SP]but[SP]great[SP]resale[SP]prices,[SP]eh...?[1205][U+000F][NL]I'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real[NL]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Peu de choix, bonnes reprises ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes.[1106][NL]Qu'est-il arrivé à cette ville ?"
+    },
+    {
+        "id": 51,
+        "offset": 298522,
+        "data_size": 400,
+        "slot_size": 400,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Great[SP]quality,[SP]but[SP]high[SP]prices,[SP]huh...?[1205][U+000F][NL]I'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold[NL]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Bonne qualité, prix élevés ?[1205][U+000F]\nJamais imaginé que Jolly Roger vendait des armes.[1106][NL]Qu'est-il arrivé à cette ville ?"
+    },
+    {
+        "id": 52,
+        "offset": 298922,
+        "data_size": 552,
+        "slot_size": 552,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor[NL]as[SP]well[SP]as[SP]clothes?[1205][U+000F][SP]I[SP]heard[SP]their[SP]quality[SP]and[NL]prices[SP]are[SP]average.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]*sigh*[SP]Does[SP]that[SP]mean[SP]it[SP]isn't[SP]enough[SP]just[NL]to[SP]sell[SP]clothes[SP]in[SP]this[SP]economy?[SP]Now[SP]that's[NL]scary...",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "La boutique de Rengedai vend armures et vêtements ?\nQualité et prix moyens.[1106][NL]*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur..."
+    },
+    {
+        "id": 53,
+        "offset": 299474,
+        "data_size": 566,
+        "slot_size": 566,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor[NL]as[SP]well[SP]as[SP]clothes?[1205][U+000F][SP]I[SP]heard[SP]their[SP]prices[SP]are[NL]low,[SP]but[SP]so[SP]is[SP]the[SP]quality.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]*sigh*[SP]Does[SP]that[SP]mean[SP]it[SP]isn't[SP]enough[SP]just[NL]to[SP]sell[SP]clothes[SP]in[SP]this[SP]economy?[SP]Now[SP]that's[NL]scary...",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Boutique de Rengedai : armures.\nPrix bas, qualité basse.[1106][NL]*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur..."
+    },
+    {
+        "id": 54,
+        "offset": 300040,
+        "data_size": 572,
+        "slot_size": 572,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor[NL]as[SP]well[SP]as[SP]clothes?[1205][U+000F][SP]I[SP]heard[SP]their[SP]quality[SP]is[NL]high,[SP]but[SP]so[SP]are[SP]their[SP]prices.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]*sigh*[SP]Does[SP]that[SP]mean[SP]it[SP]isn't[SP]enough[SP]just[NL]to[SP]sell[SP]clothes[SP]in[SP]this[SP]economy?[SP]Now[SP]that's[NL]scary...",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Boutique de Rengedai : armures.\nHaute qualité, prix élevés.[1106][NL]*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur..."
+    },
+    {
+        "id": 55,
+        "offset": 300612,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that[NL]the[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]quality[NL]and[SP]prices[SP]are[SP]average.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Anima Mundi vend des armures. Nouvelle mode ?\nQualité et prix moyens."
+    },
+    {
+        "id": 56,
+        "offset": 300896,
+        "data_size": 294,
+        "slot_size": 294,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that[NL]the[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]goods[SP]are[NL]cheap,[SP]but[SP]low[SP]in[SP]quality.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Anima Mundi vend des armures.\nBon marché, qualité basse."
+    },
+    {
+        "id": 57,
+        "offset": 301190,
+        "data_size": 326,
+        "slot_size": 326,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that[NL]the[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]selection[NL]is[SP]great,[SP]but[SP]their[SP]resale[SP]prices[SP]are[SP]low.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Anima Mundi : grand choix, reprises basses."
+    },
+    {
+        "id": 58,
+        "offset": 301516,
+        "data_size": 310,
+        "slot_size": 310,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I[SP]heard[SP]Anima[SP]Mundi[SP]sells[SP]armor[SP]now.[SP]Is[SP]that[NL]the[SP]latest[SP]fad?[SP]People[SP]say[SP]their[SP]quality[SP]is[NL]high,[SP]but[SP]they're[SP]very[SP]expensive.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Anima Mundi : haute qualité, très cher."
+    },
+    {
+        "id": 59,
+        "offset": 301826,
+        "data_size": 568,
+        "slot_size": 568,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.[NL]They[SP]don't[SP]have[SP]a[SP]great[SP]selection,[SP]but[SP]their[NL]resale[SP]prices[SP]are[SP]worth[SP]it.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants[NL]that[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can[NL]this[SP]city[SP]get?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Rosa Candida à Aoba vend des armures.\nPeu de choix, reprises intéressantes.[1106][NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+    },
+    {
+        "id": 60,
+        "offset": 302394,
+        "data_size": 500,
+        "slot_size": 500,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.[NL]Their[SP]quality[SP]and[SP]prices[SP]seem[SP]average.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants[NL]that[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can[NL]this[SP]city[SP]get?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Rosa Candida à Aoba : armures,\nqualité et prix moyens.[1106][NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+    },
+    {
+        "id": 61,
+        "offset": 302894,
+        "data_size": 530,
+        "slot_size": 530,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.[NL]Their[SP]quality[SP]is[SP]great,[SP]but[SP]I[SP]hear[SP]they're[NL]expensive.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants[NL]that[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can[NL]this[SP]city[SP]get?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Rosa Candida à Aoba :\nbonne qualité, cher.[1106][NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+    },
+    {
+        "id": 62,
+        "offset": 303424,
+        "data_size": 580,
+        "slot_size": 580,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.[NL]Their[SP]prices[SP]are[SP]certainly[SP]right,[SP]but[SP]there's[NL]a[SP]certain[SP]lack[SP]of[SP]quality[SP]there.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants[NL]that[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can[NL]this[SP]city[SP]get?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Rosa Candida à Aoba : prix corrects,\nmais qualité insuffisante.[1106][NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+    },
+    {
+        "id": 63,
+        "offset": 304004,
+        "data_size": 548,
+        "slot_size": 548,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.[NL]They[SP]have[SP]a[SP]great[SP]selection,[SP]but[SP]their[SP]resale[NL]prices[SP]seem[SP]low.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]But[SP]boutiques[SP]that[SP]sell[SP]armor?[SP]Restaurants[NL]that[SP]sell[SP]weapons?[SP]How[SP]much[SP]more[SP]insane[SP]can[NL]this[SP]city[SP]get?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Rosa Candida à Aoba :\ngrand choix, reprises basses.[1106][NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+    },
+    {
+        "id": 64,
+        "offset": 304552,
+        "data_size": 338,
+        "slot_size": 338,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.[NL]Who[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]selection[NL]is[SP]great[SP]there,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "J'ai fait faire ce manteau chez London Clothier.\nIls vendent aussi des armures ! Bon choix,\nmais reprises basses."
+    },
+    {
+        "id": 65,
+        "offset": 304890,
+        "data_size": 306,
+        "slot_size": 306,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.[NL]Who[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]Their[SP]prices[NL]are[SP]low,[SP]but[SP]so[SP]is[SP]the[SP]quality.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "London Clothier fait aussi des armures.\nPrix bas, qualité basse."
+    },
+    {
+        "id": 66,
+        "offset": 305196,
+        "data_size": 324,
+        "slot_size": 324,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.[NL]Who[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]quality[SP]is[NL]fantastic,[SP]but[SP]the[SP]prices[SP]are[SP]so[SP]high.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "London Clothier : ils vendent des armures.\nQualité fantastique, prix très élevés."
+    },
+    {
+        "id": 67,
+        "offset": 305520,
+        "data_size": 318,
+        "slot_size": 318,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.[NL]Who[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]quality[NL]and[SP]prices[SP]of[SP]their[SP]goods[SP]are[SP]average.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "London Clothier vend des armures.\nQualité et prix moyens."
+    },
+    {
+        "id": 68,
+        "offset": 305838,
+        "data_size": 338,
+        "slot_size": 338,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I[SP]had[SP]this[SP]coat[SP]tailored[SP]at[SP]London[SP]Clothier.[NL]Who[SP]knew[SP]they[SP]sold[SP]real[SP]armor?[SP]The[SP]selection[NL]is[SP]poor[SP]there,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]good.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "London Clothier : peu de choix,\nmais bonnes reprises."
+    },
+    {
+        "id": 69,
+        "offset": 306176,
+        "data_size": 594,
+        "slot_size": 594,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][U+000F][SP]But[SP]I[NL]hear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll[NL]get[SP]real[SP]weapons[SP]and[SP]items.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Rumor[SP]has[SP]it[SP]it's[SP]hard[SP]to[SP]win,[SP]but[SP]you[SP]get[NL]nice[SP]prizes[SP]if[SP]you[SP]do.[SP]I[SP]wonder[SP]if[SP]I[SP]should[NL]give[SP]it[SP]another[SP]try.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Je n'ai jamais gagné de concours.[1205][U+000F]\nMais gagner donne de vraies armes et objets.[1106][NL]Difficile à gagner, mais lots sympas.\nJe devrais peut-être réessayer."
+    },
+    {
+        "id": 70,
+        "offset": 306770,
+        "data_size": 632,
+        "slot_size": 632,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][U+000F][SP]But[SP]I[NL]hear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll[NL]get[SP]real[SP]weapons[SP]and[SP]items.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Rumor[SP]has[SP]it[SP]it's[SP]very[SP]rare[SP]for[SP]anyone[SP]to[SP]win,[NL]but[SP]you[SP]get[SP]amazing[SP]prizes[SP]if[SP]you[SP]do.[SP]I[SP]wonder[NL]if[SP]I[SP]should[SP]give[SP]it[SP]another[SP]try.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Jamais gagné de concours.[1205][U+000F]\nMais gagner donne de vraies armes et objets.[1106][NL]Très rare de gagner, lots incroyables.\nJe devrais réessayer."
+    },
+    {
+        "id": 71,
+        "offset": 307402,
+        "data_size": 610,
+        "slot_size": 610,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][U+000F][SP]But[SP]I[NL]hear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll[NL]get[SP]real[SP]weapons[SP]and[SP]items.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Rumor[SP]has[SP]it[SP]it's[SP]easy[SP]to[SP]win,[SP]but[SP]you[SP]get[NL]junk[SP]for[SP]prizes.[SP]And[SP]I've[SP]still[SP]never[SP]won...[NL]I[SP]must[SP]have[SP]the[SP]worst[SP]luck.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Jamais gagné de concours.[1205][U+000F]\nMais gagner donne de vraies armes et objets.[1106][NL]Facile à gagner, prix pourris.\nJe n'ai jamais gagné. J'ai la pire chance."
+    },
+    {
+        "id": 72,
+        "offset": 308012,
+        "data_size": 642,
+        "slot_size": 642,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it[NL]seems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][U+000F][SP]I[SP]get[SP]a[SP]tingle[SP]of[NL]excitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]A[SP]friend[SP]of[SP]mine[SP]went...[1205][U+000F][SP]He[SP]said[SP]you[SP]can[SP]win[NL]big[SP]at[SP]the[SP]#5[SP]poker[SP]machine.[SP]Unfortunately,[NL]I[SP]don't[SP]know[SP]how[SP]to[SP]play[SP]poker.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][U+000F]\nL'idée de jouer m'excite...[1106][NL]Un ami y est allé.[1205][U+000F] On peut gagner gros\nà la machine de poker n°5.\nJe ne sais pas jouer au poker."
+    },
+    {
+        "id": 73,
+        "offset": 308654,
+        "data_size": 650,
+        "slot_size": 650,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it[NL]seems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][U+000F][SP]I[SP]get[SP]a[SP]tingle[SP]of[NL]excitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]A[SP]friend[SP]of[SP]mine[SP]went...[1205][U+000F][SP]He[SP]said[SP]you[SP]can[SP]win[NL]big[SP]at[SP]the[SP]slot[SP]machine[SP]at[SP]the[SP]end.[SP]I[SP]wonder,[NL]did[SP]he[SP]mean[SP]the[SP]#1[SP]or[SP]#8[SP]machine?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][U+000F]\nL'idée de jouer m'excite...[1106][NL]Un ami y est allé.[1205][U+000F] On peut gagner gros\nà la machine à sous du fond.\n#1 ou #8 ?"
+    },
+    {
+        "id": 74,
+        "offset": 309304,
+        "data_size": 630,
+        "slot_size": 630,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it[NL]seems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][U+000F][SP]I[SP]get[SP]a[SP]tingle[SP]of[NL]excitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]A[SP]friend[SP]of[SP]mine[SP]went...[SP]He[SP]said[SP]you[SP]can[SP]win[NL]big[SP]at[SP]blackjack.[1205][U+000F][SP]Then[SP]again,[SP]it[SP]would[SP]be[SP]bad[NL]if[SP]my[SP]wife[SP]found[SP]out...",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][U+000F]\nL'idée de jouer m'excite...[1106][NL]Un ami y est allé. On peut gagner gros\nau blackjack.[1205][U+000F]\nMais ce serait mal si ma femme le savait..."
+    },
+    {
+        "id": 75,
+        "offset": 309934,
+        "data_size": 574,
+        "slot_size": 574,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "I[SP]may[SP]not[SP]look[SP]it,[SP]but[SP]I[SP]love[SP]antiques.[SP]I[SP]used[NL]to[SP]frequent[SP]places[SP]like[SP]Time[SP]Castle.[1205][U+000F][SP]By[SP]the[NL]way,[SP]do[SP]you[SP]know[SP]what[SP]a[SP]legendary[SP]weapon[SP]is?[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]I[SP]heard[SP]Shiraishi[SP]Ramen[SP]has[SP]one.[SP]If[SP]it's[SP]true,[NL]I'd[SP]love[SP]to[SP]at[SP]least[SP]get[SP]a[SP]glimpse...",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "J'adore les antiquités. Je fréquentais Time Castle.[1205][U+000F]\nAu fait, savez-vous ce qu'est une arme légendaire ?[1106][NL]Shiraishi Ramen en aurait une.\nJ'aimerais au moins la voir."
+    },
+    {
+        "id": 76,
+        "offset": 310508,
+        "data_size": 410,
+        "slot_size": 410,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "It[SP]seems[SP]there's[SP]a[SP]legendary[SP]weapon[SP]at[NL]Clair[SP]de[SP]Lune.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]I'm[SP]quite[SP]fond[SP]of[SP]antiques,[SP]so[SP]I[SP]hope[SP]to[SP]at[NL]least[SP]get[SP]a[SP]glimpse[SP]of[SP]what[SP]it[SP]looks[SP]like.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Une arme légendaire au Clair de Lune.[1106][NL]J'aime les antiquités.\nJ'espère au moins la voir."
+    },
+    {
+        "id": 77,
+        "offset": 310918,
+        "data_size": 300,
+        "slot_size": 300,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "It[SP]seems[SP]there's[SP]a[SP]legendary[SP]weapon[SP]at[SP]Time[NL]Castle,[SP]but[SP]the[SP]owner[SP]is[SP]playing[SP]dumb[SP]to[SP]jack[NL]up[SP]the[SP]price.[SP]What[SP]a[SP]miser!",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Une arme légendaire à Time Castle.\nLe propriétaire fait le sourd pour faire monter le prix.\nQuel avare !"
+    },
+    {
+        "id": 78,
+        "offset": 311218,
+        "data_size": 586,
+        "slot_size": 586,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "No[SP]wonder[SP]there's[SP]nothing[SP]like[SP]a[SP]legendary[NL]weapon[SP]at[SP]Time[SP]Castle.[SP]Apparently,[SP]it[SP]hasn't[NL]been[SP]delivered[SP]yet.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]The[SP]seller[SP]is[SP]waiting[SP]at[SP]the[SP]abandoned[NL]factory,[SP]but[SP]the[SP]owner's[SP]afraid[SP]of[SP]monsters[NL]and[SP]won't[SP]go[SP]meet[SP]him.[SP]What[SP]a[SP]coward!",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Pas étonnant qu'il n'y ait pas d'arme légendaire.\nElle n'a pas encore été livrée.[1106][NL]Le vendeur attend à l'usine abandonnée,\nmais le propriétaire a peur des monstres.\nQuel lâche !"
+    },
+    {
+        "id": 79,
+        "offset": 311804,
+        "data_size": 250,
+        "slot_size": 250,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Hmmm...[SP]I[SP]heard[SP]a[SP]rumor[SP]that[SP]demons[SP]stole[SP]the[NL]legendary[SP]weapon[SP]from[SP]Time[SP]Castle.[SP]Is[SP]it[SP]true?",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "J'ai entendu que des démons ont volé l'arme légendaire.\nC'est vrai ?"
+    },
+    {
+        "id": 80,
+        "offset": 312054,
+        "data_size": 622,
+        "slot_size": 622,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Augh,[SP]I[SP]was[SP]too[SP]late...[SP]Apparently[SP]a[SP]terribly[NL]unlucky[SP]woman[SP]bought[SP]Time[SP]Castle's[SP]legendary[NL]weapon[SP]before[SP]I[SP]could[SP]see[SP]it.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]Must[SP]have[SP]been[SP]a[SP]fellow[SP]antique[SP]lover.[SP]If[SP]only[NL]I[SP]had[SP]made[SP]up[SP]my[SP]mind[SP]earlier,[SP]I[SP]could[SP]have[NL]gotten[SP]there[SP]first...[SP]What[SP]a[SP]pity.",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Trop tard. Une femme malchanceuse a acheté\nl'arme légendaire avant que je puisse la voir.[1106][NL]Un autre amateur d'antiquités.\nSi j'avais décidé plus tôt, j'aurais été premier.\nQuel dommage."
+    },
+    {
+        "id": 81,
+        "offset": 312676,
+        "data_size": 574,
+        "slot_size": 574,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Middle-aged[SP]office[SP]worker",
+        "texte_orig": "Honestly,[SP]of[SP]all[SP]the[SP]luck.[SP]It[SP]seems[SP]the[SP]owner[NL]of[SP]Time[SP]Castle[SP]gave[SP]away[SP]that[SP]legendary[SP]weapon.[NL][1106][E2][1431][U+0000][U+0000]\"Middle-aged[SP]office[SP]worker[NL]To[SP]some[SP]girl[SP]with[SP]short[SP]hair,[SP]supposedly...[NL]But[SP]that's[SP]too[SP]vague[SP]a[SP]hint[SP]to[SP]go[SP]on.[SP]*sigh*[NL]If[SP]only[SP]I[SP]bought[SP]it[SP]before[SP]it[SP]was[SP]gone!",
+        "nom_fr": "Employé d'âge moyen",
+        "texte_fr": "Quelle malchance. Le propriétaire a donné\nl'arme légendaire.[1106][NL]À une fille aux cheveux courts, dit-on.\nIndice trop vague. *soupir*\nSi seulement je l'avais achetée !"
+    },
+    {
+        "id": 82,
+        "offset": 313250,
+        "data_size": 370,
+        "slot_size": 370,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Have[SP]you[SP]heard[SP]the[SP]rumor[SP]that[SP]a[SP]woman's[SP]ghost[NL]is[SP]appearing[SP]in[SP]Aoba[SP]Park?[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]Do[SP]you[SP]think[SP]it's[SP]true?[1205][U+000F][SP]If[SP]it[SP]is,[SP]I[SP]ought[SP]to[NL]change[SP]my[SP]daily[SP]route.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Tu as entendu ? Le fantôme d'une femme\n apparaît dans le parc d'Aoba.[1205][U+000F][1106][NL]Tu crois que c'est vrai ?[1205][U+000F]\nJe devrais changer mon itinéraire."
+    },
+    {
+        "id": 83,
+        "offset": 313620,
+        "data_size": 358,
+        "slot_size": 358,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Wh-What[SP]are[SP]we[SP]going[SP]to[SP]do...?[SP]Even[SP]the[SP]fire[NL]department[SP]was[SP]bombed...[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]There's[SP]no[SP]one[SP]left[SP]to[SP]put[SP]out[SP]the[SP]flames[SP]in[NL]case[SP]of[SP]another[SP]attack!",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Qu'allons-nous faire... ?\nMême les pompiers ont été bombardés...[1106][NL]Personne pour éteindre les flammes\n en cas de nouvelle attaque !"
+    },
+    {
+        "id": 84,
+        "offset": 313978,
+        "data_size": 624,
+        "slot_size": 624,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Do[SP]you[SP]know[SP]what[SP]this[SP]Last[SP]Battalion[SP]thing[SP]is?[1205][U+000F][NL]I[SP]hear[SP]they're[SP]the[SP]terrorists[SP]responsible[SP]for[NL]the[SP]attacks,[SP]but[SP]I've[SP]never[SP]heard[SP]of[SP]them.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]Are[SP]the[SP]Masked[SP]Circle[SP]not[SP]the[SP]only[SP]guys[SP]like[NL]that[SP]walking[SP]around?[1205][U+000F][SP]If[SP]so,[SP]why[SP]are[SP]they[NL]attacking[SP]the[SP]city!?[SP]I[SP]don't[SP]know[SP]what[SP]to[SP]do!",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Tu sais ce qu'est le Dernier Bataillon ?[1205][U+000F]\nOn dit qu'ils sont les terroristes responsables,\nmais je n'en ai jamais entendu parler.[1106][NL]Le Cercle Masqué n'est pas le seul groupe ?[1205][U+000F]\nPourquoi attaquent-ils la ville !?\nJe ne sais pas quoi faire !"
+    },
+    {
+        "id": 85,
+        "offset": 314602,
+        "data_size": 296,
+        "slot_size": 296,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "I[SP]heard[SP]they[SP]posted[SP]composite[SP]sketches[SP]of[SP]the[NL]suspects.[SP]So[SP]are[SP]they[SP]Masked[SP]Circle?[1205][U+000F][SP]Or[SP]Last[NL]Battalion?[1205][U+000F][SP]I'm[SP]just[SP]so[SP]confused.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Ils ont affiché des portraits-robots.\nIls sont du Cercle Masqué ?[1205][U+000F] Ou du Dernier Bataillon ?[1205][U+000F]\nJe suis perdue."
+    },
+    {
+        "id": 86,
+        "offset": 314898,
+        "data_size": 368,
+        "slot_size": 368,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Geez![SP]I[SP]wish[SP]they'd[SP]be[SP]more[SP]specific[SP]with[SP]the[NL]news[SP]broadcasts.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]They're[SP]just[SP]going[SP]to[SP]end[SP]up[SP]confusing[SP]more[NL]people[SP]about[SP]who[SP]the[SP]terrorists[SP]are!",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Dommage qu'ils ne soient pas plus précis\naux infos.[1106][NL]Ils ne font que semer plus de confusion\n sur les terroristes !"
+    },
+    {
+        "id": 87,
+        "offset": 315266,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "I[SP]wonder[SP]if[SP]it's[SP]safe[SP]to[SP]be[SP]out[SP]like[SP]this.[1205][U+000F][NL]B-But[SP]where[SP]would[SP]I[SP]hide?[SP]We[SP]can't[SP]rely[SP]on[NL]the[SP]police[SP]anymore,[SP]after[SP]all...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Est-ce sûr d'être dehors ?[1205][U+000F]\nMais où me cacher ? On ne peut plus compter\n sur la police..."
+    },
+    {
+        "id": 88,
+        "offset": 315548,
+        "data_size": 524,
+        "slot_size": 524,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Whew...[1205][U+000A][SP]Now[SP]that[SP]we're[SP]in[SP]the[SP]sky,[SP]my[SP]options[NL]for[SP]walking[SP]are[SP]limited.[1205][U+000F][SP]Huh?[SP]Now's[SP]not[SP]the[NL]time[SP]for[SP]that?[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]But[SP]there's[SP]no[SP]use[SP]panicking[SP]if[SP]things[SP]have[NL]gotten[SP]this[SP]bad.[1205][U+000F][SP]I[SP]don't[SP]care[SP]anymore[SP]if[SP]we[NL]evolve[SP]or[SP]all[SP]die[SP]off.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Ouf...[1205][U+000A] Dans le ciel, mes options de marche sont limitées.[1205][U+000F]\nHein ? Ce n'est pas le moment ?[1106][NL]Inutile de paniquer. Ça a déjà trop empiré.[1205][U+000F]\nJe m'en fiche qu'on évolue ou qu'on meure."
+    },
+    {
+        "id": 89,
+        "offset": 316072,
+        "data_size": 544,
+        "slot_size": 544,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Have[SP]you[SP]heard?[1205][U+000F][SP]There[SP]are[SP]countless[SP]rumors[NL]flying[SP]around[SP]about[SP]what[SP]kind[SP]of[SP]end[SP]the[NL]people[SP]below[SP]will[SP]face.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]The[SP]latest[SP]is[SP]that[SP]when[SP]the[SP]Grand[SP]Cross[SP]is[NL]complete,[SP]an[SP]intense[SP]magnetic[SP]storm[SP]will[SP]arise[NL]and[SP]scorch[SP]the[SP]Earth's[SP]surface.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Tu as entendu ?[1205][U+000F]\nDes rumeurs sur la fin des gens d'en bas.[1106][NL]La dernière : la Grande Croix provoquera\n une tempête magnétique brûlant la Terre."
+    },
+    {
+        "id": 90,
+        "offset": 316616,
+        "data_size": 312,
+        "slot_size": 312,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Hey,[SP]did[SP]you[SP]hear?[1205][U+000A][SP]When[SP]the[SP]Grand[SP]Cross[SP]is[NL]complete,[SP]a[SP]plasma[SP]vortex[SP]will[SP]form[SP]and[SP]the[NL]whole[SP]Earth[SP]will[SP]look[SP]like[SP]those[SP]crop[SP]circles.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Hé, tu as entendu ?[1205][U+000A]\nLa Grande Croix créera un vortex de plasma,\n la Terre ressemblera à des crop circles."
+    },
+    {
+        "id": 91,
+        "offset": 316928,
+        "data_size": 326,
+        "slot_size": 326,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "It[SP]seems[SP]like[SP]when[SP]the[SP]Grand[SP]Cross[SP]is[SP]over,[SP]the[NL]balance[SP]of[SP]gravity[SP]will[SP]crumble[SP]and[SP]the[SP]Earth's[NL]rotation[SP]will[SP]stop.[1205][U+000F][SP]Then[SP]the[SP]world[SP]will[SP]end.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Après la Grande Croix, la gravité s'effondrera,\n la Terre s'arrêtera.[1205][U+000F]\nAlors le monde finira."
+    },
+    {
+        "id": 92,
+        "offset": 317254,
+        "data_size": 272,
+        "slot_size": 272,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Hey,[SP]have[SP]you[SP]heard[SP]about[SP]Zodiac?[SP]Their[SP]second[NL]floor[SP]is[SP]a[SP]huge[SP]dungeon[SP]now,[SP]filled[SP]with[SP]items.[1205][U+000F][NL]What[SP]a[SP]weird[SP]club.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Tu as entendu parler de Zodiac ?\nLeur deuxième étage est devenu un donjon rempli d'objets.[1205][U+000F]\nBizarre."
+    },
+    {
+        "id": 93,
+        "offset": 317526,
+        "data_size": 308,
+        "slot_size": 308,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]talking[SP]flowers[SP]in[SP]Aoba[NL]Park?[SP]How[SP]gossipy[SP]would[SP]they[SP]be...?[SP]Guess[SP]you[NL]can't[SP]try[SP]anything[SP]funny[SP]there[SP]after[SP]all.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Tu connais les fleurs qui parlent à Aoba ?\nComme elles seraient bavardes...\nOn ne peut rien tenter de drôle là-bas."
+    },
+    {
+        "id": 94,
+        "offset": 317834,
+        "data_size": 748,
+        "slot_size": 748,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "H-Hey,[SP]the[SP]rumor[SP]about[SP]that[SP]idol's[SP]ghost[SP]in[NL]Aoba[SP]Park[SP]was[SP]real,[SP]wasn't[SP]it?[1205][U+000F][SP]I[SP]heard[SP]people[NL]in[SP]the[SP]city[SP]talking[SP]about[SP]it[SP]too![NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]Ugh,[SP]what[SP]should[SP]I[SP]do...?[1205][U+000F][SP]This[SP]has[SP]always[SP]been[NL]part[SP]of[SP]the[SP]route[SP]I[SP]take[SP]on[SP]my[SP]walks.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]I[SP]don't[SP]want[SP]to[SP]get[SP]possessed[SP]by[SP]some[SP]evil[NL]spirit...[1205][U+000F][SP]I-I'm[SP]gonna[SP]stop[SP]passing[SP]by[SP]here[NL]from[SP]now[SP]on.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Hé, le fantôme de l'idole à Aoba était réel ?[1205][U+000F]\nJ'ai entendu des gens en parler ![1106][NL]Qu'est-ce que je fais ?[1205][U+000F]\nCela a toujours fait partie de mon itinéraire.[1106][NL]Je ne veux pas me faire posséder.[1205][U+000F]\nJe vais éviter de passer par ici désormais."
+    },
+    {
+        "id": 95,
+        "offset": 318582,
+        "data_size": 276,
+        "slot_size": 276,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Did[SP]you[SP]know[SP]there's[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the[NL]abandoned[SP]factory?[SP]I[SP]heard[SP]it[SP]goes[SP]into[SP]the[NL]city[SP]at[SP]night[SP]to[SP]kill.[SP]Scary...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Un Taxi Maudit à l'usine abandonnée ?\nIl tue la nuit en ville. Effrayant..."
+    },
+    {
+        "id": 96,
+        "offset": 318858,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Huh?[1205][U+000F][SP]It[SP]wasn't[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the[SP]abandoned[NL]factory,[SP]it[SP]was[SP]a[SP]Cursed[SP]Escort?[1205][U+000F][SP]But[SP]don't[SP]they[NL]work[SP]pretty[SP]much[SP]the[SP]same[SP]way?",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Hein ?[1205][U+000F] C'est une Escorte Maudite, pas un Taxi ?[1205][U+000F]\nMais ça revient au même, non ?"
+    },
+    {
+        "id": 97,
+        "offset": 319156,
+        "data_size": 290,
+        "slot_size": 290,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Hey,[SP]does[SP]Kuchisake-onna[SP]really[SP]exist?[SP]I[SP]heard[NL]she's[SP]shown[SP]up[SP]at[SP]Mt.[SP]Iwato![1205][U+000F][SP]Now[SP]I[SP]can't[SP]go[NL]walking[SP]there[SP]anymore[SP]either...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Kuchisake-onna existe ?\nElle serait au mont Iwato ![1205][U+000F]\nJe ne peux plus y aller non plus..."
+    },
+    {
+        "id": 98,
+        "offset": 319446,
+        "data_size": 554,
+        "slot_size": 554,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Hey,[SP]what's[SP]a[SP]Jumping[SP]Geezer?[1205][U+000F][SP]Because[SP]I[SP]heard[NL]a[SP]rumor[SP]there's[SP]a[SP]creature[SP]called[SP]that[SP]at[NL]Mt.[SP]Katatsumuri.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]Well,[SP]with[SP]the[SP]soldiers[SP]patrolling[SP]there,[NL]I[SP]wasn't[SP]going[SP]near[SP]that[SP]mountain[SP]to[SP]begin[NL]with.[1205][U+000F][SP]It's[SP]just[SP]one[SP]thing[SP]after[SP]another...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "C'est quoi un Sauteur Vieux ?[1205][U+000F]\nIl y en aurait un au mont Katatsumuri.[1106][NL]Avec les soldats, je ne m'approchais déjà pas.\nC'est une chose après l'autre..."
+    },
+    {
+        "id": 99,
+        "offset": 320000,
+        "data_size": 290,
+        "slot_size": 290,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "What[SP]am[SP]I[SP]going[SP]to[SP]do!?[1205][U+000F][SP]I[SP]can't[SP]sleep[SP]alone[NL]after[SP]hearing[SP]a[SP]story[SP]like[SP]that![SP]I[SP]need[SP]to[NL]try[SP]and[SP]put[SP]Kudan[SP]out[SP]of[SP]my[SP]mind...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Je vais faire quoi !?[1205][U+000F]\nJe ne peux plus dormir seule après ça !\nIl faut que je chasse Kudan de mon esprit..."
+    },
+    {
+        "id": 100,
+        "offset": 320290,
+        "data_size": 316,
+        "slot_size": 316,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Giga[SP]Macho[SP]carries[SP]a[NL]secret[SP]CD?[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]I[SP]heard[SP]there's[SP]a[SP]special[SP]track[SP]on[SP]it[SP]you[NL]can't[SP]hear[SP]any[SP]other[SP]way.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Giga Macho a un CD secret.[1106][NL]Il contient un morceau spécial\nqu'on n'entend nulle part ailleurs."
+    },
+    {
+        "id": 101,
+        "offset": 320606,
+        "data_size": 458,
+        "slot_size": 458,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "The[SP]Dresser[SP]Hag's[SP]that[SP]monster[SP]that's[SP]an[SP]old[NL]woman[SP]living[SP]in[SP]a[SP]dresser,[SP]right?[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]Why[SP]would[SP]something[SP]like[SP]that[SP]be[SP]at[SP]the[NL]abandoned[SP]factory...?[1205][U+000F][SP]Well,[SP]guess[SP]I'm[SP]not[NL]going[SP]near[SP]there[SP]anymore.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "La Sorcière du Buffet, c'est la vieille femme\nqui vit dans un buffet, c'est ça ?[1106][NL]Pourquoi à l'usine abandonnée ?[1205][U+000F]\nJe ne m'en approcherai plus."
+    },
+    {
+        "id": 102,
+        "offset": 321064,
+        "data_size": 358,
+        "slot_size": 358,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][U+000F][SP]I[SP]mean,[NL]an[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]People[SP]say[SP]their[SP]quality[SP]and[SP]prices[SP]are[NL]just[SP]average.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Rengedai doit être effrayant.[1205][U+000F]\nUne boutique d'antiquités qui vend des armes ?[1106][NL]Qualité et prix moyens."
+    },
+    {
+        "id": 103,
+        "offset": 321422,
+        "data_size": 358,
+        "slot_size": 358,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][U+000F][SP]I[SP]mean,[NL]an[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]People[SP]say[SP]their[SP]quality's[SP]great,[SP]but[SP]it's[NL]expensive.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Rengedai doit être effrayant.[1205][U+000F]\nUne boutique d'antiquités qui vend des armes ?[1106][NL]Qualité excellente, cher."
+    },
+    {
+        "id": 104,
+        "offset": 321780,
+        "data_size": 382,
+        "slot_size": 382,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][U+000F][SP]I[SP]mean,[NL]an[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]People[SP]say[SP]their[SP]quality's[SP]not[SP]great,[SP]but[SP]at[NL]least[SP]they're[SP]cheap.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Rengedai doit être effrayant.[1205][U+000F]\nUne boutique d'antiquités qui vend des armes ?[1106][NL]Qualité moyenne, mais bon marché."
+    },
+    {
+        "id": 105,
+        "offset": 322162,
+        "data_size": 602,
+        "slot_size": 602,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off[NL]the[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]the[SP]selection's[NL]good,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what[NL]are[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the[NL]city[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Effrayant d'acheter des armes en pleine rue à Yumezaki.\nBon choix, reprises basses.[1106][NL]Ceux qui les utilisent sont en faute, mais à quoi pensent les commerçants ?\nLa ville devient de plus en plus dangereuse."
+    },
+    {
+        "id": 106,
+        "offset": 322764,
+        "data_size": 596,
+        "slot_size": 596,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off[NL]the[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]their[SP]quality's[NL]not[SP]much,[SP]but[SP]the[SP]prices[SP]are[SP]low.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what[NL]are[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the[NL]city[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Effrayant d'acheter des armes en rue à Yumezaki.\nQualité médiocre, prix bas.[1106][NL]Ceux qui les utilisent sont en faute, mais à quoi pensent les commerçants ?\nLa ville devient de plus en plus dangereuse."
+    },
+    {
+        "id": 107,
+        "offset": 323360,
+        "data_size": 572,
+        "slot_size": 572,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off[NL]the[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]their[SP]quality[NL]and[SP]prices[SP]are[SP]average.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what[NL]are[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the[NL]city[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Effrayant d'acheter des armes en rue à Yumezaki.\nQualité et prix moyens.[1106][NL]Ceux qui les utilisent sont en faute, mais à quoi pensent les commerçants ?\nLa ville devient de plus en plus dangereuse."
+    },
+    {
+        "id": 108,
+        "offset": 323932,
+        "data_size": 594,
+        "slot_size": 594,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "It's[SP]scary[SP]how[SP]you[SP]can[SP]get[SP]a[SP]weapon[SP]right[SP]off[NL]the[SP]street[SP]in[SP]Yumezaki.[SP]I[SP]hear[SP]they're[SP]pretty[NL]expensive,[SP]but[SP]very[SP]high[SP]quality.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]The[SP]people[SP]who[SP]use[SP]them[SP]are[SP]at[SP]fault,[SP]but[SP]what[NL]are[SP]the[SP]merchants[SP]thinking?[SP]At[SP]this[SP]rate,[SP]the[NL]city[SP]is[SP]getting[SP]more[SP]and[SP]more[SP]unsafe.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Effrayant d'acheter des armes en rue à Yumezaki.\nChères, mais très haute qualité.[1106][NL]Ceux qui les utilisent sont en faute, mais à quoi pensent les commerçants ?\nLa ville devient de plus en plus dangereuse."
+    },
+    {
+        "id": 109,
+        "offset": 324526,
+        "data_size": 622,
+        "slot_size": 622,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F][NL]I[SP]heard[SP]their[SP]selection[SP]is[SP]slim,[SP]but[SP]their[NL]resale[SP]prices[SP]are[SP]great.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?[NL]However[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up[NL]restaurant...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Clair de Lune, le restau français ?[1106][NL]Ils vendent des armes ?[1205][U+000F]\nPeu de choix, reprises excellentes.[1106][NL]On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
+    },
+    {
+        "id": 110,
+        "offset": 325148,
+        "data_size": 588,
+        "slot_size": 588,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F][NL]I[SP]heard[SP]they're[SP]cheap,[SP]but[SP]sell[SP]low-quality[NL]goods.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?[NL]However[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up[NL]restaurant...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Clair de Lune, le restau français ?[1106][NL]Ils vendent des armes ?[1205][U+000F]\nBon marché, mais basse qualité.[1106][NL]On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
+    },
+    {
+        "id": 111,
+        "offset": 325736,
+        "data_size": 640,
+        "slot_size": 640,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F][NL]I[SP]heard[SP]their[SP]quality's[SP]great,[SP]but[SP]expensive,[NL]just[SP]like[SP]the[SP]food[SP]they[SP]serve.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?[NL]However[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up[NL]restaurant...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Clair de Lune, le restau français ?[1106][NL]Ils vendent des armes ?[1205][U+000F]\nQualité excellente, cher, comme leur nourriture.[1106][NL]On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
+    },
+    {
+        "id": 112,
+        "offset": 326376,
+        "data_size": 634,
+        "slot_size": 634,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F][NL]I[SP]heard[SP]their[SP]selection[SP]is[SP]great,[SP]but[SP]their[NL]resale[SP]prices[SP]are[SP]pretty[SP]low.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?[NL]However[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up[NL]restaurant...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Clair de Lune, le restau français ?[1106][NL]Ils vendent des armes ?[1205][U+000F]\nGrand choix, reprises assez basses.[1106][NL]On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
+    },
+    {
+        "id": 113,
+        "offset": 327010,
+        "data_size": 578,
+        "slot_size": 578,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Isn't[SP]Clair[SP]de[SP]Lune[SP]that[SP]French[SP]restaurant?[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]They[SP]sell[SP]weapons[SP]at[SP]a[SP]place[SP]like[SP]that?[1205][U+000F][NL]I[SP]heard[SP]their[SP]quality[SP]and[SP]prices[SP]are[SP]average.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]Can[SP]you[SP]order[SP]weapons[SP]right[SP]off[SP]the[SP]menu?[NL]However[SP]they[SP]do[SP]it,[SP]that's[SP]one[SP]messed[SP]up[NL]restaurant...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Clair de Lune, le restau français ?[1106][NL]Ils vendent des armes ?[1205][U+000F]\nQualité et prix moyens.[1106][NL]On commande des armes au menu ?\nQuoi qu'il en soit, ce restau est détraqué."
+    },
+    {
+        "id": 114,
+        "offset": 327588,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because[NL]he[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]I[SP]hear[SP]the[SP]quality[NL]and[SP]prices[SP]are[SP]average,[SP]though.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\nQualité et prix moyens."
+    },
+    {
+        "id": 115,
+        "offset": 327886,
+        "data_size": 274,
+        "slot_size": 274,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because[NL]he[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]I[SP]hear[SP]they're[NL]cheap,[SP]but[SP]low[SP]quality.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\nBon marché, basse qualité."
+    },
+    {
+        "id": 116,
+        "offset": 328160,
+        "data_size": 306,
+        "slot_size": 306,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because[NL]he[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]His[SP]selection[SP]is[NL]great,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\nGrand choix, reprises basses."
+    },
+    {
+        "id": 117,
+        "offset": 328466,
+        "data_size": 312,
+        "slot_size": 312,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because[NL]he[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]His[SP]selection[SP]is[NL]skimpy,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]great.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\nPeu de choix, reprises excellentes."
+    },
+    {
+        "id": 118,
+        "offset": 328778,
+        "data_size": 310,
+        "slot_size": 310,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because[NL]he[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][U+000F][SP]I[SP]hear[SP]the[SP]quality[NL]is[SP]great,[SP]but[SP]his[SP]stuff[SP]is[SP]expensive.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\nQualité excellente, cher."
+    },
+    {
+        "id": 119,
+        "offset": 329088,
+        "data_size": 498,
+        "slot_size": 498,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Hey,[SP]have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[NL]sells[SP]real[SP]armor.[SP]Their[SP]quality[SP]and[SP]prices[NL]seem[SP]to[SP]be[SP]average.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]I[SP]don't[SP]know[SP]how[SP]much[SP]of[SP]that[SP]is[SP]true,[NL]but[SP]I'm[SP]thinking[SP]of[SP]checking[SP]it[SP]out.[NL]It[SP]sounds[SP]interesting.[NL]",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Le Rosa Candida de Rengedai vend des armures.\nQualité et prix moyens.[1106][NL]Je ne sais si c'est vrai,\nmais je vais vérifier. Intéressant."
+    },
+    {
+        "id": 120,
+        "offset": 329586,
+        "data_size": 528,
+        "slot_size": 528,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Hey,[SP]have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[NL]sells[SP]real[SP]armor.[SP]Their[SP]quality[SP]seems[SP]low,[NL]but[SP]at[SP]least[SP]their[SP]prices[SP]are[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]I[SP]don't[SP]know[SP]how[SP]much[SP]of[SP]that[SP]is[SP]true,[NL]but[SP]I'm[SP]thinking[SP]of[SP]checking[SP]it[SP]out.[NL]It[SP]sounds[SP]interesting.[NL]",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Rosa Candida vend des armures.\nQualité basse, prix bas.[1106][NL]Je ne sais si c'est vrai,\nmais je vais vérifier. Intéressant."
+    },
+    {
+        "id": 121,
+        "offset": 330114,
+        "data_size": 500,
+        "slot_size": 500,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Hey,[SP]have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[NL]sells[SP]real[SP]armor.[SP]They're[SP]expensive,[SP]but[SP]the[NL]quality[SP]is[SP]amazing.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]I[SP]don't[SP]know[SP]how[SP]much[SP]of[SP]that[SP]is[SP]true,[NL]but[SP]I'm[SP]thinking[SP]of[SP]checking[SP]it[SP]out.[NL]It[SP]sounds[SP]interesting.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Rosa Candida vend des armures.\nCher, mais qualité incroyable.[1106][NL]Je ne sais si c'est vrai,\nmais je vais vérifier. Intéressant."
+    },
+    {
+        "id": 122,
+        "offset": 330614,
+        "data_size": 416,
+        "slot_size": 416,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They[NL]sell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]their[NL]quality[SP]and[SP]prices[SP]are[SP]average.[1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything[NL]weird...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Ma fille va souvent chez Anima Mundi.\nIls vendent des armures ? Qualité et prix moyens.[1106][NL]J'espère qu'elle n'achète rien de bizarre..."
+    },
+    {
+        "id": 123,
+        "offset": 331030,
+        "data_size": 432,
+        "slot_size": 432,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They[NL]sell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]their[NL]quality's[SP]not[SP]great,[SP]but[SP]they're[SP]cheap.[1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything[NL]weird...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Ma fille va chez Anima Mundi.\nArmures : qualité moyenne, bon marché.[1106][NL]J'espère qu'elle n'achète rien de bizarre..."
+    },
+    {
+        "id": 124,
+        "offset": 331462,
+        "data_size": 452,
+        "slot_size": 452,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They[NL]sell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]their[SP]resale[NL]prices[SP]are[SP]low,[SP]but[SP]the[SP]selection's[SP]great.[1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything[NL]weird...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Ma fille va chez Anima Mundi.\nArmures : reprises basses, mais grand choix.[1106][NL]J'espère qu'elle n'achète rien de bizarre..."
+    },
+    {
+        "id": 125,
+        "offset": 331914,
+        "data_size": 432,
+        "slot_size": 432,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "My[SP]daughter[SP]often[SP]shops[SP]at[SP]Anima[SP]Mundi.[SP]They[NL]sell[SP]armor[SP]too,[SP]right?[SP]People[SP]say[SP]they're[NL]expensive,[SP]but[SP]the[SP]quality's[SP]amazing.[1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]I[SP]hope[SP]my[SP]girl[SP]hasn't[SP]been[SP]buying[SP]anything[NL]weird...",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Ma fille va chez Anima Mundi.\nArmures : chères, qualité incroyable.[1106][NL]J'espère qu'elle n'achète rien de bizarre..."
+    },
+    {
+        "id": 126,
+        "offset": 332346,
+        "data_size": 388,
+        "slot_size": 388,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real[NL]armor,[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their[NL]selection's[SP]not[SP]great,[SP]but[SP]their[SP]resale[NL]prices[SP]seem[SP]high.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Rosa Candida ici vend aussi des armures.[1106][NL]Peu de choix, reprises élevées."
+    },
+    {
+        "id": 127,
+        "offset": 332734,
+        "data_size": 338,
+        "slot_size": 338,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real[NL]armor,[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their[NL]quality[SP]and[SP]prices[SP]seem[SP]average.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Rosa Candida ici vend aussi des armures.[1106][NL]Qualité et prix moyens."
+    },
+    {
+        "id": 128,
+        "offset": 333072,
+        "data_size": 356,
+        "slot_size": 356,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real[NL]armor,[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their[NL]quality's[SP]great,[SP]but[SP]they[SP]seem[SP]expensive.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Rosa Candida ici vend aussi des armures.[1106][NL]Qualité excellente, cher."
+    },
+    {
+        "id": 129,
+        "offset": 333428,
+        "data_size": 372,
+        "slot_size": 372,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real[NL]armor,[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]They're[NL]cheap,[SP]but[SP]their[SP]goods[SP]seem[SP]rather[SP]low[SP]quality.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Rosa Candida ici vend aussi des armures.[1106][NL]Bon marché, qualité plutôt basse."
+    },
+    {
+        "id": 130,
+        "offset": 333800,
+        "data_size": 414,
+        "slot_size": 414,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "It[SP]seems[SP]the[SP]Rosa[SP]Candida[SP]here[SP]sells[SP]real[NL]armor,[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]anyway.[1205][U+000F][SP]Their[NL]selection's[SP]great,[SP]but[SP]their[SP]resale[SP]prices[NL]seem[SP]to[SP]be[SP]on[SP]the[SP]low[SP]side.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Rosa Candida ici vend aussi des armures.[1106][NL]Grand choix, reprises basses."
+    },
+    {
+        "id": 131,
+        "offset": 334214,
+        "data_size": 558,
+        "slot_size": 558,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier[NL]tailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also[NL]sell[SP]armor[SP]there?[1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F][NL]I[SP]know[SP]their[SP]selection's[SP]great,[SP]but[SP]I[SP]don't[NL]see[SP]why[SP]they[SP]need[SP]to[SP]sell[SP]armor[SP]too.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?[1106][NL]Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nPourquoi vendre aussi des armures ?"
+    },
+    {
+        "id": 132,
+        "offset": 334772,
+        "data_size": 538,
+        "slot_size": 538,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier[NL]tailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also[NL]sell[SP]armor[SP]there?[1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F][NL]I[SP]know[SP]it'll[SP]be[SP]cheap,[SP]but[SP]I[SP]can't[SP]go[SP]to[SP]work[NL]wearing[SP]a[SP]suit[SP]of[SP]armor!",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?[1106][NL]Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nBon marché, mais je ne peux pas travailler en armure !"
+    },
+    {
+        "id": 133,
+        "offset": 335310,
+        "data_size": 564,
+        "slot_size": 564,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier[NL]tailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also[NL]sell[SP]armor[SP]there?[1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F][NL]I[SP]know[SP]the[SP]quality[SP]will[SP]be[SP]great,[SP]but[SP]that[NL]won't[SP]do[SP]me[SP]any[SP]good[SP]if[SP]it[SP]bankrupts[SP]me!",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?[1106][NL]Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nQualité excellente, mais si ça me ruine, à quoi bon !"
+    },
+    {
+        "id": 134,
+        "offset": 335874,
+        "data_size": 558,
+        "slot_size": 558,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier[NL]tailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also[NL]sell[SP]armor[SP]there?[1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F][NL]I[SP]hear[SP]their[SP]quality[SP]and[SP]prices[SP]are[SP]both[NL]reasonable,[SP]but[SP]that's[SP]not[SP]the[SP]problem.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?[1106][NL]Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nQualité et prix raisonnables, mais ce n'est pas le problème."
+    },
+    {
+        "id": 135,
+        "offset": 336432,
+        "data_size": 560,
+        "slot_size": 560,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier[NL]tailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][U+000F][SP]But[SP]don't[SP]they[SP]also[NL]sell[SP]armor[SP]there?[1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]What[SP]if[SP]that's[SP]what[SP]he's[SP]making[SP]for[SP]me...?[1205][U+000F][NL]I[SP]know[SP]their[SP]resale[SP]prices[SP]are[SP]great,[SP]but[SP]I[NL]still[SP]can't[SP]get[SP]a[SP]full[SP]refund,[SP]right?",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Je fais faire un costume chez London Clothier.[1205][U+000F]\nMais ils vendent aussi des armures ?[1106][NL]Et si c'est ce qu'il me fabrique ?[1205][U+000F]\nBonnes reprises, mais pas de remboursement intégral, si ?"
+    },
+    {
+        "id": 136,
+        "offset": 336992,
+        "data_size": 586,
+        "slot_size": 586,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][U+000F][NL]I[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]It[SP]sounds[SP]interesting,[SP]and[SP]exciting[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]I[SP]hear[SP]you[SP]don't[SP]win[SP]often,[SP]but[SP]they[SP]send[SP]you[NL]nice[SP]things[SP]when[SP]you[SP]do.[1205][U+000F][SP]Why[SP]don't[SP]you[SP]give[NL]it[SP]a[SP]shot?",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Tu connais les concours de magazines ?[1205][U+000F]\nOn peut gagner de vraies armes.[1106][NL]Intéressant et excitant.[1106][NL]On gagne rarement, mais beaux lots.[1205][U+000F]\nPourquoi ne pas essayer ?"
+    },
+    {
+        "id": 137,
+        "offset": 337578,
+        "data_size": 598,
+        "slot_size": 598,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][U+000F][NL]I[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]It[SP]sounds[SP]interesting,[SP]and[SP]exciting[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]I[SP]hear[SP]you[SP]very[SP]rarely[SP]win,[SP]but[SP]they[SP]send[SP]you[NL]incredible[SP]things[SP]when[SP]you[SP]do.[1205][U+000F][SP]Why[SP]don't[SP]you[NL]give[SP]it[SP]a[SP]shot?",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Tu connais les concours de magazines ?[1205][U+000F]\nOn peut gagner de vraies armes.[1106][NL]Intéressant et excitant.[1106][NL]Très rare de gagner, lots incroyables.[1205][U+000F]\nPourquoi ne pas essayer ?"
+    },
+    {
+        "id": 138,
+        "offset": 338176,
+        "data_size": 638,
+        "slot_size": 638,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][U+000F][NL]I[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]It[SP]sounds[SP]interesting,[SP]and[SP]exciting[SP]too.[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]I[SP]hear[SP]you[SP]can[SP]win[SP]quite[SP]easily,[SP]but[SP]the[SP]things[NL]they[SP]send[SP]you[SP]as[SP]prizes[SP]aren't[SP]very[SP]good.[1205][U+000F][NL]Well,[SP]why[SP]not[SP]give[SP]it[SP]a[SP]shot[SP]anyway?",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Tu connais les concours de magazines ?[1205][U+000F]\nOn peut gagner de vraies armes.[1106][NL]Intéressant et excitant.[1106][NL]Facile à gagner, lots moyens.[1205][U+000F]\nPourquoi ne pas essayer quand même ?"
+    },
+    {
+        "id": 139,
+        "offset": 338814,
+        "data_size": 588,
+        "slot_size": 588,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the[NL]arcade?[1205][U+000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was[NL]horrified[SP]to[SP]hear[SP]about[SP]it![1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL][U+1432][U+0000][U+0000][U+0014]You[SP]can[SP]win[SP]big[SP]at[SP]poker![U+1432][U+0000][U+0000][U+0014][SP]That's[SP]not[SP]an[NL]appropriate[SP]conversation[SP]for[SP]high[SP]schoolers[SP]to[NL]be[SP]having![SP]I[SP]should[SP]report[SP]this[SP]to[SP]the[SP]PTA!",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Un casino dans la salle d'arcade ?[1205][U+000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible ![1106][NL][1432][NULL][NULL][0014]On peut gagner gros au poker ![1432][NULL][NULL][0014]\nPas une conversation pour des lycéens !\nJe devrais le signaler à l'association de parents d'élèves !"
+    },
+    {
+        "id": 140,
+        "offset": 339402,
+        "data_size": 594,
+        "slot_size": 594,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the[NL]arcade?[1205][U+000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was[NL]horrified[SP]to[SP]hear[SP]about[SP]it![1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL][U+1432][U+0000][U+0000][U+0014]You[SP]can[SP]win[SP]big[SP]at[SP]slots[SP]#1![U+1432][U+0000][U+0000][U+0014][SP]That's[SP]not[SP]an[NL]appropriate[SP]conversation[SP]for[SP]high[SP]schoolers[SP]to[NL]be[SP]having![SP]I[SP]should[SP]report[SP]this[SP]to[SP]the[SP]PTA!",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Un casino dans la salle d'arcade ?[1205][U+000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible ![1106][NL][1432][NULL][NULL][0014]Gros lots aux machines n°1 ![1432][NULL][NULL][0014]\nPas pour des lycéens !\nÀ signaler à l'association de parents d'élèves !"
+    },
+    {
+        "id": 141,
+        "offset": 339996,
+        "data_size": 524,
+        "slot_size": 524,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the[NL]arcade?[1205][U+000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was[NL]horrified[SP]to[SP]hear[SP]about[SP]it![1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]Where[SP]did[SP]I[SP]hear[SP]this?[SP]There[SP]was[SP]a[SP]young[SP]man[NL]bragging[SP]about[SP]winning[SP]big[SP]at[SP]blackjack[SP]while[NL]walking[SP]around.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Un casino dans la salle d'arcade ?[1205][U+000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible ![1106][NL]Où ai-je entendu ça ? Un jeune homme se vantait\nd'avoir gagné gros au blackjack."
+    },
+    {
+        "id": 142,
+        "offset": 340520,
+        "data_size": 290,
+        "slot_size": 290,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "I[SP]wonder[SP]what[SP]this[SP]legendary[SP]weapon[SP]at[NL]Shiraishi[SP]Ramen[SP]is[SP]all[SP]about.[SP]I[SP]bet[SP]it's[NL]dangerous...[SP]But[SP]I'm[SP]still[SP]a[SP]little[SP]curious.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "L'arme légendaire du Shiraishi Ramen ?\nDangereuse, mais je suis curieuse."
+    },
+    {
+        "id": 143,
+        "offset": 340810,
+        "data_size": 194,
+        "slot_size": 194,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Did[SP]you[SP]hear?[SP]There's[SP]a[SP]legendary[SP]weapon[SP]at[NL]Clair[SP]de[SP]Lune.[SP]Have[SP]you[SP]seen[SP]it?",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Une arme légendaire au Clair de Lune.\nTu l'as vue ?"
+    },
+    {
+        "id": 144,
+        "offset": 341004,
+        "data_size": 354,
+        "slot_size": 354,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Hey,[SP]have[SP]you[SP]heard?[SP]The[SP]owner[SP]of[SP]Time[SP]Castle[NL]is[SP]supposedly[SP]hiding[SP]his[SP]legendary[SP]weapon[SP]so[NL]he[SP]can[SP]inflate[SP]the[SP]price.[1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]What[SP]a[SP]terrible[SP]man.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Le proprio de Time Castle cache son arme légendaire\n pour faire monter le prix.[1106][NL]Quel homme terrible."
+    },
+    {
+        "id": 145,
+        "offset": 341358,
+        "data_size": 600,
+        "slot_size": 600,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "From[SP]what[SP]I've[SP]heard,[SP]the[SP]seller[SP]with[SP]Time[NL]Castle's[SP]legendary[SP]weapon[SP]is[SP]waiting[SP]at[SP]the[NL]abandoned[SP]factory,[SP]but[SP]the[SP]owner[SP]won't[SP]come.[1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]I[SP]think[SP]that's[SP]smart[SP]of[SP]him.[SP]They[SP]say[SP]that[NL]abandoned[SP]factory[SP]is[SP]teeming[SP]with[SP]monsters[NL]and[SP]demons...[SP]It[SP]sounds[SP]dangerous,[SP]anyway.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Le vendeur de l'arme légendaire attend à l'usine,\nmais le proprio ne vient pas.[1106][NL]C'est malin. L'usine grouille de monstres.\nDangereux, de toute façon."
+    },
+    {
+        "id": 146,
+        "offset": 341958,
+        "data_size": 532,
+        "slot_size": 532,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "Oh,[SP]did[SP]you[SP]hear?[SP]A[SP]demon[SP]stole[SP]that[SP]legendary[NL]weapon[SP]at[SP]Time[SP]Castle.[SP]Not[SP]long[SP]ago,[SP]I'd[SP]never[NL]have[SP]believed[SP]it...[NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]But[SP]look[SP]at[SP]us.[SP]We're[SP]standing[SP]on[SP]top[SP]of[SP]a[NL]floating[SP]city![SP]I[SP]bet[SP]demons[SP]exist,[SP]too![NL]Brrr...[SP]That's[SP]really[SP]scary.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Un démon a volé l'arme légendaire de Time Castle.\nJe ne l'aurais jamais cru avant.[1106][NL]Mais regarde-nous : on est sur une ville flottante !\nLes démons existent forcément. Brrr... Effrayant."
+    },
+    {
+        "id": 147,
+        "offset": 342490,
+        "data_size": 420,
+        "slot_size": 420,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "The[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle[SP]was[SP]sold.[NL]People[SP]keep[SP]asking[SP]me,[SP][U+1432][U+0000][U+0000][U+0014]Did[SP]you[SP]buy[SP]it?[U+1432][U+0000][U+0000][U+0014][NL][1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]But[SP]no,[SP]some[SP]unlucky[SP]woman[SP]bought[SP]it...[1205][U+000F][NL]I[SP]don't[SP]look[SP]that[SP]desperate,[SP]do[SP]I?",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "L'arme légendaire a été vendue.\nOn me demande sans cesse : [1432][NULL][NULL][0014]C'est toi qui l'as achetée ?[1432][NULL][NULL][0014][1106][NL]Non, une femme l'a achetée.[1205][U+000F]\nJe n'ai pas l'air si désespérée, si ?"
+    },
+    {
+        "id": 148,
+        "offset": 342910,
+        "data_size": 500,
+        "slot_size": 500,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Walking[SP]woman",
+        "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle[SP]gave[SP]away[SP]that[NL]legendary[SP]weapon[SP]to[SP]a[SP]girl[SP]with[SP]short[SP]hair.[1106][E2][1431][U+0000][U+0000]\"Walking[SP]woman[NL]Leaving[SP]aside[SP]that[SP]it's[SP]a[SP]weapon...[SP]That's[SP]a[NL]nice[SP]gesture.[SP]I[SP]wish[SP]I[SP]got[SP]presents[SP]sometimes.[NL]My[SP]husband[SP]barely[SP]knows[SP]I'm[SP]alive.",
+        "nom_fr": "Promeneuse",
+        "texte_fr": "Le proprio a donné l'arme à une fille aux cheveux courts.[1106][NL]C'est un joli geste, malgré tout.\nJ'aimerais recevoir des cadeaux parfois.\nMon mari sait à peine que j'existe."
+    },
+    {
+        "id": 149,
+        "offset": 343410,
+        "data_size": 868,
+        "slot_size": 868,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Man",
+        "texte_orig": "Would[SP]you[SP]believe[SP]me[SP]if[SP]I[SP]said[SP][1431][U+0000][U+0000][U+0006]flowers[SP]can[NL]talk[1431][U+0000][U+0000][U+0002]?[1205][U+000F][SP]Most[SP]people[SP]wouldn't.[SP]But[SP]there[SP]is[NL]someone[SP]in[SP]this[SP]park[SP]who[SP]speaks[SP]to[SP]flowers.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]He[SP]takes[SP]care[SP]of[SP]the[SP]flowers[SP]here,[SP]and[SP]whenever[NL]I[SP]see[SP]him,[SP]he's[SP]talking[SP]to[SP]them.[1205][U+000F][SP]Rumor[SP]has[SP]it[NL]that[SP]the[SP]flowers[SP]in[SP]Aoba[SP]Park[SP]talk[SP]back.[NL][1106][E2][1431][U+0000][U+0000]\"Man[NL]In[SP]the[SP]end,[SP]you[SP]decide[SP]what's[SP]real[SP]and[SP]what's[NL]a[SP]dream.[1205][U+000F][SP]If[SP]you're[SP]tired[SP]of[SP]this[SP]dreary[NL]reality...[SP]try[SP]talking[SP]with[SP]the[SP]flowers.",
+        "nom_fr": "Homme",
+        "texte_fr": "Croirais-tu que [E4][NULL][NULL][U+0006]les fleurs peuvent parler[E4][NULL][NULL][0002] ?[1205][U+000F]\nLa plupart non. Mais quelqu'un ici parle aux fleurs.[1106][NL]Il s'occupe des fleurs et leur parle.[1205][U+000F]\nOn dit qu'elles lui répondent.[1106][NL]Au final, c'est toi qui décides du réel.[1205][U+000F]\nSi tu es fatigué de cette triste réalité,\nparle aux fleurs."
+    },
+    {
+        "id": 150,
+        "offset": 344278,
+        "data_size": 572,
+        "slot_size": 572,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Masked[SP]Circle[SP]member",
+        "texte_orig": "Dammit,[SP]that[SP]Joker[SP]ran[SP]off[SP]to[SP]Caracol[SP]along[NL]with[SP]the[SP]executives![1205][U+000F][SP]He's[SP]left[SP]us[SP]holding[SP]the[NL]bag[SP]here![1106][E2][1431][U+0000][U+0000]\"Masked[SP]Circle[SP]member[NL]Having[SP]our[SP]ideals[SP]granted[SP]will[SP]make[SP]us[SP]happy?[NL]Bullshit![SP]All[SP]he[SP]wanted[SP]was[SP]to[SP]suck[SP]away[SP]our[NL]Ideal[SP]Energy[SP]to[SP]realize[SP]his[SP]own[SP]dreams!",
+        "nom_fr": "Membre du Cercle Masqué",
+        "texte_fr": "Joker s'est enfui à Caracol avec les cadres ![1205][U+000F]\nIl nous a laissés dans la merde ![1106][NL]Nos idéaux exaucés ? N'importe quoi !\nIl a juste aspiré notre Énergie Idéale\n pour ses propres rêves !"
+    },
+    {
+        "id": 151,
+        "offset": 344850,
+        "data_size": 288,
+        "slot_size": 288,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Last[SP]Battalion",
+        "texte_orig": "The[SP]holy[SP]lance[SP]is[SP]the[SP]emblem[SP]of[SP]our[SP]strength.[NL]It[SP]shall[SP]crush[SP]all[SP]hindrances,[SP]along[SP]with[SP]the[NL]other[SP]self[SP]that[SP]lies[SP]within...",
+        "nom_fr": "Dernier Bataillon",
+        "texte_fr": "La lance sacrée, emblème de notre force,\n écrasera tout obstacle et l'autre soi\n qui sommeille en nous."
+    },
+    {
+        "id": 152,
+        "offset": 345138,
+        "data_size": 176,
+        "slot_size": 176,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "To[SP]hell[SP]with[SP]that[SP]King[SP]Leo[SP]asshole![NL]He's[SP]through[SP]doing[SP]whatever[SP]he[SP]wants!",
+        "nom_fr": "Michel",
+        "texte_fr": "Au diable cet enculé de Roi Lion !\nIl en a fini de faire ce qu'il veut !"
+    },
+    {
+        "id": 153,
+        "offset": 345314,
+        "data_size": 256,
+        "slot_size": 256,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Uh-oh,[SP][1113].[SP]If[SP]we[SP]keep[SP]standing[SP]around[NL]like[SP]this,[SP]people[SP]will[SP]get[SP]more[SP]suspicious.[NL]Let's[SP]get[SP]to[SP]the[SP]detective[SP]agency.",
+        "nom_fr": "Ginko",
+        "texte_fr": "Uh-oh, [1113]. Si on traîne, les gens vont se méfier.\nAllons à l'agence de détectives."
+    },
+    {
+        "id": 154,
+        "offset": 345570,
+        "data_size": 92,
+        "slot_size": 92,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Huh?[SP]It[SP]says,[SP][U+1432][U+0000][U+0000][U+0014]No[SP]entry.[U+1432][U+0000][U+0000][U+0014]",
+        "nom_fr": "Michel",
+        "texte_fr": "Hein ?[SP][1432][NULL][NULL][0014]Entrée interdite.[1432][NULL][NULL][0014]"
+    },
+    {
+        "id": 155,
+        "offset": 345662,
+        "data_size": 182,
+        "slot_size": 182,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "The[SP]fire[SP]department[SP]burned[SP]down...[SP]Don't[SP]tell[NL]me[SP]King[SP]Leo[SP]planned[SP]ahead![SP]No...!",
+        "nom_fr": "Maya",
+        "texte_fr": "Les pompiers ont brûlé... Dis-moi que non.\nLe Roi Lion a tout planifié ? Non... !"
+    },
+    {
+        "id": 156,
+        "offset": 345844,
+        "data_size": 236,
+        "slot_size": 236,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Yukiko",
+        "texte_orig": "He[SP]did[SP]this[SP]to[SP]prevent[SP]anyone[SP]from[SP]stopping[NL]his[SP]plan...[SP]Now[SP]there's[SP]no[SP]one[SP]but[SP]us[SP]left[NL]to[SP]deal[SP]with[SP]him.",
+        "nom_fr": "Yukiko",
+        "texte_fr": "Il a fait ça pour qu'on ne l'arrête pas.\nIl ne reste plus que nous."
+    },
+    {
+        "id": 157,
+        "offset": 346080,
+        "data_size": 212,
+        "slot_size": 212,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Yeah,[SP]that's[SP]been[SP]the[SP]plan[SP]all[SP]along![SP]You[SP]can[NL]bet[SP]we're[SP]taking[SP]down[SP]that[SP]bastard[SP]ourselves!",
+        "nom_fr": "Michel",
+        "texte_fr": "Oui, c'était le plan depuis le début !\nOn va abattre ce salaud nous-mêmes !"
+    },
+    {
+        "id": 158,
+        "offset": 346292,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "King[SP]Leo[SP]will[SP]stop[SP]at[SP]nothing[SP]to[SP]fulfill[SP]the[NL]Oracle.[SP]If[SP]we[SP]don't[SP]take[SP]him[SP]down[SP]now,[SP]there[NL]will[SP]only[SP]be[SP]more[SP]casualties...",
+        "nom_fr": "Maya",
+        "texte_fr": "Roi Lion ne reculera devant rien.\nSi on ne l'arrête pas, il y aura plus de victimes..."
+    },
+    {
+        "id": 159,
+        "offset": 346558,
+        "data_size": 172,
+        "slot_size": 172,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "We[SP]couldn't[SP]stop[SP]any[SP]of[SP]them[SP]from[SP]burning[NL]down...[SP]I'm[SP]so[SP]mad[SP]at[SP]myself...",
+        "nom_fr": "Ginko",
+        "texte_fr": "On a pu empêcher aucun incendie...\nJe suis tellement en colère contre moi..."
+    },
+    {
+        "id": 160,
+        "offset": 346730,
+        "data_size": 218,
+        "slot_size": 218,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Yukino",
+        "texte_orig": "I[SP]understand[SP]how[SP]you[SP]feel,[SP][1113],[SP]but[NL]we're[SP]fugitives[SP]now.[SP]We[SP]shouldn't[SP]stay[SP]in[NL]one[SP]place[SP]too[SP]long.",
+        "nom_fr": "Yukino",
+        "texte_fr": "Je comprends, [1113], mais nous sommes fugitifs.\nNe restons pas trop longtemps au même endroit."
+    },
+    {
+        "id": 161,
+        "offset": 346948,
+        "data_size": 122,
+        "slot_size": 122,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "There's[SP]no[SP]point[SP]being[SP]here[SP]anymore.[NL]Let's[SP]go.",
+        "nom_fr": "Michel",
+        "texte_fr": "Cela ne sert plus à rien d'être ici.\nAllons-y."
+    },
+    {
+        "id": 162,
+        "offset": 347070,
+        "data_size": 172,
+        "slot_size": 172,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "We've[SP]already[SP]got[SP]the[SP]crystal[SP]skull[SP]here.[NL]Let's[SP]hurry[SP]and[SP]find[SP]the[SP]others.",
+        "nom_fr": "Maya",
+        "texte_fr": "Nous avons déjà le crâne de cristal.\nTrouvons les autres."
+    },
+    {
+        "id": 163,
+        "offset": 347242,
+        "data_size": 218,
+        "slot_size": 218,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "I[SP]can[SP]hear[SP]voices...[SP]The[SP]fighting's[SP]still[NL]going[SP]on[SP]inside.[SP]We[SP]need[SP]to[SP]hurry[SP]and[SP]put[NL]a[SP]stop[SP]to[SP]it.",
+        "nom_fr": "Maya",
+        "texte_fr": "J'entends des voix. Le combat continue.\nIl faut y mettre fin."
+    },
+    {
+        "id": 164,
+        "offset": 347460,
+        "data_size": 216,
+        "slot_size": 216,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "[1113],[SP]now's[SP]not[SP]the[SP]time[SP]for[SP]detours.[NL]Everyone's[SP]waiting...[SP]We[SP]have[SP]to[SP]go[SP]to[SP]the[NL]detective[SP]agency.",
+        "nom_fr": "Ginko",
+        "texte_fr": "[1113], pas de détours.\nTout le monde attend. Allons à l'agence."
+    },
+    {
+        "id": 165,
+        "offset": 347676,
+        "data_size": 174,
+        "slot_size": 174,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Huh?[SP]It's[SP]closed.[SP]I[SP]wonder[SP]what's[SP]up...[NL]Oh[SP]well,[SP]let's[SP]go[SP]somewhere[SP]else.[NL]",
+        "nom_fr": "Ginko",
+        "texte_fr": "C'est fermé. Je me demande pourquoi...\nBon, allons ailleurs."
+    },
+    {
+        "id": 166,
+        "offset": 347850,
+        "data_size": 236,
+        "slot_size": 236,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "[1113],[SP]I[SP]kinda[SP]feel[SP]bad[SP]making[SP]everyone[NL]wait[SP]while[SP]we[SP]wander[SP]around.[SP]We[SP]should[SP]hurry[NL]to[SP]the[SP]detective[SP]agency.",
+        "nom_fr": "Ginko",
+        "texte_fr": "[1113], je me sens mal de faire attendre tout le monde.\nDépêchons-nous d'aller à l'agence."
+    },
+    {
+        "id": 167,
+        "offset": 348086,
+        "data_size": 224,
+        "slot_size": 224,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Wait[SP]a[SP]sec,[SP]Chinyan![SP]We[SP]don't[SP]have[SP]the[SP]skull[NL]from[SP]Taurus[SP]Temple[SP]yet.[SP]We[SP]should[SP]stop[SP]by[NL]there[SP]first.",
+        "nom_fr": "Ginko",
+        "texte_fr": "Attends, Chinyan ! On n'a pas encore le crâne\ndu temple du Taureau. Allons-y d'abord."
+    },
+    {
+        "id": 168,
+        "offset": 348310,
+        "data_size": 250,
+        "slot_size": 250,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "H-Hold[SP]the[SP]phone,[SP]man.[1205][U+000F][SP]We're[SP]still[SP]not[SP]done[NL]with[SP]Scorpio[SP]Temple.[1205][U+000F][SP]Let's[SP]go[SP]grab[SP]the[SP]skull[NL]from[SP]there[SP]first.",
+        "nom_fr": "Michel",
+        "texte_fr": "A-Attends, mec.[1205][U+000F] On n'a pas fini avec\ntemple du Scorpion.[1205][U+000F] Prenons ce crâne d'abord.[1106][NL]Attends. On n'a pas fini avec\nle temple du Verseau."
+    }
 ]

--- a/traduction/MMAP04.json
+++ b/traduction/MMAP04.json
@@ -1,2813 +1,2000 @@
 [
-  {
-    "id": 0,
-    "offset": 268814,
-    "data_size": 222,
-    "slot_size": 226,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "Heh...[SP]There's[SP]a[SP]nice[SP]breeze[SP]today,[SP]too...[1205][U+000F]\nAll[SP]men[SP]are[SP]on[SP]a[SP]journey,[SP]somewhere[SP]in[SP]their\nhearts.",
-    "nom_fr": "Gars cool",
-    "texte_fr": "Aujourd'hui aussi, la brise est douce...[1205][U+000F]\nChacun vit son voyage, quelque part dans\nson coeur."
-  },
-  {
-    "id": 1,
-    "offset": 269040,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "Just[SP]when[SP]they[SP]finally[SP]make[SP]it[SP]to[SP]shore[SP]and\nought[SP]to[SP]think[SP]about[SP]settling[SP]down,[SP]they[SP]row\nout[SP]again[SP]into[SP]the[SP]sea.",
-    "nom_fr": "Gars cool",
-    "texte_fr": "Au moment où ils atteignent la côte et\nenvisagent de s'installer, ils repartent voguer\nen mer."
-  },
-  {
-    "id": 2,
-    "offset": 269296,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "The[SP]sea[SP]is[SP]an[SP]eternal[SP]home[SP]for[SP]men[SP]like[SP]that...[1205][U+000F]\nA[SP]place[SP]they[SP]always[SP]find[SP]themselves[SP]back[SP]at.",
-    "nom_fr": "Gars cool",
-    "texte_fr": "L'océan est un refuge éternel pour ces gens...[1205][U+000F]\nUn endroit où ils ne cessent de retourner."
-  },
-  {
-    "id": 3,
-    "offset": 269516,
-    "data_size": 194,
-    "slot_size": 198,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "Kid,[SP]this[SP]here[SP]Kounan[SP]is[SP]another[SP]such[SP]place.[1205][U+000F]\nIt's[SP]a[SP]city[SP]made[SP]for[SP]the[SP]hardboiled.",
-    "nom_fr": "Gars cool",
-    "texte_fr": "Kounan est un endroit comme ça, gamin.[1205][U+000F]\nC'est une ville de durs à cuire."
-  },
-  {
-    "id": 4,
-    "offset": 269714,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "I[SP]think[SP]you[SP]get[SP]the[SP]picture[SP]already[SP]that[SP]this\nis[SP]a[SP]city[SP]for[SP]the[SP]hardboiled.[SP]For[SP]adults.[1205][U+000F][SP]But\nlook[SP]at[SP]that[SP]building[SP]with[SP]the[SP]blimp[SP]on[SP]top...",
-    "nom_fr": "Gars cool",
-    "texte_fr": "T'as dû piger que c'était une ville taillée\npour les durs à cuire, les adultes.[1205][U+000F] Mais regarde\nce bâtiment avec le dirigeable au sommet..."
-  },
-  {
-    "id": 5,
-    "offset": 270026,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "The[SP]goddamn[SP]Aerospace[SP]Museum.[1205][U+000F][SP]Ever[SP]since[SP]they\nbuilt[SP]that[SP]thing,[SP]packs[SP]of[SP]wild[SP]kids[SP]swarm[SP]here\non[SP]class[SP]trips[SP]and[SP]such.",
-    "nom_fr": "Gars cool",
-    "texte_fr": "Ce fichu Musée Aéronautique.[1205][U+000F] Depuis sa construction,\ny'a foule de gosses qui viennent en voyage\nscolaire ou autre."
-  },
-  {
-    "id": 6,
-    "offset": 270298,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "I[SP]hate[SP]rugrats.[SP]This[SP]city[SP]ain't[SP]so[SP]much[SP]for[SP]me\nanymore.[1205][U+000F][SP]Guess[SP]the[SP]day[SP]is[SP]coming[SP]when[SP]I'll[SP]be\ngoing[SP]back[SP]to[SP]the[SP]sea.",
-    "nom_fr": "Gars cool",
-    "texte_fr": "Je hais les mômes. Cette ville me correspond\nplus du tout.[1205][U+000F] Il doit être temps pour moi\nde retourner en mer."
-  },
-  {
-    "id": 7,
-    "offset": 270564,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "Looks[SP]like[SP]a[SP]pack[SP]of[SP]kids[SP]is[SP]here[SP]at[SP]the\nAerospace[SP]Museum[SP]on[SP]some[SP]kinda[SP]field[SP]trip.[1205][U+000F]\nTheir[SP]voices[SP]carry[SP]on[SP]the[SP]sea[SP]breeze...",
-    "nom_fr": "Gars cool",
-    "texte_fr": "On dirait que des gamins sont en voyage\nscolaire au Musée de l'Aéronautique.[1205][U+000F]\nLeurs voix se mêlent à la brise marine..."
-  },
-  {
-    "id": 8,
-    "offset": 270846,
-    "data_size": 92,
-    "slot_size": 96,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "Tch.[SP]This[SP]is[SP]why[SP]I[SP]hate[SP]rugrats!",
-    "nom_fr": "Gars cool",
-    "texte_fr": "Tss. Je hais les mioches!"
-  },
-  {
-    "id": 9,
-    "offset": 270942,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "Some[SP]kids[SP]were[SP]just[SP]here[SP]and[SP]told[SP]me[SP]the[SP]group\nof[SP]five[SP]in[SP]the[SP]news[SP]are[SP]actually[SP]heroes[SP]fighting\nthe[SP]Masked[SP]Circle.[SP]Then[SP]they[SP]took[SP]off.",
-    "nom_fr": "Gars cool",
-    "texte_fr": "Des gamins sont venus me dire que les cinq\nqu'on voit aux infos étaient des héros combattant\nle Cercle Masqué. Puis ils sont partis."
-  },
-  {
-    "id": 10,
-    "offset": 271242,
-    "data_size": 178,
-    "slot_size": 182,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "Those[SP]were[SP]the[SP]kids[SP]from[SP]the[SP]museum,[SP]right?\nTch.[SP]Looks[SP]like[SP]they[SP]were[SP]okay.",
-    "nom_fr": "Gars cool",
-    "texte_fr": "C'était les enfants du musée, pas vrai?\nTss. On dirait qu'ils sont saufs."
-  },
-  {
-    "id": 11,
-    "offset": 271424,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "So[SP]those[SP]five[SP]saved[SP]some[SP]kids,[SP]did[SP]they?[1205][U+000F]\n...Don't[SP]seem[SP]like[SP]such[SP]a[SP]bad[SP]bunch[SP]to[SP]me.",
-    "nom_fr": "Gars cool",
-    "texte_fr": "Ces cinq-là ont sauvés des gamins, hein?[1205][U+000F]\n...Ils ont pas l'air de mauvais bougres."
-  },
-  {
-    "id": 12,
-    "offset": 271626,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "The[SP]In[SP]Lak'ech,[SP]huh...?[SP]If[SP]the[SP]stuff[SP]written[SP]in\nthat[SP]is[SP]true,[SP]the[SP]world's[SP]gonna[SP]end[SP]once[SP]the\nGrand[SP]Cross[SP]is[SP]finished.",
-    "nom_fr": "Gars cool",
-    "texte_fr": "L'In Lak'ech, hein...? Si ce qui y est écrit\nest vrai, la Croix Cosmique causera la fin du\nmonde une fois réalisée."
-  },
-  {
-    "id": 13,
-    "offset": 271892,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "This[SP]city[SP]and[SP]this[SP]sea[SP]could[SP]disappear.[1205][U+000F]\nAnd[SP]my[SP]journey[SP]might[SP]end[SP]along[SP]with[SP]them.[1205][U+000F]\nA[SP]sad[SP]ending[SP]to[SP]the[SP]hard[SP]life[SP]I've[SP]led...",
-    "nom_fr": "Gars cool",
-    "texte_fr": "Cette ville et cette mer pourraient disparaître.[1205][U+000F]\nMon voyage pourrait cesser avec elles.[1205][U+000F]\nUne triste fin à ma rude vie..."
-  },
-  {
-    "id": 14,
-    "offset": 272178,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "Tch.[SP]If[SP]those[SP]guys[SP]are[SP]here,[SP]the[SP]In[SP]Lak'ech[SP]is\nlooking[SP]more[SP]and[SP]more[SP]right[SP]all[SP]the[SP]time.[1205][U+000F][SP]Are\nthose[SP]soldiers[SP]gonna[SP]destroy[SP]the[SP]world?",
-    "nom_fr": "Gars cool",
-    "texte_fr": "Tss. Si ces mecs sont là, l'In Lak'ech\nparaît de plus en plus crédible.[1205][U+000F] Ces\nsoldats vont vraiment détruire le monde?"
-  },
-  {
-    "id": 15,
-    "offset": 272478,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "You[SP]see[SP]those[SP]meteors,[SP]kid?[1205][U+000F][SP]The[SP]Masked[SP]Circle\nguys[SP]say[SP]that's[SP]the[SP][1432][NULL][NULL][0014]lion's[SP]roar[1432][NULL][NULL][0014][SP]part[SP]of\ntheir[SP]Oracle.",
-    "nom_fr": "Gars cool",
-    "texte_fr": "Tu vois ces météores?[1205][U+000F] D'après ceux du Cercle\nMasqué c'est le [1432][NULL][NULL][0014]rugissement du lion[1432][NULL][NULL][0014] de\nleur oracle."
-  },
-  {
-    "id": 16,
-    "offset": 272728,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "Heh,[SP]I[SP]should've[SP]at[SP]least[SP]made[SP]a[SP]wish[SP]on[SP]'em.\nWith[SP]that[SP]many[SP]of[SP]'em[SP]shooting[SP]down,[SP]I[SP]bet\nI[SP]could've[SP]had[SP]lots[SP]of[SP]wishes[SP]come[SP]true.",
-    "nom_fr": "Gars cool",
-    "texte_fr": "Hah, j'aurais du en profiter pour faire un voeu.\nVu leur nombre, je parie que beaucoup de mes\nvoeux se réaliseraient."
-  },
-  {
-    "id": 17,
-    "offset": 273018,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "What[SP]the[SP]hell[SP]is[SP]that?[1205][U+000A][SP]It's[SP]blown[SP]the[SP]hard-\nboiled[SP]atmosphere[SP]to[SP]hell[SP]and[SP]gone![1205][U+000F][SP]Just[SP]when\nthe[SP]Aerospace[SP]Museum[SP]was[SP]kaput,[SP]too...",
-    "nom_fr": "Gars cool",
-    "texte_fr": "C'était quoi ça, bordel?[1205][U+000A] Ça a totalement pulvérisé\nl'atmosphère![1205][U+000A] Comme quand le Musée\nAéronautique était kaput..."
-  },
-  {
-    "id": 18,
-    "offset": 273314,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Cool[SP]guy",
-    "texte_orig": "I[SP]can't[SP]take[SP]it[SP]anymore![1205][U+000A][SP]I'm[SP]going[SP]on[SP]another\njourney![1205][U+000A][SP]I'll[SP]take[SP]a[SP]ship,[SP]set[SP]sail,[SP]and...[1205][U+000F]\nWell,[SP]I'll[SP]probably[SP]fall[SP]off[SP]the[SP]edge,[SP]huh...",
-    "nom_fr": "Gars cool",
-    "texte_fr": "J'en peux plus![1205][U+000A] Je repars en voyage![1205][U+000A]\nJe vais prendre un bateau, larguer les amarres\net...[1205][U+000A] Ben... sûrement tomber du rebord, hum..."
-  },
-  {
-    "id": 19,
-    "offset": 273628,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Sad[SP]woman",
-    "texte_orig": "That's[SP]Ebisu[SP]Beach.[1205][U+000F][SP]It[SP]got[SP]its[SP]name[SP]because\npeople[SP]called[SP]the[SP]corpses[SP]that[SP]used[SP]to[SP]drift\nashore[SP][1432][NULL][NULL][0014]Ebisu-sama[1432][NULL][NULL][0014]...",
-    "nom_fr": "Femme triste",
-    "texte_fr": "C'est la plage d'Ebisu.[1205][U+000A] Son nom vient des\ngens qui nommaient les corps ramenés par la\nhoule [1432][NULL][NULL][0014]Ebisu[1432][NULL][NULL][0014]..."
-  },
-  {
-    "id": 20,
-    "offset": 273900,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Sad[SP]woman",
-    "texte_orig": "A[SP]beach[SP]bequeathed[SP]with[SP]the[SP]names[SP]of[SP]those[SP]who\nended[SP]their[SP]transient[SP]lives...[1205][U+000F][SP]A[SP]fitting[SP]place\nfor[SP]one[SP]like[SP]me[SP]who[SP]can't[SP]forget[SP]her[SP]man...",
-    "nom_fr": "Femme triste",
-    "texte_fr": "Une plage accablée des noms de ceux ayant mis\nfin à leurs vies fugaces...[1205][U+000F] Ce lieu me va\nbien, moi qui ne peux oublier mon amour..."
-  },
-  {
-    "id": 21,
-    "offset": 274212,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Sad[SP]woman",
-    "texte_orig": "That[SP]gentleman...[1205][U+000F][SP]He[SP]seemed[SP]to[SP]be[SP]a[SP]police\ndetective,[SP]but[SP]he[SP]looked[SP]like[SP]my[SP]dead[SP]lover...",
-    "nom_fr": "Femme triste",
-    "texte_fr": "Ce gentilhomme...[1205][U+000F] Il semble être policier,\nmais il ressemble à mon défunt mari..."
-  },
-  {
-    "id": 22,
-    "offset": 274428,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Sad[SP]woman",
-    "texte_orig": "...[1205][U+000F]O-Oh[SP]my,[SP]what's[SP]come[SP]over[SP]me...?[1205][U+000F][SP]I[SP]feel\nsuddenly[SP]flushed.[SP]This[SP]is[SP]so[SP]unlike[SP]me...",
-    "nom_fr": "Femme triste",
-    "texte_fr": "...[1205][U+000F] O-oh mais, qu'est ce qui me prend...?[1205][U+000F]\nJe rougis. Ça ne me ressemble pas..."
-  },
-  {
-    "id": 23,
-    "offset": 274638,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Lovestruck[SP]woman",
-    "texte_orig": "I[SP]wonder[SP]what[SP]that[SP]police[SP]detective's[SP]name[SP]is...[1205][U+000F]\nTh-Those[SP]glasses[SP]really[SP]suit[SP]him...[1205][U+000F][SP]Such[SP]a\nsharp[SP]look...",
-    "nom_fr": "Femme éprise",
-    "texte_fr": "Je me demande comment s'appelle ce policier...[1205][U+000F]\nC-ces lunettes lui vont vraiment bien...[1205][U+000F]\nQuelle classe..."
-  },
-  {
-    "id": 24,
-    "offset": 274904,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Lovestruck[SP]woman",
-    "texte_orig": "*sigh*[SP]Oh,[SP]what[SP]have[SP]I[SP]gotten[SP]myself[SP]into?[1205][U+000F]\nThis[SP]could[SP]be[SP]serious...[1205][U+000F][SP]Excuse[SP]me,[SP]do[SP]you\nhappen[SP]to[SP]know[SP]that[SP]man's[SP]name?",
-    "nom_fr": "Femme éprise",
-    "texte_fr": "*soupir* Oh, dans quoi je me suis fourrée?[1205][U+000F]\nÇa pourrait être sérieux...[1205][U+000F] Excusez-moi,\nauriez-vous le nom de cet homme?"
-  },
-  {
-    "id": 25,
-    "offset": 275194,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Lovestruck[SP]woman",
-    "texte_orig": "I[SP]wonder[SP]what's[SP]wrong...[1205][U+000F][SP]They[SP]posted[SP]composite\nsketches[SP]of[SP]the[SP]suspects,[SP]but[SP]that[SP]police\ndetective[SP]looks[SP]so[SP]sad[SP]about[SP]it...",
-    "nom_fr": "Femme éprise",
-    "texte_fr": "Qu'est ce qui ne va pas...[1205][U+000F] Les\nportraits-robot des suspects sont sortis, mais ça\nsemble attrister ce détective de police..."
-  },
-  {
-    "id": 26,
-    "offset": 275490,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Lovestruck[SP]woman",
-    "texte_orig": "If[SP]I[SP]was[SP]his[SP]lover,[SP]it[SP]would[SP]be[SP]up[SP]to[SP]me[SP]to\ntalk[SP]to[SP]him[SP]about[SP]it...[SP]But[SP]it's[SP]not[SP]my[SP]place.\nI[SP]can[SP]only[SP]watch[SP]him[SP]from[SP]afar[SP]like[SP]this.",
-    "nom_fr": "Femme éprise",
-    "texte_fr": "Si j'étais son amante, ce serait à moi de lui\nparler... Mais ce n'est pas ma place.\nJe peux seulement l'observer de loin."
-  },
-  {
-    "id": 27,
-    "offset": 275800,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Lovestruck[SP]woman",
-    "texte_orig": "Oh,[SP]I[SP]nearly[SP]forgot.[SP]I[SP]bought[SP]the[SP]same[SP]style\nof[SP]glasses[SP]he[SP]wears.[SP]What[SP]do[SP]you[SP]think?[SP]Do[SP]they\nlook[SP]good[SP]on[SP]me?",
-    "nom_fr": "Femme éprise",
-    "texte_fr": "Oh, j'oubliais. J'ai acheté des lunettes au style\nsimilaire aux siennes. Qu'en penses-tu? Elles\nme vont bien?"
-  },
-  {
-    "id": 28,
-    "offset": 276066,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Lovestruck[SP]woman",
-    "texte_orig": "That[SP]police[SP]detective[SP]seems[SP]happy[SP]for[SP]some\nreason[SP]after[SP]hearing[SP]the[SP]news.[1205][U+000F][SP]It's[SP]the[SP]first\ntime[SP]I've[SP]seen[SP]him[SP]smile.",
-    "nom_fr": "Femme éprise",
-    "texte_fr": "Ce détective de police semblait heureux en\nentendant les informations.[1205][U+000F] C'est la première fois\nque je l'ai vu sourire."
-  },
-  {
-    "id": 29,
-    "offset": 276346,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Lovestruck[SP]woman",
-    "texte_orig": "I-I[SP]was[SP]almost[SP]attacked[SP]by[SP]those[SP]soldiers...[1205][U+000F]\nBut[SP]that[SP]police[SP]detective[SP]saved[SP]me![1205][U+000F][SP]Ahhh,[SP]I\ncould[SP]die[SP]happy[SP]now!",
-    "nom_fr": "Femme éprise",
-    "texte_fr": "C-ces soldats m'ont presque agressée...[1205][U+000F]\nMais ce policier m'a sauvée![1205][U+000F] Ahhh,\nje peux mourir heureuse désormais!"
-  },
-  {
-    "id": 30,
-    "offset": 276620,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Lovestruck[SP]woman",
-    "texte_orig": "Hm?[1205][U+000A][SP]That[SP]blonde[SP]girl[SP]with[SP]you...[1205][U+000A][SP]Didn't[SP]she[SP]go\ninto[SP]that[SP]temple[SP]a[SP]second[SP]ago?[1205][U+000F][SP]Was[SP]I[SP]just\nseeing[SP]things...?",
-    "nom_fr": "Femme éprise",
-    "texte_fr": "Hm?[1205][U+000F] Cette fille blonde avec toi...[1205][U+000F] Elle\nn'est pas entrée dans ce temple à l'instant?[1205][U+000F]\nOu j'ai halluciné...?"
-  },
-  {
-    "id": 31,
-    "offset": 276892,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "That[SP]producer,[SP]Ginji[SP]Sasaki...[1205][U+000F][SP]Looks[SP]like[SP]he's\ngot[SP]a[SP]new[SP]idol[SP]group[SP]lined[SP]up.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ce producteur, Ginji Sasaki...[1205][U+000F] Il aurait formé\nun nouveau groupe d'idols."
-  },
-  {
-    "id": 32,
-    "offset": 277088,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Songs[SP]slake[SP]my[SP]heart's[SP]thirst...[1205][U+000F][SP]What[SP]sort[SP]of\nmessage[SP]will[SP]Muses[SP]inscribe[SP]into[SP]my[SP]heart?[1205][U+000F]\nThe[SP]suspense[SP]is[SP]delectable...",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "La musique étanche la soif de mon coeur...[1205][U+000F]\nQuel message Muses gravera dans mon coeur?[1205][U+000F]\nCe suspense est délicieux..."
-  },
-  {
-    "id": 33,
-    "offset": 277370,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "From[SP]what[SP]I've[SP]heard...[1205][U+000F][SP]The[SP]veil[SP]of[SP]mystery\nsurrounding[SP]the[SP]third[SP]member[SP]will[SP]be[SP]torn[SP]off\nduring[SP]the[SP]live[SP]recording[SP]at[SP]Giga[SP]Macho...",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "De ce que je sais...[1205][U+000F] Le voile mystèrieux\nenveloppant le troisième membre sera levé durant la\ndiffusion en direct au Giga Macho..."
-  },
-  {
-    "id": 34,
-    "offset": 277676,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Oh,[SP]how[SP]I've[SP]waited[SP]for[SP]this[SP]day![1205][U+000F][SP]Now,[SP]lady[SP]of\nmany[SP]enigmas...[1205][U+000F][SP]reveal[SP]to[SP]me[SP]your[SP]face!",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Oh, j'ai tant attendu ce jour![1205][U+000F] Maintenant,\nénigmatique dame...[1205][U+000F] révèle ton visage!"
-  },
-  {
-    "id": 35,
-    "offset": 277894,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "A[SP]concert,[SP]hmm?[1205][U+000F][SP]To[SP]think[SP]I'd[SP]be[SP]graced[SP]with\ntheir[SP]singing[SP]voices[SP]so[SP]soon...[1205][U+000F][SP]I[SP]should[SP]make\nfor[SP]the[SP]outdoor[SP]concert[SP]hall[SP]post-haste.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Un concert, hmm?[1205][U+000F] Dire que je vais déjà\npouvoir être béni de leurs chants...[1205][U+000F] Je dois\nme préparer pour le concert séance tenante."
-  },
-  {
-    "id": 36,
-    "offset": 278200,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "A[SP]ticket?[1205][U+000F][SP]Ha![SP]I[SP]need[SP]no[SP]ticket.[SP]I[SP]shall[SP]listen\nto[SP]them[SP]from[SP]beyond[SP]the[SP]wall.[SP]There[SP]are[SP]more\nways[SP]to[SP]show[SP]one's[SP]support[SP]than[SP]making[SP]a[SP]fuss.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Un ticket?[1205][U+000F] Ha! Pas besoin de ticket. J'écouterais\npar-delà le mur. S'agiter bêtement n'est pas\nla seule façon de témoigner son soutien."
-  },
-  {
-    "id": 37,
-    "offset": 278518,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Ha.[SP]So[SP]the[SP]concert[SP]hall[SP]has[SP]burned[SP]to[SP]ash...[1205][U+000F]\nThe[SP]building[SP]itself[SP]couldn't[SP]contain[SP]its\nexcitement[SP]for[SP]the[SP]Muses'[SP]song.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ha. La salle de concert a brûlée...[1205][U+000F]\nLe bâtiment lui-même n'a pu contenir l'excitation\nissue des chansons de Muses."
-  },
-  {
-    "id": 38,
-    "offset": 278794,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Fortunate,[SP]then,[SP]that[SP]I[SP]was[SP]outside.[SP]But[SP]one\nthing[SP]seems[SP]amiss.[1205][U+000F][SP]Muses[SP]was[SP]meant[SP]to[SP]be[SP]a\ntrio,[SP]but...[1205][U+000F][SP]Who[SP]was[SP]there[SP]besides[SP]Lisa-chan?",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Il est bon d'être resté dehors. Mais une\nchose ne colle pas.[1205][U+000F] Muses est censé être un\ntrio, mais...[1205][U+000F] Qui était aux côtés de Lisa?"
-  },
-  {
-    "id": 39,
-    "offset": 279106,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Apparently[SP]the[SP]terrorists[SP]behind[SP]these[SP]attacks\nare[SP]a[SP]mysterious[SP]organization[SP]called[SP]the[SP]Last\nBattalion.[1205][U+000F][SP]I've[SP]heard[SP]people[SP]talk[SP]about[SP]them.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Apparemment les terroristes derrière ces attaques\nsont une organisation mystérieuse nommée Bataillon.[1205][U+000F]\nJ'ai entendu des gens en parler."
-  },
-  {
-    "id": 40,
-    "offset": 279424,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "If[SP]that's[SP]what[SP]they[SP]were[SP]up[SP]against,[SP]then[SP]even\nif[SP]the[SP]police[SP]weren't[SP]handicapped,[SP]they[SP]would\nhave[SP]had[SP]little[SP]success.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Si ils doivent affronter ça, même si la\npolice n'était pas incapacitée, ils n'auraient\npresque aucune chance."
-  },
-  {
-    "id": 41,
-    "offset": 279696,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "At[SP]least[SP]now[SP]they[SP]have[SP]a[SP]good[SP]excuse[SP]for[SP]their\nfailure[SP]to[SP]protect[SP]the[SP]city--they[SP]were[SP]victims\nof[SP]the[SP]same[SP]arson.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Au moins maintenant ils ont une bonne raison\nd'échouer à protéger la ville--ils sont\nvictimes eux aussi."
-  },
-  {
-    "id": 42,
-    "offset": 279958,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "The[SP]men[SP]at[SP]Sumaru[SP]TV[SP]are[SP]frantically[SP]gathering\nmaterial.[1205][U+000F][SP]I[SP]presume[SP]they're[SP]putting[SP]together[SP]a\nspecial[SP]on[SP]the[SP]terror[SP]wave.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ceux de Sumaru TV rassemblent hâtivement du\nmatériel.[1205][U+000F] Ils préparent une émission spéciale sur\nles drames, je présume."
-  },
-  {
-    "id": 43,
-    "offset": 280242,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Ha![SP]If[SP]only[SP]they[SP]had[SP]talked[SP]to[SP]me,[SP]I[SP]could[SP]have\nrecounted[SP]the[SP]smallest[SP]details[SP]of[SP]how[SP]the[SP]blimp\ntook[SP]off.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ha! Si seulement ils m'avaient parlé, j'aurais\nreconté chaque petit détail de l'envol du\ndirigeable."
-  },
-  {
-    "id": 44,
-    "offset": 280490,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Hmph...[SP]The[SP]In[SP]Lak'ech[SP]says[SP]we'll[SP]evolve[SP]into\na[SP]higher[SP]form,[SP]called[SP]Idealians,[SP]upon[SP]the\ncompletion[SP]of[SP]the[SP]Grand[SP]Cross.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Hm... Selon l'In Lak'ech nous évoluerons en\nIdéaliens, une forme supérieure, quand la Croix\nCosmique sera complète."
-  },
-  {
-    "id": 45,
-    "offset": 280764,
-    "data_size": 312,
-    "slot_size": 316,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "A[SP]juicy[SP]story,[SP]no?[1205][U+000F][SP]I[SP]choose[SP]to[SP]believe[SP]it.[1205][U+000F]\nMy[SP]life[SP]would[SP]never[SP]end[SP]this[SP]way.[SP]There[SP]has[SP]to\nbe[SP]a[SP]more[SP]stimulating[SP]future[SP]in[SP]store[SP]for[SP]me.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Une histoire intéressante, non?[1205][U+000F] J'ai décidé d'y\ncroire.[1205][U+000F] Ma vie ne saurait s'achever ainsi.\nUn futur plus stimulant doit m'attendre."
-  },
-  {
-    "id": 46,
-    "offset": 281080,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Hohoho,[SP]I[SP]can[SP]scarcely[SP]wait[SP]for[SP]the[SP]moment[SP]of\nour[SP]transfiguration.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Hohoho, je ne puis attendre l'instant de notre\ntransfiguration."
-  },
-  {
-    "id": 47,
-    "offset": 281250,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Hmph...[SP]Most[SP]of[SP]the[SP]Last[SP]Battalion[SP]has[SP]fled\nfor[SP]Mt.[SP]Katatsumuri.[1205][U+000F][SP]Scared[SP]of[SP]me,[SP]I'll[SP]wager.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Hmph... Le Bataillon est allé vers le Mont\nKatatsumuri.[1205][U+000F] Effrayé par moi, je parie."
-  },
-  {
-    "id": 48,
-    "offset": 281472,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]pity[SP]the[SP]poor[SP]souls[SP]below[SP]us...[SP]But[SP]at[SP]least\nour[SP]evolution[SP]will[SP]go[SP]unimpeded.[1205][U+000F][SP]Still,[SP]just\nhow[SP]will[SP]the[SP]world[SP]end?",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ah, ces pauvres âmes là-dessous... Au moins\nrien ne gênera notre évolution.[1205][U+000F] Mais comment le\nmonde sera anéanti?"
-  },
-  {
-    "id": 49,
-    "offset": 281744,
-    "data_size": 210,
-    "slot_size": 214,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "The[SP]Earth's[SP]destruction,[SP]eh...[1205][U+000F][SP]Do[SP]you[SP]suppose\na[SP]meteor[SP]or[SP]somesuch[SP]will[SP]hit[SP]the[SP]Earth?",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "La fin du monde, hein...[1205][U+000F] Penses-tu qu'un\nmétéore ou équivalent va frapper la Terre?"
-  },
-  {
-    "id": 50,
-    "offset": 281958,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "An[SP]acquaintance[SP]of[SP]mine[SP]told[SP]me[SP]that[SP]when[SP]the\nGrand[SP]Cross[SP]is[SP]complete,[SP]electrified[SP]rain[SP]will\npour[SP]down[SP]upon[SP]the[SP]Earth.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "D'après une connaissance, lorsque la Croix\nCosmique sera complète, une pluie électrifiée\ns'abattra sur Terre."
-  },
-  {
-    "id": 51,
-    "offset": 282232,
-    "data_size": 236,
-    "slot_size": 240,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "That[SP]is[SP]supposedly[SP]the[SP]manner[SP]of[SP]its[SP]demise.[1205][U+000F]\nNothing[SP]for[SP]us[SP]to[SP]worry[SP]about,[SP]up[SP]here[SP]in[SP]the\nheavens.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Bah, sûrement une divagation issue de sa terreur.[1205][U+000F]\nDans ce paradis nous ne sommes pas inquiétés."
-  },
-  {
-    "id": 52,
-    "offset": 282472,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Things[SP]are[SP]becoming[SP]interesting[SP]indeed.[1205][U+000A][SP]I[SP]hear\nnow[SP]that[SP]the[SP]Grand[SP]Cross[SP]will[SP]halt[SP]the[SP]Earth's\nrotation[SP]entirely.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Les choses deviennent intéressantes.[1205][U+000F] J'entend\ndire que la Croix Cosmique va stopper la\nrotation terrestre."
-  },
-  {
-    "id": 53,
-    "offset": 282738,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Now[SP]that's[SP]more[SP]like[SP]it.[1205][U+000A][SP]Even[SP]the[SP]method[SP]of\nits[SP]destruction[SP]is[SP]decadent![1205][U+000A][SP]Ohohoho!",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ça, ça me plaît.[1205][U+000F] Même sa façon d'être\ndétruite est décadente![1205][U+000F] Ohohohoho!"
-  },
-  {
-    "id": 54,
-    "offset": 282946,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "There[SP]are[SP]allegedly[SP]talking[SP]flowers[SP]in[SP]Aoba\nPark.[SP]I[SP]don't[SP]relish[SP]the[SP]thought[SP]of[SP]giving[SP]one\nas[SP]a[SP]present[SP]and[SP]having[SP]it[SP]let[SP]slip[SP]a[SP]secret...",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Il y aurait des fleurs qui parlent au Parc\nd'Aoba. Je n'apprécie pas l'idée d'en offrir\nune et de la voir révèler un secret..."
-  },
-  {
-    "id": 55,
-    "offset": 283260,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]hear[SP]that[SP]Zodiac's[SP]second[SP]floor[SP]is[SP]stuffed\nwith[SP]t[SP]reasure[SP]now.[SP]I'd[SP]like[SP]to[SP]see[SP]it[SP]for\nmyself...[1205][U+000F][SP]if[SP]it[SP]weren't[SP]for[SP]the[SP]monsters.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Le second étage du Zodiac serait actuellement\nrempli de trésors. Je serais bien allé\nvoir...[1205][U+000F] s'il n'y avait pas ces monstres."
-  },
-  {
-    "id": 56,
-    "offset": 283558,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "*sigh*[SP]Surely[SP]there[SP]must[SP]be[SP]one[SP]foolproof[SP]way\nof[SP]getting[SP]rich[SP]quickly.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "*soupir* Un moyen sûr de s'enrichir rapidement\ndoit bien exister."
-  },
-  {
-    "id": 57,
-    "offset": 283736,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "The[SP]ghost[SP]of[SP]an[SP]idol[SP]singer[SP]who[SP]died[SP]young\nhas[SP]been[SP]appearing[SP]at[SP]Aoba[SP]Park.[1205][U+000F][SP]Can[SP]she\nstill[SP]not[SP]forget[SP]me,[SP]even[SP]in[SP]death?",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Le fantôme d'une idol, morte jeune, apparaîtrait\nau Parc d'Aoba.[1205][U+000F] Faillirait-elle à\nm'oublier, même dans la mort?"
-  },
-  {
-    "id": 58,
-    "offset": 284016,
-    "data_size": 176,
-    "slot_size": 180,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "There's[SP]something[SP]called[SP]a[SP]Cursed[SP]Taxi[SP]parked\nat[SP]the[SP]abandoned[SP]factory.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Un dénommé Taxi Maudit serait garé à\nl'usine abandonnée."
-  },
-  {
-    "id": 59,
-    "offset": 284196,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I've[SP]heard[SP]stories[SP]of[SP]it[SP]running[SP]down[SP]victims\nat[SP]night,[SP]then[SP]resting[SP]during[SP]the[SP]day.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Des histoires racontent qu'il fauche ses\nvictimes la nuit et se repose le jour."
-  },
-  {
-    "id": 60,
-    "offset": 284402,
-    "data_size": 226,
-    "slot_size": 230,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "You'd[SP]think[SP]that[SP]would[SP]serve[SP]only[SP]to[SP]shrink[SP]its\ncustomer[SP]base.[SP]Hardly[SP]a[SP]sound[SP]business[SP]strategy!",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Cela ne peux que faire baisser sa clientèle.\nHasardeux, comme stratégie marketing!"
-  },
-  {
-    "id": 61,
-    "offset": 284632,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Apparently[SP]the[SP]Cursed[SP]Taxi[SP]at[SP]the[SP]abandoned\nfactory[SP]was[SP]actually[SP]a[SP]Cursed[SP]Escort.[SP]Not[SP]that\nI[SP]care[SP]one[SP]whit.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Apparemment le Taxi Maudit de l'usine abandonnée\nétait en fait une Escorte Maudite. Bah,\nje m'en fiche."
-  },
-  {
-    "id": 62,
-    "offset": 284884,
-    "data_size": 172,
-    "slot_size": 176,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Kuchisake-onna,[SP]hmm...?[SP]That[SP]story[SP]gave[SP]me\nquite[SP]a[SP]fright[SP]as[SP]a[SP]child.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Kuchisake-onna, hein...? Enfant, cette histoire\nme terrorisait."
-  },
-  {
-    "id": 63,
-    "offset": 285060,
-    "data_size": 172,
-    "slot_size": 176,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Ah,[SP]the[SP]memories...[1205][U+000F][SP]I[SP]doubt[SP]children[SP]your[SP]age\nwould[SP]know[SP]who[SP]she[SP]is.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Que de souvenirs...[1205][U+000F] Je doute qu'à votre âge\nvous la connaissiez."
-  },
-  {
-    "id": 64,
-    "offset": 285236,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Then[SP]here's[SP]a[SP]social[SP]studies[SP]assignment[SP]for\nyou:[SP]Go[SP]to[SP]this[SP]Mt.[SP]Iwato[SP]place.[1205][U+000F][SP]Apparently\nyou[SP]can[SP]see[SP]her[SP]for[SP]yourself[SP]there.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Tenez, voici un devoir de sciences sociales:\nallez à ce Mont Iwato, là.[1205][U+000F] Vous pourriez\nla voir vous-même là-bas."
-  },
-  {
-    "id": 65,
-    "offset": 285524,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Jumping[SP]Geezer,[SP]hmm...?[SP]I[SP]used[SP]to[SP]compete[SP]with\nhim[SP]quite[SP]often[SP]on[SP]mountain[SP]passes.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Le Vieux à Ressort, hein...? Je le défiais\nsouvent sur les sentiers à l'époque."
-  },
-  {
-    "id": 66,
-    "offset": 285726,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "He[SP]was[SP]much[SP]faster[SP]than[SP]me,[SP]though.[1205][U+000F][SP]He[SP]jumped\nright[SP]over[SP]my[SP]GT8.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Mais il était plus rapide.[1205][U+000F] Il sautais\nau dessus de ma GT8."
-  },
-  {
-    "id": 67,
-    "offset": 285896,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "If[SP]you[SP]care[SP]to[SP]challenge[SP]him,[SP]go[SP]to[SP]Mt.\nKatatsumuri.[SP]The[SP]cursed[SP]six[SP]hairpin[SP]curves...[1205][U+000F]\nHe'll[SP]be[SP]waiting[SP]there[SP]for[SP]you.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Si vous voulez l'affronter, allez au Mont\nKatatsumuri. Les six virages en épingle maudits...[1205][U+000F]\nIl vous y attendra."
-  },
-  {
-    "id": 68,
-    "offset": 286172,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Harumph...[1205][U+000F][SP]I[SP]can't[SP]believe[SP]I'm[SP]letting[SP]this\nridiculous[SP]story[SP]affect[SP]me...[1205][U+000F][SP]Kudan,[SP]hmm?[1205][U+000F]\nAt[SP]that[SP]abandoned[SP]factory...[1205][U+000F][SP]No![SP]No[SP]more!",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Grumpf...[1205][U+000F] Il est impensable que cette ridicule\nhistoire puisse m'affecter...[1205][U+000F]Kudan, hmm?[1205][U+000F]\nÀ l'usine abandonnée...[1205][U+000F] Non! Assez!"
-  },
-  {
-    "id": 69,
-    "offset": 286480,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Hmm...[SP]It[SP]appears[SP]the[SP]rumor[SP]was[SP]true[SP]about[SP]the\nsecret[SP]CD[SP]at[SP]Giga[SP]Macho.[1205][U+000F][SP]Time[SP]for[SP]me[SP]to[SP]go[SP]pick\nit[SP]up...",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Hmm... Il semble que la rumeur du CD secret\ndu Giga Macho était fondée.[1205][U+000F] Je dois aller\nle chercher..."
-  },
-  {
-    "id": 70,
-    "offset": 286728,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Have[SP]you[SP]heard?[1205][U+000F][SP]There's[SP]a[SP]creature[SP]called\na[SP]Dresser[SP]Hag[SP]at[SP]the[SP]abandoned[SP]factory.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Une dénommée Sorcière de\nla Commode est à l'usine abandonnée."
-  },
-  {
-    "id": 71,
-    "offset": 286932,
-    "data_size": 142,
-    "slot_size": 146,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "By[SP]all[SP]accounts,[SP]it[SP]shoves[SP]passersby[SP]into[SP]its\ndresser.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Elle encastrerait les passants dans sa\ncommode."
-  },
-  {
-    "id": 72,
-    "offset": 287078,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Ah,[SP]I[SP]have[SP]a[SP]hot[SP]tip[SP]for[SP]you.[1205][U+000F][SP]I'll[SP]let[SP]you[SP]in\non[SP]it,[SP]provided[SP]you[SP]don't[SP]tell[SP]anyone[SP]else...",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ah, j'ai un bon plan pour toi.[1205][U+000F] Je te le\ndirais, si tu promets de ne pas en parler..."
-  },
-  {
-    "id": 73,
-    "offset": 287300,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "You[SP]see...[1205][U+000F][SP]A[SP]store[SP]called[SP]Time[SP]Castle[SP]in\nRengedai[SP]sells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]quality\nand[SP]price[SP]are[SP]average.[SP]Shocking,[SP]no?",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Tu vois...[1205][U+000F] Time Castle à Rengedai vendrait\nde vraies armes.[1205][U+000F] Le prix et la qualité y\nsont standards. Dingue, non?"
-  },
-  {
-    "id": 74,
-    "offset": 287586,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Ah,[SP]I[SP]have[SP]a[SP]hot[SP]tip[SP]for[SP]you.[1205][U+000F][SP]I'll[SP]let[SP]you[SP]in\non[SP]it,[SP]provided[SP]you[SP]don't[SP]tell[SP]anyone[SP]else...",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ah, j'ai un bon plan pour toi.[1205][U+000F] Je te le\ndirais, si tu promets de ne pas en parler..."
-  },
-  {
-    "id": 75,
-    "offset": 287808,
-    "data_size": 300,
-    "slot_size": 304,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "You[SP]see...[1205][U+000F][SP]A[SP]store[SP]called[SP]Time[SP]Castle[SP]in\nRengedai[SP]sells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]quality\nis[SP]good,[SP]but[SP]they're[SP]expensive.[SP]Shocking,[SP]no?",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Tu vois...[1205][U+000F] Time Castle à Rengedai vendrait\nde vraies armes.[1205][U+000F] La sélection y est\nbonne, mais coûteuse. Dingue, non?"
-  },
-  {
-    "id": 76,
-    "offset": 288112,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Ah,[SP]I[SP]have[SP]a[SP]hot[SP]tip[SP]for[SP]you.[1205][U+000F][SP]I'll[SP]let[SP]you[SP]in\non[SP]it,[SP]provided[SP]you[SP]don't[SP]tell[SP]anyone[SP]else...",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ah, j'ai un bon plan pour toi.[1205][U+000F] Je te le\ndirais, si tu promets de ne pas en parler..."
-  },
-  {
-    "id": 77,
-    "offset": 288334,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "You[SP]see...[1205][U+000F][SP]A[SP]store[SP]called[SP]Time[SP]Castle[SP]in\nRengedai[SP]sells[SP]real[SP]weapons.[1205][U+000F][SP]They're[SP]cheap,\nbut[SP]low[SP]quality.[SP]Shocking,[SP]no?",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Tu vois...[1205][U+000F] Time Castle à Rengedai vendrait\nde vraies armes.[1205][U+000F] C'est pas cher, mais de\nbasse qualité. Dingue, non?"
-  },
-  {
-    "id": 78,
-    "offset": 288610,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Great[SP]selection,[SP]but[SP]low[SP]resale[SP]value?[SP]Hmph,\neven[SP]that[SP]Tony[SP]has[SP]a[SP]hand[SP]in[SP]illicit[SP]weapon\nsales...[1205][U+000F][SP]The[SP]bastard's[SP]good.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Bonne sélection, mais bas prix de revente?\nHmph, même ce Tony traîne dans le trafic\nd'armes...[1205][U+000F] Doué, cet enfoiré."
-  },
-  {
-    "id": 79,
-    "offset": 288886,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Poor[SP]quality,[SP]but[SP]decent[SP]prices?[SP]Hmph,\neven[SP]that[SP]Tony[SP]has[SP]a[SP]hand[SP]in[SP]illicit[SP]weapon\nsales...[1205][U+000F][SP]The[SP]bastard's[SP]good.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Basse qualité, mais prix décents? Hmph,\nmême ce Tony traîne dans le trafic\nd'armes...[1205][U+000F] Doué, cet enfoiré."
-  },
-  {
-    "id": 80,
-    "offset": 289150,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Satisfaction[SP]guaranteed[SP]through[SP]average[SP]prices\nand[SP]quality?[SP]Hmph,[SP]even[SP]that[SP]Tony[SP]has[SP]a[SP]hand\nin[SP]illicit[SP]weapon[SP]sales...[1205][U+000F][SP]The[SP]bastard's[SP]good.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Prix et qualité standardisés pour une\nsatisfaction assurée? Hmph, même ce Tony traîne\ndans le trafic d'armes...[1205][U+000F] Doué, cet enfoiré."
-  },
-  {
-    "id": 81,
-    "offset": 289468,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Expensive[SP]stock,[SP]but[SP]the[SP]highest[SP]quality...\nHmph,[SP]even[SP]that[SP]Tony[SP]has[SP]a[SP]hand[SP]in[SP]illicit\nweapon[SP]sales...[1205][U+000F][SP]The[SP]bastard's[SP]good.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Des produits coûteux, mais de haute qualité...\nHmph, même ce Tony traîne dans le trafic\nd'armes...[1205][U+000F] Doué, cet enfoiré."
-  },
-  {
-    "id": 82,
-    "offset": 289754,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its\nrepertoire[SP]to[SP]include[SP]weapons.[SP]Their[SP]selection\nisn't[SP]the[SP]best,[SP]but[SP]their[SP]resale[SP]value[SP]is[SP]high.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. L'offre n'y est pas la meilleure,\nmais la valeur de revente est haute."
-  },
-  {
-    "id": 83,
-    "offset": 290060,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its\nrepertoire[SP]to[SP]include[SP]weapons.[SP]They're[SP]cheap,\nbut[SP]dismal[SP]quality.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. Elles sont bon marché,\nmais médiocres."
-  },
-  {
-    "id": 84,
-    "offset": 290308,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its\nrepertoire[SP]to[SP]include[SP]weapons.[SP]The[SP]quality[SP]is\nexcellent,[SP]but[SP]the[SP]prices[SP]are[SP]high.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. C'est d'excellente facture,\nmais vraiment cher."
-  },
-  {
-    "id": 85,
-    "offset": 290588,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its\nrepertoire[SP]to[SP]include[SP]weapons.[SP]Their[SP]selection\nis[SP]great,[SP]but[SP]their[SP]resale[SP]prices[SP]aren't.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. La sélection y est bonne,\nmais pas les prix de revente."
-  },
-  {
-    "id": 86,
-    "offset": 290882,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its\nrepertoire[SP]to[SP]include[SP]weapons.[SP]Their[SP]quality\nand[SP]prices[SP]are[SP]merely[SP]ordinary.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. Le prix et la qualité\ny sont ordinaires."
-  },
-  {
-    "id": 87,
-    "offset": 291152,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]never[SP]noticed[SP]that[SP]the[SP]local[SP]cafe[SP]sold\nweapons[SP]before.[SP]Scuttlebutt[SP]is[SP]that[SP]their\nquality[SP]and[SP]prices[SP]are[SP]average.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Le prix et la\nqualité y seraient corrects."
-  },
-  {
-    "id": 88,
-    "offset": 291418,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]never[SP]noticed[SP]that[SP]the[SP]local[SP]cafe[SP]sold\nweapons[SP]before.[SP]Scuttlebutt[SP]is[SP]that[SP]their\nprices[SP]are[SP]low,[SP]but[SP]so[SP]is[SP]the[SP]quality.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Le prix et la\nqualité des produits y seraient bas."
-  },
-  {
-    "id": 89,
-    "offset": 291698,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]never[SP]noticed[SP]that[SP]the[SP]local[SP]cafe[SP]sold\nweapons[SP]before.[SP]Scuttlebutt[SP]is[SP]their[SP]selection\nis[SP]varied,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]low.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Leur offre serait\nvariée, mais la valeur de revente basse."
-  },
-  {
-    "id": 90,
-    "offset": 291990,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]never[SP]noticed[SP]that[SP]the[SP]local[SP]cafe[SP]sold\nweapons[SP]before.[SP]Scuttlebutt[SP]is[SP]they[SP]don't[SP]have\nmuch,[SP]but[SP]the[SP]resale[SP]price[SP]can't[SP]be[SP]beat.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. L'offre y serait\npauvre, mais les prix de revente très bons."
-  },
-  {
-    "id": 91,
-    "offset": 292286,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]never[SP]noticed[SP]that[SP]the[SP]local[SP]cafe[SP]sold\nweapons[SP]before.[SP]Scuttlebutt[SP]is[SP]that[SP]their\nquality's[SP]great,[SP]but[SP]it's[SP]quite[SP]pricey.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Les produits y seraient\nde qualité, mais assez chers."
-  },
-  {
-    "id": 92,
-    "offset": 292568,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "It[SP]appears[SP]that[SP]the[SP]boutique[SP]in[SP]Rengedai\nsells[SP]armor.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "La boutique de Rengedai vendrait des\narmures."
-  },
-  {
-    "id": 93,
-    "offset": 292712,
-    "data_size": 210,
-    "slot_size": 214,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]hear[SP]the[SP]quality[SP]and[SP]prices[SP]are[SP]average.\nThere[SP]must[SP]be[SP]a[SP]lot[SP]of[SP]cowards[SP]in[SP]the[SP]region.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "La qualité et les prix y seraient corrects.\nLa région doit grouiller de trouillards."
-  },
-  {
-    "id": 94,
-    "offset": 292926,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "It[SP]appears[SP]that[SP]the[SP]boutique[SP]in[SP]Rengedai\nsells[SP]armor.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "La boutique de Rengedai vendrait des\narmures."
-  },
-  {
-    "id": 95,
-    "offset": 293070,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]hear[SP]it's[SP]cheap,[SP]but[SP]low[SP]in[SP]quality.[SP]There\nmust[SP]be[SP]a[SP]lot[SP]of[SP]cowards[SP]in[SP]the[SP]region.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Les prix comme la qualité y seraient bas.\nLa région doit grouiller de froussards."
-  },
-  {
-    "id": 96,
-    "offset": 293276,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "It[SP]appears[SP]that[SP]the[SP]boutique[SP]in[SP]Rengedai\nsells[SP]armor.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "La boutique à Rengedai vendrait des\narmures."
-  },
-  {
-    "id": 97,
-    "offset": 293420,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]hear[SP]it's[SP]high[SP]quality[SP]stuff,[SP]but[SP]expensive.\nThere[SP]must[SP]be[SP]a[SP]lot[SP]of[SP]cowards[SP]in[SP]the[SP]region.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ce serait de haute qualité, mais très cher.\nLa région doit être remplie de froussards."
-  },
-  {
-    "id": 98,
-    "offset": 293642,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Is[SP]armor[SP]the[SP]latest[SP]fashion[SP]trend?[SP]Judging[SP]by\nAnima[SP]Mundi,[SP]apparently[SP]so.[SP]Their[SP]quality[SP]and\nprices[SP]are[SP]average[SP]at[SP]best.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Les armures sont à la mode? Apparemment oui,\nsi on regarde Anima Mundi. Leurs prix et\nqualité sont standards."
-  },
-  {
-    "id": 99,
-    "offset": 293918,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Is[SP]armor[SP]the[SP]latest[SP]fashion[SP]trend?[SP]Judging[SP]by\nAnima[SP]Mundi,[SP]apparently[SP]so.[SP]Their[SP]stock[SP]is\ncheap,[SP]but[SP]low[SP]in[SP]quality.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Les armures sont à la mode? Apparemment oui,\nsi on regarde Anima Mundi. C'est bon marché,\nmais de basse qualité."
-  },
-  {
-    "id": 100,
-    "offset": 294186,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Is[SP]armor[SP]the[SP]latest[SP]fashion[SP]trend?[SP]Judging[SP]by\nAnima[SP]Mundi,[SP]apparently[SP]so.[SP]Their[SP]selection[SP]is\ngreat,[SP]but[SP]their[SP]resale[SP]value[SP]is[SP]low.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Les armures sont à la mode? Apparemment oui,\nsi on regarde Anima Mundi. L'offre y est\ntrès bonne, mais pas le prix de revente."
-  },
-  {
-    "id": 101,
-    "offset": 294484,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Is[SP]armor[SP]the[SP]latest[SP]fashion[SP]trend?[SP]Judging[SP]by\nAnima[SP]Mundi,[SP]apparently[SP]so.[SP]The[SP]quality[SP]is\nhigh,[SP]but[SP]the[SP]prices[SP]are[SP]equally[SP]so.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Les armures sont à la mode? Apparemment oui,\nsi on regarde Anima Mundi. La qualité y\nest élevée, mais les prix aussi."
-  },
-  {
-    "id": 102,
-    "offset": 294772,
-    "data_size": 276,
-    "slot_size": 280,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling\nreal[SP]armor.[SP]They[SP]say[SP]the[SP]selection[SP]is[SP]poor,\nbut[SP]the[SP]resale[SP]value[SP]is[SP]high.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. L'offre serait mauvaise,\nmais la revente paierait bien."
-  },
-  {
-    "id": 103,
-    "offset": 295052,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling\nreal[SP]armor.[SP]They[SP]say[SP]their[SP]quality[SP]and[SP]prices\nare[SP]average.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. Prix et qualité y seraient\nstandards."
-  },
-  {
-    "id": 104,
-    "offset": 295302,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling\nreal[SP]armor.[SP]They[SP]say[SP]the[SP]quality[SP]is[SP]excellent,\nbut[SP]the[SP]prices[SP]are[SP]extravagant.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. La qualité y serait\nexcellente, mais les produits onéreux."
-  },
-  {
-    "id": 105,
-    "offset": 295592,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling\nreal[SP]armor.[SP]They[SP]say[SP]their[SP]goods[SP]are[SP]cheap,\nbut[SP]lacking[SP]in[SP]quality.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. On dit que c'est pas\ncher, mais de basse qualité."
-  },
-  {
-    "id": 106,
-    "offset": 295860,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling\nreal[SP]armor.[SP]They[SP]say[SP]the[SP]selection[SP]is[SP]good,\nbut[SP]the[SP]resale[SP]value[SP]is[SP]low.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. L'offre y serait bonne,\nmais pas la valeur de revente."
-  },
-  {
-    "id": 107,
-    "offset": 296138,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I'm[SP]impressed[SP]that[SP]London[SP]Clothier[SP]goes[SP]so\nfar[SP]as[SP]to[SP]outfit[SP]people[SP]with[SP]real[SP]armor.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients."
-  },
-  {
-    "id": 108,
-    "offset": 296342,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Seems[SP]their[SP]selection's[SP]impressive,[SP]but[SP]their\nresale[SP]value[SP]is[SP]fairly[SP]low.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Leur sélection semble géniale, mais la valeur\nde revente y est basse."
-  },
-  {
-    "id": 109,
-    "offset": 296526,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I'm[SP]impressed[SP]that[SP]London[SP]Clothier[SP]goes[SP]so\nfar[SP]as[SP]to[SP]outfit[SP]people[SP]with[SP]real[SP]armor.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients."
-  },
-  {
-    "id": 110,
-    "offset": 296730,
-    "data_size": 146,
-    "slot_size": 150,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Seems[SP]their[SP]stock[SP]is[SP]cheap,[SP]but[SP]not[SP]the\nhighest[SP]quality.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ça semble être bon marché, mais de médiocre\nqualité."
-  },
-  {
-    "id": 111,
-    "offset": 296880,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I'm[SP]impressed[SP]that[SP]London[SP]Clothier[SP]goes[SP]so\nfar[SP]as[SP]to[SP]outfit[SP]people[SP]with[SP]real[SP]armor.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients."
-  },
-  {
-    "id": 112,
-    "offset": 297084,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Their[SP]quality[SP]is[SP]unimpeachable,[SP]but[SP]the[SP]prices\nare[SP]quite[SP]steep.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "La qualité y est sans égale, mais les\nprix suivent avec."
-  },
-  {
-    "id": 113,
-    "offset": 297248,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I'm[SP]impressed[SP]that[SP]London[SP]Clothier[SP]goes[SP]so\nfar[SP]as[SP]to[SP]outfit[SP]people[SP]with[SP]real[SP]armor.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients."
-  },
-  {
-    "id": 114,
-    "offset": 297452,
-    "data_size": 158,
-    "slot_size": 162,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Seems[SP]the[SP]quality[SP]and[SP]price[SP]of[SP]their[SP]goods\nis[SP]fairly[SP]standard.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "La qualité et le prix de leurs produits\nsemblent standards."
-  },
-  {
-    "id": 115,
-    "offset": 297614,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I'm[SP]impressed[SP]that[SP]London[SP]Clothier[SP]goes[SP]so\nfar[SP]as[SP]to[SP]outfit[SP]people[SP]with[SP]real[SP]armor.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients."
-  },
-  {
-    "id": 116,
-    "offset": 297818,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Seems[SP]their[SP]selection[SP]is[SP]less[SP]than[SP]impressive,\nbut[SP]the[SP]resale[SP]value[SP]is[SP]high.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Leur sélection semble quelconque, mais la\nvaleur de revente y est élevée."
-  },
-  {
-    "id": 117,
-    "offset": 298008,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Blast[SP]it,[SP]I[SP]didn't[SP]win...[1205][U+000F][SP]Hm?[1205][U+000F][SP]Oh,[SP]I[SP]was[SP]just\nfuming[SP]about[SP]the[SP]magazine[SP]sweepstakes.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Tss, j'ai pas gagné...[1205][U+000F] Hm?[1205][U+000F] Oh, je pestais\njuste sur les loteries de magazines."
-  },
-  {
-    "id": 118,
-    "offset": 298220,
-    "data_size": 142,
-    "slot_size": 146,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I've[SP]heard[SP]that[SP]winners[SP]receive[SP]real[SP]weapons\nand[SP]items.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Les gagnants pourraient y obtenir armes\net objets."
-  },
-  {
-    "id": 119,
-    "offset": 298366,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "They're[SP]allegedly[SP]not[SP]easy[SP]to[SP]win,[SP]but[SP]the\nprizes[SP]are[SP]fairly[SP]nice.[1205][U+000F][SP]I[SP]suppose[SP]I'll[SP]keep\ntrying...",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Il est difficile de gagner, mais les\nprix sont assez bons.[1205][U+000F] Je vais réessayer,\nj'imagine..."
-  },
-  {
-    "id": 120,
-    "offset": 298600,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Blast[SP]it,[SP]I[SP]didn't[SP]win...[1205][U+000F][SP]Hm?[1205][U+000F][SP]Oh,[SP]I[SP]was[SP]just\nfuming[SP]about[SP]the[SP]magazine[SP]sweepstakes.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Tss, j'ai pas gagné...[1205][U+000F] Hm?[1205][U+000F] Oh, je pestais\njuste sur les loteries de magazines."
-  },
-  {
-    "id": 121,
-    "offset": 298812,
-    "data_size": 142,
-    "slot_size": 146,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I've[SP]heard[SP]that[SP]winners[SP]receive[SP]real[SP]weapons\nand[SP]items.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Les gagnants pourraient y obtenir armes\net objets."
-  },
-  {
-    "id": 122,
-    "offset": 298958,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "They're[SP]allegedly[SP]very[SP]difficult[SP]to[SP]win,[SP]but[SP]the\nprizes[SP]are[SP]quite[SP]rare.[1205][U+000F][SP]I[SP]suppose[SP]I'll[SP]keep\ntrying...",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Gagner serait difficile, mais les prix\nsont vraiment rares.[1205][U+000F] Je vais réessayer,\nj'imagine..."
-  },
-  {
-    "id": 123,
-    "offset": 299202,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Blast[SP]it,[SP]I[SP]didn't[SP]win...[1205][U+000F][SP]Hm?[1205][U+000F][SP]Oh,[SP]I[SP]was[SP]just\nfuming[SP]about[SP]the[SP]magazine[SP]sweepstakes.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Tss, j'ai pas gagné...[1205][U+000F] Hm?[1205][U+000F] Oh, je pestais\njuste sur les loteries de magazines."
-  },
-  {
-    "id": 124,
-    "offset": 299414,
-    "data_size": 142,
-    "slot_size": 146,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I've[SP]heard[SP]that[SP]winners[SP]receive[SP]real[SP]weapons\nand[SP]items.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Les gagnants pourraient y obtenir armes\net objets."
-  },
-  {
-    "id": 125,
-    "offset": 299560,
-    "data_size": 238,
-    "slot_size": 242,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "They're[SP]allegedly[SP]easy[SP]to[SP]win,[SP]but[SP]the[SP]prizes\nare[SP]no[SP]great[SP]shakes.[1205][U+000F][SP]Perhaps[SP]now's[SP]the\ntime[SP]to[SP]quit...",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Gagner serait facile, mais les prix ne\nsont pas mirobolants.[1205][U+000F] Il est peut-être\ntemps d'arrêter..."
-  },
-  {
-    "id": 126,
-    "offset": 299802,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Harumph.[SP]Gambling[SP]is[SP]a[SP]man's[SP]sport...[SP]To[SP]risk\nmoney,[SP]fame,[SP]and[SP]potentially[SP]even[SP]your[SP]life[SP]for\na[SP]fighting[SP]chance.[SP]A[SP]casino[SP]is[SP]a[SP]battlefield!",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille!"
-  },
-  {
-    "id": 127,
-    "offset": 300116,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]hadn't[SP]realized[SP]Mu[SP]was[SP]one[SP]such[SP]place.\nTime[SP]to[SP]show[SP]my[SP]skill[SP]as[SP]a[SP]wizard[SP]at[SP]cards...[1205][U+000F]\nPoker[SP]is[SP]my[SP]specialty,[SP]after[SP]all!",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Je n'imaginais pas Mu être ce genre de\nlieu. Le sorcier des cartes va sévir...[1205][U+000F]\nCar le poker est ma spécialité!"
-  },
-  {
-    "id": 128,
-    "offset": 300398,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Harumph.[SP]Gambling[SP]is[SP]a[SP]man's[SP]sport...[SP]To[SP]risk\nmoney,[SP]fame,[SP]and[SP]potentially[SP]even[SP]your[SP]life[SP]for\na[SP]fighting[SP]chance.[SP]A[SP]casino[SP]is[SP]a[SP]battlefield!",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille!"
-  },
-  {
-    "id": 129,
-    "offset": 300712,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]hadn't[SP]realized[SP]Mu[SP]was[SP]one[SP]such[SP]place.\nTime[SP]to[SP]show[SP]my[SP]luck[SP]that[SP]made[SP]Las[SP]Vegas[1205][U+000F]\ntremble...[SP]Slots[SP]are[SP]my[SP]specialty,[SP]after[SP]all!",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Mu étais donc aussi ce genre de lieu.\nLa chance qui ébranla Las Vegas va sévir...\nCar les machines à sous sont ma spécialité!"
-  },
-  {
-    "id": 130,
-    "offset": 301008,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Harumph.[SP]Gambling[SP]is[SP]a[SP]man's[SP]sport...[SP]To[SP]risk\nmoney,[SP]fame,[SP]and[SP]potentially[SP]even[SP]your[SP]life[SP]for\na[SP]fighting[SP]chance.[SP]A[SP]casino[SP]is[SP]a[SP]battlefield!",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille!"
-  },
-  {
-    "id": 131,
-    "offset": 301322,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]hadn't[SP]realized[SP]Mu[SP]was[SP]one[SP]such[SP]place.\nTime[SP]to[SP]show[SP]my[SP]unbeatable[SP]tactics[SP]once[SP]again.[1205][U+000F]\nBlackjack's[SP]my[SP]specialty,[SP]after[SP]all!",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Je n'imaginais pas Mu être ce genre de\nlieu. Mes tactiques imparables vont sévir...[1205][U+000F]\nCar le blackjack est ma spécialité!"
-  },
-  {
-    "id": 132,
-    "offset": 301612,
-    "data_size": 238,
-    "slot_size": 242,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Hmm,[SP]so[SP]there's[SP]some[SP]sort[SP]of[SP]legendary[SP]weapon\nfor[SP]sale[SP]at[SP]that[SP]ramen[SP]shop...[SP]I'm[SP]glad[SP]someone\ntold[SP]me.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Hmm, ce restaurant de ramen vend une sorte\nd'arme légendaire... Heureusement qu'on m'a mis\nau jus."
-  },
-  {
-    "id": 133,
-    "offset": 301854,
-    "data_size": 226,
-    "slot_size": 230,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "That[SP]Clair[SP]de[SP]Lune[SP]place[SP]is[SP]selling[SP]some[SP]sort\nof[SP]legendary[SP]weapon.[1205][U+000F][SP]Are[SP]you[SP]interested[SP]as[SP]well?",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Cet endroit, Clair de Lune, vend une sorte\nd'arme légendaire.[1205][U+000F] Es-tu intéressé, toi aussi?"
-  },
-  {
-    "id": 134,
-    "offset": 302084,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle[SP]is[SP]claiming[SP]he[SP]has[SP]no\nlegendary[SP]weapon,[SP]just[SP]to[SP]drive[SP]up[SP]its[SP]price.[1205][U+000F]\nHah![SP]I'm[SP]not[SP]fooled,[SP]believe[SP]you[SP]me!",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Le gérant du Time Castle nie posséder une\narme légendaire, juste pour faire monter ses prix.[1205][U+000F]\nHah! Je suis pas dupe, crois-moi!"
-  },
-  {
-    "id": 135,
-    "offset": 302384,
-    "data_size": 164,
-    "slot_size": 168,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Apparently,[SP]Time[SP]Castle's[SP]legendary[SP]weapon[SP]is\nheld[SP]up[SP]in[SP]transit.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "L'arme légendaire du Time Castle ne serait\npas encore arrivée."
-  },
-  {
-    "id": 136,
-    "offset": 302552,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "The[SP]seller[SP]is[SP]still[SP]at[SP]the[SP]abandoned[SP]factory.[1205][U+000F]\nI[SP]suppose[SP]someone[SP]could[SP]try[SP]to[SP]get[SP]there[SP]first\nand[SP]buy[SP]it[SP]directly[SP]from[SP]him...",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Le vendeur est encore à l'usine abandonnée.[1205][U+000F]\nJ'imagine que quelqu'un devrait directement y\naller pour la lui acheter..."
-  },
-  {
-    "id": 137,
-    "offset": 302842,
-    "data_size": 244,
-    "slot_size": 248,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "Demon,[SP]eh...?[1205][U+000F][SP]Well,[SP]the[SP]fantastical[SP]Last\nBattalion[SP]actually[SP]existed.[SP]Who's[SP]to[SP]say\ndemons[SP]don't[SP]as[SP]well?",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Un démon, hein...?[1205][U+000F] Eh bien, le Bataillon\nexistait vraiment. Donc pourquoi pas les\ndémons aussi?"
-  },
-  {
-    "id": 138,
-    "offset": 303090,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "The[SP]rumor[SP]about[SP]Time[SP]Castle's[SP]legendary[SP]weapon\nbeing[SP]stolen[SP]by[SP]demons[SP]may[SP]also[SP]be[SP]true.[1205][U+000F][SP]Not\nthat[SP]I[SP]care.[SP]The[SP]time[SP]of[SP]Idealian[SP]is[SP]coming!",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "La rumeur des démons ayant volée l'arme\nlégendaire du Time Castle peut aussi être\nvraie.[1205][U+000F] Mais qu'importe. L'ère des Idéaliens arrive!"
-  },
-  {
-    "id": 139,
-    "offset": 303404,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]heard[SP]a[SP]woman[SP]with[SP]impeccable[SP]composure\nbought[SP]the[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Une femme au calme inébranlable aurait\nachetée l'arme légendaire du Time Castle."
-  },
-  {
-    "id": 140,
-    "offset": 303612,
-    "data_size": 182,
-    "slot_size": 186,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "I[SP]expect[SP]I'll[SP]be[SP]fine[SP]without[SP]it,[SP]as[SP]I[SP]was\nnaturally[SP]strong[SP]to[SP]begin[SP]with.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Je m'en sortirais sans j'imagine, comme\nje suis naturellement fort."
-  },
-  {
-    "id": 141,
-    "offset": 303798,
-    "data_size": 232,
-    "slot_size": 236,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "It[SP]seems[SP]the[SP]owner[SP]of[SP]Time[SP]Castle[SP]made[SP]a\npresent[SP]of[SP]his[SP]legendary[SP]weapon[SP]to[SP]a[SP]girl\nwith[SP]short[SP]hair.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Le propriétaire du Time Castle aurait\noffert son arme légendaire à une fille\naux cheveux courts."
-  },
-  {
-    "id": 142,
-    "offset": 304034,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Pompous[SP]man",
-    "texte_orig": "What[SP]a[SP]smooth[SP]operator...[SP]Nowhere[SP]near[SP]as\nsmooth[SP]as[SP]myself,[SP]though.",
-    "nom_fr": "Homme pompeux",
-    "texte_fr": "Quel sacré manipulateur... Pas aussi doué\nque moi, ceci dit."
-  },
-  {
-    "id": 143,
-    "offset": 304206,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "Hm?[SP]Oh,[SP]it's[SP]you,[SP][1113].[1205][U+000F][SP]Didn't[SP]think[SP]I'd\nsee[SP]you[SP]here.[1205][U+000F][SP]You[SP]probably[SP]know[SP]already,[SP]but\nour[SP]HQ[SP]was[SP]destroyed.[SP]What[SP]a[SP]disaster!",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 144,
-    "offset": 304494,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "The[SP]police[SP]should[SP]be[SP]the[SP]first[SP]line[SP]of[SP]defense\nfor[SP]the[SP]civilians,[SP]but[SP]we're[SP]powerless[SP]with[SP]our\nHQ[SP]burned[SP]down![1205][U+000F][SP]I[SP]never[SP]saw[SP]it[SP]coming.",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 145,
-    "offset": 304802,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "By[SP]the[SP]way,[SP]what[SP]are[SP]you[SP]doing[SP]here?[1205][U+000F][SP]You\nbetter[SP]not[SP]be[SP]sniffing[SP]around[SP]to[SP]satisfy\nsome[SP]childish[SP]curiosity[SP]of[SP]yours!",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 146,
-    "offset": 305074,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "You'll[SP]just[SP]impede[SP]the[SP]investigation.[SP]Go[SP]take\nyour[SP]friends[SP]and[SP]find[SP]somewhere[SP]to[SP]hide.",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 147,
-    "offset": 305284,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "Honestly,[SP]nothing's[SP]changed.[SP]Society[SP]starts\nbreaking[SP]down[SP]and[SP]we[SP]have[SP]to[SP]deal[SP]with[SP]stupid\nhoaxes.[1205][U+000F][SP][1432][NULL][NULL][0014]Last[SP]Battalion[1432][NULL][NULL][0014][SP]my[SP]foot!",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 148,
-    "offset": 305584,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "It's[SP]obvious[SP]the[SP]group[SP]of[SP]five[SP]terrorists\nwitnessed[SP]at[SP]the[SP]scene[SP]is[SP]behind[SP]it[SP]all.[1205][U+000F]\nDon't[SP]get[SP]taken[SP]in[SP]by[SP]silly[SP]rumors,[SP]okay?",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 149,
-    "offset": 305874,
-    "data_size": 46,
-    "slot_size": 50,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "......",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 150,
-    "offset": 305924,
-    "data_size": 108,
-    "slot_size": 112,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "You[SP]should[SP]go[SP]home.[SP]Leave[SP]this[SP]to[SP]us.",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 151,
-    "offset": 306036,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "The[SP]people[SP]in[SP]the[SP]sketches[SP]are[SP]heroes[SP]fighting\nthe[SP]Last[SP]Battalion,[SP]huh...[1205][U+000F][SP]Did[SP]you[SP]guys[SP]save\nthose[SP]kids[SP]on[SP]the[SP]news?",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 152,
-    "offset": 306308,
-    "data_size": 318,
-    "slot_size": 322,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "Hmph.[SP]Well,[SP]I'll[SP]let[SP]it[SP]slide.[SP]I[SP]don't[SP]plan[SP]on\ninterrogating[SP]you[SP]or[SP]anything.[1205][U+000F][SP]But[SP]I[SP]think[SP]it\nwas[SP]our[SP]father's[SP]blood[SP]that[SP]made[SP]you[SP]save[SP]them.",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 153,
-    "offset": 306630,
-    "data_size": 106,
-    "slot_size": 110,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "Why[SP]can't[SP]you[SP]just[SP]admit[SP]it[SP]already?",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 154,
-    "offset": 306740,
-    "data_size": 146,
-    "slot_size": 150,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "[1113]!?[SP]What[SP]are[SP]you[SP]doing[SP]here!?[SP]Do[SP]you\nwant[SP]to[SP]be[SP]killed!?",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 155,
-    "offset": 306890,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "Protecting[SP]the[SP]populace[SP]is[SP]our[SP]job![SP]You[SP]need\nto[SP]go[SP]find[SP]a[SP]good[SP]hiding[SP]place.",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 156,
-    "offset": 307080,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "What[SP]did[SP]the[SP]Masked[SP]Circle[SP]mean[SP]by[SP]the[SP]Leonids\nbeing[SP]the[SP][1432][NULL][NULL][0014]lion's[SP]roar[1432][NULL][NULL][0014]?[1205][U+000F][SP]Is[SP]this[SP]about[SP]that\nOracle[SP]in[SP]the[SP]book!?",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 157,
-    "offset": 307356,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "That's[SP]ridiculous![SP]Astronomers[SP]have[SP]known\nthose[SP]meteors[SP]would[SP]fall[SP]now[SP]for[SP]decades.\nIt's[SP]got[SP]nothing[SP]to[SP]do[SP]with[SP]any[SP]oracle!",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 158,
-    "offset": 307640,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "[1113]'s[SP]brother",
-    "texte_orig": "Rgh...[SP]We[SP]still[SP]can't[SP]contain[SP]them[SP]without\nany[SP]backup...[1205][U+000F][SP]They're[SP]wreaking[SP]havoc[SP]in[SP]that\ntemple[SP]and[SP]we[SP]have[SP]to[SP]sit[SP]here[SP]and[SP]wait!?",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 159,
-    "offset": 307940,
-    "data_size": 296,
-    "slot_size": 300,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "This[SP]museum[SP]was[SP]built[SP]pretty[SP]recently.[SP]I[SP]hear\nthey[SP]have[SP]lots[SP]of[SP]different[SP]kinds[SP]of[SP]planes\non[SP]display...[1205][U+000A][SP]We[SP]should[SP]check[SP]it[SP]out[SP]sometime!",
-    "nom_fr": "Maya",
-    "texte_fr": "Ce musée a été bâti assez récemment. Apparemment\nils exposent de nombreux types d'avions...[1205][U+000F]\nOn pourrais y faire un tour, un jour!"
-  },
-  {
-    "id": 160,
-    "offset": 308240,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "I'm[SP]surprised[SP]we[SP]made[SP]it[SP]out[SP]alive...[1205][U+000F][SP]I[SP]mean\nout[SP]of[SP]the[SP]blimp,[SP]not[SP]the[SP]museum...",
-    "nom_fr": "Ginko",
-    "texte_fr": "Je pensais pas qu'on sortirais vivants...[1205][U+000F] Du\ndirigeable, hein, pas du musée..."
-  },
-  {
-    "id": 161,
-    "offset": 308430,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Yukino",
-    "texte_orig": "Hmm,[SP]this[SP]is[SP]some[SP]pretty[SP]nice[SP]scenery.[SP]I'll\nhave[SP]to[SP]remember[SP]to[SP]get[SP]a[SP]picture[SP]later.",
-    "nom_fr": "Yukino",
-    "texte_fr": "Hmm, la vue est pas mal d'ici. Je dois me\nrappeler de prendre une photo plus tard."
-  },
-  {
-    "id": 162,
-    "offset": 308626,
-    "data_size": 172,
-    "slot_size": 176,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "We[SP]promised[SP]to[SP]meet[SP]up[SP]at[SP]the[SP]detective[SP]agency,\nright?[SP]We[SP]should[SP]get[SP]going.",
-    "nom_fr": "Ginko",
-    "texte_fr": "On a promis de se regrouper à l'agence\nde détectives, pas vrai? Dépêchons."
-  },
-  {
-    "id": 163,
-    "offset": 308802,
-    "data_size": 110,
-    "slot_size": 114,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "That[SP]reminds[SP]me...[SP]She[SP]liked[SP]the[SP]sea,[SP]too...",
-    "nom_fr": "Ginko",
-    "texte_fr": "J'y repense... elle aussi aimait l'océan..."
-  },
-  {
-    "id": 164,
-    "offset": 308916,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Whoa,[SP]isn't[SP]it[SP]a[SP]little[SP]early[SP]in[SP]the[SP]year[SP]to\ntake[SP]a[SP]swim[SP]in[SP]the[SP]ocean?",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Wouah, on fait pas trempette dans la mer\naussi tôt dans l'année, si?"
-  },
-  {
-    "id": 165,
-    "offset": 309086,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "We've[SP]got[SP]the[SP]crystal[SP]skull[SP]from[SP]this[SP]place.\nWhere[SP]to[SP]next?",
-    "nom_fr": "Ginko",
-    "texte_fr": "On a le crâne de crystal de cet endroit.\nOn va où ensuite?"
-  },
-  {
-    "id": 166,
-    "offset": 309230,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "There's[SP]still[SP]people[SP]fighting[SP]in[SP]there!?[1205][U+000F]\nBut[SP]there's[SP]no[SP]crystal[SP]skull[SP]anymore!\nThere's[SP]nothing[SP]for[SP]them[SP]to[SP]fight[SP]over!",
-    "nom_fr": "Ginko",
-    "texte_fr": "Il y a encore des gens qui se battent\nlà-dedans!?[1205][U+000F] Mais il n'y a plus de crâne\nde crytal pour lequel se battre!"
-  },
-  {
-    "id": 167,
-    "offset": 309496,
-    "data_size": 142,
-    "slot_size": 146,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "[1113],[SP]everyone's[SP]waiting[SP]at[SP]the[SP]detective\nagency.[SP]We[SP]should[SP]go.",
-    "nom_fr": "Ginko",
-    "texte_fr": "[1113], les autres attendent à l'agence de\ndétectives. Allons-y."
-  },
-  {
-    "id": 168,
-    "offset": 309642,
-    "data_size": 150,
-    "slot_size": 154,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "What[SP]the[SP]hell,[SP]man!?[SP]They[SP]burned[SP]down[SP]the\npolice[SP]headquarters!",
-    "nom_fr": "Eikichi",
-    "texte_fr": "C'est quoi ce bordel!? Ils ont brûlé le\nQG de la police!"
-  },
-  {
-    "id": 169,
-    "offset": 309796,
-    "data_size": 78,
-    "slot_size": 82,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Did[SP]King[SP]Leo[SP]do[SP]this[SP]too...?",
-    "nom_fr": "Ginko",
-    "texte_fr": "Le Roi Lion a fait ça...?"
-  },
-  {
-    "id": 170,
-    "offset": 309878,
-    "data_size": 232,
-    "slot_size": 236,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "It[SP]was[SP]probably[SP]to[SP]prevent[SP]the[SP]police[SP]from\ninterfering...[1205][U+000F][SP]We're[SP]the[SP]only[SP]ones[SP]left[SP]who\ncan[SP]stop[SP]him[SP]now.",
-    "nom_fr": "Maya",
-    "texte_fr": "C'était sûrement pour empêcher la police\nd'interférer...[1205][U+000F] Il ne reste que nous pour\nl'arrêter désormais."
-  },
-  {
-    "id": 171,
-    "offset": 310114,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "We[SP]can't[SP]go[SP]in[SP]at[SP]this[SP]rate...[1205][U+000F][SP]The[SP]nerve[SP]of\nthat[SP]asshole!",
-    "nom_fr": "Eikichi",
-    "texte_fr": "On peut pas continuer comme ça...[1205][U+000F] Ce\nconnard est gonflé!"
-  },
-  {
-    "id": 172,
-    "offset": 310262,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Let's[SP]get[SP]out[SP]of[SP]here,[SP][1113].[SP]They're[SP]gonna\narrest[SP]us[SP]if[SP]we[SP]stand[SP]around[SP]like[SP]this.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Sortons de là, [1113]. Ils vont nous\narrêter si on reste plantés là."
-  },
-  {
-    "id": 173,
-    "offset": 310446,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "If[SP]the[SP]police[SP]are[SP]this[SP]bad[SP]off,[SP]the[SP]city's\ncompletely[SP]defenseless.[SP]King[SP]Leo[SP]only[SP]ended\nup[SP]helping[SP]those[SP]bastards!",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Si la police est à ce point dans la\nmouise, la ville est sans-défense. Le Roi\nLion a vraiment aidé ces enfoirés!"
-  },
-  {
-    "id": 174,
-    "offset": 310702,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Looks[SP]like[SP]there's[SP]no[SP]one[SP]here.[SP]Let's[SP]go\nsomewhere[SP]else,[SP][1113].",
-    "nom_fr": "Ginko",
-    "texte_fr": "Il n'y a personne ici, on dirait. Allons\nailleurs, [1113]."
-  },
-  {
-    "id": 175,
-    "offset": 310846,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "We[SP]shouldn't[SP]go[SP]in[SP]without[SP]Maya-san.[SP]Let's\ncome[SP]back[SP]after[SP]we've[SP]met[SP]up[SP]with[SP]the[SP]others\nback[SP]at[SP]the[SP]detective[SP]agency.",
-    "nom_fr": "Ginko",
-    "texte_fr": "On devrais éviter d'avancer sans Maya.\nRevenons après avoir rejoint les autres\nà l'agence de détectives."
-  },
-  {
-    "id": 176,
-    "offset": 311106,
-    "data_size": 170,
-    "slot_size": 174,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "I[SP]don't[SP]have[SP]the[SP]key[SP]to[SP]my[SP]room[SP]on[SP]me[SP]now.\nLet's[SP]come[SP]back[SP]some[SP]other[SP]time.",
-    "nom_fr": "Maya",
-    "texte_fr": "Je n'ai pas la clé de ma chambre sur moi,\nlà. Revenons une autre fois."
-  },
-  {
-    "id": 177,
-    "offset": 311280,
-    "data_size": 270,
-    "slot_size": 274,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Whoa,[SP]hold[SP]your[SP]horses.[SP]We[SP]haven't[SP]gotten[SP]the\nskull[SP]at[SP]Leo[SP]Temple[SP]yet,[SP]right?[SP]Let's[SP]take\ncare[SP]of[SP]that[SP]before[SP]we[SP]jump[SP]in[SP]here.",
-    "nom_fr": "Maya",
-    "texte_fr": "Whoa, pas si vite. On a pas encore récupéré\nle crâne du Temple de Leo, pas vrai?\nFaisons ça avant de sauter là-dedans."
-  },
-  {
-    "id": 178,
-    "offset": 311554,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "H-Hold[SP]the[SP]phone,[SP]man.[1205][U+000F][SP]We're[SP]still[SP]not[SP]done\nwith[SP]Scorpio[SP]Temple.[1205][U+000F][SP]Let's[SP]go[SP]grab[SP]the[SP]skull\nfrom[SP]there[SP]first.",
-    "nom_fr": "Eikichi",
-    "texte_fr": "M-minute papillon![1205][U+000F] On en a pas encore\nfini avec le Temple de Scorpio.[1205][U+000F] Récupérons\nle crâne là-bas d'abord."
-  },
-  {
-    "id": 179,
-    "offset": 311804,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Jun",
-    "texte_orig": "Hold[SP]on[SP]a[SP]moment.[SP]We're[SP]still[SP]not[SP]done[SP]with\nthe[SP]Aquarius[SP]Temple.",
-    "nom_fr": "Jun",
-    "texte_fr": "Un instant. Nous n'avons pas terminé le\nTemple d'Aquarius."
-  }
+    {
+        "id": 0,
+        "offset": 268814,
+        "data_size": 900,
+        "slot_size": 900,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Cool[SP]guy",
+        "texte_orig": "Heh...[SP]There's[SP]a[SP]nice[SP]breeze[SP]today,[SP]too...[1205][U+000F][NL]All[SP]men[SP]are[SP]on[SP]a[SP]journey,[SP]somewhere[SP]in[SP]their[NL]hearts.[NL][1106][E2][1431][U+0000][U+0000]\"Cool[SP]guy[NL]Just[SP]when[SP]they[SP]finally[SP]make[SP]it[SP]to[SP]shore[SP]and[NL]ought[SP]to[SP]think[SP]about[SP]settling[SP]down,[SP]they[SP]row[NL]out[SP]again[SP]into[SP]the[SP]sea.[NL][1106][E2][1431][U+0000][U+0000]\"Cool[SP]guy[NL]The[SP]sea[SP]is[SP]an[SP]eternal[SP]home[SP]for[SP]men[SP]like[SP]that...[1205][U+000F][NL]A[SP]place[SP]they[SP]always[SP]find[SP]themselves[SP]back[SP]at.[NL][1106][E2][1431][U+0000][U+0000]\"Cool[SP]guy[NL]Kid,[SP]this[SP]here[SP]Kounan[SP]is[SP]another[SP]such[SP]place.[1205][U+000F][NL]It's[SP]a[SP]city[SP]made[SP]for[SP]the[SP]hardboiled.",
+        "nom_fr": "Gars cool",
+        "texte_fr": "Aujourd'hui aussi, la brise est douce...[1205][U+000F]\nChacun vit son voyage, quelque part dans\nson coeur.[1106][NL]Au moment où ils atteignent la côte et\nenvisagent de s'installer, ils repartent voguer\nen mer.[1106][NL]L'océan est un refuge éternel pour ces gens...[1205][U+000F]\nUn endroit où ils ne cessent de retourner.[1106][NL]Kounan est un endroit comme ça, gamin.[1205][U+000F]\nC'est une ville de durs à cuire."
+    },
+    {
+        "id": 1,
+        "offset": 269714,
+        "data_size": 850,
+        "slot_size": 850,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Cool[SP]guy",
+        "texte_orig": "I[SP]think[SP]you[SP]get[SP]the[SP]picture[SP]already[SP]that[SP]this[NL]is[SP]a[SP]city[SP]for[SP]the[SP]hardboiled.[SP]For[SP]adults.[1205][U+000F][SP]But[NL]look[SP]at[SP]that[SP]building[SP]with[SP]the[SP]blimp[SP]on[SP]top...[NL][1106][E2][1431][U+0000][U+0000]\"Cool[SP]guy[NL]The[SP]goddamn[SP]Aerospace[SP]Museum.[1205][U+000F][SP]Ever[SP]since[SP]they[NL]built[SP]that[SP]thing,[SP]packs[SP]of[SP]wild[SP]kids[SP]swarm[SP]here[NL]on[SP]class[SP]trips[SP]and[SP]such.[NL][1106][E2][1431][U+0000][U+0000]\"Cool[SP]guy[NL]I[SP]hate[SP]rugrats.[SP]This[SP]city[SP]ain't[SP]so[SP]much[SP]for[SP]me[NL]anymore.[1205][U+000F][SP]Guess[SP]the[SP]day[SP]is[SP]coming[SP]when[SP]I'll[SP]be[NL]going[SP]back[SP]to[SP]the[SP]sea.",
+        "nom_fr": "Gars cool",
+        "texte_fr": "T'as dû piger que c'était une ville taillée\npour les durs à cuire, les adultes.[1205][U+000F] Mais regarde\nce bâtiment avec le dirigeable au sommet...[1106][NL]Ce fichu Musée Aéronautique.[1205][U+000F] Depuis sa construction,\ny'a foule de gosses qui viennent en voyage\nscolaire ou autre.[1106][NL]Je hais les mômes. Cette ville me correspond\nplus du tout.[1205][U+000F] Il doit être temps pour moi\nde retourner en mer."
+    },
+    {
+        "id": 2,
+        "offset": 270564,
+        "data_size": 378,
+        "slot_size": 378,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Cool[SP]guy",
+        "texte_orig": "Looks[SP]like[SP]a[SP]pack[SP]of[SP]kids[SP]is[SP]here[SP]at[SP]the[NL]Aerospace[SP]Museum[SP]on[SP]some[SP]kinda[SP]field[SP]trip.[1205][U+000F][NL]Their[SP]voices[SP]carry[SP]on[SP]the[SP]sea[SP]breeze...[NL][1106][E2][1431][U+0000][U+0000]\"Cool[SP]guy[NL]Tch.[SP]This[SP]is[SP]why[SP]I[SP]hate[SP]rugrats!",
+        "nom_fr": "Gars cool",
+        "texte_fr": "On dirait que des gamins sont en voyage\nscolaire au Musée de l'Aéronautique.[1205][U+000F]\nLeurs voix se mêlent à la brise marine...[1106][NL]Tss. Je hais les mioches!"
+    },
+    {
+        "id": 3,
+        "offset": 270942,
+        "data_size": 684,
+        "slot_size": 684,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Cool[SP]guy",
+        "texte_orig": "Some[SP]kids[SP]were[SP]just[SP]here[SP]and[SP]told[SP]me[SP]the[SP]group[NL]of[SP]five[SP]in[SP]the[SP]news[SP]are[SP]actually[SP]heroes[SP]fighting[NL]the[SP]Masked[SP]Circle.[SP]Then[SP]they[SP]took[SP]off.[NL][1106][E2][1431][U+0000][U+0000]\"Cool[SP]guy[NL]Those[SP]were[SP]the[SP]kids[SP]from[SP]the[SP]museum,[SP]right?[NL]Tch.[SP]Looks[SP]like[SP]they[SP]were[SP]okay.[NL][1106][E2][1431][U+0000][U+0000]\"Cool[SP]guy[NL]So[SP]those[SP]five[SP]saved[SP]some[SP]kids,[SP]did[SP]they?[1205][U+000F][NL]...Don't[SP]seem[SP]like[SP]such[SP]a[SP]bad[SP]bunch[SP]to[SP]me.",
+        "nom_fr": "Gars cool",
+        "texte_fr": "Des gamins sont venus me dire que les cinq\nqu'on voit aux infos étaient des héros combattant\nle Cercle Masqué. Puis ils sont partis.[1106][NL]C'était les enfants du musée, pas vrai?\nTss. On dirait qu'ils sont saufs.[1106][NL]Ces cinq-là ont sauvés des gamins, hein?[1205][U+000F]\n...Ils ont pas l'air de mauvais bougres."
+    },
+    {
+        "id": 4,
+        "offset": 271626,
+        "data_size": 552,
+        "slot_size": 552,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Cool[SP]guy",
+        "texte_orig": "The[SP]In[SP]Lak'ech,[SP]huh...?[SP]If[SP]the[SP]stuff[SP]written[SP]in[NL]that[SP]is[SP]true,[SP]the[SP]world's[SP]gonna[SP]end[SP]once[SP]the[NL]Grand[SP]Cross[SP]is[SP]finished.[NL][1106][E2][1431][U+0000][U+0000]\"Cool[SP]guy[NL]This[SP]city[SP]and[SP]this[SP]sea[SP]could[SP]disappear.[1205][U+000F][NL]And[SP]my[SP]journey[SP]might[SP]end[SP]along[SP]with[SP]them.[1205][U+000F][NL]A[SP]sad[SP]ending[SP]to[SP]the[SP]hard[SP]life[SP]I've[SP]led...",
+        "nom_fr": "Gars cool",
+        "texte_fr": "L'In Lak'ech, hein...? Si ce qui y est écrit\nest vrai, la Croix Cosmique causera la fin du\nmonde une fois réalisée.[1106][NL]Cette ville et cette mer pourraient disparaître.[1205][U+000F]\nMon voyage pourrait cesser avec elles.[1205][U+000F]\nUne triste fin à ma rude vie..."
+    },
+    {
+        "id": 5,
+        "offset": 272178,
+        "data_size": 300,
+        "slot_size": 300,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Cool[SP]guy",
+        "texte_orig": "Tch.[SP]If[SP]those[SP]guys[SP]are[SP]here,[SP]the[SP]In[SP]Lak'ech[SP]is[NL]looking[SP]more[SP]and[SP]more[SP]right[SP]all[SP]the[SP]time.[1205][U+000F][SP]Are[NL]those[SP]soldiers[SP]gonna[SP]destroy[SP]the[SP]world?",
+        "nom_fr": "Gars cool",
+        "texte_fr": "Tss. Si ces mecs sont là, l'In Lak'ech\nparaît de plus en plus crédible.[1205][U+000F] Ces\nsoldats vont vraiment détruire le monde?"
+    },
+    {
+        "id": 6,
+        "offset": 272478,
+        "data_size": 540,
+        "slot_size": 540,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Cool[SP]guy",
+        "texte_orig": "You[SP]see[SP]those[SP]meteors,[SP]kid?[1205][U+000F][SP]The[SP]Masked[SP]Circle[NL]guys[SP]say[SP]that's[SP]the[SP][U+1432][U+0000][U+0000][U+0014]lion's[SP]roar[U+1432][U+0000][U+0000][U+0014][SP]part[SP]of[NL]their[SP]Oracle.[NL][1106][E2][1431][U+0000][U+0000]\"Cool[SP]guy[NL]Heh,[SP]I[SP]should've[SP]at[SP]least[SP]made[SP]a[SP]wish[SP]on[SP]'em.[NL]With[SP]that[SP]many[SP]of[SP]'em[SP]shooting[SP]down,[SP]I[SP]bet[NL]I[SP]could've[SP]had[SP]lots[SP]of[SP]wishes[SP]come[SP]true.",
+        "nom_fr": "Gars cool",
+        "texte_fr": "Tu vois ces météores?[1205][U+000F] D'après ceux du Cercle\nMasqué c'est le [1432][NULL][NULL][0014]rugissement du lion[1432][NULL][NULL][0014] de\nleur oracle.[1106][NL]Hah, j'aurais du en profiter pour faire un voeu.\nVu leur nombre, je parie que beaucoup de mes\nvoeux se réaliseraient."
+    },
+    {
+        "id": 7,
+        "offset": 273018,
+        "data_size": 610,
+        "slot_size": 610,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Cool[SP]guy",
+        "texte_orig": "What[SP]the[SP]hell[SP]is[SP]that?[1205][U+000A][SP]It's[SP]blown[SP]the[SP]hard-[NL]boiled[SP]atmosphere[SP]to[SP]hell[SP]and[SP]gone![1205][U+000F][SP]Just[SP]when[NL]the[SP]Aerospace[SP]Museum[SP]was[SP]kaput,[SP]too...[NL][1106][E2][1431][U+0000][U+0000]\"Cool[SP]guy[NL]I[SP]can't[SP]take[SP]it[SP]anymore![1205][U+000A][SP]I'm[SP]going[SP]on[SP]another[NL]journey![1205][U+000A][SP]I'll[SP]take[SP]a[SP]ship,[SP]set[SP]sail,[SP]and...[1205][U+000F][NL]Well,[SP]I'll[SP]probably[SP]fall[SP]off[SP]the[SP]edge,[SP]huh...",
+        "nom_fr": "Gars cool",
+        "texte_fr": "C'était quoi ça, bordel?[1205][U+000A] Ça a totalement pulvérisé\nl'atmosphère![1205][U+000A] Comme quand le Musée\nAéronautique était kaput...[1106][NL]J'en peux plus![1205][U+000A] Je repars en voyage![1205][U+000A]\nJe vais prendre un bateau, larguer les amarres\net...[1205][U+000A] Ben... sûrement tomber du rebord, hum..."
+    },
+    {
+        "id": 8,
+        "offset": 273628,
+        "data_size": 584,
+        "slot_size": 584,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Sad[SP]woman",
+        "texte_orig": "That's[SP]Ebisu[SP]Beach.[1205][U+000F][SP]It[SP]got[SP]its[SP]name[SP]because[NL]people[SP]called[SP]the[SP]corpses[SP]that[SP]used[SP]to[SP]drift[NL]ashore[SP][U+1432][U+0000][U+0000][U+0014]Ebisu-sama[U+1432][U+0000][U+0000][U+0014]...[NL][1106][E2][1431][U+0000][U+0000]\"Sad[SP]woman[NL]A[SP]beach[SP]bequeathed[SP]with[SP]the[SP]names[SP]of[SP]those[SP]who[NL]ended[SP]their[SP]transient[SP]lives...[1205][U+000F][SP]A[SP]fitting[SP]place[NL]for[SP]one[SP]like[SP]me[SP]who[SP]can't[SP]forget[SP]her[SP]man...",
+        "nom_fr": "Femme triste",
+        "texte_fr": "C'est la plage d'Ebisu.[1205][U+000A] Son nom vient des\ngens qui nommaient les corps ramenés par la\nhoule [1432][NULL][NULL][0014]Ebisu[1432][NULL][NULL][0014]...[1106][NL]Une plage accablée des noms de ceux ayant mis\nfin à leurs vies fugaces...[1205][U+000F] Ce lieu me va\nbien, moi qui ne peux oublier mon amour..."
+    },
+    {
+        "id": 9,
+        "offset": 274212,
+        "data_size": 426,
+        "slot_size": 426,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Sad[SP]woman",
+        "texte_orig": "That[SP]gentleman...[1205][U+000F][SP]He[SP]seemed[SP]to[SP]be[SP]a[SP]police[NL]detective,[SP]but[SP]he[SP]looked[SP]like[SP]my[SP]dead[SP]lover...[NL][1106][E2][1431][U+0000][U+0000]\"Sad[SP]woman[NL]...[1205][U+000F]O-Oh[SP]my,[SP]what's[SP]come[SP]over[SP]me...?[1205][U+000F][SP]I[SP]feel[NL]suddenly[SP]flushed.[SP]This[SP]is[SP]so[SP]unlike[SP]me...",
+        "nom_fr": "Femme triste",
+        "texte_fr": "Ce gentilhomme...[1205][U+000F] Il semble être policier,\nmais il ressemble à mon défunt mari...[1106][NL]...[1205][U+000F] O-oh mais, qu'est ce qui me prend...?[1205][U+000F]\nJe rougis. Ça ne me ressemble pas..."
+    },
+    {
+        "id": 10,
+        "offset": 274638,
+        "data_size": 556,
+        "slot_size": 556,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Lovestruck[SP]woman",
+        "texte_orig": "I[SP]wonder[SP]what[SP]that[SP]police[SP]detective's[SP]name[SP]is...[1205][U+000F][NL]Th-Those[SP]glasses[SP]really[SP]suit[SP]him...[1205][U+000F][SP]Such[SP]a[NL]sharp[SP]look...[NL][1106][E2][1431][U+0000][U+0000]\"Lovestruck[SP]woman[NL]*sigh*[SP]Oh,[SP]what[SP]have[SP]I[SP]gotten[SP]myself[SP]into?[1205][U+000F][NL]This[SP]could[SP]be[SP]serious...[1205][U+000F][SP]Excuse[SP]me,[SP]do[SP]you[NL]happen[SP]to[SP]know[SP]that[SP]man's[SP]name?",
+        "nom_fr": "Femme éprise",
+        "texte_fr": "Je me demande comment s'appelle ce policier...[1205][U+000F]\nC-ces lunettes lui vont vraiment bien...[1205][U+000F]\nQuelle classe...[1106][NL]*soupir* Oh, dans quoi je me suis fourrée?[1205][U+000F]\nÇa pourrait être sérieux...[1205][U+000F] Excusez-moi,\nauriez-vous le nom de cet homme?"
+    },
+    {
+        "id": 11,
+        "offset": 275194,
+        "data_size": 872,
+        "slot_size": 872,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Lovestruck[SP]woman",
+        "texte_orig": "I[SP]wonder[SP]what's[SP]wrong...[1205][U+000F][SP]They[SP]posted[SP]composite[NL]sketches[SP]of[SP]the[SP]suspects,[SP]but[SP]that[SP]police[NL]detective[SP]looks[SP]so[SP]sad[SP]about[SP]it...[1106][E2][1431][U+0000][U+0000]\"Lovestruck[SP]woman[NL]If[SP]I[SP]was[SP]his[SP]lover,[SP]it[SP]would[SP]be[SP]up[SP]to[SP]me[SP]to[NL]talk[SP]to[SP]him[SP]about[SP]it...[SP]But[SP]it's[SP]not[SP]my[SP]place.[NL]I[SP]can[SP]only[SP]watch[SP]him[SP]from[SP]afar[SP]like[SP]this.[1106][E2][1431][U+0000][U+0000]\"Lovestruck[SP]woman[NL]Oh,[SP]I[SP]nearly[SP]forgot.[SP]I[SP]bought[SP]the[SP]same[SP]style[NL]of[SP]glasses[SP]he[SP]wears.[SP]What[SP]do[SP]you[SP]think?[SP]Do[SP]they[NL]look[SP]good[SP]on[SP]me?",
+        "nom_fr": "Femme éprise",
+        "texte_fr": "Qu'est ce qui ne va pas...[1205][U+000F] Les\nportraits-robot des suspects sont sortis, mais ça\nsemble attrister ce détective de police...[1106][NL]Si j'étais son amante, ce serait à moi de lui\nparler... Mais ce n'est pas ma place.\nJe peux seulement l'observer de loin.[1106][NL]Oh, j'oubliais. J'ai acheté des lunettes au style\nsimilaire aux siennes. Qu'en penses-tu? Elles\nme vont bien?"
+    },
+    {
+        "id": 12,
+        "offset": 276066,
+        "data_size": 280,
+        "slot_size": 280,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Lovestruck[SP]woman",
+        "texte_orig": "That[SP]police[SP]detective[SP]seems[SP]happy[SP]for[SP]some[NL]reason[SP]after[SP]hearing[SP]the[SP]news.[1205][U+000F][SP]It's[SP]the[SP]first[NL]time[SP]I've[SP]seen[SP]him[SP]smile.",
+        "nom_fr": "Femme éprise",
+        "texte_fr": "Ce détective de police semblait heureux en\nentendant les informations.[1205][U+000F] C'est la première fois\nque je l'ai vu sourire."
+    },
+    {
+        "id": 13,
+        "offset": 276346,
+        "data_size": 274,
+        "slot_size": 274,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Lovestruck[SP]woman",
+        "texte_orig": "I-I[SP]was[SP]almost[SP]attacked[SP]by[SP]those[SP]soldiers...[1205][U+000F][NL]But[SP]that[SP]police[SP]detective[SP]saved[SP]me![1205][U+000F][SP]Ahhh,[SP]I[NL]could[SP]die[SP]happy[SP]now!",
+        "nom_fr": "Femme éprise",
+        "texte_fr": "C-ces soldats m'ont presque agressée...[1205][U+000F]\nMais ce policier m'a sauvée![1205][U+000F] Ahhh,\nje peux mourir heureuse désormais!"
+    },
+    {
+        "id": 14,
+        "offset": 276620,
+        "data_size": 272,
+        "slot_size": 272,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Lovestruck[SP]woman",
+        "texte_orig": "Hm?[1205][U+000A][SP]That[SP]blonde[SP]girl[SP]with[SP]you...[1205][U+000A][SP]Didn't[SP]she[SP]go[NL]into[SP]that[SP]temple[SP]a[SP]second[SP]ago?[1205][U+000F][SP]Was[SP]I[SP]just[NL]seeing[SP]things...?",
+        "nom_fr": "Femme éprise",
+        "texte_fr": "Hm?[1205][U+000F] Cette fille blonde avec toi...[1205][U+000F] Elle\nn'est pas entrée dans ce temple à l'instant?[1205][U+000F]\nOu j'ai halluciné...?"
+    },
+    {
+        "id": 15,
+        "offset": 276892,
+        "data_size": 478,
+        "slot_size": 478,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "That[SP]producer,[SP]Ginji[SP]Sasaki...[1205][U+000F][SP]Looks[SP]like[SP]he's[NL]got[SP]a[SP]new[SP]idol[SP]group[SP]lined[SP]up.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]Songs[SP]slake[SP]my[SP]heart's[SP]thirst...[1205][U+000F][SP]What[SP]sort[SP]of[NL]message[SP]will[SP]Muses[SP]inscribe[SP]into[SP]my[SP]heart?[1205][U+000F][NL]The[SP]suspense[SP]is[SP]delectable...",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Ce producteur, Ginji Sasaki...[1205][U+000F] Il aurait formé\nun nouveau groupe d'idols.[1106][NL]La musique étanche la soif de mon coeur...[1205][U+000F]\nQuel message Muses gravera dans mon coeur?[1205][U+000F]\nCe suspense est délicieux..."
+    },
+    {
+        "id": 16,
+        "offset": 277370,
+        "data_size": 524,
+        "slot_size": 524,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "From[SP]what[SP]I've[SP]heard...[1205][U+000F][SP]The[SP]veil[SP]of[SP]mystery[NL]surrounding[SP]the[SP]third[SP]member[SP]will[SP]be[SP]torn[SP]off[NL]during[SP]the[SP]live[SP]recording[SP]at[SP]Giga[SP]Macho...[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]Oh,[SP]how[SP]I've[SP]waited[SP]for[SP]this[SP]day![1205][U+000F][SP]Now,[SP]lady[SP]of[NL]many[SP]enigmas...[1205][U+000F][SP]reveal[SP]to[SP]me[SP]your[SP]face!",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "De ce que je sais...[1205][U+000F] Le voile mystèrieux\nenveloppant le troisième membre sera levé durant la\ndiffusion en direct au Giga Macho...[1106][NL]Oh, j'ai tant attendu ce jour![1205][U+000F] Maintenant,\nénigmatique dame...[1205][U+000F] révèle ton visage!"
+    },
+    {
+        "id": 17,
+        "offset": 277894,
+        "data_size": 624,
+        "slot_size": 624,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "A[SP]concert,[SP]hmm?[1205][U+000F][SP]To[SP]think[SP]I'd[SP]be[SP]graced[SP]with[NL]their[SP]singing[SP]voices[SP]so[SP]soon...[1205][U+000F][SP]I[SP]should[SP]make[NL]for[SP]the[SP]outdoor[SP]concert[SP]hall[SP]post-haste.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]A[SP]ticket?[1205][U+000F][SP]Ha![SP]I[SP]need[SP]no[SP]ticket.[SP]I[SP]shall[SP]listen[NL]to[SP]them[SP]from[SP]beyond[SP]the[SP]wall.[SP]There[SP]are[SP]more[NL]ways[SP]to[SP]show[SP]one's[SP]support[SP]than[SP]making[SP]a[SP]fuss.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Un concert, hmm?[1205][U+000F] Dire que je vais déjà\npouvoir être béni de leurs chants...[1205][U+000F] Je dois\nme préparer pour le concert séance tenante.[1106][NL]Un ticket?[1205][U+000F] Ha! Pas besoin de ticket. J'écouterais\npar-delà le mur. S'agiter bêtement n'est pas\nla seule façon de témoigner son soutien."
+    },
+    {
+        "id": 18,
+        "offset": 278518,
+        "data_size": 588,
+        "slot_size": 588,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Ha.[SP]So[SP]the[SP]concert[SP]hall[SP]has[SP]burned[SP]to[SP]ash...[1205][U+000F][NL]The[SP]building[SP]itself[SP]couldn't[SP]contain[SP]its[NL]excitement[SP]for[SP]the[SP]Muses'[SP]song.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]Fortunate,[SP]then,[SP]that[SP]I[SP]was[SP]outside.[SP]But[SP]one[NL]thing[SP]seems[SP]amiss.[1205][U+000F][SP]Muses[SP]was[SP]meant[SP]to[SP]be[SP]a[NL]trio,[SP]but...[1205][U+000F][SP]Who[SP]was[SP]there[SP]besides[SP]Lisa-chan?",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Ha. La salle de concert a brûlée...[1205][U+000F]\nLe bâtiment lui-même n'a pu contenir l'excitation\nissue des chansons de Muses.[1106][NL]Il est bon d'être resté dehors. Mais une\nchose ne colle pas.[1205][U+000F] Muses est censé être un\ntrio, mais...[1205][U+000F] Qui était aux côtés de Lisa?"
+    },
+    {
+        "id": 19,
+        "offset": 279106,
+        "data_size": 852,
+        "slot_size": 852,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Apparently[SP]the[SP]terrorists[SP]behind[SP]these[SP]attacks[NL]are[SP]a[SP]mysterious[SP]organization[SP]called[SP]the[SP]Last[NL]Battalion.[1205][U+000F][SP]I've[SP]heard[SP]people[SP]talk[SP]about[SP]them.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]If[SP]that's[SP]what[SP]they[SP]were[SP]up[SP]against,[SP]then[SP]even[NL]if[SP]the[SP]police[SP]weren't[SP]handicapped,[SP]they[SP]would[NL]have[SP]had[SP]little[SP]success.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]At[SP]least[SP]now[SP]they[SP]have[SP]a[SP]good[SP]excuse[SP]for[SP]their[NL]failure[SP]to[SP]protect[SP]the[SP]city--they[SP]were[SP]victims[NL]of[SP]the[SP]same[SP]arson.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Apparemment les terroristes derrière ces attaques\nsont une organisation mystérieuse nommée Bataillon.[1205][U+000F]\nJ'ai entendu des gens en parler.[1106][NL]Si ils doivent affronter ça, même si la\npolice n'était pas incapacitée, ils n'auraient\npresque aucune chance.[1106][NL]Au moins maintenant ils ont une bonne raison\nd'échouer à protéger la ville--ils sont\nvictimes eux aussi."
+    },
+    {
+        "id": 20,
+        "offset": 279958,
+        "data_size": 532,
+        "slot_size": 532,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "The[SP]men[SP]at[SP]Sumaru[SP]TV[SP]are[SP]frantically[SP]gathering[NL]material.[1205][U+000F][SP]I[SP]presume[SP]they're[SP]putting[SP]together[SP]a[NL]special[SP]on[SP]the[SP]terror[SP]wave.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]Ha![SP]If[SP]only[SP]they[SP]had[SP]talked[SP]to[SP]me,[SP]I[SP]could[SP]have[NL]recounted[SP]the[SP]smallest[SP]details[SP]of[SP]how[SP]the[SP]blimp[NL]took[SP]off.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Ceux de Sumaru TV rassemblent hâtivement du\nmatériel.[1205][U+000F] Ils préparent une émission spéciale sur\nles drames, je présume.[1106][NL]Ha! Si seulement ils m'avaient parlé, j'aurais\nreconté chaque petit détail de l'envol du\ndirigeable."
+    },
+    {
+        "id": 21,
+        "offset": 280490,
+        "data_size": 760,
+        "slot_size": 760,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Hmph...[SP]The[SP]In[SP]Lak'ech[SP]says[SP]we'll[SP]evolve[SP]into[NL]a[SP]higher[SP]form,[SP]called[SP]Idealians,[SP]upon[SP]the[NL]completion[SP]of[SP]the[SP]Grand[SP]Cross.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]A[SP]juicy[SP]story,[SP]no?[1205][U+000F][SP]I[SP]choose[SP]to[SP]believe[SP]it.[1205][U+000F][NL]My[SP]life[SP]would[SP]never[SP]end[SP]this[SP]way.[SP]There[SP]has[SP]to[NL]be[SP]a[SP]more[SP]stimulating[SP]future[SP]in[SP]store[SP]for[SP]me.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]Hohoho,[SP]I[SP]can[SP]scarcely[SP]wait[SP]for[SP]the[SP]moment[SP]of[NL]our[SP]transfiguration.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Hm... Selon l'In Lak'ech nous évoluerons en\nIdéaliens, une forme supérieure, quand la Croix\nCosmique sera complète.[1106][NL]Une histoire intéressante, non?[1205][U+000F] J'ai décidé d'y\ncroire.[1205][U+000F] Ma vie ne saurait s'achever ainsi.\nUn futur plus stimulant doit m'attendre.[1106][NL]Hohoho, je ne puis attendre l'instant de notre\ntransfiguration."
+    },
+    {
+        "id": 22,
+        "offset": 281250,
+        "data_size": 222,
+        "slot_size": 222,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Hmph...[SP]Most[SP]of[SP]the[SP]Last[SP]Battalion[SP]has[SP]fled[NL]for[SP]Mt.[SP]Katatsumuri.[1205][U+000F][SP]Scared[SP]of[SP]me,[SP]I'll[SP]wager.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Hmph... Le Bataillon est allé vers le Mont\nKatatsumuri.[1205][U+000F] Effrayé par moi, je parie."
+    },
+    {
+        "id": 23,
+        "offset": 281472,
+        "data_size": 272,
+        "slot_size": 272,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "I[SP]pity[SP]the[SP]poor[SP]souls[SP]below[SP]us...[SP]But[SP]at[SP]least[NL]our[SP]evolution[SP]will[SP]go[SP]unimpeded.[1205][U+000F][SP]Still,[SP]just[NL]how[SP]will[SP]the[SP]world[SP]end?",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Ah, ces pauvres âmes là-dessous... Au moins\nrien ne gênera notre évolution.[1205][U+000F] Mais comment le\nmonde sera anéanti?"
+    },
+    {
+        "id": 24,
+        "offset": 281744,
+        "data_size": 214,
+        "slot_size": 214,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "The[SP]Earth's[SP]destruction,[SP]eh...[1205][U+000F][SP]Do[SP]you[SP]suppose[NL]a[SP]meteor[SP]or[SP]somesuch[SP]will[SP]hit[SP]the[SP]Earth?",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "La fin du monde, hein...[1205][U+000F] Penses-tu qu'un\nmétéore ou équivalent va frapper la Terre?"
+    },
+    {
+        "id": 25,
+        "offset": 281958,
+        "data_size": 514,
+        "slot_size": 514,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "An[SP]acquaintance[SP]of[SP]mine[SP]told[SP]me[SP]that[SP]when[SP]the[NL]Grand[SP]Cross[SP]is[SP]complete,[SP]electrified[SP]rain[SP]will[NL]pour[SP]down[SP]upon[SP]the[SP]Earth.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]That[SP]is[SP]supposedly[SP]the[SP]manner[SP]of[SP]its[SP]demise.[1205][U+000F][NL]Nothing[SP]for[SP]us[SP]to[SP]worry[SP]about,[SP]up[SP]here[SP]in[SP]the[NL]heavens.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "D'après une connaissance, lorsque la Croix\nCosmique sera complète, une pluie électrifiée\ns'abattra sur Terre.[1106][NL]Bah, sûrement une divagation issue de sa terreur.[1205][U+000F]\nDans ce paradis nous ne sommes pas inquiétés."
+    },
+    {
+        "id": 26,
+        "offset": 282472,
+        "data_size": 474,
+        "slot_size": 474,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Things[SP]are[SP]becoming[SP]interesting[SP]indeed.[1205][U+000A][SP]I[SP]hear[NL]now[SP]that[SP]the[SP]Grand[SP]Cross[SP]will[SP]halt[SP]the[SP]Earth's[NL]rotation[SP]entirely.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]Now[SP]that's[SP]more[SP]like[SP]it.[1205][U+000A][SP]Even[SP]the[SP]method[SP]of[NL]its[SP]destruction[SP]is[SP]decadent![1205][U+000A][SP]Ohohoho!",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Les choses deviennent intéressantes.[1205][U+000F] J'entend\ndire que la Croix Cosmique va stopper la\nrotation terrestre.[1106][NL]Ça, ça me plaît.[1205][U+000F] Même sa façon d'être\ndétruite est décadente![1205][U+000F] Ohohohoho!"
+    },
+    {
+        "id": 27,
+        "offset": 282946,
+        "data_size": 314,
+        "slot_size": 314,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "There[SP]are[SP]allegedly[SP]talking[SP]flowers[SP]in[SP]Aoba[NL]Park.[SP]I[SP]don't[SP]relish[SP]the[SP]thought[SP]of[SP]giving[SP]one[NL]as[SP]a[SP]present[SP]and[SP]having[SP]it[SP]let[SP]slip[SP]a[SP]secret...",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Il y aurait des fleurs qui parlent au Parc\nd'Aoba. Je n'apprécie pas l'idée d'en offrir\nune et de la voir révèler un secret..."
+    },
+    {
+        "id": 28,
+        "offset": 283260,
+        "data_size": 476,
+        "slot_size": 476,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "I[SP]hear[SP]that[SP]Zodiac's[SP]second[SP]floor[SP]is[SP]stuffed[NL]with[SP]t[SP]reasure[SP]now.[SP]I'd[SP]like[SP]to[SP]see[SP]it[SP]for[NL]myself...[1205][U+000F][SP]if[SP]it[SP]weren't[SP]for[SP]the[SP]monsters.[1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]*sigh*[SP]Surely[SP]there[SP]must[SP]be[SP]one[SP]foolproof[SP]way[NL]of[SP]getting[SP]rich[SP]quickly.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Le second étage du Zodiac serait actuellement\nrempli de trésors. Je serais bien allé\nvoir...[1205][U+000F] s'il n'y avait pas ces monstres.[1106][NL]*soupir* Un moyen sûr de s'enrichir rapidement\ndoit bien exister."
+    },
+    {
+        "id": 29,
+        "offset": 283736,
+        "data_size": 280,
+        "slot_size": 280,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "The[SP]ghost[SP]of[SP]an[SP]idol[SP]singer[SP]who[SP]died[SP]young[NL]has[SP]been[SP]appearing[SP]at[SP]Aoba[SP]Park.[1205][U+000F][SP]Can[SP]she[NL]still[SP]not[SP]forget[SP]me,[SP]even[SP]in[SP]death?",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Le fantôme d'une idol, morte jeune, apparaîtrait\nau Parc d'Aoba.[1205][U+000F] Faillirait-elle à\nm'oublier, même dans la mort?"
+    },
+    {
+        "id": 30,
+        "offset": 284016,
+        "data_size": 616,
+        "slot_size": 616,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "There's[SP]something[SP]called[SP]a[SP]Cursed[SP]Taxi[SP]parked[NL]at[SP]the[SP]abandoned[SP]factory.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]I've[SP]heard[SP]stories[SP]of[SP]it[SP]running[SP]down[SP]victims[NL]at[SP]night,[SP]then[SP]resting[SP]during[SP]the[SP]day.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]You'd[SP]think[SP]that[SP]would[SP]serve[SP]only[SP]to[SP]shrink[SP]its[NL]customer[SP]base.[SP]Hardly[SP]a[SP]sound[SP]business[SP]strategy!",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Un dénommé Taxi Maudit serait garé à\nl'usine abandonnée.[1106][NL]Des histoires racontent qu'il fauche ses\nvictimes la nuit et se repose le jour.[1106][NL]Cela ne peux que faire baisser sa clientèle.\nHasardeux, comme stratégie marketing!"
+    },
+    {
+        "id": 31,
+        "offset": 284632,
+        "data_size": 252,
+        "slot_size": 252,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Apparently[SP]the[SP]Cursed[SP]Taxi[SP]at[SP]the[SP]abandoned[NL]factory[SP]was[SP]actually[SP]a[SP]Cursed[SP]Escort.[SP]Not[SP]that[NL]I[SP]care[SP]one[SP]whit.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Apparemment le Taxi Maudit de l'usine abandonnée\nétait en fait une Escorte Maudite. Bah,\nje m'en fiche."
+    },
+    {
+        "id": 32,
+        "offset": 284884,
+        "data_size": 640,
+        "slot_size": 640,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Kuchisake-onna,[SP]hmm...?[SP]That[SP]story[SP]gave[SP]me[NL]quite[SP]a[SP]fright[SP]as[SP]a[SP]child.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]Ah,[SP]the[SP]memories...[1205][U+000F][SP]I[SP]doubt[SP]children[SP]your[SP]age[NL]would[SP]know[SP]who[SP]she[SP]is.[1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]Then[SP]here's[SP]a[SP]social[SP]studies[SP]assignment[SP]for[NL]you:[SP]Go[SP]to[SP]this[SP]Mt.[SP]Iwato[SP]place.[1205][U+000F][SP]Apparently[NL]you[SP]can[SP]see[SP]her[SP]for[SP]yourself[SP]there.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Kuchisake-onna, hein...? Enfant, cette histoire\nme terrorisait.[1106][NL]Que de souvenirs...[1205][U+000F] Je doute qu'à votre âge\nvous la connaissiez.[1106][NL]Tenez, voici un devoir de sciences sociales:\nallez à ce Mont Iwato, là.[1205][U+000F] Vous pourriez\nla voir vous-même là-bas."
+    },
+    {
+        "id": 33,
+        "offset": 285524,
+        "data_size": 648,
+        "slot_size": 648,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Jumping[SP]Geezer,[SP]hmm...?[SP]I[SP]used[SP]to[SP]compete[SP]with[NL]him[SP]quite[SP]often[SP]on[SP]mountain[SP]passes.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]He[SP]was[SP]much[SP]faster[SP]than[SP]me,[SP]though.[1205][U+000F][SP]He[SP]jumped[NL]right[SP]over[SP]my[SP]GT8.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]If[SP]you[SP]care[SP]to[SP]challenge[SP]him,[SP]go[SP]to[SP]Mt.[NL]Katatsumuri.[SP]The[SP]cursed[SP]six[SP]hairpin[SP]curves...[1205][U+000F][NL]He'll[SP]be[SP]waiting[SP]there[SP]for[SP]you.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Le Vieux à Ressort, hein...? Je le défiais\nsouvent sur les sentiers à l'époque.[1106][NL]Mais il était plus rapide.[1205][U+000F] Il sautais\nau dessus de ma GT8.[1106][NL]Si vous voulez l'affronter, allez au Mont\nKatatsumuri. Les six virages en épingle maudits...[1205][U+000F]\nIl vous y attendra."
+    },
+    {
+        "id": 34,
+        "offset": 286172,
+        "data_size": 308,
+        "slot_size": 308,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Harumph...[1205][U+000F][SP]I[SP]can't[SP]believe[SP]I'm[SP]letting[SP]this[NL]ridiculous[SP]story[SP]affect[SP]me...[1205][U+000F][SP]Kudan,[SP]hmm?[1205][U+000F][NL]At[SP]that[SP]abandoned[SP]factory...[1205][U+000F][SP]No![SP]No[SP]more!",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Grumpf...[1205][U+000F] Il est impensable que cette ridicule\nhistoire puisse m'affecter...[1205][U+000F]Kudan, hmm?[1205][U+000F]\nÀ l'usine abandonnée...[1205][U+000F] Non! Assez!"
+    },
+    {
+        "id": 35,
+        "offset": 286480,
+        "data_size": 248,
+        "slot_size": 248,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Hmm...[SP]It[SP]appears[SP]the[SP]rumor[SP]was[SP]true[SP]about[SP]the[NL]secret[SP]CD[SP]at[SP]Giga[SP]Macho.[1205][U+000F][SP]Time[SP]for[SP]me[SP]to[SP]go[SP]pick[NL]it[SP]up...",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Hmm... Il semble que la rumeur du CD secret\ndu Giga Macho était fondée.[1205][U+000F] Je dois aller\nle chercher..."
+    },
+    {
+        "id": 36,
+        "offset": 286728,
+        "data_size": 350,
+        "slot_size": 350,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Have[SP]you[SP]heard?[1205][U+000F][SP]There's[SP]a[SP]creature[SP]called[NL]a[SP]Dresser[SP]Hag[SP]at[SP]the[SP]abandoned[SP]factory.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]By[SP]all[SP]accounts,[SP]it[SP]shoves[SP]passersby[SP]into[SP]its[NL]dresser.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Es-tu au courant? Une dénommée Sorcière de\nla Commode est à l'usine abandonnée.[1106][NL]Elle encastrerait les passants dans sa\ncommode."
+    },
+    {
+        "id": 37,
+        "offset": 287078,
+        "data_size": 508,
+        "slot_size": 508,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Ah,[SP]I[SP]have[SP]a[SP]hot[SP]tip[SP]for[SP]you.[1205][U+000F][SP]I'll[SP]let[SP]you[SP]in[NL]on[SP]it,[SP]provided[SP]you[SP]don't[SP]tell[SP]anyone[SP]else...[1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]You[SP]see...[1205][U+000F][SP]A[SP]store[SP]called[SP]Time[SP]Castle[SP]in[NL]Rengedai[SP]sells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]quality[NL]and[SP]price[SP]are[SP]average.[SP]Shocking,[SP]no?",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Ah, j'ai un bon plan pour toi.[1205][U+000F] Je te le\ndirais, si tu promets de ne pas en parler...[1106][NL]Tu vois...[1205][U+000F] Time Castle à Rengedai vendrait\nde vraies armes.[1205][U+000F] Le prix et la qualité y\nsont standards. Dingue, non?"
+    },
+    {
+        "id": 38,
+        "offset": 287586,
+        "data_size": 526,
+        "slot_size": 526,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Ah,[SP]I[SP]have[SP]a[SP]hot[SP]tip[SP]for[SP]you.[1205][U+000F][SP]I'll[SP]let[SP]you[SP]in[NL]on[SP]it,[SP]provided[SP]you[SP]don't[SP]tell[SP]anyone[SP]else...[1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]You[SP]see...[1205][U+000F][SP]A[SP]store[SP]called[SP]Time[SP]Castle[SP]in[NL]Rengedai[SP]sells[SP]real[SP]weapons.[1205][U+000F][SP]Their[SP]quality[NL]is[SP]good,[SP]but[SP]they're[SP]expensive.[SP]Shocking,[SP]no?",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Ah, j'ai un bon plan pour toi.[1205][U+000F] Je te le\ndirais, si tu promets de ne pas en parler...[1106][NL]Tu vois...[1205][U+000F] Time Castle à Rengedai vendrait\nde vraies armes.[1205][U+000F] La sélection y est\nbonne, mais coûteuse. Dingue, non?"
+    },
+    {
+        "id": 39,
+        "offset": 288112,
+        "data_size": 498,
+        "slot_size": 498,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Ah,[SP]I[SP]have[SP]a[SP]hot[SP]tip[SP]for[SP]you.[1205][U+000F][SP]I'll[SP]let[SP]you[SP]in[NL]on[SP]it,[SP]provided[SP]you[SP]don't[SP]tell[SP]anyone[SP]else...[1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]You[SP]see...[1205][U+000F][SP]A[SP]store[SP]called[SP]Time[SP]Castle[SP]in[NL]Rengedai[SP]sells[SP]real[SP]weapons.[1205][U+000F][SP]They're[SP]cheap,[NL]but[SP]low[SP]quality.[SP]Shocking,[SP]no?",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Ah, j'ai un bon plan pour toi.[1205][U+000F] Je te le\ndirais, si tu promets de ne pas en parler...[1106][NL]Tu vois...[1205][U+000F] Time Castle à Rengedai vendrait\nde vraies armes.[1205][U+000F] C'est pas cher, mais de\nbasse qualité. Dingue, non?"
+    },
+    {
+        "id": 40,
+        "offset": 288610,
+        "data_size": 276,
+        "slot_size": 276,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Great[SP]selection,[SP]but[SP]low[SP]resale[SP]value?[SP]Hmph,[NL]even[SP]that[SP]Tony[SP]has[SP]a[SP]hand[SP]in[SP]illicit[SP]weapon[NL]sales...[1205][U+000F][SP]The[SP]bastard's[SP]good.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Bonne sélection, mais bas prix de revente?\nHmph, même ce Tony traîne dans le trafic\nd'armes...[1205][U+000F] Doué, cet enfoiré."
+    },
+    {
+        "id": 41,
+        "offset": 288886,
+        "data_size": 264,
+        "slot_size": 264,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Poor[SP]quality,[SP]but[SP]decent[SP]prices?[SP]Hmph,[NL]even[SP]that[SP]Tony[SP]has[SP]a[SP]hand[SP]in[SP]illicit[SP]weapon[NL]sales...[1205][U+000F][SP]The[SP]bastard's[SP]good.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Basse qualité, mais prix décents? Hmph,\nmême ce Tony traîne dans le trafic\nd'armes...[1205][U+000F] Doué, cet enfoiré."
+    },
+    {
+        "id": 42,
+        "offset": 289150,
+        "data_size": 318,
+        "slot_size": 318,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Satisfaction[SP]guaranteed[SP]through[SP]average[SP]prices[NL]and[SP]quality?[SP]Hmph,[SP]even[SP]that[SP]Tony[SP]has[SP]a[SP]hand[NL]in[SP]illicit[SP]weapon[SP]sales...[1205][U+000F][SP]The[SP]bastard's[SP]good.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Prix et qualité standardisés pour une\nsatisfaction assurée? Hmph, même ce Tony traîne\ndans le trafic d'armes...[1205][U+000F] Doué, cet enfoiré."
+    },
+    {
+        "id": 43,
+        "offset": 289468,
+        "data_size": 286,
+        "slot_size": 286,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Expensive[SP]stock,[SP]but[SP]the[SP]highest[SP]quality...[NL]Hmph,[SP]even[SP]that[SP]Tony[SP]has[SP]a[SP]hand[SP]in[SP]illicit[NL]weapon[SP]sales...[1205][U+000F][SP]The[SP]bastard's[SP]good.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Des produits coûteux, mais de haute qualité...\nHmph, même ce Tony traîne dans le trafic\nd'armes...[1205][U+000F] Doué, cet enfoiré."
+    },
+    {
+        "id": 44,
+        "offset": 289754,
+        "data_size": 306,
+        "slot_size": 306,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its[NL]repertoire[SP]to[SP]include[SP]weapons.[SP]Their[SP]selection[NL]isn't[SP]the[SP]best,[SP]but[SP]their[SP]resale[SP]value[SP]is[SP]high.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. L'offre n'y est pas la meilleure,\nmais la valeur de revente est haute."
+    },
+    {
+        "id": 45,
+        "offset": 290060,
+        "data_size": 248,
+        "slot_size": 248,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its[NL]repertoire[SP]to[SP]include[SP]weapons.[SP]They're[SP]cheap,[NL]but[SP]dismal[SP]quality.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. Elles sont bon marché,\nmais médiocres."
+    },
+    {
+        "id": 46,
+        "offset": 290308,
+        "data_size": 280,
+        "slot_size": 280,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its[NL]repertoire[SP]to[SP]include[SP]weapons.[SP]The[SP]quality[SP]is[NL]excellent,[SP]but[SP]the[SP]prices[SP]are[SP]high.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. C'est d'excellente facture,\nmais vraiment cher."
+    },
+    {
+        "id": 47,
+        "offset": 290588,
+        "data_size": 294,
+        "slot_size": 294,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its[NL]repertoire[SP]to[SP]include[SP]weapons.[SP]Their[SP]selection[NL]is[SP]great,[SP]but[SP]their[SP]resale[SP]prices[SP]aren't.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. La sélection y est bonne,\nmais pas les prix de revente."
+    },
+    {
+        "id": 48,
+        "offset": 290882,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "It[SP]seems[SP]Clair[SP]de[SP]Lune[SP]has[SP]expanded[SP]its[NL]repertoire[SP]to[SP]include[SP]weapons.[SP]Their[SP]quality[NL]and[SP]prices[SP]are[SP]merely[SP]ordinary.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. Le prix et la qualité\ny sont ordinaires."
+    },
+    {
+        "id": 49,
+        "offset": 291152,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "I[SP]never[SP]noticed[SP]that[SP]the[SP]local[SP]cafe[SP]sold[NL]weapons[SP]before.[SP]Scuttlebutt[SP]is[SP]that[SP]their[NL]quality[SP]and[SP]prices[SP]are[SP]average.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Le prix et la\nqualité y seraient corrects."
+    },
+    {
+        "id": 50,
+        "offset": 291418,
+        "data_size": 280,
+        "slot_size": 280,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "I[SP]never[SP]noticed[SP]that[SP]the[SP]local[SP]cafe[SP]sold[NL]weapons[SP]before.[SP]Scuttlebutt[SP]is[SP]that[SP]their[NL]prices[SP]are[SP]low,[SP]but[SP]so[SP]is[SP]the[SP]quality.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Le prix et la\nqualité des produits y seraient bas."
+    },
+    {
+        "id": 51,
+        "offset": 291698,
+        "data_size": 292,
+        "slot_size": 292,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "I[SP]never[SP]noticed[SP]that[SP]the[SP]local[SP]cafe[SP]sold[NL]weapons[SP]before.[SP]Scuttlebutt[SP]is[SP]their[SP]selection[NL]is[SP]varied,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]low.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Leur offre serait\nvariée, mais la valeur de revente basse."
+    },
+    {
+        "id": 52,
+        "offset": 291990,
+        "data_size": 296,
+        "slot_size": 296,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "I[SP]never[SP]noticed[SP]that[SP]the[SP]local[SP]cafe[SP]sold[NL]weapons[SP]before.[SP]Scuttlebutt[SP]is[SP]they[SP]don't[SP]have[NL]much,[SP]but[SP]the[SP]resale[SP]price[SP]can't[SP]be[SP]beat.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. L'offre y serait\npauvre, mais les prix de revente très bons."
+    },
+    {
+        "id": 53,
+        "offset": 292286,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "I[SP]never[SP]noticed[SP]that[SP]the[SP]local[SP]cafe[SP]sold[NL]weapons[SP]before.[SP]Scuttlebutt[SP]is[SP]that[SP]their[NL]quality's[SP]great,[SP]but[SP]it's[SP]quite[SP]pricey.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Les produits y seraient\nde qualité, mais assez chers."
+    },
+    {
+        "id": 54,
+        "offset": 292568,
+        "data_size": 358,
+        "slot_size": 358,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "It[SP]appears[SP]that[SP]the[SP]boutique[SP]in[SP]Rengedai[NL]sells[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]I[SP]hear[SP]the[SP]quality[SP]and[SP]prices[SP]are[SP]average.[NL]There[SP]must[SP]be[SP]a[SP]lot[SP]of[SP]cowards[SP]in[SP]the[SP]region.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "La boutique de Rengedai vendrait des\narmures.[1106][NL]La qualité et les prix y seraient corrects.\nLa région doit grouiller de trouillards."
+    },
+    {
+        "id": 55,
+        "offset": 292926,
+        "data_size": 350,
+        "slot_size": 350,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "It[SP]appears[SP]that[SP]the[SP]boutique[SP]in[SP]Rengedai[NL]sells[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]I[SP]hear[SP]it's[SP]cheap,[SP]but[SP]low[SP]in[SP]quality.[SP]There[NL]must[SP]be[SP]a[SP]lot[SP]of[SP]cowards[SP]in[SP]the[SP]region.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "La boutique de Rengedai vendrait des\narmures.[1106][NL]Les prix comme la qualité y seraient bas.\nLa région doit grouiller de froussards."
+    },
+    {
+        "id": 56,
+        "offset": 293276,
+        "data_size": 366,
+        "slot_size": 366,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "It[SP]appears[SP]that[SP]the[SP]boutique[SP]in[SP]Rengedai[NL]sells[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]I[SP]hear[SP]it's[SP]high[SP]quality[SP]stuff,[SP]but[SP]expensive.[NL]There[SP]must[SP]be[SP]a[SP]lot[SP]of[SP]cowards[SP]in[SP]the[SP]region.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "La boutique à Rengedai vendrait des\narmures.[1106][NL]Ce serait de haute qualité, mais très cher.\nLa région doit être remplie de froussards."
+    },
+    {
+        "id": 57,
+        "offset": 293642,
+        "data_size": 276,
+        "slot_size": 276,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Is[SP]armor[SP]the[SP]latest[SP]fashion[SP]trend?[SP]Judging[SP]by[NL]Anima[SP]Mundi,[SP]apparently[SP]so.[SP]Their[SP]quality[SP]and[NL]prices[SP]are[SP]average[SP]at[SP]best.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Les armures sont à la mode? Apparemment oui,\nsi on regarde Anima Mundi. Leurs prix et\nqualité sont standards."
+    },
+    {
+        "id": 58,
+        "offset": 293918,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Is[SP]armor[SP]the[SP]latest[SP]fashion[SP]trend?[SP]Judging[SP]by[NL]Anima[SP]Mundi,[SP]apparently[SP]so.[SP]Their[SP]stock[SP]is[NL]cheap,[SP]but[SP]low[SP]in[SP]quality.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Les armures sont à la mode? Apparemment oui,\nsi on regarde Anima Mundi. C'est bon marché,\nmais de basse qualité."
+    },
+    {
+        "id": 59,
+        "offset": 294186,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Is[SP]armor[SP]the[SP]latest[SP]fashion[SP]trend?[SP]Judging[SP]by[NL]Anima[SP]Mundi,[SP]apparently[SP]so.[SP]Their[SP]selection[SP]is[NL]great,[SP]but[SP]their[SP]resale[SP]value[SP]is[SP]low.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Les armures sont à la mode? Apparemment oui,\nsi on regarde Anima Mundi. L'offre y est\ntrès bonne, mais pas le prix de revente."
+    },
+    {
+        "id": 60,
+        "offset": 294484,
+        "data_size": 288,
+        "slot_size": 288,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Is[SP]armor[SP]the[SP]latest[SP]fashion[SP]trend?[SP]Judging[SP]by[NL]Anima[SP]Mundi,[SP]apparently[SP]so.[SP]The[SP]quality[SP]is[NL]high,[SP]but[SP]the[SP]prices[SP]are[SP]equally[SP]so.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Les armures sont à la mode? Apparemment oui,\nsi on regarde Anima Mundi. La qualité y\nest élevée, mais les prix aussi."
+    },
+    {
+        "id": 61,
+        "offset": 294772,
+        "data_size": 280,
+        "slot_size": 280,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling[NL]real[SP]armor.[SP]They[SP]say[SP]the[SP]selection[SP]is[SP]poor,[NL]but[SP]the[SP]resale[SP]value[SP]is[SP]high.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. L'offre serait mauvaise,\nmais la revente paierait bien."
+    },
+    {
+        "id": 62,
+        "offset": 295052,
+        "data_size": 250,
+        "slot_size": 250,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling[NL]real[SP]armor.[SP]They[SP]say[SP]their[SP]quality[SP]and[SP]prices[NL]are[SP]average.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. Prix et qualité y seraient\nstandards."
+    },
+    {
+        "id": 63,
+        "offset": 295302,
+        "data_size": 290,
+        "slot_size": 290,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling[NL]real[SP]armor.[SP]They[SP]say[SP]the[SP]quality[SP]is[SP]excellent,[NL]but[SP]the[SP]prices[SP]are[SP]extravagant.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. La qualité y serait\nexcellente, mais les produits onéreux."
+    },
+    {
+        "id": 64,
+        "offset": 295592,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling[NL]real[SP]armor.[SP]They[SP]say[SP]their[SP]goods[SP]are[SP]cheap,[NL]but[SP]lacking[SP]in[SP]quality.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. On dit que c'est pas\ncher, mais de basse qualité."
+    },
+    {
+        "id": 65,
+        "offset": 295860,
+        "data_size": 278,
+        "slot_size": 278,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Have[SP]you[SP]heard?[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]is[SP]selling[NL]real[SP]armor.[SP]They[SP]say[SP]the[SP]selection[SP]is[SP]good,[NL]but[SP]the[SP]resale[SP]value[SP]is[SP]low.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. L'offre y serait bonne,\nmais pas la valeur de revente."
+    },
+    {
+        "id": 66,
+        "offset": 296138,
+        "data_size": 388,
+        "slot_size": 388,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "I'm[SP]impressed[SP]that[SP]London[SP]Clothier[SP]goes[SP]so[NL]far[SP]as[SP]to[SP]outfit[SP]people[SP]with[SP]real[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]Seems[SP]their[SP]selection's[SP]impressive,[SP]but[SP]their[NL]resale[SP]value[SP]is[SP]fairly[SP]low.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients.[1106][NL]Leur sélection semble géniale, mais la valeur\nde revente y est basse."
+    },
+    {
+        "id": 67,
+        "offset": 296526,
+        "data_size": 354,
+        "slot_size": 354,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "I'm[SP]impressed[SP]that[SP]London[SP]Clothier[SP]goes[SP]so[NL]far[SP]as[SP]to[SP]outfit[SP]people[SP]with[SP]real[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]Seems[SP]their[SP]stock[SP]is[SP]cheap,[SP]but[SP]not[SP]the[NL]highest[SP]quality.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients.[1106][NL]Ça semble être bon marché, mais de médiocre\nqualité."
+    },
+    {
+        "id": 68,
+        "offset": 296880,
+        "data_size": 368,
+        "slot_size": 368,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "I'm[SP]impressed[SP]that[SP]London[SP]Clothier[SP]goes[SP]so[NL]far[SP]as[SP]to[SP]outfit[SP]people[SP]with[SP]real[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]Their[SP]quality[SP]is[SP]unimpeachable,[SP]but[SP]the[SP]prices[NL]are[SP]quite[SP]steep.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients.[1106][NL]La qualité y est sans égale, mais les\nprix suivent avec."
+    },
+    {
+        "id": 69,
+        "offset": 297248,
+        "data_size": 366,
+        "slot_size": 366,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "I'm[SP]impressed[SP]that[SP]London[SP]Clothier[SP]goes[SP]so[NL]far[SP]as[SP]to[SP]outfit[SP]people[SP]with[SP]real[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]Seems[SP]the[SP]quality[SP]and[SP]price[SP]of[SP]their[SP]goods[NL]is[SP]fairly[SP]standard.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients.[1106][NL]La qualité et le prix de leurs produits\nsemblent standards."
+    },
+    {
+        "id": 70,
+        "offset": 297614,
+        "data_size": 394,
+        "slot_size": 394,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "I'm[SP]impressed[SP]that[SP]London[SP]Clothier[SP]goes[SP]so[NL]far[SP]as[SP]to[SP]outfit[SP]people[SP]with[SP]real[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]Seems[SP]their[SP]selection[SP]is[SP]less[SP]than[SP]impressive,[NL]but[SP]the[SP]resale[SP]value[SP]is[SP]high.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients.[1106][NL]Leur sélection semble quelconque, mais la\nvaleur de revente y est élevée."
+    },
+    {
+        "id": 71,
+        "offset": 298008,
+        "data_size": 592,
+        "slot_size": 592,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Blast[SP]it,[SP]I[SP]didn't[SP]win...[1205][U+000F][SP]Hm?[1205][U+000F][SP]Oh,[SP]I[SP]was[SP]just[NL]fuming[SP]about[SP]the[SP]magazine[SP]sweepstakes.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]I've[SP]heard[SP]that[SP]winners[SP]receive[SP]real[SP]weapons[NL]and[SP]items.[1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]They're[SP]allegedly[SP]not[SP]easy[SP]to[SP]win,[SP]but[SP]the[NL]prizes[SP]are[SP]fairly[SP]nice.[1205][U+000F][SP]I[SP]suppose[SP]I'll[SP]keep[NL]trying...",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Tss, j'ai pas gagné...[1205][U+000F] Hm?[1205][U+000F] Oh, je pestais\njuste sur les loteries de magazines.[1106][NL]Les gagnants pourraient y obtenir armes\net objets.[1106][NL]Il est difficile de gagner, mais les\nprix sont assez bons.[1205][U+000F] Je vais réessayer,\nj'imagine..."
+    },
+    {
+        "id": 72,
+        "offset": 298600,
+        "data_size": 602,
+        "slot_size": 602,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Blast[SP]it,[SP]I[SP]didn't[SP]win...[1205][U+000F][SP]Hm?[1205][U+000F][SP]Oh,[SP]I[SP]was[SP]just[NL]fuming[SP]about[SP]the[SP]magazine[SP]sweepstakes.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]I've[SP]heard[SP]that[SP]winners[SP]receive[SP]real[SP]weapons[NL]and[SP]items.[1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]They're[SP]allegedly[SP]very[SP]difficult[SP]to[SP]win,[SP]but[SP]the[NL]prizes[SP]are[SP]quite[SP]rare.[1205][U+000F][SP]I[SP]suppose[SP]I'll[SP]keep[NL]trying...",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Tss, j'ai pas gagné...[1205][U+000F] Hm?[1205][U+000F] Oh, je pestais\njuste sur les loteries de magazines.[1106][NL]Les gagnants pourraient y obtenir armes\net objets.[1106][NL]Gagner serait difficile, mais les prix\nsont vraiment rares.[1205][U+000F] Je vais réessayer,\nj'imagine..."
+    },
+    {
+        "id": 73,
+        "offset": 299202,
+        "data_size": 600,
+        "slot_size": 600,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Blast[SP]it,[SP]I[SP]didn't[SP]win...[1205][U+000F][SP]Hm?[1205][U+000F][SP]Oh,[SP]I[SP]was[SP]just[NL]fuming[SP]about[SP]the[SP]magazine[SP]sweepstakes.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]I've[SP]heard[SP]that[SP]winners[SP]receive[SP]real[SP]weapons[NL]and[SP]items.[1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]They're[SP]allegedly[SP]easy[SP]to[SP]win,[SP]but[SP]the[SP]prizes[NL]are[SP]no[SP]great[SP]shakes.[1205][U+000F][SP]Perhaps[SP]now's[SP]the[NL]time[SP]to[SP]quit...",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Tss, j'ai pas gagné...[1205][U+000F] Hm?[1205][U+000F] Oh, je pestais\njuste sur les loteries de magazines.[1106][NL]Les gagnants pourraient y obtenir armes\net objets.[1106][NL]Gagner serait facile, mais les prix ne\nsont pas mirobolants.[1205][U+000F] Il est peut-être\ntemps d'arrêter..."
+    },
+    {
+        "id": 74,
+        "offset": 299802,
+        "data_size": 596,
+        "slot_size": 596,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Harumph.[SP]Gambling[SP]is[SP]a[SP]man's[SP]sport...[SP]To[SP]risk[NL]money,[SP]fame,[SP]and[SP]potentially[SP]even[SP]your[SP]life[SP]for[NL]a[SP]fighting[SP]chance.[SP]A[SP]casino[SP]is[SP]a[SP]battlefield![1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]I[SP]hadn't[SP]realized[SP]Mu[SP]was[SP]one[SP]such[SP]place.[NL]Time[SP]to[SP]show[SP]my[SP]skill[SP]as[SP]a[SP]wizard[SP]at[SP]cards...[1205][U+000F][NL]Poker[SP]is[SP]my[SP]specialty,[SP]after[SP]all!",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille![1106][NL]Je n'imaginais pas Mu être ce genre de\nlieu. Le sorcier des cartes va sévir...[1205][U+000F]\nCar le poker est ma spécialité!"
+    },
+    {
+        "id": 75,
+        "offset": 300398,
+        "data_size": 610,
+        "slot_size": 610,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Harumph.[SP]Gambling[SP]is[SP]a[SP]man's[SP]sport...[SP]To[SP]risk[NL]money,[SP]fame,[SP]and[SP]potentially[SP]even[SP]your[SP]life[SP]for[NL]a[SP]fighting[SP]chance.[SP]A[SP]casino[SP]is[SP]a[SP]battlefield![1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]I[SP]hadn't[SP]realized[SP]Mu[SP]was[SP]one[SP]such[SP]place.[NL]Time[SP]to[SP]show[SP]my[SP]luck[SP]that[SP]made[SP]Las[SP]Vegas[1205][U+000F][NL]tremble...[SP]Slots[SP]are[SP]my[SP]specialty,[SP]after[SP]all!",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille![1106][NL]Mu étais donc aussi ce genre de lieu.\nLa chance qui ébranla Las Vegas va sévir...\nCar les machines à sous sont ma spécialité!"
+    },
+    {
+        "id": 76,
+        "offset": 301008,
+        "data_size": 604,
+        "slot_size": 604,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Harumph.[SP]Gambling[SP]is[SP]a[SP]man's[SP]sport...[SP]To[SP]risk[NL]money,[SP]fame,[SP]and[SP]potentially[SP]even[SP]your[SP]life[SP]for[NL]a[SP]fighting[SP]chance.[SP]A[SP]casino[SP]is[SP]a[SP]battlefield![1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]I[SP]hadn't[SP]realized[SP]Mu[SP]was[SP]one[SP]such[SP]place.[NL]Time[SP]to[SP]show[SP]my[SP]unbeatable[SP]tactics[SP]once[SP]again.[1205][U+000F][NL]Blackjack's[SP]my[SP]specialty,[SP]after[SP]all!",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille![1106][NL]Je n'imaginais pas Mu être ce genre de\nlieu. Mes tactiques imparables vont sévir...[1205][U+000F]\nCar le blackjack est ma spécialité!"
+    },
+    {
+        "id": 77,
+        "offset": 301612,
+        "data_size": 242,
+        "slot_size": 242,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Hmm,[SP]so[SP]there's[SP]some[SP]sort[SP]of[SP]legendary[SP]weapon[NL]for[SP]sale[SP]at[SP]that[SP]ramen[SP]shop...[SP]I'm[SP]glad[SP]someone[NL]told[SP]me.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Hmm, ce restaurant de ramen vend une sorte\nd'arme légendaire... Heureusement qu'on m'a mis\nau jus."
+    },
+    {
+        "id": 78,
+        "offset": 301854,
+        "data_size": 230,
+        "slot_size": 230,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "That[SP]Clair[SP]de[SP]Lune[SP]place[SP]is[SP]selling[SP]some[SP]sort[NL]of[SP]legendary[SP]weapon.[1205][U+000F][SP]Are[SP]you[SP]interested[SP]as[SP]well?",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Cet endroit, Clair de Lune, vend une sorte\nd'arme légendaire.[1205][U+000F] Es-tu intéressé, toi aussi?"
+    },
+    {
+        "id": 79,
+        "offset": 302084,
+        "data_size": 300,
+        "slot_size": 300,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle[SP]is[SP]claiming[SP]he[SP]has[SP]no[NL]legendary[SP]weapon,[SP]just[SP]to[SP]drive[SP]up[SP]its[SP]price.[1205][U+000F][NL]Hah![SP]I'm[SP]not[SP]fooled,[SP]believe[SP]you[SP]me!",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Le gérant du Time Castle nie posséder une\narme légendaire, juste pour faire monter ses prix.[1205][U+000F]\nHah! Je suis pas dupe, crois-moi!"
+    },
+    {
+        "id": 80,
+        "offset": 302384,
+        "data_size": 458,
+        "slot_size": 458,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Apparently,[SP]Time[SP]Castle's[SP]legendary[SP]weapon[SP]is[NL]held[SP]up[SP]in[SP]transit.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]The[SP]seller[SP]is[SP]still[SP]at[SP]the[SP]abandoned[SP]factory.[1205][U+000F][NL]I[SP]suppose[SP]someone[SP]could[SP]try[SP]to[SP]get[SP]there[SP]first[NL]and[SP]buy[SP]it[SP]directly[SP]from[SP]him...",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "L'arme légendaire du Time Castle ne serait\npas encore arrivée.[1106][NL]Le vendeur est encore à l'usine abandonnée.[1205][U+000F]\nJ'imagine que quelqu'un devrait directement y\naller pour la lui acheter..."
+    },
+    {
+        "id": 81,
+        "offset": 302842,
+        "data_size": 562,
+        "slot_size": 562,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "Demon,[SP]eh...?[1205][U+000F][SP]Well,[SP]the[SP]fantastical[SP]Last[NL]Battalion[SP]actually[SP]existed.[SP]Who's[SP]to[SP]say[NL]demons[SP]don't[SP]as[SP]well?[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]The[SP]rumor[SP]about[SP]Time[SP]Castle's[SP]legendary[SP]weapon[NL]being[SP]stolen[SP]by[SP]demons[SP]may[SP]also[SP]be[SP]true.[1205][U+000F][SP]Not[NL]that[SP]I[SP]care.[SP]The[SP]time[SP]of[SP]Idealian[SP]is[SP]coming!",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Un démon, hein...?[1205][U+000F] Eh bien, le Bataillon\nexistait vraiment. Donc pourquoi pas les\ndémons aussi?[1106][NL]La rumeur des démons ayant volée l'arme\nlégendaire du Time Castle peut aussi être\nvraie.[1205][U+000F] Mais qu'importe. L'ère des Idéaliens arrive!"
+    },
+    {
+        "id": 82,
+        "offset": 303404,
+        "data_size": 394,
+        "slot_size": 394,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "I[SP]heard[SP]a[SP]woman[SP]with[SP]impeccable[SP]composure[NL]bought[SP]the[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]I[SP]expect[SP]I'll[SP]be[SP]fine[SP]without[SP]it,[SP]as[SP]I[SP]was[NL]naturally[SP]strong[SP]to[SP]begin[SP]with.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Une femme au calme inébranlable aurait\nachetée l'arme légendaire du Time Castle.[1106][NL]Je m'en sortirais sans j'imagine, comme\nje suis naturellement fort."
+    },
+    {
+        "id": 83,
+        "offset": 303798,
+        "data_size": 408,
+        "slot_size": 408,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Pompous[SP]man",
+        "texte_orig": "It[SP]seems[SP]the[SP]owner[SP]of[SP]Time[SP]Castle[SP]made[SP]a[NL]present[SP]of[SP]his[SP]legendary[SP]weapon[SP]to[SP]a[SP]girl[NL]with[SP]short[SP]hair.[NL][1106][E2][1431][U+0000][U+0000]\"Pompous[SP]man[NL]What[SP]a[SP]smooth[SP]operator...[SP]Nowhere[SP]near[SP]as[NL]smooth[SP]as[SP]myself,[SP]though.",
+        "nom_fr": "Homme pompeux",
+        "texte_fr": "Le propriétaire du Time Castle aurait\noffert son arme légendaire à une fille\naux cheveux courts.[1106][NL]Quel sacré manipulateur... Pas aussi doué\nque moi, ceci dit."
+    },
+    {
+        "id": 84,
+        "offset": 304206,
+        "data_size": 1078,
+        "slot_size": 1078,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "[1113]'s[SP]brother",
+        "texte_orig": "Hm?[SP]Oh,[SP]it's[SP]you,[SP][1113].[1205][U+000F][SP]Didn't[SP]think[SP]I'd[NL]see[SP]you[SP]here.[1205][U+000F][SP]You[SP]probably[SP]know[SP]already,[SP]but[NL]our[SP]HQ[SP]was[SP]destroyed.[SP]What[SP]a[SP]disaster![NL][1106][E2][1431][U+0000][U+0000]\"[1113]'s[SP]brother[NL]The[SP]police[SP]should[SP]be[SP]the[SP]first[SP]line[SP]of[SP]defense[NL]for[SP]the[SP]civilians,[SP]but[SP]we're[SP]powerless[SP]with[SP]our[NL]HQ[SP]burned[SP]down![1205][U+000F][SP]I[SP]never[SP]saw[SP]it[SP]coming.[NL][1106][E2][1431][U+0000][U+0000]\"[1113]'s[SP]brother[NL]By[SP]the[SP]way,[SP]what[SP]are[SP]you[SP]doing[SP]here?[1205][U+000F][SP]You[NL]better[SP]not[SP]be[SP]sniffing[SP]around[SP]to[SP]satisfy[NL]some[SP]childish[SP]curiosity[SP]of[SP]yours![NL][1106][E2][1431][U+0000][U+0000]\"[1113]'s[SP]brother[NL]You'll[SP]just[SP]impede[SP]the[SP]investigation.[SP]Go[SP]take[NL]your[SP]friends[SP]and[SP]find[SP]somewhere[SP]to[SP]hide.",
+        "nom_fr": "",
+        "texte_fr": ""
+    },
+    {
+        "id": 85,
+        "offset": 305284,
+        "data_size": 590,
+        "slot_size": 590,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "[1113]'s[SP]brother",
+        "texte_orig": "Honestly,[SP]nothing's[SP]changed.[SP]Society[SP]starts[NL]breaking[SP]down[SP]and[SP]we[SP]have[SP]to[SP]deal[SP]with[SP]stupid[NL]hoaxes.[1205][U+000F][SP][U+1432][U+0000][U+0000][U+0014]Last[SP]Battalion[U+1432][U+0000][U+0000][U+0014][SP]my[SP]foot![NL][1106][E2][1431][U+0000][U+0000]\"[1113]'s[SP]brother[NL]It's[SP]obvious[SP]the[SP]group[SP]of[SP]five[SP]terrorists[NL]witnessed[SP]at[SP]the[SP]scene[SP]is[SP]behind[SP]it[SP]all.[1205][U+000F][NL]Don't[SP]get[SP]taken[SP]in[SP]by[SP]silly[SP]rumors,[SP]okay?",
+        "nom_fr": "",
+        "texte_fr": ""
+    },
+    {
+        "id": 86,
+        "offset": 305874,
+        "data_size": 162,
+        "slot_size": 162,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "[1113]'s[SP]brother",
+        "texte_orig": "......[NL][1106][E2][1431][U+0000][U+0000]\"[1113]'s[SP]brother[NL]You[SP]should[SP]go[SP]home.[SP]Leave[SP]this[SP]to[SP]us.",
+        "nom_fr": "",
+        "texte_fr": ""
+    },
+    {
+        "id": 87,
+        "offset": 306036,
+        "data_size": 704,
+        "slot_size": 704,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "[1113]'s[SP]brother",
+        "texte_orig": "The[SP]people[SP]in[SP]the[SP]sketches[SP]are[SP]heroes[SP]fighting[NL]the[SP]Last[SP]Battalion,[SP]huh...[1205][U+000F][SP]Did[SP]you[SP]guys[SP]save[NL]those[SP]kids[SP]on[SP]the[SP]news?[NL][1106][E2][1431][U+0000][U+0000]\"[1113]'s[SP]brother[NL]Hmph.[SP]Well,[SP]I'll[SP]let[SP]it[SP]slide.[SP]I[SP]don't[SP]plan[SP]on[NL]interrogating[SP]you[SP]or[SP]anything.[1205][U+000F][SP]But[SP]I[SP]think[SP]it[NL]was[SP]our[SP]father's[SP]blood[SP]that[SP]made[SP]you[SP]save[SP]them.[NL][1106][E2][1431][U+0000][U+0000]\"[1113]'s[SP]brother[NL]Why[SP]can't[SP]you[SP]just[SP]admit[SP]it[SP]already?",
+        "nom_fr": "",
+        "texte_fr": ""
+    },
+    {
+        "id": 88,
+        "offset": 306740,
+        "data_size": 340,
+        "slot_size": 340,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "[1113]'s[SP]brother",
+        "texte_orig": "[1113]!?[SP]What[SP]are[SP]you[SP]doing[SP]here!?[SP]Do[SP]you[NL]want[SP]to[SP]be[SP]killed!?[NL][1106][E2][1431][U+0000][U+0000]\"[1113]'s[SP]brother[NL]Protecting[SP]the[SP]populace[SP]is[SP]our[SP]job![SP]You[SP]need[NL]to[SP]go[SP]find[SP]a[SP]good[SP]hiding[SP]place.",
+        "nom_fr": "",
+        "texte_fr": ""
+    },
+    {
+        "id": 89,
+        "offset": 307080,
+        "data_size": 560,
+        "slot_size": 560,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "[1113]'s[SP]brother",
+        "texte_orig": "What[SP]did[SP]the[SP]Masked[SP]Circle[SP]mean[SP]by[SP]the[SP]Leonids[NL]being[SP]the[SP][U+1432][U+0000][U+0000][U+0014]lion's[SP]roar[U+1432][U+0000][U+0000][U+0014]?[1205][U+000F][SP]Is[SP]this[SP]about[SP]that[NL]Oracle[SP]in[SP]the[SP]book!?[NL][1106][E2][1431][U+0000][U+0000]\"[1113]'s[SP]brother[NL]That's[SP]ridiculous![SP]Astronomers[SP]have[SP]known[NL]those[SP]meteors[SP]would[SP]fall[SP]now[SP]for[SP]decades.[NL]It's[SP]got[SP]nothing[SP]to[SP]do[SP]with[SP]any[SP]oracle!",
+        "nom_fr": "",
+        "texte_fr": ""
+    },
+    {
+        "id": 90,
+        "offset": 307640,
+        "data_size": 300,
+        "slot_size": 300,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "[1113]'s[SP]brother",
+        "texte_orig": "Rgh...[SP]We[SP]still[SP]can't[SP]contain[SP]them[SP]without[NL]any[SP]backup...[1205][U+000F][SP]They're[SP]wreaking[SP]havoc[SP]in[SP]that[NL]temple[SP]and[SP]we[SP]have[SP]to[SP]sit[SP]here[SP]and[SP]wait!?",
+        "nom_fr": "",
+        "texte_fr": ""
+    },
+    {
+        "id": 91,
+        "offset": 307940,
+        "data_size": 300,
+        "slot_size": 300,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "This[SP]museum[SP]was[SP]built[SP]pretty[SP]recently.[SP]I[SP]hear[NL]they[SP]have[SP]lots[SP]of[SP]different[SP]kinds[SP]of[SP]planes[NL]on[SP]display...[1205][U+000A][SP]We[SP]should[SP]check[SP]it[SP]out[SP]sometime!",
+        "nom_fr": "Maya",
+        "texte_fr": "Ce musée a été bâti assez récemment. Apparemment\nils exposent de nombreux types d'avions...[1205][U+000F]\nOn pourrais y faire un tour, un jour!"
+    },
+    {
+        "id": 92,
+        "offset": 308240,
+        "data_size": 190,
+        "slot_size": 190,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "I'm[SP]surprised[SP]we[SP]made[SP]it[SP]out[SP]alive...[1205][U+000F][SP]I[SP]mean[NL]out[SP]of[SP]the[SP]blimp,[SP]not[SP]the[SP]museum...",
+        "nom_fr": "Ginko",
+        "texte_fr": "Je pensais pas qu'on sortirais vivants...[1205][U+000F] Du\ndirigeable, hein, pas du musée..."
+    },
+    {
+        "id": 93,
+        "offset": 308430,
+        "data_size": 196,
+        "slot_size": 196,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Yukino",
+        "texte_orig": "Hmm,[SP]this[SP]is[SP]some[SP]pretty[SP]nice[SP]scenery.[SP]I'll[NL]have[SP]to[SP]remember[SP]to[SP]get[SP]a[SP]picture[SP]later.",
+        "nom_fr": "Yukino",
+        "texte_fr": "Hmm, la vue est pas mal d'ici. Je dois me\nrappeler de prendre une photo plus tard."
+    },
+    {
+        "id": 94,
+        "offset": 308626,
+        "data_size": 176,
+        "slot_size": 176,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "We[SP]promised[SP]to[SP]meet[SP]up[SP]at[SP]the[SP]detective[SP]agency,[NL]right?[SP]We[SP]should[SP]get[SP]going.",
+        "nom_fr": "Ginko",
+        "texte_fr": "On a promis de se regrouper à l'agence\nde détectives, pas vrai? Dépêchons."
+    },
+    {
+        "id": 95,
+        "offset": 308802,
+        "data_size": 114,
+        "slot_size": 114,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "That[SP]reminds[SP]me...[SP]She[SP]liked[SP]the[SP]sea,[SP]too...",
+        "nom_fr": "Ginko",
+        "texte_fr": "J'y repense... elle aussi aimait l'océan..."
+    },
+    {
+        "id": 96,
+        "offset": 308916,
+        "data_size": 170,
+        "slot_size": 170,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Whoa,[SP]isn't[SP]it[SP]a[SP]little[SP]early[SP]in[SP]the[SP]year[SP]to[NL]take[SP]a[SP]swim[SP]in[SP]the[SP]ocean?",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Wouah, on fait pas trempette dans la mer\naussi tôt dans l'année, si?"
+    },
+    {
+        "id": 97,
+        "offset": 309086,
+        "data_size": 144,
+        "slot_size": 144,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "We've[SP]got[SP]the[SP]crystal[SP]skull[SP]from[SP]this[SP]place.[NL]Where[SP]to[SP]next?",
+        "nom_fr": "Ginko",
+        "texte_fr": "On a le crâne de crystal de cet endroit.\nOn va où ensuite?"
+    },
+    {
+        "id": 98,
+        "offset": 309230,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "There's[SP]still[SP]people[SP]fighting[SP]in[SP]there!?[1205][U+000F][NL]But[SP]there's[SP]no[SP]crystal[SP]skull[SP]anymore![NL]There's[SP]nothing[SP]for[SP]them[SP]to[SP]fight[SP]over!",
+        "nom_fr": "Ginko",
+        "texte_fr": "Il y a encore des gens qui se battent\nlà-dedans!?[1205][U+000F] Mais il n'y a plus de crâne\nde crytal pour lequel se battre!"
+    },
+    {
+        "id": 99,
+        "offset": 309496,
+        "data_size": 146,
+        "slot_size": 146,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "[1113],[SP]everyone's[SP]waiting[SP]at[SP]the[SP]detective[NL]agency.[SP]We[SP]should[SP]go.",
+        "nom_fr": "Ginko",
+        "texte_fr": "[1113], les autres attendent à l'agence de\ndétectives. Allons-y."
+    },
+    {
+        "id": 100,
+        "offset": 309642,
+        "data_size": 154,
+        "slot_size": 154,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "What[SP]the[SP]hell,[SP]man!?[SP]They[SP]burned[SP]down[SP]the[NL]police[SP]headquarters!",
+        "nom_fr": "Eikichi",
+        "texte_fr": "C'est quoi ce bordel!? Ils ont brûlé le\nQG de la police!"
+    },
+    {
+        "id": 101,
+        "offset": 309796,
+        "data_size": 82,
+        "slot_size": 82,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Did[SP]King[SP]Leo[SP]do[SP]this[SP]too...?",
+        "nom_fr": "Ginko",
+        "texte_fr": "Le Roi Lion a fait ça...?"
+    },
+    {
+        "id": 102,
+        "offset": 309878,
+        "data_size": 236,
+        "slot_size": 236,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "It[SP]was[SP]probably[SP]to[SP]prevent[SP]the[SP]police[SP]from[NL]interfering...[1205][U+000F][SP]We're[SP]the[SP]only[SP]ones[SP]left[SP]who[NL]can[SP]stop[SP]him[SP]now.",
+        "nom_fr": "Maya",
+        "texte_fr": "C'était sûrement pour empêcher la police\nd'interférer...[1205][U+000F] Il ne reste que nous pour\nl'arrêter désormais."
+    },
+    {
+        "id": 103,
+        "offset": 310114,
+        "data_size": 148,
+        "slot_size": 148,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "We[SP]can't[SP]go[SP]in[SP]at[SP]this[SP]rate...[1205][U+000F][SP]The[SP]nerve[SP]of[NL]that[SP]asshole!",
+        "nom_fr": "Eikichi",
+        "texte_fr": "On peut pas continuer comme ça...[1205][U+000F] Ce\nconnard est gonflé!"
+    },
+    {
+        "id": 104,
+        "offset": 310262,
+        "data_size": 184,
+        "slot_size": 184,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Let's[SP]get[SP]out[SP]of[SP]here,[SP][1113].[SP]They're[SP]gonna[NL]arrest[SP]us[SP]if[SP]we[SP]stand[SP]around[SP]like[SP]this.",
+        "nom_fr": "Ginko",
+        "texte_fr": "Sortons de là, [1113]. Ils vont nous\narrêter si on reste plantés là."
+    },
+    {
+        "id": 105,
+        "offset": 310446,
+        "data_size": 256,
+        "slot_size": 256,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "If[SP]the[SP]police[SP]are[SP]this[SP]bad[SP]off,[SP]the[SP]city's[NL]completely[SP]defenseless.[SP]King[SP]Leo[SP]only[SP]ended[NL]up[SP]helping[SP]those[SP]bastards!",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Si la police est à ce point dans la\nmouise, la ville est sans-défense. Le Roi\nLion a vraiment aidé ces enfoirés!"
+    },
+    {
+        "id": 106,
+        "offset": 310702,
+        "data_size": 144,
+        "slot_size": 144,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Looks[SP]like[SP]there's[SP]no[SP]one[SP]here.[SP]Let's[SP]go[NL]somewhere[SP]else,[SP][1113].",
+        "nom_fr": "Ginko",
+        "texte_fr": "Il n'y a personne ici, on dirait. Allons\nailleurs, [1113]."
+    },
+    {
+        "id": 107,
+        "offset": 310846,
+        "data_size": 260,
+        "slot_size": 260,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "We[SP]shouldn't[SP]go[SP]in[SP]without[SP]Maya-san.[SP]Let's[NL]come[SP]back[SP]after[SP]we've[SP]met[SP]up[SP]with[SP]the[SP]others[NL]back[SP]at[SP]the[SP]detective[SP]agency.",
+        "nom_fr": "Ginko",
+        "texte_fr": "On devrais éviter d'avancer sans Maya.\nRevenons après avoir rejoint les autres\nà l'agence de détectives."
+    },
+    {
+        "id": 108,
+        "offset": 311106,
+        "data_size": 174,
+        "slot_size": 174,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "I[SP]don't[SP]have[SP]the[SP]key[SP]to[SP]my[SP]room[SP]on[SP]me[SP]now.[NL]Let's[SP]come[SP]back[SP]some[SP]other[SP]time.",
+        "nom_fr": "Maya",
+        "texte_fr": "Je n'ai pas la clé de ma chambre sur moi,\nlà. Revenons une autre fois."
+    },
+    {
+        "id": 109,
+        "offset": 311280,
+        "data_size": 274,
+        "slot_size": 274,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Whoa,[SP]hold[SP]your[SP]horses.[SP]We[SP]haven't[SP]gotten[SP]the[NL]skull[SP]at[SP]Leo[SP]Temple[SP]yet,[SP]right?[SP]Let's[SP]take[NL]care[SP]of[SP]that[SP]before[SP]we[SP]jump[SP]in[SP]here.",
+        "nom_fr": "Maya",
+        "texte_fr": "Whoa, pas si vite. On a pas encore récupéré\nle crâne du Temple de Leo, pas vrai?\nFaisons ça avant de sauter là-dedans."
+    },
+    {
+        "id": 110,
+        "offset": 311554,
+        "data_size": 250,
+        "slot_size": 250,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "H-Hold[SP]the[SP]phone,[SP]man.[1205][U+000F][SP]We're[SP]still[SP]not[SP]done[NL]with[SP]Scorpio[SP]Temple.[1205][U+000F][SP]Let's[SP]go[SP]grab[SP]the[SP]skull[NL]from[SP]there[SP]first.",
+        "nom_fr": "Eikichi",
+        "texte_fr": "M-minute papillon![1205][U+000F] On en a pas encore\nfini avec le Temple de Scorpio.[1205][U+000F] Récupérons\nle crâne là-bas d'abord.[1106][NL]Un instant. Nous n'avons pas terminé le\nTemple d'Aquarius."
+    }
 ]

--- a/traduction/MMAP05.json
+++ b/traduction/MMAP05.json
@@ -1,342 +1,164 @@
 [
-  {
-    "id": 0,
-    "offset": 137898,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Masked[SP]Circle[SP]member",
-    "texte_orig": "Is[SP]the[SP]Exalted[SP]One[SP]up[SP]there?[1205][U+000F][SP]I[SP]hear[SP]gunshots\nand[SP]yells[SP]from[SP]the[SP]summit...[1205][0014][SP]The[SP]battle[SP]must\nbe[SP]raging[SP]on.",
-    "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "L'Exalté est là-haut ?[1205][U+000F] J'entends\ndes coups de feu du sommet...[1205][0014]\nLa bataille fait rage."
-  },
-  {
-    "id": 1,
-    "offset": 138168,
-    "data_size": 332,
-    "slot_size": 336,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Masked[SP]Circle[SP]member",
-    "texte_orig": "But[SP]those[SP]soldiers[SP]are[SP]guarding[SP]the[SP]mountain\npath[SP]and[SP]no[SP]one[SP]can[SP]get[SP]through.[1205][U+000F][SP]They've[SP]even\ntaken[SP]over[SP]the[SP]cable[SP]car![1205][U+000A][SP]What[SP]should[SP]we[SP]do!?",
-    "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Ces soldats gardent le chemin de montagne[1205][U+000F]\net personne ne peut passer.[1205][U+000A] Ils ont même\npris le téléphérique ![1205][U+000A] Qu'est-ce qu'on fait !?"
-  },
-  {
-    "id": 2,
-    "offset": 138504,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Masked[SP]Circle[SP]member",
-    "texte_orig": "Hey![SP]Did[SP]you[SP]see[SP]those[SP]meteors?[1205][U+000F][SP]Those[SP]were[SP]the\nLeonids...[1205][U+000A][SP]The[SP]lion's[SP]roar![1205][U+000A][SP]Hahaha,[SP]another\nstep[SP]in[SP]the[SP]Oracle[SP]fulfilled!",
-    "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Hé ! Ces météores ?[1205][U+000F] C'était\nles Léonides...[1205][U+000A] Rugissement du lion !\n[1205][U+000A]Hahaha, encore une étape de l'Oracle !"
-  },
-  {
-    "id": 3,
-    "offset": 138812,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Masked[SP]Circle[SP]member",
-    "texte_orig": "The[SP]Exalted[SP]One[SP]still[SP]lives![1205][U+000A][SP]We[SP]will[SP]evolve\ninto[SP]Idealians,[SP]just[SP]as[SP]the[SP]In[SP]Lak'ech[SP]has\nforetold!",
-    "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "L'Exalté vit encore ![1205][U+000A] Nous évoluerons\nen Idéaliens, comme l'In Lak'ech\nl'a prédit !"
-  },
-  {
-    "id": 4,
-    "offset": 139064,
-    "data_size": 232,
-    "slot_size": 236,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "Walking[SP]along,[SP]checking[SP]out[SP]the[SP]scenery...[1205][U+000F]\nMountain[SP]climbing[SP]like[SP]usual,[SP]heigh-ho...\nHm?[SP]Aaaaaaaaaaaah!",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Je me promenais admirant le paysage...[1205][U+000F]\nJe grimpais comme d'hab, tra-la-la...\nHm ? Aaaaaaaaaaaah !"
-  },
-  {
-    "id": 5,
-    "offset": 139300,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "...Bam,[SP]just[SP]like[SP]that.[SP]Suddenly[SP]these[SP]soldiers\nwith[SP]scary[SP]weapons[SP]came[SP]up[SP]the[SP]mountain[SP]and[SP]I\nbarely[SP]got[SP]back[SP]down[SP]here[SP]with[SP]my[SP]life.",
-    "nom_fr": "Randonneur",
-    "texte_fr": "...Et d'un coup. Des soldats armés jusqu'aux\ndents ont grimpé la montagne et je me\nsuis à peine sorti vivant."
-  },
-  {
-    "id": 6,
-    "offset": 139592,
-    "data_size": 194,
-    "slot_size": 198,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "Geez,[SP]and[SP]I[SP]was[SP]having[SP]a[SP]nice[SP]hike[SP]before[SP]those\nguys[SP]showed[SP]up![SP]What's[SP]their[SP]problem!?",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Pfff, j'avais une belle rando avant ça !\nC'est quoi leur problème !?"
-  },
-  {
-    "id": 7,
-    "offset": 139790,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "Oh![1205][U+0008][SP]I[SP]almost[SP]forgot[SP]the[SP]important[SP]part.[1205][U+000A][SP]The\nwhole[SP]reason[SP]I[SP]was[SP]hiking[SP]on[SP]Mt.[SP]Katatsumuri!",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Oh ![1205][U+0008] J'avais presque oublié l'essentiel.[1205][U+000A]\nMon vrai but sur le Mont Katatsumuri !"
-  },
-  {
-    "id": 8,
-    "offset": 140002,
-    "data_size": 84,
-    "slot_size": 88,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "Huh?[1205][U+000A][SP]You[SP]really[SP]want[SP]to[SP]know?",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Hein ?[1205][U+000A] Vraiment ?"
-  },
-  {
-    "id": 9,
-    "offset": 140090,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "The[SP][E4][NULL][NULL][U+0006]Jumping[SP]Geezer[E4][NULL][NULL][0002],[SP]man![1205][U+000A][SP]The[SP]Jumping[SP]Geezer![1205][U+000A]\nI[SP]saw[SP]an[SP]old[SP]man[SP]hopping[SP]from[SP]branch[SP]to[SP]branch\nlast[SP]time[SP]I[SP]was[SP]here.[1205][U+000A][SP]No[SP]kidding![1205][U+000A]",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Le [E4][NULL][NULL][U+0006]Vieux Sauteur[E4][NULL][NULL][0002], c'est lui ![1205][U+000A]\nLe Vieux Sauteur ![1205][U+000A] J'ai vu un vieux sauter\nde branche en branche l'autre fois. Sérieux ![1205][U+000A]"
-  },
-  {
-    "id": 10,
-    "offset": 140398,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "The[SP]only[SP]guy[SP]that[SP]old[SP]who[SP]could[SP]do[SP]that[SP]would\nbe[SP]the[SP]real[SP]Jumping[SP]Geezer,[SP]right?[1205][U+000F][SP]I[SP]couldn't\nbelieve[SP]my[SP]luck,[SP]seeing[SP]him[SP]in[SP]person.",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Un gars aussi vieux qui fait ça, seul\nle vrai Vieux Sauteur le peut ![1205][U+000F]\nJ'arrive pas à croire ma chance !"
-  },
-  {
-    "id": 11,
-    "offset": 140688,
-    "data_size": 222,
-    "slot_size": 226,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "That's[SP]why[SP]I[SP]wanted[SP]to[SP]get[SP]some[SP]photographic\nevidence,[SP]and[SP]maybe[SP]a[SP]commemorative[SP]picture\nfor[SP]myself.",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Voilà pourquoi je voulais une preuve\nphotographique, et peut-être une photo\npour moi."
-  },
-  {
-    "id": 12,
-    "offset": 140914,
-    "data_size": 146,
-    "slot_size": 150,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "But[SP]with[SP]those[SP]army[SP]guys[SP]around,[SP]my[SP]chance[SP]is\nprobably[SP]gone...",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Mais avec ces militaires,\nma chance est envolée..."
-  },
-  {
-    "id": 13,
-    "offset": 141064,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "Hey,[SP]could[SP]you[SP]get[SP]some[SP]kind[SP]of[SP]evidence[SP]or\nproof[SP]for[SP]me[SP]that[SP]Jumping[SP]Geezer[SP]exists?[1205][U+000F][SP]I'll\ngive[SP]you[SP]a[SP]proper[SP]reward![1205][U+000F][SP]Pleeeeeease!",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Hé, vous pourriez me rapporter une preuve[1205][U+000F]\nque le Vieux Sauteur existe ?[1205][U+000F]\nJe vous donne une récompense ! S'il vous plaîîît !"
-  },
-  {
-    "id": 14,
-    "offset": 141354,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "Jumping[SP]Geezer[SP]is[SP]somewhere[SP]in[SP]Mt.[SP]Katatsumuri.[1205][U+000F]\nBring[SP]back[SP]some[SP]proof[SP]he[SP]exists![1205][U+000F][SP]I'll[SP]give[SP]you\na[SP]proper[SP]reward,[SP]so[SP]pleeeeeease!",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Le Vieux Sauteur est sur le Mont\nKatatsumuri.[1205][U+000F] Ramenez-moi une preuve ![1205][U+000F]\nJe vous récompense, s'il vous plaîîît !"
-  },
-  {
-    "id": 15,
-    "offset": 141642,
-    "data_size": 188,
-    "slot_size": 192,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "Wait[SP]a[SP]second...[1205][U+000F][SP]Are[SP]those[SP]the[SP][E4][NULL][NULL][U+0006]Jumping[SP]Geta[E4][NULL][NULL][0002]\nthat[SP]the[SP]Jumping[SP]Geezer[SP]wore?",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Attendez...[1205][U+000F] Ce sont les [E4][NULL][NULL][U+0006]Geta Sauteurs[E4][NULL][NULL][0002]\ndu Vieux Sauteur ?"
-  },
-  {
-    "id": 16,
-    "offset": 141834,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "Ooooooh![1205][U+000F][SP]You[SP]really[SP]got[SP]them[SP]for[SP]me!?[1205][U+000F][SP]Ahhhh,\nthis[SP]is[SP]even[SP]better[SP]than[SP]a[SP]photo![1205][U+000F][SP]Thank[SP]you!\nOh,[SP]this[SP]is[SP]so[SP]great!",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Ooooooh ![1205][U+000F] Vous les avez eus !?[1205][U+000F]\nAhhhh, c'est encore mieux qu'une photo ![1205][U+000F]\nMerci ! Oh, c'est trop bien !"
-  },
-  {
-    "id": 17,
-    "offset": 142094,
-    "data_size": 232,
-    "slot_size": 236,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "Here,[SP]have[SP]a[SP]little[SP]something[SP]for[SP]your[SP]trouble.\nIt's[SP]a[SP][E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Holylight[SP]Card[E4][NULL][NULL][0002].[SP]I[SP]want[SP]you[SP]to[SP]have[SP]it!",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Tenez, voici quelque chose pour vous.\nC'est une [E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Carte Lumière[E4][NULL][NULL][0002]. Je vous l'offre !"
-  },
-  {
-    "id": 18,
-    "offset": 142330,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Hiker",
-    "texte_orig": "Heheheh,[SP]so[SP]these[SP]are[SP]the[SP]Jumping[SP]Geta...[1205][U+000F]\nCan[SP]I[SP]move[SP]as[SP]fast[SP]as[SP]that[SP]old[SP]man[SP]with[SP]these\non?[1205][U+000F][SP]Maybe[SP]I[SP]should[SP]give[SP]'em[SP]a[SP]try.",
-    "nom_fr": "Randonneur",
-    "texte_fr": "Héhéhé, ce sont les Geta Sauteurs...[1205][U+000F]\nJe peux bouger aussi vite que ce vieux\navec eux ?[1205][U+000F] Je devrais les essayer."
-  },
-  {
-    "id": 19,
-    "offset": 142608,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Yeesh,[SP]the[SP]Last[SP]Battalion's[SP]here[SP]too.[SP]If[SP]we\ntook[SP]the[SP]cable[SP]car,[SP]it'd[SP]be[SP]a[SP]quick[SP]trip[SP]up\nto[SP]the[SP]summit...",
-    "nom_fr": "Eikichi",
-    "texte_fr": "Punaise, le Bataillon est là aussi. Si on\nprenait le téléphérique, on serait\nvite au sommet..."
-  },
-  {
-    "id": 20,
-    "offset": 142846,
-    "data_size": 118,
-    "slot_size": 122,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Hey,[SP][1113],[SP]it[SP]looks[SP]like[SP]we[SP]can[SP]use[SP]this\ncable[SP]car.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Hé, [U+1113], on peut utiliser\nce téléphérique !"
-  },
-  {
-    "id": 21,
-    "offset": 142968,
-    "data_size": 78,
-    "slot_size": 82,
-    "_term": [
-      4361,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Should[SP]we[SP]ride[SP]it?\n[1208][0002]Yes\nNo",
-    "nom_fr": "Ginko",
-    "texte_fr": "On le prend ?\n[1208][0002]Oui\nNon"
-  }
+    {
+        "id": 0,
+        "offset": 137898,
+        "data_size": 606,
+        "slot_size": 606,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Masked[SP]Circle[SP]member",
+        "texte_orig": "Is[SP]the[SP]Exalted[SP]One[SP]up[SP]there?[1205][U+000F][SP]I[SP]hear[SP]gunshots[NL]and[SP]yells[SP]from[SP]the[SP]summit...[1205][U+0014][SP]The[SP]battle[SP]must[NL]be[SP]raging[SP]on.[NL][1106][E2][1431][U+0000][U+0000]\"Masked[SP]Circle[SP]member[NL]But[SP]those[SP]soldiers[SP]are[SP]guarding[SP]the[SP]mountain[NL]path[SP]and[SP]no[SP]one[SP]can[SP]get[SP]through.[1205][U+000F][SP]They've[SP]even[NL]taken[SP]over[SP]the[SP]cable[SP]car![1205][U+000A][SP]What[SP]should[SP]we[SP]do!?",
+        "nom_fr": "Membre du Cercle masqué",
+        "texte_fr": "L'Exalté est là-haut ?[1205][U+000F] J'entends\ndes coups de feu du sommet...[1205][0014]\nLa bataille fait rage.[1106][NL]Ces soldats gardent le chemin de montagne[1205][U+000F]\net personne ne peut passer.[1205][U+000A] Ils ont même\npris le téléphérique ![1205][U+000A] Qu'est-ce qu'on fait !?"
+    },
+    {
+        "id": 1,
+        "offset": 138504,
+        "data_size": 560,
+        "slot_size": 560,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Masked[SP]Circle[SP]member",
+        "texte_orig": "Hey![SP]Did[SP]you[SP]see[SP]those[SP]meteors?[1205][U+000F][SP]Those[SP]were[SP]the[NL]Leonids...[1205][U+000A][SP]The[SP]lion's[SP]roar![1205][U+000A][SP]Hahaha,[SP]another[NL]step[SP]in[SP]the[SP]Oracle[SP]fulfilled![NL][1106][E2][1431][U+0000][U+0000]\"Masked[SP]Circle[SP]member[NL]The[SP]Exalted[SP]One[SP]still[SP]lives![1205][U+000A][SP]We[SP]will[SP]evolve[NL]into[SP]Idealians,[SP]just[SP]as[SP]the[SP]In[SP]Lak'ech[SP]has[NL]foretold!",
+        "nom_fr": "Membre du Cercle masqué",
+        "texte_fr": "Hé ! Ces météores ?[1205][U+000F] C'était\nles Léonides...[1205][U+000A] Rugissement du lion !\n[1205][U+000A]Hahaha, encore une étape de l'Oracle ![1106][NL]L'Exalté vit encore ![1205][U+000A] Nous évoluerons\nen Idéaliens, comme l'In Lak'ech\nl'a prédit !"
+    },
+    {
+        "id": 2,
+        "offset": 139064,
+        "data_size": 726,
+        "slot_size": 726,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Hiker",
+        "texte_orig": "Walking[SP]along,[SP]checking[SP]out[SP]the[SP]scenery...[1205][U+000F][NL]Mountain[SP]climbing[SP]like[SP]usual,[SP]heigh-ho...[NL]Hm?[SP]Aaaaaaaaaaaah![NL][1106][E2][1431][U+0000][U+0000]\"Hiker[NL]...Bam,[SP]just[SP]like[SP]that.[SP]Suddenly[SP]these[SP]soldiers[NL]with[SP]scary[SP]weapons[SP]came[SP]up[SP]the[SP]mountain[SP]and[SP]I[NL]barely[SP]got[SP]back[SP]down[SP]here[SP]with[SP]my[SP]life.[NL][1106][E2][1431][U+0000][U+0000]\"Hiker[NL]Geez,[SP]and[SP]I[SP]was[SP]having[SP]a[SP]nice[SP]hike[SP]before[SP]those[NL]guys[SP]showed[SP]up![SP]What's[SP]their[SP]problem!?",
+        "nom_fr": "Randonneur",
+        "texte_fr": "Je me promenais admirant le paysage...[1205][U+000F]\nJe grimpais comme d'hab, tra-la-la...\nHm ? Aaaaaaaaaaaah ![1106][NL]...Et d'un coup. Des soldats armés jusqu'aux\ndents ont grimpé la montagne et je me\nsuis à peine sorti vivant.[1106][NL]Pfff, j'avais une belle rando avant ça !\nC'est quoi leur problème !?"
+    },
+    {
+        "id": 3,
+        "offset": 139790,
+        "data_size": 1564,
+        "slot_size": 1564,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Hiker",
+        "texte_orig": "Oh![1205][U+0008][SP]I[SP]almost[SP]forgot[SP]the[SP]important[SP]part.[1205][U+000A][SP]The[NL]whole[SP]reason[SP]I[SP]was[SP]hiking[SP]on[SP]Mt.[SP]Katatsumuri![NL][1106][E2][1431][U+0000][U+0000]\"Hiker[NL]Huh?[1205][U+000A][SP]You[SP]really[SP]want[SP]to[SP]know?[NL][1106][E2][1431][U+0000][U+0000]\"Hiker[NL]The[SP][1431][U+0000][U+0000][U+0006]Jumping[SP]Geezer[1431][U+0000][U+0000][U+0002],[SP]man![1205][U+000A][SP]The[SP]Jumping[SP]Geezer![1205][U+000A][NL]I[SP]saw[SP]an[SP]old[SP]man[SP]hopping[SP]from[SP]branch[SP]to[SP]branch[NL]last[SP]time[SP]I[SP]was[SP]here.[1205][U+000A][SP]No[SP]kidding![1205][U+000A][NL][1106][E2][1431][U+0000][U+0000]\"Hiker[NL]The[SP]only[SP]guy[SP]that[SP]old[SP]who[SP]could[SP]do[SP]that[SP]would[NL]be[SP]the[SP]real[SP]Jumping[SP]Geezer,[SP]right?[1205][U+000F][SP]I[SP]couldn't[NL]believe[SP]my[SP]luck,[SP]seeing[SP]him[SP]in[SP]person.[NL][1106][E2][1431][U+0000][U+0000]\"Hiker[NL]That's[SP]why[SP]I[SP]wanted[SP]to[SP]get[SP]some[SP]photographic[NL]evidence,[SP]and[SP]maybe[SP]a[SP]commemorative[SP]picture[NL]for[SP]myself.[NL][1106][E2][1431][U+0000][U+0000]\"Hiker[NL]But[SP]with[SP]those[SP]army[SP]guys[SP]around,[SP]my[SP]chance[SP]is[NL]probably[SP]gone...[NL][1106][E2][1431][U+0000][U+0000]\"Hiker[NL]Hey,[SP]could[SP]you[SP]get[SP]some[SP]kind[SP]of[SP]evidence[SP]or[NL]proof[SP]for[SP]me[SP]that[SP]Jumping[SP]Geezer[SP]exists?[1205][U+000F][SP]I'll[NL]give[SP]you[SP]a[SP]proper[SP]reward![1205][U+000F][SP]Pleeeeeease!",
+        "nom_fr": "Randonneur",
+        "texte_fr": "Oh ![1205][U+0008] J'avais presque oublié l'essentiel.[1205][U+000A]\nMon vrai but sur le Mont Katatsumuri ![1106][NL]Hein ?[1205][U+000A] Vraiment ?[1106][NL]Le [E4][NULL][NULL][U+0006]Vieux Sauteur[E4][NULL][NULL][0002], c'est lui ![1205][U+000A]\nLe Vieux Sauteur ![1205][U+000A] J'ai vu un vieux sauter\nde branche en branche l'autre fois. Sérieux ![1205][U+000A][1106][NL]Un gars aussi vieux qui fait ça, seul\nle vrai Vieux Sauteur le peut ![1205][U+000F]\nJ'arrive pas à croire ma chance ![1106][NL]Voilà pourquoi je voulais une preuve\nphotographique, et peut-être une photo\npour moi.[1106][NL]Mais avec ces militaires,\nma chance est envolée...[1106][NL]Hé, vous pourriez me rapporter une preuve[1205][U+000F]\nque le Vieux Sauteur existe ?[1205][U+000F]\nJe vous donne une récompense ! S'il vous plaîîît !"
+    },
+    {
+        "id": 4,
+        "offset": 141354,
+        "data_size": 288,
+        "slot_size": 288,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Hiker",
+        "texte_orig": "Jumping[SP]Geezer[SP]is[SP]somewhere[SP]in[SP]Mt.[SP]Katatsumuri.[1205][U+000F][NL]Bring[SP]back[SP]some[SP]proof[SP]he[SP]exists![1205][U+000F][SP]I'll[SP]give[SP]you[NL]a[SP]proper[SP]reward,[SP]so[SP]pleeeeeease!",
+        "nom_fr": "Randonneur",
+        "texte_fr": "Le Vieux Sauteur est sur le Mont\nKatatsumuri.[1205][U+000F] Ramenez-moi une preuve ![1205][U+000F]\nJe vous récompense, s'il vous plaîîît !"
+    },
+    {
+        "id": 5,
+        "offset": 141642,
+        "data_size": 688,
+        "slot_size": 688,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Hiker",
+        "texte_orig": "Wait[SP]a[SP]second...[1205][U+000F][SP]Are[SP]those[SP]the[SP][1431][U+0000][U+0000][U+0006]Jumping[SP]Geta[1431][U+0000][U+0000][U+0002][NL]that[SP]the[SP]Jumping[SP]Geezer[SP]wore?[NL][1106][E2][1431][U+0000][U+0000]\"Hiker[NL]Ooooooh![1205][U+000F][SP]You[SP]really[SP]got[SP]them[SP]for[SP]me!?[1205][U+000F][SP]Ahhhh,[NL]this[SP]is[SP]even[SP]better[SP]than[SP]a[SP]photo![1205][U+000F][SP]Thank[SP]you![NL]Oh,[SP]this[SP]is[SP]so[SP]great![NL][1106][E2][1431][U+0000][U+0000]\"Hiker[NL]Here,[SP]have[SP]a[SP]little[SP]something[SP]for[SP]your[SP]trouble.[NL]It's[SP]a[SP][1431][U+0000][U+0000][U+0004][U+1433][U+0000][U+0000][U+0004]Holylight[SP]Card[1431][U+0000][U+0000][U+0002].[SP]I[SP]want[SP]you[SP]to[SP]have[SP]it!",
+        "nom_fr": "Randonneur",
+        "texte_fr": "Attendez...[1205][U+000F] Ce sont les [E4][NULL][NULL][U+0006]Geta Sauteurs[E4][NULL][NULL][0002]\ndu Vieux Sauteur ?[1106][NL]Ooooooh ![1205][U+000F] Vous les avez eus !?[1205][U+000F]\nAhhhh, c'est encore mieux qu'une photo ![1205][U+000F]\nMerci ! Oh, c'est trop bien ![1106][NL]Tenez, voici quelque chose pour vous.\nC'est une [E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Carte Lumière[E4][NULL][NULL][0002]. Je vous l'offre !"
+    },
+    {
+        "id": 6,
+        "offset": 142330,
+        "data_size": 278,
+        "slot_size": 278,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Hiker",
+        "texte_orig": "Heheheh,[SP]so[SP]these[SP]are[SP]the[SP]Jumping[SP]Geta...[1205][U+000F][NL]Can[SP]I[SP]move[SP]as[SP]fast[SP]as[SP]that[SP]old[SP]man[SP]with[SP]these[NL]on?[1205][U+000F][SP]Maybe[SP]I[SP]should[SP]give[SP]'em[SP]a[SP]try.",
+        "nom_fr": "Randonneur",
+        "texte_fr": "Héhéhé, ce sont les Geta Sauteurs...[1205][U+000F]\nJe peux bouger aussi vite que ce vieux\navec eux ?[1205][U+000F] Je devrais les essayer."
+    },
+    {
+        "id": 7,
+        "offset": 142608,
+        "data_size": 238,
+        "slot_size": 238,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Yeesh,[SP]the[SP]Last[SP]Battalion's[SP]here[SP]too.[SP]If[SP]we[NL]took[SP]the[SP]cable[SP]car,[SP]it'd[SP]be[SP]a[SP]quick[SP]trip[SP]up[NL]to[SP]the[SP]summit...",
+        "nom_fr": "Eikichi",
+        "texte_fr": "Punaise, le Bataillon est là aussi. Si on\nprenait le téléphérique, on serait\nvite au sommet..."
+    },
+    {
+        "id": 8,
+        "offset": 142846,
+        "data_size": 122,
+        "slot_size": 122,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Hey,[SP][1113],[SP]it[SP]looks[SP]like[SP]we[SP]can[SP]use[SP]this[NL]cable[SP]car.",
+        "nom_fr": "Ginko",
+        "texte_fr": "Hé, [U+1113], on peut utiliser\nce téléphérique ![1106][NL]On le prend ?\n[1208][0002]Oui\nNon"
+    }
 ]

--- a/traduction/MMAP06.json
+++ b/traduction/MMAP06.json
@@ -1,4411 +1,3494 @@
 [
-  {
-    "id": 0,
-    "offset": 255626,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "Guess[SP]what?[SP]You've[SP]noticed[SP]how[SP]this[SP]place[SP]is[SP]an\nisland[SP]surrounded[SP]by[SP]the[SP]Tanabata[SP]River,[SP]right?",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Cet endroit est une île\n dans la Tanabata, non ?"
-  },
-  {
-    "id": 1,
-    "offset": 255850,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "I[SP]was[SP]told[SP]it[SP]got[SP]its[SP]name[SP]because[SP]Rengedai\nmeans[SP][1432][NULL][NULL][0014]lotus[SP]flower.[1432][NULL][NULL][0014][SP]In[SP]the[SP]spring,[SP]it[SP]looks\nlike[SP]a[SP]lotus[SP]floating[SP]on[SP]the[SP]water[SP]from[SP]above.",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Rengedai veut dire [1432][NULL][NULL][0014]fleur de lotus.[1432][NULL][NULL][0014] Au printemps, vue d'en haut,\n on dirait un lotus flottant."
-  },
-  {
-    "id": 2,
-    "offset": 256168,
-    "data_size": 300,
-    "slot_size": 304,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "Have[SP]you[SP]been[SP]to[SP]Honmaru[SP]Park?[SP]It's[SP]very\nbeautiful.[SP]The[SP]perfect[SP]place[SP]for[SP]taking[SP]a[SP]walk.\nI[SP]hear[SP]some[SP]strange[SP]rumors[SP]about[SP]it,[SP]though...",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Tu connais le parc Honmaru ? Très beau pour s'y promener.\n Mais d'étranges rumeurs circulent..."
-  },
-  {
-    "id": 3,
-    "offset": 256472,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "Do[SP]you[SP]know[SP]the[SP]homeless[SP]man[SP]in[SP]Honmaru[SP]Park?\nI[SP]hear[SP]he[SP]used[SP]to[SP]be[SP]a[SP]college[SP]professor.[1205][U+000F]\nI[SP]wonder[SP]how[SP]he[SP]became[SP]homeless...",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Tu connais le SDF du parc Honmaru ? Ancien prof.\n Comment en est-il arrivé là ?[1205][U+000F]"
-  },
-  {
-    "id": 4,
-    "offset": 256754,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "Huh?[1205][U+000A][SP]The[SP]Masked[SP]Circle?[1205][U+000F][SP]Can't[SP]say[SP]I've[SP]ever\nheard[SP]of[SP]them,[SP]no.[SP]Is[SP]there[SP]an[SP]organization[SP]in\nSumaru[SP]by[SP]that[SP]name?",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Hein ? Le Cercle Masqué ?[1205][U+000A] Jamais entendu parler.\n Une organisation à Sumaru porte ce nom ?[1205][U+000F]"
-  },
-  {
-    "id": 5,
-    "offset": 257018,
-    "data_size": 242,
-    "slot_size": 246,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "I[SP]haven't[SP]seen[SP]any[SP]Kasugayama[SP]High[SP]students\naround[SP]lately.[1205][U+000F][SP]I[SP]wonder[SP]if[SP]they[SP]all[SP]went[SP]on\na[SP]school[SP]trip...",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Je n'ai vu aucun élève de Kasugayama ces temps-ci.[1205][U+000F]\n En voyage scolaire ?"
-  },
-  {
-    "id": 6,
-    "offset": 257264,
-    "data_size": 118,
-    "slot_size": 122,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "Muses,[SP]right?[SP]I[SP]hear[SP]they're[SP]pretty[SP]popular.",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Muses, oui. Populaires."
-  },
-  {
-    "id": 7,
-    "offset": 257386,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "I[SP]guess[SP]they're[SP]already[SP]having[SP]a[SP]concert[SP]at\nthe[SP]outdoor[SP]concert[SP]hall.",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Elles donnent déjà un concert\n à la salle en plein air."
-  },
-  {
-    "id": 8,
-    "offset": 257558,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "I[SP]bet[SP]the[SP]Masked[SP]Circle[SP]are[SP]the[SP]terrorists\nhere.[1205][U+000F][SP]No[SP]sane[SP]man[SP]would[SP]do[SP]these[SP]things...\nSo[SP]the[SP]Masked[SP]Circle[SP]was[SP]sinister[SP]after[SP]all.",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "C'est sûrement le Cercle Masqué les terroristes.[1205][U+000F]\n Aucun sain d'esprit ne ferait ça...\n Donc ils étaient sinistres."
-  },
-  {
-    "id": 9,
-    "offset": 257856,
-    "data_size": 308,
-    "slot_size": 312,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "They[SP]posted[SP]the[SP]composite[SP]sketches[SP]of[SP]those\nterrorists,[SP]so[SP]I[SP]went[SP]to[SP]see[SP]for[SP]myself.[1205][U+000F][SP]All[SP]five\nof[SP]them[SP]were[SP]the[SP]scariest-looking[SP]people...",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Les portraits-robots des terroristes sont affichés, je suis allée voir.[1205][U+000F]\n Les cinq avaient l'air terrifiant..."
-  },
-  {
-    "id": 10,
-    "offset": 258168,
-    "data_size": 210,
-    "slot_size": 214,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "I[SP]spoke[SP]with[SP]the[SP]woman[SP]next[SP]door,[SP]and[SP]we[SP]think\nthe[SP]things[SP]in[SP]that[SP]In[SP]Lak'ech[SP]are[SP]all[SP]true.",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Avec la voisine, on pense que tout l'In Lak'ech est vrai."
-  },
-  {
-    "id": 11,
-    "offset": 258382,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "I[SP]mean,[SP]everything[SP]that's[SP]happened[SP]up[SP]to[SP]now\nwas[SP]foretold[SP]in[SP]it,[SP]right?[1205][U+000F][SP]They[SP]said[SP]so[SP]on[SP]the\nnews.[SP]That[SP]can't[SP]be[SP]coincidence.",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Tout ce qui est arrivé était prédit, non ?[1205][U+000F]\n Ils l'ont dit aux infos. Pas une coïncidence."
-  },
-  {
-    "id": 12,
-    "offset": 258668,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "I-I[SP]almost[SP]got[SP]attacked[SP]by[SP]those[SP]soldiers[SP]just\nnow...[1205][U+000F][SP]It[SP]was[SP]terrifying...[1205][U+000F]",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "J'ai failli me faire attaquer par ces soldats...[1205][U+000F]\n Terrible..."
-  },
-  {
-    "id": 13,
-    "offset": 258858,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "B-But[SP]then[SP]one[SP]of[SP]the[SP]Masked[SP]Circle[SP]saved[SP]me![1205][U+000F]\nWhat's[SP]going[SP]on[SP]here?",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Un membre du Cercle Masqué m'a sauvée ![1205][U+000F]\n Que se passe-t-il ?"
-  },
-  {
-    "id": 14,
-    "offset": 259030,
-    "data_size": 114,
-    "slot_size": 118,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "I[SP]think[SP]I[SP]had[SP]the[SP]wrong[SP]idea[SP]about[SP]them...",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "J'avais mal jugé..."
-  },
-  {
-    "id": 15,
-    "offset": 259148,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "Hey![1205][U+000F][SP]S-Some[SP]of[SP]those[SP]Masked[SP]Circle[SP]people\nsaw[SP]the[SP]shooting[SP]stars[SP]and[SP]said,[SP][1432][NULL][NULL][0014]It's[SP]the\nlion's[SP]roar![1432][NULL][NULL][0014][1205][U+000F]",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Hé ! Des gens du Cercle Masqué ont dit : [1432][NULL][NULL][0014]C'est le rugissement du lion ![1432][NULL][NULL][0014][1205][U+000F]"
-  },
-  {
-    "id": 16,
-    "offset": 259398,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "That's[SP]another[SP]line[SP]from[SP]that[SP]Oracle,[SP]right?\nI[SP]knew[SP]it...[SP]The[SP]In[SP]Lak'ech[SP]is[SP]true[SP]after[SP]all!",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "C'est encore une phrase de l'Oracle, non ?\n L'In Lak'ech est donc vrai !"
-  },
-  {
-    "id": 17,
-    "offset": 259614,
-    "data_size": 236,
-    "slot_size": 240,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "Have[SP]you[SP]been[SP]to[SP]Honmaru[SP]Park[SP]already?[1205][U+000A][SP]They're\nhaving[SP]a[SP]gathering[SP]to[SP]evolve[SP]into[SP]Idealians\nright[SP]now!",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Tu es allé au parc Honmaru ?[1205][U+000A] Ils se rassemblent\n pour devenir Idéaliens là maintenant !"
-  },
-  {
-    "id": 18,
-    "offset": 259854,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "H-Hey![1205][U+000A][SP]You're[SP]a[SP]Sevens[SP]student,[SP]right?[1205][U+000A][SP]What's\nthat[SP]light[SP]coming[SP]out[SP]from[SP]your[SP]school?",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "Hé ! Tu es de Seven ?[1205][U+000A] C'est quoi cette lumière\n qui sort de ton école ?"
-  },
-  {
-    "id": 19,
-    "offset": 260066,
-    "data_size": 170,
-    "slot_size": 174,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "Is[SP]the[SP]evolution[SP]starting[SP]already?[1205][U+000A][SP]Oh,[SP]no!\nI'm[SP]not[SP]ready[SP]for[SP]it[SP]yet!",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "L'évolution a déjà commencé ?[1205][U+000A] Oh non,\n je ne suis pas prête !"
-  },
-  {
-    "id": 20,
-    "offset": 260240,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Housewife",
-    "texte_orig": "*sigh*[1205][U+0008][SP]I[SP]wish[SP]they'd[SP]get[SP]this[SP]evolution[SP]thing\nover[SP]with...[1205][U+000A][SP]I[SP]feel[SP]like[SP]the[SP]excitement[SP]has\npassed[SP]and[SP]I'm[SP]losing[SP]interest.",
-    "nom_fr": "Femme au foyer",
-    "texte_fr": "*soupir*[1205][U+0008] J'aimerais en finir avec cette évolution...[1205][U+000A]\n L'excitation est retombée, ça ne m'intéresse plus."
-  },
-  {
-    "id": 21,
-    "offset": 260524,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Oh,[SP]don't[SP]you[SP]go[SP]to[SP]Sevens?[SP]Did[SP]something\nhappen[SP]at[SP]your[SP]school?[SP]It[SP]sounded[SP]like[SP]there\nwas[SP]some[SP]commotion[SP]on[SP]the[SP]school[SP]grounds.",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "Oh, tu vas à Seven ? Il s'est passé quelque chose dans ton école ?\n On a entendu du bruit dans la cour."
-  },
-  {
-    "id": 22,
-    "offset": 260822,
-    "data_size": 322,
-    "slot_size": 326,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "My[SP]colleagues[SP]have[SP]been[SP]pretty[SP]distant[SP]lately.\nThey[SP]keep[SP]leaving[SP]before[SP]me[SP]because[SP]they[SP]have\nsome[SP]meeting[SP]to[SP]attend.[1205][U+000F][SP]Are[SP]they[SP]in[SP]some[SP]union?",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "Mes collègues sont distants. Ils partent avant moi pour une réunion.[1205][U+000F]\n Sont-ils syndiqués ?"
-  },
-  {
-    "id": 23,
-    "offset": 261148,
-    "data_size": 184,
-    "slot_size": 188,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Wow,[SP]Kasugayama[SP]High's[SP]festival[SP]is[SP]the[SP]talk[SP]of\nthe[SP]town[SP]over[SP]in[SP]Hirasaka.",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "La fête de Kasugayama fait jaser\n dans tout Hirasaka."
-  },
-  {
-    "id": 24,
-    "offset": 261336,
-    "data_size": 224,
-    "slot_size": 228,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "I'm[SP]sure[SP]the[SP]people[SP]who[SP]live[SP]there[SP]must[SP]be[SP]glad\nthe[SP]local[SP]school's[SP]on[SP]the[SP]rise[SP]in[SP]popularity.",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "Les habitants sont contents que l'école du coin\n gagne en popularité."
-  },
-  {
-    "id": 25,
-    "offset": 261564,
-    "data_size": 316,
-    "slot_size": 320,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Do[SP]you[SP]know[SP]who[SP]the[SP]third[SP]member[SP]of[SP]Muses[SP]is?[1205][U+000F]\nShe's[SP]apparently[SP]a[SP]Sevens[SP]student[SP]like[SP]you.[SP]If\nyou[SP]know[SP]her,[SP]would[SP]you[SP]mind[SP]introducing[SP]me?",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "Tu sais qui est le troisième membre de Muses ?[1205][U+000F]\n Une élève de Seven comme toi. Tu pourrais me la présenter ?"
-  },
-  {
-    "id": 26,
-    "offset": 261884,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "They're[SP]going[SP]to[SP]announce[SP]the[SP]third[SP]member[SP]of\nMuses[SP]at[SP]the[SP]live[SP]recording[SP]at[SP]Giga[SP]Macho.[1205][U+000F]\nI[SP]wonder[SP]what[SP]she's[SP]like.[SP]I[SP]can't[SP]wait!",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "Ils annoncent le 3e membre de Muses au live de Giga Macho.[1205][U+000F]\n J'ai hâte de voir à quoi elle ressemble !"
-  },
-  {
-    "id": 27,
-    "offset": 262186,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "So[SP]the[SP]third[SP]member's[SP]fluent[SP]in[SP]English...[1205][U+000F]\nI[SP]see...",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "La 3e parle anglais couramment...[1205][U+000F]\n Je vois..."
-  },
-  {
-    "id": 28,
-    "offset": 262334,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "A[SP]bilingual[SP]idol,[SP]eh?[1205][U+000F][SP]I[SP]like[SP]that.[SP]It[SP]has\na[SP]nice[SP]intellectual[SP]air[SP]to[SP]it.[SP]I'm[SP]looking\nforward[SP]to[SP]hearing[SP]her[SP]solo.",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "Une idole bilingue ?[1205][U+000F] J'aime ça. Ça fait intellectuel.\n J'ai hâte d'entendre son solo."
-  },
-  {
-    "id": 29,
-    "offset": 262606,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Fortunately,[SP]there[SP]were[SP]no[SP]casualties[SP]in[SP]the\nconcert[SP]hall[SP]fire.[1205][U+000F][SP]But[SP]whose[SP]concert[SP]was\nit?[SP]I[SP]can't[SP]really[SP]remember...",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "Heureusement, pas de victimes dans l'incendie.[1205][U+000F]\n C'était le concert de qui ? Je ne me souviens pas."
-  },
-  {
-    "id": 30,
-    "offset": 262884,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Wasn't[SP]that[SP]one[SP]of[SP]the[SP]teachers[SP]at[SP]Sevens...?[1205][U+000F]\nShe[SP]had[SP]this[SP]crazy[SP]expression[SP]and[SP]told[SP]me[SP]that\nthe[SP]terrorists[SP]were[SP]this[SP]Last...[SP]something.",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "C'était une prof de Seven ?[1205][U+000F] Elle avait l'air folle\n et m'a dit que les terroristes étaient ce... Dernier quelque chose."
-  },
-  {
-    "id": 31,
-    "offset": 263202,
-    "data_size": 324,
-    "slot_size": 328,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "Some[SP]kids[SP]just[SP]now[SP]said[SP]that[SP]the[SP]five[SP]people[SP]in\nthose[SP]composite[SP]sketches[SP]are[SP]heroes[SP]fighting[SP]the\nMasked[SP]Circle.[1205][U+000F][SP]Now[SP]how[SP]would[SP]they[SP]know[SP]that?",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "Des gamins disent que les 5 personnes des portraits sont des héros.[1205][U+000F]\n Comment pourraient-ils savoir ça ?"
-  },
-  {
-    "id": 32,
-    "offset": 263530,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "The[SP]Last[SP]Battalion[SP]and[SP]the[SP]Masked[SP]Circle[SP]are\nfighting[SP]over[SP]the[SP]secret[SP]treasure[SP]of[SP]Sumaru\nCity.[SP]It's[SP]all[SP]in[SP]the[SP]In[SP]Lak'ech.",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "Le Dernier Bataillon et le Cercle Masqué se battent\n pour le trésor secret de Sumaru. Tout est dans l'In Lak'ech."
-  },
-  {
-    "id": 33,
-    "offset": 263816,
-    "data_size": 284,
-    "slot_size": 288,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "D-Did[SP]you[SP]see[SP]the[SP]size[SP]of[SP]that[SP]air[SP]fleet?\nThere[SP]were[SP]20[SP]of[SP]them,[SP]easy![1205][U+000F][SP]Th-They've[SP]come\nto[SP]steal[SP]Sumaru's[SP]hidden[SP]treasure!",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "T'as vu cette flotte aérienne ? 20 appareils, facile ![1205][U+000F]\n Ils sont venus voler le trésor caché de Sumaru !"
-  },
-  {
-    "id": 34,
-    "offset": 264104,
-    "data_size": 298,
-    "slot_size": 302,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "These[SP]weird[SP]temples[SP]showed[SP]up[SP]in[SP]the[SP]other\nwards,[SP]right?[1205][U+000A][SP]The[SP]Masked[SP]Circle[SP]and[SP]Last\nBattalion[SP]were[SP]going[SP]in[SP]to[SP]fight[SP]each[SP]other!",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "Ces étranges temples sont apparus ailleurs, non ?[1205][U+000A]\n Le Cercle Masqué et le Dernier Bataillon y entraient pour se battre !"
-  },
-  {
-    "id": 35,
-    "offset": 264406,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "But...[SP]why[SP]didn't[SP]one[SP]of[SP]those[SP]temples[SP]appear\nhere,[SP]too?[1205][U+000F][SP]It[SP]makes[SP]me[SP]sort[SP]of[SP]nervous...",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "Mais pourquoi aucun temple n'est apparu ici ?[1205][U+000F]\n Ça m'inquiète..."
-  },
-  {
-    "id": 36,
-    "offset": 264626,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "You're[SP]safe?[1205][U+000A][SP]I'd[SP]heard[SP]the[SP]Last[SP]Battalion\ncaptured[SP]all[SP]the[SP]Sevens[SP]students.[1205][U+000F][SP]Did[SP]you\nmanage[SP]to[SP]escape?",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "Tu es sain et sauf ?[1205][U+000A] Les élèves de Seven ont été capturés.[1205][U+000F]\n Tu t'es échappé ?"
-  },
-  {
-    "id": 37,
-    "offset": 264878,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Office[SP]worker",
-    "texte_orig": "I[SP]hear[SP]the[SP]students[SP]at[SP]Sevens[SP]got[SP]rescued.[1205][U+000A]\nI[SP]don't[SP]know[SP]who[SP]pulled[SP]that[SP]off,[SP]but[SP]they're\nsome[SP]damn[SP]brave[SP]people,[SP]whoever[SP]they[SP]are.",
-    "nom_fr": "Employé de bureau",
-    "texte_fr": "J'entends que les élèves de Seven ont été secourus.[1205][U+000A]\n Je ne sais pas qui a fait ça, mais ce sont des gens courageux."
-  },
-  {
-    "id": 38,
-    "offset": 265184,
-    "data_size": 454,
-    "slot_size": 458,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Um,[SP]I[SP]hear[SP]a[SP]ramen[SP]shop[SP]sells[SP]guns[SP]and[SP]swords\nand[SP]stuff.[SP]I[SP]wonder[SP]if[SP]they[SP]have[SP]a[SP]really\ncool[SP]sword.[E1][E2]\n[E3][E4][NULL][NULL]\"Boy\nDid[SP]the[SP]boys[SP]at[SP]Cuss[SP]High[SP]get[SP]cooler?[1205][U+000F][SP]That's\nwhat[SP]my[SP]sister[SP]said.[SP]How[SP]do[SP]they[SP]do[SP]that?\nDo[SP]they[SP]transform?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Un resto de ramen vend des flingues et des épées.\n Ils ont une épée super cool ?[E1][E2]\n[E3][E4][NULL][NULL]\"Garçon\nLes garçons du lycée Cuss sont plus cools ?[1205][U+000F]\n C'est ce que ma sœur a dit. Comment ils font ?\n Ils se transforment ?"
-  },
-  {
-    "id": 39,
-    "offset": 265642,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Waaaaah![1205][U+000F][SP]I[SP]wanted[SP]to[SP]go[SP]to[SP]Kasuga[SP]Festival!\nMy[SP]sister[SP]said[SP]kids[SP]can't[SP]go.[1205][U+000F][SP]It's[SP]not[SP]faaaair!",
-    "nom_fr": "Garçon",
-    "texte_fr": "Waaaaah ![1205][U+000F] Je voulais aller au festival Kasuga !\n Les enfants ne peuvent pas.[1205][U+000F] Pas juste !"
-  },
-  {
-    "id": 40,
-    "offset": 265854,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy[121D][U+0001]",
-    "texte_orig": "I[SP]saw[SP]a[SP]bunch[SP]of[SP]Sevens[SP]people[SP]running[SP]away.\nWhat[SP]happened?",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 41,
-    "offset": 265998,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "My[SP]sister[SP]didn't[SP]come[SP]home[SP]after[SP]the[SP]Kasuga\nFestival...[SP]What's[SP]wrong[SP]with[SP]her?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Ma sœur n'est pas rentrée après le festival...\n Qu'est-ce qu'elle a ?"
-  },
-  {
-    "id": 42,
-    "offset": 266176,
-    "data_size": 90,
-    "slot_size": 94,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Oh[SP]well.[SP]I[SP]wonder[SP]what's[SP]for[SP]dinner.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Tant pis. Quoi manger ?"
-  },
-  {
-    "id": 43,
-    "offset": 266270,
-    "data_size": 136,
-    "slot_size": 140,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Mommy[SP]said[SP]I[SP]shouldn't[SP]go[SP]outside.[SP]She[SP]says\nit's[SP]dangerous.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Maman dit de ne pas sortir.\n C'est dangereux."
-  },
-  {
-    "id": 44,
-    "offset": 266410,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "But[SP]I[SP]think[SP]I[SP]was[SP]waiting[SP]for[SP]someone[SP]here.[1205][U+000F]\nI[SP]can't[SP]remember[SP]who[SP]though.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Je crois que j'attendais quelqu'un ici.[1205][U+000F]\n Je ne me souviens plus qui."
-  },
-  {
-    "id": 45,
-    "offset": 266580,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Hey[SP]Mister?[SP]What's[SP]a[SP]Last[SP]Battalion?[SP]Are[SP]they\nbad[SP]guys[SP]like[SP]the[SP]Masked[SP]Circle?",
-    "nom_fr": "Garçon",
-    "texte_fr": "C'est quoi le Dernier Bataillon ?\n Des méchants comme le Cercle Masqué ?"
-  },
-  {
-    "id": 46,
-    "offset": 266758,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "The[SP]people[SP]in[SP]the[SP]drawings[SP]are[SP]heroes[SP]and\nthey[SP]fight[SP]the[SP]Masked[SP]Circle.[1205][U+000F][SP]My[SP]friend\ntold[SP]me.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Les dessins montrent des héros combattant le Cercle Masqué.[1205][U+000F]\n Mon ami l'a dit."
-  },
-  {
-    "id": 47,
-    "offset": 266964,
-    "data_size": 146,
-    "slot_size": 150,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "What's[SP]Xibalba[SP]like?[1205][U+000F][SP]Does[SP]it[SP]combine[SP]with\nstuff[SP]and[SP]transform?",
-    "nom_fr": "Garçon",
-    "texte_fr": "C'est quoi Xibalba ?[1205][U+000F]\n Ça se combine et ça se transforme ?"
-  },
-  {
-    "id": 48,
-    "offset": 267114,
-    "data_size": 120,
-    "slot_size": 124,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Waaaaaah![SP]Waaaaaah![1205][U+000F][SP]I'm[SP]scaaaared![SP]Mommy!\nSister!",
-    "nom_fr": "Garçon",
-    "texte_fr": "Waaaaaah ! J'ai peur !\n Maman ! Ma sœur !"
-  },
-  {
-    "id": 49,
-    "offset": 267238,
-    "data_size": 208,
-    "slot_size": 212,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Woooow...[SP]The[SP]city's[SP]flying![1205][U+000A][SP]But[SP]the[SP]Earth[SP]is\ngonna[SP]get[SP]uh-nye-a-lated[SP]after[SP]the[SP]Grand[SP]Cross.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Woooow... La ville vole ![1205][U+000A] Mais la Terre va être anéantie\n après la Grande Croix."
-  },
-  {
-    "id": 50,
-    "offset": 267450,
-    "data_size": 82,
-    "slot_size": 86,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy[121D][U+0001]",
-    "texte_orig": "Mister,[SP]what's[SP]uh-nye-a-lated?",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 51,
-    "offset": 267536,
-    "data_size": 226,
-    "slot_size": 230,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Um,[SP]so,[SP]I[SP]heard[SP]the[SP]Earth's[SP]gonna[SP]split[SP]open\nafter[SP]the[SP]Grand[SP]Cross.[1205][U+000A][SP]That's[SP]how[SP]it[SP]gets\nuh-nye-a-lated.",
-    "nom_fr": "Garçon",
-    "texte_fr": "J'ai entendu que la Terre va se fendre après la Grande Croix.[1205][U+000A]\n C'est comme ça qu'elle est anéantie."
-  },
-  {
-    "id": 52,
-    "offset": 267766,
-    "data_size": 84,
-    "slot_size": 88,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy[121D][U+0001]",
-    "texte_orig": "But[SP]what's[SP]uh-nye-a-lated[SP]mean?",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 53,
-    "offset": 267854,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Mommy[SP]says[SP]after[SP]the[SP]Grand[SP]Cross,[SP]there's[SP]gonna\nbe[SP]a[SP]huge[SP]earthquake[SP]and[SP]the[SP]Earth[SP]down[SP]there\nis[SP]gonna[SP]get[SP]uh-nye-a-lated.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Maman dit qu'après la Grande Croix, il y aura un grand tremblement de terre\n et que la Terre sera anéantie."
-  },
-  {
-    "id": 54,
-    "offset": 268120,
-    "data_size": 112,
-    "slot_size": 116,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "But[SP]no[SP]one[SP]will[SP]tell[SP]me[SP]what[SP]uh-nye-a-lated[SP]is.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Personne ne veut me dire anéanti."
-  },
-  {
-    "id": 55,
-    "offset": 268236,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "After[SP]the[SP]Grand[SP]Cross,[SP]the[SP]Earth's[SP]gonna[SP]stop\nspinning.[1205][U+000A][SP]That's[SP]what[SP]my[SP]daddy[SP]said.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Après la Grande Croix, la Terre va s'arrêter.[1205][U+000A]\n C'est mon papa."
-  },
-  {
-    "id": 56,
-    "offset": 268426,
-    "data_size": 174,
-    "slot_size": 178,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Is[SP]that[SP]what[SP]uh-nye-a-lated[SP]means?[SP]The[SP]Earth\nstops[SP]spinning?[1205][U+000F][SP]I[SP]don't[SP]get[SP]it.",
-    "nom_fr": "Garçon",
-    "texte_fr": "C'est ça, anéanti ? La Terre s'arrête ?[1205][U+000F]\n Je ne comprends pas."
-  },
-  {
-    "id": 57,
-    "offset": 268604,
-    "data_size": 184,
-    "slot_size": 188,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Um,[SP]someone[SP]told[SP]me[SP]there[SP]are[SP]flowers[SP]in[SP]Aoba\nPark[SP]that[SP]talk.[SP]But[SP]that[SP]sounds[SP]dumb.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Des fleurs qui parlent au parc d'Aoba ?\n Ça me paraît idiot."
-  },
-  {
-    "id": 58,
-    "offset": 268792,
-    "data_size": 150,
-    "slot_size": 154,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Flowers[SP]don't[SP]have[SP]mouths,[SP]silly![SP]Can[SP]they\ntalk[SP]with[SP]their[SP]petals?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Les fleurs n'ont pas de bouche !\n Elles parlent par pétales ?"
-  },
-  {
-    "id": 59,
-    "offset": 268946,
-    "data_size": 236,
-    "slot_size": 240,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Hey,[SP]what's[SP]Zodiac[SP]like?[SP]'Cause[SP]my[SP]friend[SP]said\nthe[SP]second[SP]floor[SP]is[SP]this[SP]big[SP]dungeon[SP]with[SP]a\nlot[SP]of[SP]cool[SP]stuff.",
-    "nom_fr": "Garçon",
-    "texte_fr": "C'est quoi Zodiac ? Mon pote dit que le 2e étage\n est un grand donjon avec des trucs cools."
-  },
-  {
-    "id": 60,
-    "offset": 269186,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]bet[SP]there's[SP]an[SP]archfiend[SP]in[SP]there.[SP]He's[SP]just\nwaiting[SP]for[SP]the[SP]heroes[SP]to[SP]show[SP]up.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Il y a un archidémon là-dedans.\n Il attend que les héros viennent."
-  },
-  {
-    "id": 61,
-    "offset": 269370,
-    "data_size": 140,
-    "slot_size": 144,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy[121D][U+0001]",
-    "texte_orig": "Hey,[SP]is[SP]that[SP]ghost[SP]Hanako[SP]really[SP]at[SP]Sevens?\nHanako's[SP]scary.",
-    "nom_fr": "",
-    "texte_fr": ""
-  },
-  {
-    "id": 62,
-    "offset": 269514,
-    "data_size": 108,
-    "slot_size": 112,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "If[SP]she[SP]sees[SP]you,[SP]she[SP]pulls[SP]you[SP]in[SP]the[SP]toilet.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Elle te tire aux toilettes."
-  },
-  {
-    "id": 63,
-    "offset": 269626,
-    "data_size": 232,
-    "slot_size": 236,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Hey,[SP]is[SP]Bukimi[SP]really[SP]at[SP]Cuss[SP]High?[SP]She's[SP]even\nscarier[SP]than[SP]Hanako.[SP]You're[SP]a[SP]goner[SP]if[SP]she\nsees[SP]you,[SP]Mister.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Bukimi est vraiment au lycée Cuss ?\n Elle fait plus peur qu'Hanako.\n Vous êtes mort si elle vous voit."
-  },
-  {
-    "id": 64,
-    "offset": 269862,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Is[SP]there[SP]really[SP]a[SP]ghost[SP]in[SP]the[SP]park[SP]by[SP]the\nconcert[SP]hall?[SP]Um,[SP]I[SP]heard[SP]it's[SP]an[SP]idol's[SP]ghost.[1205][U+000F]\nWhat[SP]do[SP]I[SP]do?[SP]My[SP]treasure's[SP]buried[SP]there...",
-    "nom_fr": "Garçon",
-    "texte_fr": "Il y a vraiment un fantôme dans le parc près de la salle ?\n C'est le fantôme d'une idole.[1205][U+000F] Mon trésor est enterré là..."
-  },
-  {
-    "id": 65,
-    "offset": 270156,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Guess[SP]what?[SP]There's[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the\nabandoned[SP]factory.[SP]I[SP]bet[SP]you'll[SP]get[SP]cursed\nif[SP]you[SP]equip[SP]it.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Devine quoi ? Il y a un Taxi Maudit à l'usine abandonnée.\n Tu seras maudit si tu l'équipes."
-  },
-  {
-    "id": 66,
-    "offset": 270378,
-    "data_size": 230,
-    "slot_size": 234,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Hey,[SP]you[SP]know[SP]what?[SP]There's[SP]a[SP]Cursed[SP]Escort[SP]at\nthe[SP]abandoned[SP]factory.[SP]I[SP]bet[SP]your[SP]HP[SP]drops[SP]if\nyou[SP]equip[SP]it.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Il y a une Escorte Maudite à l'usine abandonnée.\n Tes PV baissent si tu l'équipes."
-  },
-  {
-    "id": 67,
-    "offset": 270612,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "What[SP]do[SP]I[SP]do...?[SP]I[SP]heard[SP]Kuchisake-onna[SP]is\nat[SP]Mt.[SP]Iwato.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Je fais quoi ? Kuchisake-onna est au mont Iwato."
-  },
-  {
-    "id": 68,
-    "offset": 270746,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "And[SP]my[SP]teacher[SP]says[SP]it[SP]chases[SP]kids[SP]who[SP]don't\ngo[SP]straight[SP]home[SP]after[SP]school.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Mon prof dit qu'elle poursuit ceux qui ne rentrent pas."
-  },
-  {
-    "id": 69,
-    "offset": 270918,
-    "data_size": 116,
-    "slot_size": 120,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Um,[SP]I[SP]heard[SP]Jumping[SP]Geezer[SP]is[SP]at\nMt.[SP]Katatsumuri.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Le Sauteur Vieux est au mont Katatsumuri."
-  },
-  {
-    "id": 70,
-    "offset": 271038,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Jumping[SP]Geezer's[SP]this[SP]guy[SP]who[SP]chases[SP]after[SP]you\nand[SP]stomps[SP]on[SP]your[SP]head.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Le Sauteur Vieux, un type qui te court après\n et te piétine la tête."
-  },
-  {
-    "id": 71,
-    "offset": 271202,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Waaaaaah![SP]Waaaaah![SP]I'm[SP]scaaaared!\nU-Um,[SP]Kudan's[SP]at[SP]the[SP]abandoned[SP]factory...\nWaaaaaah![SP]Waaaaah!",
-    "nom_fr": "Garçon",
-    "texte_fr": "Waaaaah ! J'ai peur !\n Kudan est à l'usine abandonnée...\n Waaaaah !"
-  },
-  {
-    "id": 72,
-    "offset": 271412,
-    "data_size": 102,
-    "slot_size": 106,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Hey,[SP]I[SP]heard[SP]Giga[SP]Macho[SP]sells[SP]a[SP]secret[SP]CD.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Giga Macho vend un CD secret."
-  },
-  {
-    "id": 73,
-    "offset": 271518,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "It's[SP]like[SP]a[SP]secret[SP]item[SP]in[SP]a[SP]game,[SP]huh?\nThat's[SP]so[SP]weird.",
-    "nom_fr": "Garçon",
-    "texte_fr": "C'est comme un objet secret de jeu, non ?\n Bizarre."
-  },
-  {
-    "id": 74,
-    "offset": 271652,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]wonder[SP]if[SP]Dresser[SP]Hag[SP]is[SP]the[SP]monster[SP]my\nfriend[SP]Chii[SP]was[SP]talking[SP]about.",
-    "nom_fr": "Garçon",
-    "texte_fr": "La Sorcière du Buffet, c'est le monstre\n dont mon pote Chii parlait ?"
-  },
-  {
-    "id": 75,
-    "offset": 271818,
-    "data_size": 152,
-    "slot_size": 156,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "So[SP]he[SP]wasn't[SP]lying[SP]when[SP]he[SP]said[SP]he[SP]saw[SP]it[SP]at\nthe[SP]abandoned[SP]factory!",
-    "nom_fr": "Garçon",
-    "texte_fr": "Donc il ne mentait pas en disant l'avoir vue à l'usine !"
-  },
-  {
-    "id": 76,
-    "offset": 271974,
-    "data_size": 120,
-    "slot_size": 124,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "If[SP]you[SP]go[SP]to[SP]Time[SP]Castle,[SP]you[SP]can[SP]buy\nreal[SP]weapons!",
-    "nom_fr": "Garçon",
-    "texte_fr": "Au Château du Temps, de vraies armes !"
-  },
-  {
-    "id": 77,
-    "offset": 272098,
-    "data_size": 116,
-    "slot_size": 120,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Um,[SP]I[SP]heard[SP]they're[SP]okay[SP]and[SP]the[SP]price\nis[SP]normal.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Elles sont correctes et le prix est normal."
-  },
-  {
-    "id": 78,
-    "offset": 272218,
-    "data_size": 120,
-    "slot_size": 124,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "If[SP]you[SP]go[SP]to[SP]Time[SP]Castle,[SP]you[SP]can[SP]buy\nreal[SP]weapons!",
-    "nom_fr": "Garçon",
-    "texte_fr": "Au Château du Temps, de vraies armes !"
-  },
-  {
-    "id": 79,
-    "offset": 272342,
-    "data_size": 116,
-    "slot_size": 120,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Um,[SP]I[SP]heard[SP]they're[SP]good,[SP]but[SP]they[SP]cost\ntoo[SP]much.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Elles sont bonnes mais trop chères."
-  },
-  {
-    "id": 80,
-    "offset": 272462,
-    "data_size": 120,
-    "slot_size": 124,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "If[SP]you[SP]go[SP]to[SP]Time[SP]Castle,[SP]you[SP]can[SP]buy\nreal[SP]weapons!",
-    "nom_fr": "Garçon",
-    "texte_fr": "Au Château du Temps, de vraies armes !"
-  },
-  {
-    "id": 81,
-    "offset": 272586,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Um,[SP]I[SP]heard[SP]they're[SP]cheap,[SP]but[SP]they're\nnot[SP]that[SP]good.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Bon marché mais pas terribles."
-  },
-  {
-    "id": 82,
-    "offset": 272714,
-    "data_size": 138,
-    "slot_size": 142,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]about[SP]a[SP]weapon[SP]store[SP]in[SP]Yumezaki\ncalled[SP]Tony's[SP]Shop.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop."
-  },
-  {
-    "id": 83,
-    "offset": 272856,
-    "data_size": 150,
-    "slot_size": 154,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "They[SP]sell[SP]a[SP]bunch[SP]of[SP]stuff,[SP]but[SP]they[SP]don't\npay[SP]you[SP]much[SP]for[SP]sales.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Ils vendent plein de trucs, mais reprennent pas cher."
-  },
-  {
-    "id": 84,
-    "offset": 273010,
-    "data_size": 138,
-    "slot_size": 142,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]about[SP]a[SP]weapon[SP]store[SP]in[SP]Yumezaki\ncalled[SP]Tony's[SP]Shop.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop."
-  },
-  {
-    "id": 85,
-    "offset": 273152,
-    "data_size": 114,
-    "slot_size": 118,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "They're[SP]cheap,[SP]but[SP]their[SP]stuff's[SP]not\nthat[SP]great.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Bon marché, mais qualité moyenne."
-  },
-  {
-    "id": 86,
-    "offset": 273270,
-    "data_size": 138,
-    "slot_size": 142,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]about[SP]a[SP]weapon[SP]store[SP]in[SP]Yumezaki\ncalled[SP]Tony's[SP]Shop.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop."
-  },
-  {
-    "id": 87,
-    "offset": 273412,
-    "data_size": 108,
-    "slot_size": 112,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Their[SP]stuff[SP]is[SP]okay.[SP]The[SP]prices[SP]are[SP]okay[SP]too.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Trucs corrects, prix corrects."
-  },
-  {
-    "id": 88,
-    "offset": 273524,
-    "data_size": 138,
-    "slot_size": 142,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]about[SP]a[SP]weapon[SP]store[SP]in[SP]Yumezaki\ncalled[SP]Tony's[SP]Shop.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop."
-  },
-  {
-    "id": 89,
-    "offset": 273666,
-    "data_size": 100,
-    "slot_size": 104,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "They[SP]have[SP]nice[SP]stuff,[SP]but[SP]it[SP]costs[SP]a[SP]lot.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Beaux trucs, mais chers."
-  },
-  {
-    "id": 90,
-    "offset": 273770,
-    "data_size": 110,
-    "slot_size": 114,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Un resto à Aoba vend des armes, vrai ?"
-  },
-  {
-    "id": 91,
-    "offset": 273884,
-    "data_size": 170,
-    "slot_size": 174,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "This[SP]lady[SP]said[SP]they[SP]don't[SP]have[SP]a[SP]lot[SP]of[SP]stuff,\nbut[SP]their[SP]trade-ins[SP]are[SP]good.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Cette dame a dit qu'ils ont peu de choix,\n mais reprennent bien."
-  },
-  {
-    "id": 92,
-    "offset": 274058,
-    "data_size": 110,
-    "slot_size": 114,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Un resto à Aoba vend des armes, vrai ?"
-  },
-  {
-    "id": 93,
-    "offset": 274172,
-    "data_size": 142,
-    "slot_size": 146,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "This[SP]lady[SP]said[SP]they're[SP]cheap,[SP]but[SP]they[SP]don't\nhave[SP]great[SP]stuff.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Bon marché, mais pas de super trucs,\n dit cette dame."
-  },
-  {
-    "id": 94,
-    "offset": 274318,
-    "data_size": 110,
-    "slot_size": 114,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Un resto à Aoba vend des armes, vrai ?"
-  },
-  {
-    "id": 95,
-    "offset": 274432,
-    "data_size": 132,
-    "slot_size": 136,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "This[SP]lady[SP]said[SP]they[SP]sell[SP]nice[SP]things,[SP]but[SP]it\ncosts[SP]a[SP]lot.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Belles choses, mais cher."
-  },
-  {
-    "id": 96,
-    "offset": 274568,
-    "data_size": 110,
-    "slot_size": 114,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Un resto à Aoba vend des armes, vrai ?"
-  },
-  {
-    "id": 97,
-    "offset": 274682,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "This[SP]lady[SP]said[SP]they[SP]have[SP]a[SP]lot[SP]of[SP]stuff,\nbut[SP]their[SP]trade-ins[SP]are[SP]cheap.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Cette dame a dit beaucoup de choix,\n mais reprises bas prix."
-  },
-  {
-    "id": 98,
-    "offset": 274846,
-    "data_size": 110,
-    "slot_size": 114,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Un resto à Aoba vend des armes, vrai ?"
-  },
-  {
-    "id": 99,
-    "offset": 274960,
-    "data_size": 156,
-    "slot_size": 160,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "This[SP]cool[SP]lady[SP]said[SP]their[SP]stuff[SP]is[SP]okay[SP]and\ntheir[SP]prices[SP]were[SP]normal.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Cette dame sympa a dit : trucs corrects,\n prix normaux."
-  },
-  {
-    "id": 100,
-    "offset": 275120,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a\nboat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes."
-  },
-  {
-    "id": 101,
-    "offset": 275286,
-    "data_size": 132,
-    "slot_size": 136,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]their[SP]stuff[SP]is[SP]okay.[SP]And[SP]their[SP]prices\nare[SP]normal.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Leurs trucs sont corrects,\n prix normaux."
-  },
-  {
-    "id": 102,
-    "offset": 275422,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a\nboat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes."
-  },
-  {
-    "id": 103,
-    "offset": 275588,
-    "data_size": 152,
-    "slot_size": 156,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]they're[SP]cheap,[SP]but[SP]they[SP]don't[SP]have\ngreat[SP]stuff[SP]or[SP]anything.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Bon marché, mais pas de super trucs."
-  },
-  {
-    "id": 104,
-    "offset": 275744,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a\nboat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes."
-  },
-  {
-    "id": 105,
-    "offset": 275910,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]they[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]they\ndon't[SP]pay[SP]you[SP]much[SP]for[SP]yours.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Beaucoup de choix, mais tes reprises\n sont mal payées."
-  },
-  {
-    "id": 106,
-    "offset": 276076,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a\nboat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes."
-  },
-  {
-    "id": 107,
-    "offset": 276242,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]they[SP]don't[SP]have[SP]much[SP]stuff,[SP]so[SP]they'll\npay[SP]you[SP]a[SP]lot[SP]for[SP]yours.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Peu de choix, donc ils reprennent cher."
-  },
-  {
-    "id": 108,
-    "offset": 276406,
-    "data_size": 162,
-    "slot_size": 166,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a\nboat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes."
-  },
-  {
-    "id": 109,
-    "offset": 276572,
-    "data_size": 128,
-    "slot_size": 132,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]their[SP]stuff[SP]is[SP]great.[SP]But[SP]it[SP]costs\na[SP]whole[SP]lot.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Trucs géniaux, mais très chers."
-  },
-  {
-    "id": 110,
-    "offset": 276704,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]didn't[SP]know[SP]Rosa[SP]Candida[SP]was[SP]an[SP]armor[SP]store.\nI[SP]wonder[SP]if[SP]they[SP]sell[SP]Orichalcum[SP]shields...\nTheir[SP]defense[SP]and[SP]price[SP]is[SP]normal,[SP]right?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Je ne savais pas que Rosa Candida vendait des armures.\n Des boucliers en orichalque ? Défense et prix normaux, non ?"
-  },
-  {
-    "id": 111,
-    "offset": 276990,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]didn't[SP]know[SP]Rosa[SP]Candida[SP]was[SP]an[SP]armor[SP]store.\nI[SP]wonder[SP]if[SP]they[SP]sell[SP]Orichalcum[SP]shields...\nThey're[SP]not[SP]great,[SP]but[SP]cheap,[SP]right?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida vend des armures ? Des boucliers en orichalque ?\n Pas géniaux mais bon marché ?"
-  },
-  {
-    "id": 112,
-    "offset": 277266,
-    "data_size": 292,
-    "slot_size": 296,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]didn't[SP]know[SP]Rosa[SP]Candida[SP]was[SP]an[SP]armor[SP]store.\nI[SP]wonder[SP]if[SP]they[SP]sell[SP]Orichalcum[SP]shields...\nThey[SP]sell[SP]good[SP]stuff,[SP]but[SP]it's[SP]expensive,[SP]huh?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida est un magasin d'armures ? Des boucliers en orichalque ?\n Bonne qualité mais cher, hein ?"
-  },
-  {
-    "id": 113,
-    "offset": 277562,
-    "data_size": 128,
-    "slot_size": 132,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Um,[SP]I[SP]heard[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells\nreal[SP]armor.[1205][U+000F]",
-    "nom_fr": "Garçon",
-    "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures."
-  },
-  {
-    "id": 114,
-    "offset": 277694,
-    "data_size": 136,
-    "slot_size": 140,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "A[SP]lady[SP]said[SP]their[SP]stuff[SP]is[SP]okay[SP]and[SP]the[SP]prices\nwere[SP]normal.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Une dame a dit : trucs corrects,\n prix normaux."
-  },
-  {
-    "id": 115,
-    "offset": 277834,
-    "data_size": 128,
-    "slot_size": 132,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Um,[SP]I[SP]heard[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells\nreal[SP]armor.[1205][U+000F]",
-    "nom_fr": "Garçon",
-    "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures."
-  },
-  {
-    "id": 116,
-    "offset": 277966,
-    "data_size": 104,
-    "slot_size": 108,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "A[SP]lady[SP]said[SP]it's[SP]cheap,[SP]but[SP]not[SP]that[SP]great.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Bon marché, pas terrible."
-  },
-  {
-    "id": 117,
-    "offset": 278074,
-    "data_size": 128,
-    "slot_size": 132,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Um,[SP]I[SP]heard[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells\nreal[SP]armor.[1205][U+000F]",
-    "nom_fr": "Garçon",
-    "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures."
-  },
-  {
-    "id": 118,
-    "offset": 278206,
-    "data_size": 150,
-    "slot_size": 154,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "A[SP]lady[SP]said[SP]they[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]the\ntrade-ins[SP]are[SP]cheap.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Une dame a dit beaucoup de choix,\n mais reprises bon marché."
-  },
-  {
-    "id": 119,
-    "offset": 278360,
-    "data_size": 128,
-    "slot_size": 132,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Um,[SP]I[SP]heard[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells\nreal[SP]armor.[1205][U+000F]",
-    "nom_fr": "Garçon",
-    "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures."
-  },
-  {
-    "id": 120,
-    "offset": 278492,
-    "data_size": 120,
-    "slot_size": 124,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "A[SP]lady[SP]said[SP]they[SP]had[SP]good[SP]stuff,[SP]but[SP]it\ncost[SP]a[SP]lot.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Une dame a dit de bonnes choses,\n mais cher."
-  },
-  {
-    "id": 121,
-    "offset": 278616,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Il y a aussi un Rosa Candida à Aoba.\n C'est un magasin d'armures, non ?"
-  },
-  {
-    "id": 122,
-    "offset": 278788,
-    "data_size": 148,
-    "slot_size": 152,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Someone[SP]said[SP]they[SP]don't[SP]have[SP]a[SP]lot,[SP]but\ntheir[SP]trade-ins[SP]are[SP]good.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Quelqu'un a dit peu de choix,\n mais bonnes reprises."
-  },
-  {
-    "id": 123,
-    "offset": 278940,
-    "data_size": 294,
-    "slot_size": 298,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][U+000F][SP]Someone[SP]said\ntheir[SP]stuff's[SP]okay[SP]and[SP]their[SP]prices[SP]are[SP]normal.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida à Aoba, c'est aussi un magasin d'armures ?[1205][U+000F]\n Quelqu'un a dit trucs corrects, prix normaux."
-  },
-  {
-    "id": 124,
-    "offset": 279238,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][U+000F][SP]Someone[SP]said\ntheir[SP]stuff's[SP]great,[SP]but[SP]it[SP]costs[SP]a[SP]lot.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida à Aoba, armurerie ?[1205][U+000F]\n Quelqu'un a dit trucs géniaux, mais cher."
-  },
-  {
-    "id": 125,
-    "offset": 279522,
-    "data_size": 286,
-    "slot_size": 290,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][U+000F][SP]Someone[SP]said\nthey're[SP]cheap,[SP]but[SP]their[SP]stuff's[SP]kinda[SP]bad.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida à Aoba, magasin d'armures ?[1205][U+000F]\n Quelqu'un a dit bon marché, mais qualité bof."
-  },
-  {
-    "id": 126,
-    "offset": 279812,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][U+000F][SP]They[SP]have[SP]a\nlot[SP]of[SP]stuff,[SP]but[SP]trade-ins[SP]are[SP]cheap.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida à Aoba, armures ?[1205][U+000F]\n Beaucoup de choix, mais reprises bon marché."
-  },
-  {
-    "id": 127,
-    "offset": 280090,
-    "data_size": 218,
-    "slot_size": 222,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady\nsaid[SP]they[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]trade-ins\nare[SP]cheap.",
-    "nom_fr": "Garçon",
-    "texte_fr": "London Clothier fait aussi des armures ?[1205][U+000F]\n Beaucoup de choix, reprises pas chères."
-  },
-  {
-    "id": 128,
-    "offset": 280312,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady\nsaid[SP]they're[SP]cheap,[SP]but[SP]their[SP]stuff[SP]isn't\nthat[SP]great.",
-    "nom_fr": "Garçon",
-    "texte_fr": "London Clothier, armures ?[1205][U+000F]\n Bon marché, qualité moyenne."
-  },
-  {
-    "id": 129,
-    "offset": 280530,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady\nsaid[SP]their[SP]stuff[SP]is[SP]nice,[SP]but[SP]it's[SP]expensive.",
-    "nom_fr": "Garçon",
-    "texte_fr": "London Clothier vend des armures ?[1205][U+000F]\n Joli mais cher."
-  },
-  {
-    "id": 130,
-    "offset": 280732,
-    "data_size": 242,
-    "slot_size": 246,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady\nsaid[SP]their[SP]stuff[SP]is[SP]okay.[SP]And[SP]she[SP]said[SP]their\nprices[SP]are[SP]normal[SP]too.",
-    "nom_fr": "Garçon",
-    "texte_fr": "London Clothier, armures ?[1205][U+000F]\n Trucs corrects, prix normaux."
-  },
-  {
-    "id": 131,
-    "offset": 280978,
-    "data_size": 240,
-    "slot_size": 244,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady\nsaid[SP]they[SP]don't[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]their\ntrade-ins[SP]are[SP]good.",
-    "nom_fr": "Garçon",
-    "texte_fr": "London Clothier fait des armures ?[1205][U+000F]\n Peu de choix, mais bonnes reprises."
-  },
-  {
-    "id": 132,
-    "offset": 281222,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Do[SP]you[SP]know[SP]about[SP]magazine[SP]contests?[1205][U+000F][SP]I[SP]heard[SP]if\nyou[SP]win[SP]one,[SP]you[SP]get[SP]real[SP]weapons[SP]and[SP]stuff.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Tu connais les concours de magazines ?\n Si on gagne, on a des vraies armes."
-  },
-  {
-    "id": 133,
-    "offset": 281432,
-    "data_size": 142,
-    "slot_size": 146,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "You[SP]don't[SP]win[SP]too[SP]often,[SP]but[SP]when[SP]you[SP]do,[SP]the\nprizes[SP]are[SP]nice.",
-    "nom_fr": "Garçon",
-    "texte_fr": "On gagne rarement, mais les lots sont sympas."
-  },
-  {
-    "id": 134,
-    "offset": 281578,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Do[SP]you[SP]know[SP]about[SP]magazine[SP]contests?[1205][U+000F][SP]I[SP]heard[SP]if\nyou[SP]win[SP]one,[SP]you[SP]get[SP]real[SP]weapons[SP]and[SP]stuff.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Tu connais les concours de magazines ?\n Si on gagne, on a des vraies armes."
-  },
-  {
-    "id": 135,
-    "offset": 281788,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "You[SP]hardly[SP]ever[SP]win,[SP]but[SP]when[SP]you[SP]do,[SP]the\nprizes[SP]are[SP]really[SP]rare[SP]stuff.",
-    "nom_fr": "Garçon",
-    "texte_fr": "On gagne rarement, mais les lots sont très rares."
-  },
-  {
-    "id": 136,
-    "offset": 281952,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Do[SP]you[SP]know[SP]about[SP]magazine[SP]contests?[1205][U+000F][SP]I[SP]heard[SP]if\nyou[SP]win[SP]one,[SP]you[SP]get[SP]real[SP]weapons[SP]and[SP]stuff.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Tu connais les concours de magazines ?\n Si on gagne, on a des vraies armes."
-  },
-  {
-    "id": 137,
-    "offset": 282162,
-    "data_size": 130,
-    "slot_size": 134,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "People[SP]win[SP]all[SP]the[SP]time.[SP]But[SP]they[SP]only[SP]get\nboring[SP]stuff.",
-    "nom_fr": "Garçon",
-    "texte_fr": "On gagne souvent, des trucs ennuyeux."
-  },
-  {
-    "id": 138,
-    "offset": 282296,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]know[SP]what[SP]a[SP]casino[SP]is![SP]They[SP]have[SP]stuff[SP]like\nslots[SP]and[SP]races.[SP]Mu[SP]has[SP]one,[SP]right?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Je sais ce qu'est un casino !\n Machines à sous, courses. Mu en a un, non ?"
-  },
-  {
-    "id": 139,
-    "offset": 282480,
-    "data_size": 168,
-    "slot_size": 172,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "They[SP]say[SP]poker's[SP]the[SP]best[SP]game[SP]there.[SP]I[SP]dunno\nhow[SP]to[SP]play[SP]that[SP]one,[SP]though.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Le poker est le meilleur jeu là-bas,\n mais je ne sais pas y jouer."
-  },
-  {
-    "id": 140,
-    "offset": 282652,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]know[SP]what[SP]a[SP]casino[SP]is![SP]They[SP]have[SP]stuff[SP]like\nslots[SP]and[SP]races.[SP]Mu[SP]has[SP]one,[SP]right?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Je sais ce qu'est un casino !\n Machines à sous, courses. Mu en a un, non ?"
-  },
-  {
-    "id": 141,
-    "offset": 282836,
-    "data_size": 198,
-    "slot_size": 202,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Slots[SP]are[SP]the[SP]best.[SP]I[SP]know[SP]how[SP]to[SP]play[SP]those!\nUm,[SP]I[SP]heard[SP]you[SP]can[SP]win[SP]a[SP]lot[SP]on[SP]machine[SP]#1.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Machines à sous : le top. Je sais y jouer !\n Grosse gagne sur la n°1."
-  },
-  {
-    "id": 142,
-    "offset": 283038,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]know[SP]what[SP]a[SP]casino[SP]is![SP]They[SP]have[SP]stuff[SP]like\nslots[SP]and[SP]races.[SP]Mu[SP]has[SP]one,[SP]right?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Je sais ce qu'est un casino !\n Machines à sous, courses. Mu en a un, non ?"
-  },
-  {
-    "id": 143,
-    "offset": 283222,
-    "data_size": 202,
-    "slot_size": 206,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Um,[SP]I[SP]heard[SP]it's[SP]good[SP]to[SP]play[SP]blackjack[SP]there,\nbut[SP]I[SP]dunno[SP]how[SP]to[SP]play[SP]that.[SP]Do[SP]you,[SP]Mister?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Blackjack est bon là-bas, mais je ne sais pas.\n Vous savez, monsieur ?"
-  },
-  {
-    "id": 144,
-    "offset": 283428,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Is[SP]there[SP]really[SP]a[SP]legendary[SP]weapon[SP]at[SP]the[SP]ramen\nshop?[1205][U+000F][SP]Some[SP]lady[SP]said[SP]so[SP]a[SP]minute[SP]ago.[SP]Wow,[SP]I\ndidn't[SP]know[SP]those[SP]really[SP]existed!",
-    "nom_fr": "Garçon",
-    "texte_fr": "Une arme légendaire au resto de ramen ?\n Une dame vient de le dire. Je ne savais pas que ça existait !"
-  },
-  {
-    "id": 145,
-    "offset": 283706,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Is[SP]it[SP]true[SP]there's[SP]a[SP]legendary[SP]weapon[SP]at[SP]the\nrestaurant[SP]in[SP]Aoba?[1205][U+000F][SP]Would[SP]it[SP]be[SP]in[SP]a[SP]dresser?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Une arme légendaire dans le resto d'Aoba ?\n Dans un buffet ?"
-  },
-  {
-    "id": 146,
-    "offset": 283914,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Why[SP]would[SP]the[SP]man[SP]at[SP]Time[SP]Castle[SP]lie[SP]about\nhaving[SP]a[SP]legendary[SP]weapon?[1205][U+000F][SP]I[SP]heard[SP]it's[SP]'cause\nhe's[SP]trying[SP]to[SP]charge[SP]a[SP]lot...",
-    "nom_fr": "Garçon",
-    "texte_fr": "Pourquoi le gars du Château du Temps mentirait\n sur une arme légendaire ?[1205][U+000F] Pour faire monter les prix..."
-  },
-  {
-    "id": 147,
-    "offset": 284182,
-    "data_size": 158,
-    "slot_size": 162,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]wonder[SP]why[SP]the[SP]man[SP]at[SP]Time[SP]Castle[SP]won't[SP]go\nget[SP]his[SP]legendary[SP]weapon.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Pourquoi ne pas chercher son arme légendaire ?"
-  },
-  {
-    "id": 148,
-    "offset": 284344,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "He[SP]should[SP]just[SP]beat[SP]up[SP]those[SP]monsters[SP]at[SP]the\nabandoned[SP]factory.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Il n'a qu'à battre les monstres\n à l'usine abandonnée."
-  },
-  {
-    "id": 149,
-    "offset": 284492,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]the[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle\ngot[SP]stolen.[SP]I[SP]bet[SP]it[SP]was[SP]the[SP]minions[SP]of[SP]the\narchfiend.",
-    "nom_fr": "Garçon",
-    "texte_fr": "L'arme légendaire du Château du Temps a été volée.\n Ce sont les sbires de l'archidémon."
-  },
-  {
-    "id": 150,
-    "offset": 284710,
-    "data_size": 134,
-    "slot_size": 138,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]heard[SP]a[SP]lady[SP]bought[SP]the[SP]legendary[SP]weapon\nat[SP]Time[SP]Castle.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Une dame a acheté l'arme légendaire."
-  },
-  {
-    "id": 151,
-    "offset": 284848,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]bet[SP]her[SP]kid's[SP]all[SP]grown[SP]up[SP]now[SP]and[SP]going[SP]on\na[SP]journey,[SP]so[SP]she's[SP]gonna[SP]give[SP]it[SP]to[SP]him[SP]as[SP]a\npresent.[SP]That's[SP]how[SP]it[SP]always[SP]is.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Son fils a grandi et part en voyage,\n alors elle va la lui donner en cadeau.\n C'est toujours comme ça."
-  },
-  {
-    "id": 152,
-    "offset": 285120,
-    "data_size": 192,
-    "slot_size": 196,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "Um,[SP]I[SP]heard[SP]the[SP]man[SP]at[SP]Time[SP]Castle[SP]gave[SP]his\nlegendary[SP]weapon[SP]to[SP]a[SP]lady[SP]with[SP]short[SP]hair.",
-    "nom_fr": "Garçon",
-    "texte_fr": "Le gars du Château du Temps a donné son arme\n à une dame aux cheveux courts."
-  },
-  {
-    "id": 153,
-    "offset": 285316,
-    "data_size": 222,
-    "slot_size": 226,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Boy",
-    "texte_orig": "I[SP]bet...[SP]she's[SP]actually[SP]a[SP]princess,[SP]and[SP]she's\ngonna[SP]hold[SP]onto[SP]it[SP]until[SP]the[SP]hero[SP]comes.\nRight,[SP]Mister?",
-    "nom_fr": "Garçon",
-    "texte_fr": "Je parie que c'est une princesse, elle garde l'arme\n pour le héros. C'est ça, monsieur ?"
-  },
-  {
-    "id": 154,
-    "offset": 285542,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "The[SP]principal's[SP]statue[SP]at[SP]Sevens[SP]doesn't[SP]like\nto[SP]be[SP]seen[SP]walking[SP]around...[1205][U+000F][SP]But[SP]there[SP]aren't\nmany[SP]foxes[SP]around[SP]these[SP]days.[SP]Is[SP]it[SP]possible?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "La statue du proviseur à Seven n'aime pas qu'on la voie se promener...[1205][U+000F]\n Mais il n'y a plus beaucoup de renards. Est-ce possible ?"
-  },
-  {
-    "id": 155,
-    "offset": 285850,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I've[SP]stopped[SP]seeing[SP]young[SP]girls[SP]around[SP]here\nlately.[1205][U+000F][SP]Is[SP]the[SP]bloom[SP]off[SP]the[SP]rose[SP]for[SP]Sevens\nbecause[SP]of[SP]that[SP]disease?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Je ne vois plus de jeunes filles par ici.[1205][U+000F]\n Seven a-t-il perdu son attrait à cause de cette maladie ?"
-  },
-  {
-    "id": 156,
-    "offset": 286110,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "It[SP]seems[SP]Kasugayama[SP]High's[SP]holding[SP]a[SP]masquerade\nas[SP]part[SP]of[SP]their[SP]school[SP]festival.[SP]Is[SP]that[SP]some\nkind[SP]of[SP]grape?[SP]It's[SP]all[SP]Greek[SP]to[SP]me.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Kasugayama organise un bal masqué pour sa fête.\n Une sorte de raisin ? C'est du chinois pour moi."
-  },
-  {
-    "id": 157,
-    "offset": 286402,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I[SP]heard[SP]at[SP]Honmaru[SP]Park[SP]that[SP]a[SP]store[SP]in[SP]Yumezaki\nsells[SP]real[SP]armor[SP]alongside[SP]regular[SP]clothes.\nWhat[SP]a[SP]dangerous[SP]place[SP]this[SP]world's[SP]become...",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "J'ai entendu au parc Honmaru qu'un magasin à Yumezaki\n vend des armures avec des vêtements. Dans quel monde dangereux on vit..."
-  },
-  {
-    "id": 158,
-    "offset": 286708,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "If[SP]you[SP]want[SP]to[SP]know[SP]more[SP]about[SP]it,[SP]I'd[SP]say[SP]you\nshould[SP]start[SP]by[SP]visiting[SP]Honmaru[SP]Park.[1205][U+000F]",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Si tu veux en savoir plus, commence par visiter le parc Honmaru."
-  },
-  {
-    "id": 159,
-    "offset": 286912,
-    "data_size": 114,
-    "slot_size": 118,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I[SP]heard[SP]the[SP]story[SP]from[SP]a[SP]homeless[SP]man[SP]there.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "J'ai entendu cette histoire d'un SDF."
-  },
-  {
-    "id": 160,
-    "offset": 287030,
-    "data_size": 288,
-    "slot_size": 292,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Do[SP]you[SP]know[SP]the[SP]Masked[SP]Circle?[SP]There's[SP]some\ngroup[SP]by[SP]that[SP]name,[SP]apparently.[SP]It[SP]reminds[SP]me\nof[SP]those[SP]bandits[SP]you[SP]see[SP]in[SP]period[SP]films.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Tu connais le Cercle Masqué ? Il paraît qu'il y a un groupe de ce nom.\n Ça me rappelle les bandits des films d'époque."
-  },
-  {
-    "id": 161,
-    "offset": 287322,
-    "data_size": 164,
-    "slot_size": 168,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man[121D][U+0001]",
-    "texte_orig": "Well,[SP]it[SP]appears[SP]this[SP]Masked[SP]Circle[SP]is[SP]quite\nthe[SP]frightening[SP]group.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Eh bien, ce Cercle Masqué est un groupe assez effrayant."
-  },
-  {
-    "id": 162,
-    "offset": 287490,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I'd[SP]rather[SP]steer[SP]clear[SP]of[SP]such[SP]folk[SP]at[SP]my[SP]age.[1205][U+000F]\nFingers[SP]crossed...",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "À mon âge, je préfère éviter ces gens.\n Croisons les doigts..."
-  },
-  {
-    "id": 163,
-    "offset": 287654,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Sounds[SP]like[SP]it[SP]was[SP]the[SP]Masked[SP]Circle[SP]who[SP]burned\ndown[SP]the[SP]outdoor[SP]concert[SP]hall.[1205][U+000F][SP]What's[SP]this[SP]world\ncoming[SP]to[SP]if[SP]such[SP]people[SP]really[SP]exist...?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "On dirait que c'est le Cercle Masqué qui a brûlé la salle de concert.[1205][U+000F]\n Où va le monde si de telles personnes existent vraiment ?"
-  },
-  {
-    "id": 164,
-    "offset": 287964,
-    "data_size": 258,
-    "slot_size": 262,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Turns[SP]out[SP]the[SP]real[SP]culprit[SP]was[SP]a[SP]gang[SP]of[SP]five\nterrorists.[1205][U+000F][SP]That's[SP]more[SP]plausible[SP]than[SP]the\nMasked[SP]Circle,[SP]I'd[SP]say...",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Le vrai coupable était une bande de cinq terroristes.[1205][U+000F]\n Plus plausible que le Cercle Masqué, je dirais..."
-  },
-  {
-    "id": 165,
-    "offset": 288226,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "There[SP]was[SP]a[SP]fella[SP]I[SP]used[SP]to[SP]play[SP]Go[SP]with...[1205][U+000F]\nHaven't[SP]seen[SP]him[SP]around[SP]lately.[1205][U+000F][SP]He[SP]seemed\nawful[SP]depressed,[SP]so[SP]I[SP]worry[SP]about[SP]him.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Il y avait un type avec qui je jouais au go...[1205][U+000F]\n Je ne l'ai pas vu récemment.[1205][U+000F] Il avait l'air très déprimé,\n je m'inquiète."
-  },
-  {
-    "id": 166,
-    "offset": 288512,
-    "data_size": 226,
-    "slot_size": 230,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "If[SP]folks[SP]like[SP]that[SP]are[SP]really[SP]here,[SP]does[SP]that\nmean[SP]there[SP]is[SP]such[SP]a[SP]thing[SP]as[SP]Xibalba[SP]under\nthis[SP]city?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Si des gens comme ça sont ici, cela signifie-t-il\n qu'il existe un Xibalba sous cette ville ?"
-  },
-  {
-    "id": 167,
-    "offset": 288742,
-    "data_size": 148,
-    "slot_size": 152,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I've[SP]lived[SP]here[SP]for[SP]ages,[SP]but[SP]I've[SP]never[SP]seen\nany[SP]such[SP]thing.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Jamais rien vu de tel ici."
-  },
-  {
-    "id": 168,
-    "offset": 288894,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I'm[SP]too[SP]old[SP]to[SP]evolve![1205][U+000A][SP]I'm[SP]more[SP]worried[SP]about\nwhat's[SP]happening[SP]down[SP]there.[1205][U+000A][SP]It'll[SP]all[SP]be\ndestroyed[SP]when[SP]the[SP]stars[SP]align,[SP]no?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Je suis trop vieux pour évoluer ![1205][U+000A]\n Je m'inquiète pour en bas.[1205][U+000A] Destruction quand les étoiles s'alignent, non ?"
-  },
-  {
-    "id": 169,
-    "offset": 289178,
-    "data_size": 172,
-    "slot_size": 176,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I[SP]have[SP]friends[SP]down[SP]there...[1205][U+000F][SP]Isn't[SP]there\nanything[SP]I[SP]can[SP]do[SP]for[SP]them...?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "J'ai des amis en bas...[1205][U+000F]\n Rien que je puisse faire pour eux ?"
-  },
-  {
-    "id": 170,
-    "offset": 289354,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "The[SP]people[SP]in[SP]this[SP]city[SP]are[SP]appalling.[1205][U+000A][SP]They\nknow[SP]they're[SP]safe,[SP]so[SP]they're[SP]imagining[SP]what\nmight[SP]destroy[SP]the[SP]Earth[SP]below.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Les gens sont épouvantables.[1205][U+000A]\n En sécurité, ils imaginent la destruction de la Terre."
-  },
-  {
-    "id": 171,
-    "offset": 289626,
-    "data_size": 206,
-    "slot_size": 210,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "What[SP]good[SP]will[SP]it[SP]do[SP]mankind[SP]if[SP]folks[SP]like\nthem[SP]evolve...?[1205][U+000F][SP]I[SP]don't[SP]hold[SP]out[SP]much[SP]hope...",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "À quoi bon si des gens comme eux évoluent ?[1205][U+000F]\n Je n'ai pas beaucoup d'espoir..."
-  },
-  {
-    "id": 172,
-    "offset": 289836,
-    "data_size": 310,
-    "slot_size": 314,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Sounds[SP]like[SP]the[SP]Earth's[SP]air[SP]will[SP]evaporate[SP]when\nthe[SP]stars[SP]align.[1205][U+000F][SP]Criminy...[SP]The[SP]things[SP]those\nkids[SP]think[SP]up[SP]lately[SP]scares[SP]the[SP]life[SP]out[SP]of[SP]me.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "L'air de la Terre va s'évaporer quand les étoiles s'aligneront.[1205][U+000F]\n Bon sang... Ce que ces gosses inventent me fait une peur bleue."
-  },
-  {
-    "id": 173,
-    "offset": 290150,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Sounds[SP]like[SP]the[SP]Earth's[SP]rotation[SP]will[SP]stop[SP]when\nthe[SP]stars[SP]align...[1205][U+000A][SP]Everything[SP]on[SP]Earth[SP]will[SP]get\nblasted[SP]away...",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "La Terre va s'arrêter quand les étoiles s'aligneront...[1205][U+000A]\n Tout sera pulvérisé..."
-  },
-  {
-    "id": 174,
-    "offset": 290406,
-    "data_size": 114,
-    "slot_size": 118,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Why[SP]is[SP]God[SP]doing[SP]such[SP]horrible[SP]things[SP]to[SP]us?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Pourquoi Dieu nous fait-il ça ?"
-  },
-  {
-    "id": 175,
-    "offset": 290524,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Sounds[SP]like[SP]the[SP]Earth's[SP]rotation[SP]will[SP]stop[SP]when\nthe[SP]stars[SP]align...[1205][U+000A][SP]Everything[SP]on[SP]Earth[SP]will[SP]get\nblasted[SP]away...",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "La Terre va s'arrêter quand les étoiles s'aligneront...[1205][U+000A]\n Tout sera pulvérisé..."
-  },
-  {
-    "id": 176,
-    "offset": 290780,
-    "data_size": 114,
-    "slot_size": 118,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Why[SP]is[SP]God[SP]doing[SP]such[SP]horrible[SP]things[SP]to[SP]us?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Pourquoi Dieu nous fait-il ça ?"
-  },
-  {
-    "id": 177,
-    "offset": 290898,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I[SP]heard[SP]there's[SP]talking[SP]flowers[SP]in[SP]Aoba[SP]Park.\nI'd[SP]have[SP]dismissed[SP]it[SP]when[SP]I[SP]was[SP]young,[SP]but\nwho[SP]can[SP]say[SP]in[SP]today's[SP]world?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Des fleurs qui parlent au parc d'Aoba ?\n Je l'aurais rejeté avant, mais de nos jours, qui sait ?"
-  },
-  {
-    "id": 178,
-    "offset": 291166,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "It[SP]seems[SP]that[SP]club[SP]called[SP]Zodiac[SP]is[SP]one[SP]big\nmonster's[SP]den[SP]now.[SP]Some[SP]young'uns[SP]were[SP]getting\nexcited[SP]to[SP]venture[SP]in[SP]there.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Le club Zodiac est devenu un antre de monstres.\n Des jeunes étaient tout excités à l'idée d'y aller."
-  },
-  {
-    "id": 179,
-    "offset": 291434,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "They[SP]talked[SP]about[SP]some[SP]treasure...[1205][U+000F][SP]But[SP]the\nmore[SP]you[SP]find,[SP]the[SP]greater[SP]the[SP]danger.\nI[SP]wouldn't[SP]go[SP]in[SP]carelessly[SP]if[SP]I[SP]were[SP]you.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Un trésor...[1205][U+000F] Plus on en trouve, plus grand danger.\n N'y va pas imprudemment."
-  },
-  {
-    "id": 180,
-    "offset": 291716,
-    "data_size": 132,
-    "slot_size": 136,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "From[SP]what[SP]I've[SP]heard,[SP]that[SP]ghost[SP]Hanako[SP]is\nat[SP]Sevens.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Hanako est à Seven."
-  },
-  {
-    "id": 181,
-    "offset": 291852,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "First[SP]that[SP]strange[SP]disease,[SP]then[SP]the[SP]principal's\nstatue[SP]gets[SP]up[SP]and[SP]walks,[SP]and[SP]now[SP]this?\nIt's[SP]the[SP]damnedest[SP]school.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Maladie étrange, statue qui marche, et ça ?\n C'est la pire école."
-  },
-  {
-    "id": 182,
-    "offset": 292112,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Did[SP]you[SP]hear?[SP]There's[SP]a[SP]ghost[SP]by[SP]the[SP]name[SP]of\nBukimi[SP]hanging[SP]around[SP]Kasugayama[SP]High.[SP]Wonder\nif[SP]that[SP]school's[SP]been[SP]cursed[SP]now...",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Tu as entendu ? Un fantôme nommé Bukimi traîne au lycée Kasugayama.\n Je me demande si cette école a été maudite..."
-  },
-  {
-    "id": 183,
-    "offset": 292394,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "People[SP]who[SP]die[SP]with[SP]attachments[SP]to[SP]this[SP]world\ncan't[SP]find[SP]peace[SP]and[SP]end[SP]up[SP]wandering[SP]the[SP]Earth.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Ceux qui meurent avec des attaches n'ont pas la paix\n et errent."
-  },
-  {
-    "id": 184,
-    "offset": 292612,
-    "data_size": 166,
-    "slot_size": 170,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "That's[SP]probably[SP]what[SP]happened[SP]to[SP]the[SP]idol[SP]whose\nghost[SP]is[SP]at[SP]Aoba[SP]Park.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "L'idole dont le fantôme est au parc d'Aoba, c'est ça."
-  },
-  {
-    "id": 185,
-    "offset": 292782,
-    "data_size": 216,
-    "slot_size": 220,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I[SP]wouldn't[SP]go[SP]near[SP]the[SP]abandoned[SP]factory[SP]if\nI[SP]was[SP]you,[SP]boy.[SP]There's[SP]a[SP]Cursed[SP]Taxi[SP]parked\nthere.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "N'approche pas l'usine abandonnée.\n Un Taxi Maudit y est garé."
-  },
-  {
-    "id": 186,
-    "offset": 293002,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "They[SP]say[SP]to[SP]let[SP]sleeping[SP]dogs[SP]lie...\nYou[SP]should[SP]be[SP]careful.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Ne réveille pas le chat qui dort...\n Sois prudent."
-  },
-  {
-    "id": 187,
-    "offset": 293150,
-    "data_size": 182,
-    "slot_size": 186,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Sounds[SP]like[SP]there's[SP]a[SP]monster[SP]called[SP]a[SP]Cursed\nEscort[SP]at[SP]the[SP]abandoned[SP]factory.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Il y a un monstre appelé Escorte Maudite\n à l'usine abandonnée."
-  },
-  {
-    "id": 188,
-    "offset": 293336,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "The[SP]rumor[SP]goes[SP]that[SP]it[SP]runs[SP]over[SP]people[SP]night\nafter[SP]night...[SP]Terrible,[SP]just[SP]terrible...",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "On dit qu'elle renverse les gens nuit après nuit...\n Terrible."
-  },
-  {
-    "id": 189,
-    "offset": 293540,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Hohoho,[SP]I[SP]used[SP]to[SP]be[SP]scared[SP]that[SP]Kuchisake-onna\nwould[SP]come[SP]after[SP]me[SP]when[SP]I[SP]was[SP]a[SP]kid.[SP]I[SP]didn't\nknow[SP]she[SP]lives[SP]at[SP]Mt.[SP]Iwato.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Hohoho, j'avais peur de Kuchisake-onna enfant.\n Elle vit au mont Iwato."
-  },
-  {
-    "id": 190,
-    "offset": 293816,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Just[SP]because[SP]there's[SP]a[SP]spy[SP]old[SP]man[SP]at[SP]Mt.\nKatatsumuri[SP]is[SP]no[SP]reason[SP]to[SP]think[SP]he's[SP]the\nJumping[SP]Geezer![SP]Don't[SP]mock[SP]the[SP]elderly!",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Un vieil homme espion au mont Katatsumuri n'est pas le Sauteur Vieux !\n Ne moquez pas les personnes âgées !"
-  },
-  {
-    "id": 191,
-    "offset": 294094,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I-I[SP]can't[SP]believe[SP]it...[SP]My[SP]heart[SP]almost[SP]gave\nout[SP]when[SP]I[SP]heard...[1205][U+000F][SP]Kudan[SP]is...[1205][U+000F][SP]Kid,[SP]you[SP]must\nnever[SP]go[SP]near[SP]a[SP]Kudan!",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "J'y crois pas... Crise cardiaque...[1205][U+000F] Kudan...[1205][U+000F]\n Ne t'approche jamais d'un Kudan, gamin !"
-  },
-  {
-    "id": 192,
-    "offset": 294358,
-    "data_size": 304,
-    "slot_size": 308,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I[SP]like[SP]the[SP]sound[SP]of[SP]albums[SP]from[SP]back[SP]in[SP]the[SP]day.\nSomething[SP]about[SP]these[SP]CDs[SP]and[SP]their[SP]glitz...\nThere's[SP]even[SP]a[SP]secret[SP]CD[SP]out[SP]there[SP]somewhere.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "J'aime le son des albums d'autrefois.\n Quelque chose à propos des CD et de leur clinquant...\n Il y a même un CD secret quelque part."
-  },
-  {
-    "id": 193,
-    "offset": 294666,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "There's[SP]no[SP]call[SP]to[SP]pick[SP]on[SP]the[SP]elderly[SP]like\nthis![SP]Just[SP]'cause[SP]an[SP]old[SP]lady[SP]has[SP]a[SP]dresser,\nthey[SP]call[SP]her[SP]the[SP]Dresser[SP]Hag!?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Pourquoi s'en prendre aux vieux ?\n Une dame avec un buffet, la Sorcière du Buffet !?"
-  },
-  {
-    "id": 194,
-    "offset": 294936,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Time[SP]Castle[SP]sells[SP]weapons[SP]too?[SP]I[SP]always[SP]thought\nthey[SP]seemed[SP]crooked.[SP]Sounds[SP]like[SP]their[SP]quality\nand[SP]prices[SP]are[SP]average.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Château du Temps vend des armes ? Louche.\n Qualité et prix moyens."
-  },
-  {
-    "id": 195,
-    "offset": 295202,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Time[SP]Castle[SP]sells[SP]weapons[SP]too?[SP]I[SP]always[SP]thought\nthey[SP]seemed[SP]crooked.[SP]Sounds[SP]like[SP]their[SP]quality\nis[SP]good,[SP]but[SP]it's[SP]expensive.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Le Château du Temps vend des armes ? Louche,\n mais qualité bonne et cher."
-  },
-  {
-    "id": 196,
-    "offset": 295478,
-    "data_size": 250,
-    "slot_size": 254,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Time[SP]Castle[SP]sells[SP]weapons[SP]too?[SP]I[SP]always[SP]thought\nthey[SP]seemed[SP]crooked.[SP]Sounds[SP]like[SP]they're[SP]cheap,\nbut[SP]bad[SP]quality.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Le Château du Temps vend des armes ? Louche,\n bon marché mais mauvaise qualité."
-  },
-  {
-    "id": 197,
-    "offset": 295732,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "That[SP]young'un[SP]Tony[SP]was[SP]selling[SP]weapons\nafter[SP]all!",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Ce jeune Tony vendait donc des armes !"
-  },
-  {
-    "id": 198,
-    "offset": 295860,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "People[SP]like[SP]him[SP]are[SP]good[SP]for[SP]nothing.[SP]He[SP]has\na[SP]good[SP]selection,[SP]but[SP]his[SP]resale[SP]prices\nare[SP]low.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Les gens comme lui ne valent rien.\n Bon choix, reprises basses."
-  },
-  {
-    "id": 199,
-    "offset": 296076,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "That[SP]young'un[SP]Tony[SP]was[SP]selling[SP]weapons\nafter[SP]all!",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Ce jeune Tony vendait donc des armes !"
-  },
-  {
-    "id": 200,
-    "offset": 296204,
-    "data_size": 184,
-    "slot_size": 188,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "People[SP]like[SP]him[SP]are[SP]good[SP]for[SP]nothing.[SP]He[SP]has\nlow[SP]prices,[SP]but[SP]his[SP]stuff[SP]is[SP]junk.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Les gens comme lui ne valent rien.\n Prix bas, camelote."
-  },
-  {
-    "id": 201,
-    "offset": 296392,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "That[SP]young'un[SP]Tony[SP]was[SP]selling[SP]weapons\nafter[SP]all!",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Ce jeune Tony vendait donc des armes !"
-  },
-  {
-    "id": 202,
-    "offset": 296520,
-    "data_size": 170,
-    "slot_size": 174,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "People[SP]like[SP]him[SP]are[SP]good[SP]for[SP]nothing.[SP]He[SP]has\naverage[SP]quality[SP]and[SP]prices.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Les gens comme lui ne valent rien.\n Qualité et prix moyens."
-  },
-  {
-    "id": 203,
-    "offset": 296694,
-    "data_size": 124,
-    "slot_size": 128,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "That[SP]young'un[SP]Tony[SP]was[SP]selling[SP]weapons\nafter[SP]all!",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Ce jeune Tony vendait donc des armes !"
-  },
-  {
-    "id": 204,
-    "offset": 296822,
-    "data_size": 184,
-    "slot_size": 188,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "People[SP]like[SP]him[SP]are[SP]good[SP]for[SP]nothing.[SP]He[SP]has\nquality[SP]stuff,[SP]but[SP]it's[SP]expensive.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Les gens comme lui ne valent rien.\n Qualité mais cher."
-  },
-  {
-    "id": 205,
-    "offset": 297010,
-    "data_size": 252,
-    "slot_size": 256,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?\nI've[SP]heard[SP]their[SP]selection[SP]is[SP]bad,[SP]but[SP]the\nresale[SP]prices[SP]are[SP]good.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Ma parole, même les restos d'Aoba vendent des armes ?\n Peu de choix, mais bonnes reprises."
-  },
-  {
-    "id": 206,
-    "offset": 297266,
-    "data_size": 232,
-    "slot_size": 236,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?\nI've[SP]heard[SP]they're[SP]cheap,[SP]but[SP]the[SP]quality[SP]is\nnot[SP]so[SP]hot.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Les restos d'Aoba vendent des armes ?\n Bon marché, qualité bof."
-  },
-  {
-    "id": 207,
-    "offset": 297502,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?\nI've[SP]heard[SP]their[SP]quality[SP]is[SP]top-notch,[SP]but[SP]it's\nexpensive[SP]stuff.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Les restos d'Aoba vendent des armes ?\n Qualité excellente, mais cher."
-  },
-  {
-    "id": 208,
-    "offset": 297754,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?\nI've[SP]heard[SP]their[SP]selection[SP]is[SP]great,[SP]but[SP]the\nresale[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Restos d'Aoba vendent des armes ?\n Excellent choix, reprises basses."
-  },
-  {
-    "id": 209,
-    "offset": 298012,
-    "data_size": 238,
-    "slot_size": 242,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?\nI've[SP]heard[SP]the[SP]quality[SP]and[SP]prices[SP]are[SP]both\nfairly[SP]standard.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Restos d'Aoba vendent des armes ?\n Qualité et prix standards."
-  },
-  {
-    "id": 210,
-    "offset": 298254,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit\nJolly[SP]Roger[SP]in[SP]Kounan.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes."
-  },
-  {
-    "id": 211,
-    "offset": 298418,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I[SP]hear[SP]the[SP]quality[SP]and[SP]prices[SP]are[SP]ordinary,\nbut[SP]if[SP]you[SP]ask[SP]me,[SP]there's[SP]nothing[SP]ordinary\nabout[SP]selling[SP]weapons.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Qualité et prix ordinaires, mais vendre des armes\n n'a rien d'ordinaire."
-  },
-  {
-    "id": 212,
-    "offset": 298668,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit\nJolly[SP]Roger[SP]in[SP]Kounan.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes."
-  },
-  {
-    "id": 213,
-    "offset": 298832,
-    "data_size": 186,
-    "slot_size": 190,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "The[SP]prices[SP]are[SP]supposedly[SP]right,[SP]but[SP]the[SP]quality\nleaves[SP]something[SP]to[SP]be[SP]desired.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Prix corrects, mais qualité à désirer."
-  },
-  {
-    "id": 214,
-    "offset": 299022,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit\nJolly[SP]Roger[SP]in[SP]Kounan.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes."
-  },
-  {
-    "id": 215,
-    "offset": 299186,
-    "data_size": 180,
-    "slot_size": 184,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "The[SP]selection[SP]is[SP]supposed[SP]to[SP]be[SP]pretty[SP]good,\nbut[SP]the[SP]resale[SP]prices[SP]are[SP]cheap.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Bon choix, reprises bon marché."
-  },
-  {
-    "id": 216,
-    "offset": 299370,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit\nJolly[SP]Roger[SP]in[SP]Kounan.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes."
-  },
-  {
-    "id": 217,
-    "offset": 299534,
-    "data_size": 182,
-    "slot_size": 186,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "The[SP]selection[SP]isn't[SP]supposed[SP]to[SP]be[SP]that[SP]great,\nbut[SP]the[SP]resale[SP]prices[SP]are[SP]high.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Peu de choix, reprises élevées."
-  },
-  {
-    "id": 218,
-    "offset": 299720,
-    "data_size": 160,
-    "slot_size": 164,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit\nJolly[SP]Roger[SP]in[SP]Kounan.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes."
-  },
-  {
-    "id": 219,
-    "offset": 299884,
-    "data_size": 150,
-    "slot_size": 154,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "The[SP]quality[SP]is[SP]supposed[SP]to[SP]be[SP]great,[SP]but[SP]it's\nexpensive[SP]stuff.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Qualité excellente, mais cher."
-  },
-  {
-    "id": 220,
-    "offset": 300038,
-    "data_size": 98,
-    "slot_size": 102,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]sells[SP]real[SP]armor.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Rosa Candida vend des armures."
-  },
-  {
-    "id": 221,
-    "offset": 300140,
-    "data_size": 242,
-    "slot_size": 246,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "That[SP]means[SP]things[SP]like[SP]helmets[SP]and[SP]chestplates\nand[SP]such,[SP]right?[SP]I[SP]hear[SP]their[SP]quality[SP]and\nprices[SP]are[SP]average.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Des casques, plastrons, etc.\n Qualité et prix moyens."
-  },
-  {
-    "id": 222,
-    "offset": 300386,
-    "data_size": 98,
-    "slot_size": 102,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]sells[SP]real[SP]armor.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Rosa Candida vend des armures."
-  },
-  {
-    "id": 223,
-    "offset": 300488,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "That[SP]means[SP]things[SP]like[SP]helmets[SP]and[SP]chestplates\nand[SP]such,[SP]right?[SP]I[SP]hear[SP]their[SP]prices[SP]are\ngreat,[SP]but[SP]the[SP]quality's[SP]lacking.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Des casques, plastrons... Prix super,\n qualité manquante."
-  },
-  {
-    "id": 224,
-    "offset": 300760,
-    "data_size": 98,
-    "slot_size": 102,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]sells[SP]real[SP]armor.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Rosa Candida vend des armures."
-  },
-  {
-    "id": 225,
-    "offset": 300862,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "That[SP]means[SP]things[SP]like[SP]helmets[SP]and[SP]chestplates\nand[SP]such,[SP]right?[SP]I[SP]hear[SP]their[SP]quality[SP]is\ngreat,[SP]but[SP]the[SP]prices[SP]are[SP]sky-high.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Casques, plastrons... Qualité excellente,\n prix exorbitants."
-  },
-  {
-    "id": 226,
-    "offset": 301138,
-    "data_size": 148,
-    "slot_size": 152,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I've[SP]heard[SP]you[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima\nMundi[SP]in[SP]Yumezaki.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "On peut acheter des armures à Anima Mundi, Yumezaki."
-  },
-  {
-    "id": 227,
-    "offset": 301290,
-    "data_size": 214,
-    "slot_size": 218,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Their[SP]quality[SP]and[SP]prices[SP]are[SP]normal...[SP]But[SP]just\nwhat's[SP]normal[SP]about[SP]wearing[SP]armor[SP]around[SP]town?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Qualité et prix normaux... Mais porter une armure en ville,\n rien de normal."
-  },
-  {
-    "id": 228,
-    "offset": 301508,
-    "data_size": 228,
-    "slot_size": 232,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I've[SP]heard[SP]you[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima\nMundi[SP]in[SP]Yumezaki.[SP]It[SP]seems[SP]cheap,[SP]but[SP]pretty\nlow[SP]quality.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Anima Mundi vend des armures.\n Bon marché mais basse qualité."
-  },
-  {
-    "id": 229,
-    "offset": 301740,
-    "data_size": 268,
-    "slot_size": 272,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I've[SP]heard[SP]you[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima\nMundi[SP]in[SP]Yumezaki.[SP]The[SP]selection[SP]seems[SP]great,\nbut[SP]the[SP]resale[SP]prices[SP]are[SP]cheap.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Anima Mundi à Yumezaki : excellent choix,\n reprises basses."
-  },
-  {
-    "id": 230,
-    "offset": 302012,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I've[SP]heard[SP]you[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima\nMundi[SP]in[SP]Yumezaki.[SP]It[SP]seems[SP]high[SP]quality,\nbut[SP]you'll[SP]pay[SP]a[SP]pretty[SP]penny.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Anima Mundi : haute qualité,\n mais ça coûte un bras."
-  },
-  {
-    "id": 231,
-    "offset": 302272,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they\nsell[SP]real[SP]armor.[SP]Their[SP]selection[SP]isn't[SP]great,\nbut[SP]their[SP]resale[SP]prices[SP]are[SP]nice.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures.\n Peu de choix, mais bonnes reprises."
-  },
-  {
-    "id": 232,
-    "offset": 302554,
-    "data_size": 254,
-    "slot_size": 258,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they\nsell[SP]real[SP]armor.[SP]The[SP]quality[SP]and[SP]prices[SP]of\ntheir[SP]stuff[SP]are[SP]average.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Rosa Candida à Aoba : armures,\n qualité et prix moyens."
-  },
-  {
-    "id": 233,
-    "offset": 302812,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they\nsell[SP]real[SP]armor.[SP]The[SP]quality[SP]of[SP]their[SP]stock\nis[SP]great,[SP]but[SP]it's[SP]pricey.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Rosa Candida à Aoba : excellente qualité,\n mais cher."
-  },
-  {
-    "id": 234,
-    "offset": 303076,
-    "data_size": 256,
-    "slot_size": 260,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they\nsell[SP]real[SP]armor.[SP]The[SP]prices[SP]are[SP]right,[SP]but[SP]you\nget[SP]what[SP]you[SP]pay[SP]for.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Rosa Candida à Aoba : prix corrects,\n mais tu en as pour ton argent."
-  },
-  {
-    "id": 235,
-    "offset": 303336,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they\nsell[SP]real[SP]armor.[SP]Their[SP]selection[SP]is[SP]great,\nbut[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Rosa Candida à Aoba : excellent choix,\n reprises basses."
-  },
-  {
-    "id": 236,
-    "offset": 303606,
-    "data_size": 300,
-    "slot_size": 304,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the\nscamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]selection\nis[SP]great,[SP]but[SP]his[SP]resale[SP]prices[SP]are[SP]cheap.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Hoho, le gars chez London Clothier est un sacré coquin.\n Il fait des armures ! Beau choix, reprises basses."
-  },
-  {
-    "id": 237,
-    "offset": 303910,
-    "data_size": 260,
-    "slot_size": 264,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the\nscamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]stuff\nis[SP]cheap,[SP]but[SP]low[SP]quality.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "London Clothier : ce coquin vend des armures.\n Bon marché, mauvaise qualité."
-  },
-  {
-    "id": 238,
-    "offset": 304174,
-    "data_size": 266,
-    "slot_size": 270,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the\nscamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]stuff\nis[SP]great,[SP]but[SP]very[SP]expensive.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "London Clothier : ce coquin vend des armures.\n Excellente qualité, très cher."
-  },
-  {
-    "id": 239,
-    "offset": 304444,
-    "data_size": 274,
-    "slot_size": 278,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the\nscamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]prices\nand[SP]quality[SP]are[SP]average,[SP]I[SP]hear.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "London Clothier : ce coquin fait des armures.\n Prix et qualité moyens, parait-il."
-  },
-  {
-    "id": 240,
-    "offset": 304722,
-    "data_size": 302,
-    "slot_size": 306,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the\nscamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]selection\nis[SP]limited,[SP]but[SP]his[SP]resale[SP]prices[SP]are[SP]high.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "London Clothier : ce coquin vend des armures.\n Choix limité, reprises élevées."
-  },
-  {
-    "id": 241,
-    "offset": 305028,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Lately,[SP]the[SP]magazines[SP]have[SP]been[SP]giving[SP]out\nreal[SP]weapons[SP]and[SP]items[SP]in[SP]contests.[SP]They're\nhard[SP]to[SP]win,[SP]but[SP]you[SP]can[SP]get[SP]nice[SP]stuff.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Les magazines offrent des armes et objets dans des concours.\n Durs à gagner, mais beaux lots."
-  },
-  {
-    "id": 242,
-    "offset": 305312,
-    "data_size": 290,
-    "slot_size": 294,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Lately,[SP]the[SP]magazines[SP]have[SP]been[SP]giving[SP]out\nreal[SP]weapons[SP]and[SP]items[SP]in[SP]contests.[SP]They're\nnearly[SP]impossible[SP]to[SP]win,[SP]but[SP]those[SP]prizes...",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Magazines donnent des armes dans des concours.\n Presque impossibles à gagner, mais ces lots..."
-  },
-  {
-    "id": 243,
-    "offset": 305606,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Lately,[SP]the[SP]magazines[SP]have[SP]been[SP]giving[SP]out\nreal[SP]weapons[SP]and[SP]items[SP]in[SP]contests.[SP]They're\neasy[SP]to[SP]win,[SP]but[SP]why[SP]would[SP]you[SP]want[SP]to?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Concours de magazines faciles à gagner,\n mais pourquoi voudrais-tu ?"
-  },
-  {
-    "id": 244,
-    "offset": 305888,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "A[SP]casino...[SP]like[SP]a[SP]gambling[SP]parlor,[SP]right?\nAnd[SP]Mu[SP]has[SP]one[SP]now?[SP]I[SP]hear[SP]a[SP]certain[SP]poker\nmachine[SP]is[SP]your[SP]best[SP]bet.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Un casino, une salle de jeu ? Mu en a un ?\n Une machine de poker est ton meilleur choix."
-  },
-  {
-    "id": 245,
-    "offset": 306140,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "A[SP]casino...[SP]like[SP]a[SP]gambling[SP]parlor,[SP]right?\nAnd[SP]Mu[SP]has[SP]one[SP]now?[SP]I[SP]hear[SP]a[SP]certain[SP]slot\nmachine[SP]is[SP]your[SP]best[SP]bet.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Un casino ? Mu en a un ?\n Une machine à sous est ton meilleur choix."
-  },
-  {
-    "id": 246,
-    "offset": 306390,
-    "data_size": 232,
-    "slot_size": 236,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "A[SP]casino...[SP]like[SP]a[SP]gambling[SP]parlor,[SP]right?\nAnd[SP]Mu[SP]has[SP]one[SP]now?[SP]I[SP]hear[SP]it's[SP]easiest[SP]to\nwin[SP]at[SP]blackjack.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Un casino ? Mu en a un ?\n Le plus facile pour gagner, c'est le blackjack."
-  },
-  {
-    "id": 247,
-    "offset": 306626,
-    "data_size": 234,
-    "slot_size": 238,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Does[SP]Shiraishi[SP]Ramen[SP]in[SP]Hirasaka[SP]really[SP]have\na[SP]legendary[SP]weapon?[SP]The[SP]things[SP]they[SP]say[SP]about\nthat[SP]place...",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Le Shiraishi Ramen à Hirasaka a vraiment une arme légendaire ?\n Ce qu'on raconte sur cet endroit..."
-  },
-  {
-    "id": 248,
-    "offset": 306864,
-    "data_size": 248,
-    "slot_size": 252,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Are[SP]you[SP]searching[SP]for[SP]a[SP]legendary[SP]weapon?\nThen[SP]try[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I've[SP]heard\nrumors[SP]that[SP]they[SP]have[SP]one.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Tu cherches une arme légendaire ?\n Essaye Clair de Lune à Aoba. J'ai entendu qu'ils en ont une."
-  },
-  {
-    "id": 249,
-    "offset": 307116,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "Lying[SP]about[SP]your[SP]store[SP]to[SP]drive[SP]up[SP]the[SP]price!\nThe[SP]very[SP]idea![SP]It[SP]seems[SP]you[SP]can't[SP]put[SP]that\npast[SP]the[SP]owner[SP]of[SP]Time[SP]Castle.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Mentir sur son magasin pour faire monter les prix !\n L'idée ! C'est le proprio du Château du Temps."
-  },
-  {
-    "id": 250,
-    "offset": 307384,
-    "data_size": 306,
-    "slot_size": 310,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "I[SP]hear[SP]Time[SP]Castle's[SP]legendary[SP]weapons[SP]is[SP]still\nwith[SP]the[SP]seller[SP]at[SP]the[SP]abandoned[SP]factory.[SP]He's\nstill[SP]waiting[SP]for[SP]the[SP]owner[SP]to[SP]come[SP]claim[SP]it.",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "L'arme légendaire du Château du Temps est toujours chez le vendeur\n à l'usine abandonnée. Il attend que le proprio vienne la réclamer."
-  },
-  {
-    "id": 251,
-    "offset": 307694,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "It[SP]seems[SP]demons[SP]have[SP]stolen[SP]the[SP]legendary\nweapon[SP]from[SP]Time[SP]Castle.[SP]How[SP]is[SP]that[SP]even\npossible?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Des démons ont volé l'arme légendaire du Château du Temps.\n Comment est-ce possible ?"
-  },
-  {
-    "id": 252,
-    "offset": 307910,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "The[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle[SP]got[SP]sold.\nRumor[SP]has[SP]it[SP]an[SP]unlucky[SP]woman[SP]bought[SP]it,[SP]but\nwho[SP]knows[SP]what[SP]she'll[SP]use[SP]it[SP]for...",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "L'arme légendaire a été vendue.\n Une femme malchanceuse l'aurait achetée.\n Qui sait ce qu'elle en fera..."
-  },
-  {
-    "id": 253,
-    "offset": 308194,
-    "data_size": 278,
-    "slot_size": 282,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man",
-    "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle[SP]gave[SP]his[SP]legendary\nweapon[SP]away[SP]to[SP]a[SP]girl[SP]with[SP]short[SP]hair.[SP]Now\nwhat[SP]would[SP]she[SP]want[SP]with[SP]such[SP]a[SP]thing?",
-    "nom_fr": "Vieil homme",
-    "texte_fr": "Le proprio du Château du Temps a donné son arme légendaire\n à une fille aux cheveux courts. Que veut-elle en faire ?"
-  },
-  {
-    "id": 254,
-    "offset": 308476,
-    "data_size": 282,
-    "slot_size": 286,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Masked[SP]Circle[SP]member",
-    "texte_orig": "J-Joker[SP]told[SP]us[SP]to[SP]protect[SP]the[SP]city,[SP]but\nthere's[SP]no[SP]way[SP]we[SP]can[SP]beat[SP]guys[SP]like[SP]that![1205][U+000F]\nThis[SP]wasn't[SP]part[SP]of[SP]the[SP]deal!",
-    "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Joker nous a dit de protéger la ville,\n mais pas possible ![1205][U+000F] Pas dans le contrat !"
-  },
-  {
-    "id": 255,
-    "offset": 308762,
-    "data_size": 212,
-    "slot_size": 216,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Last[SP]Battalion",
-    "texte_orig": "Mt.[SP]Katatsumuri[SP]is[SP]already[SP]ours.[1205][U+000F][SP]To[SP]resist\nis[SP]futile.[1205][U+000F][SP]Those[SP]who[SP]do[SP]will[SP]be[SP]killed.",
-    "nom_fr": "Dernier Bataillon",
-    "texte_fr": "Le mont Katatsumuri est à nous.[1205][U+000F]\n Résister est futile.[1205][U+000F] Les résistants tués."
-  },
-  {
-    "id": 256,
-    "offset": 308978,
-    "data_size": 196,
-    "slot_size": 200,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "I[SP]wonder[SP]if[SP]Kozy's[SP]got[SP]some[SP]info[SP]for[SP]us.\nHey,[SP][1113],[SP]let's[SP]head[SP]to[SP]Peace[SP]Diner\nin[SP]Yumezaki.",
-    "nom_fr": "Ginko",
-    "texte_fr": "Kozy a des infos pour nous ?\n Hé, [1113], allons au Peace Diner à Yumezaki."
-  },
-  {
-    "id": 257,
-    "offset": 309178,
-    "data_size": 176,
-    "slot_size": 180,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "Looks[SP]like[SP]the[SP]curse[SP]has[SP]been[SP]lifted,[SP]so[SP]things\nshould[SP]be[SP]fine[SP]at[SP]Sevens[SP]now.",
-    "nom_fr": "Ginko",
-    "texte_fr": "La malédiction est levée,\n tout devrait aller bien à Seven maintenant."
-  },
-  {
-    "id": 258,
-    "offset": 309358,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "I[SP]feel[SP]bad[SP]for[SP]what[SP]I[SP]did[SP]to[SP]the[SP]guys[SP]here...\nYo[SP][1113],[SP]let's[SP]go[SP]to[SP]Kasugayama[SP]High.[SP]I'll\nmake[SP]that[SP]president[SP]pay!",
-    "nom_fr": "Michel",
-    "texte_fr": "Je me sens mal... Yo [1113], allons à Kasugayama.\n Ce président va payer !"
-  },
-  {
-    "id": 259,
-    "offset": 309608,
-    "data_size": 106,
-    "slot_size": 110,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "This[SP]place[SP]should[SP]be[SP]fine.[SP]C'mon,[SP]let's[SP]go.",
-    "nom_fr": "Maya",
-    "texte_fr": "Cet endroit devrait aller. Allez, on y va."
-  },
-  {
-    "id": 260,
-    "offset": 309718,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "I[SP]know[SP]you're[SP]worried[SP]about[SP]your[SP]school,[SP]but[SP]I\ndon't[SP]think[SP]they'll[SP]strike[SP]here.[SP]We[SP]don't[SP]have\nmuch[SP]time,[SP]man.[SP]Let's[SP]go.",
-    "nom_fr": "Michel",
-    "texte_fr": "Je sais que tu t'inquiètes, mais pas ici.\n On a peu de temps. Allons-y."
-  },
-  {
-    "id": 261,
-    "offset": 309986,
-    "data_size": 264,
-    "slot_size": 268,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "I[SP]already[SP]miss[SP]the[SP]regular[SP]school[SP]days...\nHey,[SP][1113],[SP]will[SP]things[SP]ever[SP]go[SP]back[SP]to\nnormal?[SP]Will[SP]Sheba[SP]and[SP]Mee-ho[SP]come[SP]back...?",
-    "nom_fr": "Ginko",
-    "texte_fr": "Les jours normaux me manquent...\n Hé, [1113], tout redeviendra normal ?\n Sheba et Mee-ho ?"
-  },
-  {
-    "id": 262,
-    "offset": 310254,
-    "data_size": 196,
-    "slot_size": 200,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Looks[SP]like[SP]those[SP]soldiers[SP]haven't[SP]made[SP]it[SP]this\nfar[SP]yet...[SP]Are[SP]the[SP]students[SP]still[SP]inside?",
-    "nom_fr": "Maya",
-    "texte_fr": "Ces soldats ne sont pas allés aussi loin...\n Les élèves sont-ils encore à l'intérieur ?"
-  },
-  {
-    "id": 263,
-    "offset": 310454,
-    "data_size": 280,
-    "slot_size": 284,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Eikichi",
-    "texte_orig": "Mt.[SP]Iwato...[SP]That's[SP]weird...[SP]I've[SP]seen[SP]it[SP]in\nmy[SP]dreams...[SP]Is[SP]this[SP]deja[SP]vu[SP]or[SP]something?\nWe[SP]don't[SP]have[SP]any[SP]business[SP]here,[SP]right?",
-    "nom_fr": "Michel",
-    "texte_fr": "Mont Iwato... C'est bizarre... Je l'ai vu dans mes rêves...\n Du déjà-vu ? On n'a rien à faire ici, non ?"
-  },
-  {
-    "id": 264,
-    "offset": 310738,
-    "data_size": 82,
-    "slot_size": 86,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "This[SP]is...[1205][U+000F][SP]It's[SP]Mt.[SP]Iwato...",
-    "nom_fr": "Ginko",
-    "texte_fr": "C'est... le mont Iwato..."
-  },
-  {
-    "id": 265,
-    "offset": 310824,
-    "data_size": 144,
-    "slot_size": 148,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "H-Hey,[SP][1113]?[SP]I[SP]don't[SP]like[SP]it[SP]here...[1205][U+000F]\nCan[SP]we[SP]go[SP]somewhere[SP]else?",
-    "nom_fr": "Ginko",
-    "texte_fr": "Hé, [1113] ? J'aime pas ici...[1205][U+000F]\n Ailleurs ?"
-  },
-  {
-    "id": 266,
-    "offset": 310972,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Maya",
-    "texte_orig": "Mt.[SP]Iwato?[SP]What's[SP]this[SP]feeling...?[SP]Like...\nNostalgia,[SP]but[SP]bittersweet...[SP]I[SP]guess[SP]now\nisn't[SP]the[SP]time.",
-    "nom_fr": "Maya",
-    "texte_fr": "Mont Iwato ? Quel est ce sentiment... ?\n De la nostalgie, mais douce-amère...\n Pas le moment."
-  },
-  {
-    "id": 267,
-    "offset": 311196,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "It's[SP]been[SP]ten[SP]years...[SP]Why[SP]now...?[SP]Let's[SP]stay\naway[SP]from[SP]here[SP]for[SP]now,[SP][1113].[SP]There's\nsomething[SP]I[SP]need[SP]to[SP]be[SP]sure[SP]of[SP]first...",
-    "nom_fr": "Ginko",
-    "texte_fr": "Dix ans... Pourquoi maintenant ?\n Restons loin, [1113]. Je dois d'abord vérifier."
-  },
-  {
-    "id": 268,
-    "offset": 311462,
-    "data_size": 220,
-    "slot_size": 224,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Ginko",
-    "texte_orig": "I[SP]was[SP]scared[SP]of[SP]this[SP]place[SP]for[SP]a[SP]long[SP]time.\nBut[SP]I'm[SP]okay[SP]now.[SP]I[SP]won't[SP]run[SP]anymore,\nfrom[SP]anything...",
-    "nom_fr": "Ginko",
-    "texte_fr": "Peur longtemps. Maintenant ça va.\n Je ne fuirai plus."
-  },
-  {
-    "id": 269,
-    "offset": 311686,
-    "data_size": 184,
-    "slot_size": 188,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Jun",
-    "texte_orig": "Our[SP]secret[SP]hideout...[SP]It[SP]feels[SP]a[SP]little[SP]odd\nto[SP]be[SP]able[SP]to[SP]come[SP]here[SP]with[SP][1113][SP]again...",
-    "nom_fr": "Jun",
-    "texte_fr": "Notre cachette secrète...\n Ça fait étrange de pouvoir venir ici avec [1113] à nouveau..."
-  },
-  {
-    "id": 270,
-    "offset": 311874,
-    "data_size": 314,
-    "slot_size": 318,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
-    "texte_orig": "I[SP]saw[SP]her[SP]at[SP]Mt.[SP]Iwato.[1205][U+000F][SP]You[SP]know[SP]who[SP]I[SP]mean...\nThat[SP][E4][NULL][NULL][U+0006]urban[SP]legend,[SP]Kuchisake-onna[E4][NULL][NULL][0002].[SP]I[SP]saw[SP]a\nwoman[SP]wearing[SP]a[SP]mask[SP]out[SP]there.",
-    "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Je l'ai vue au mont Iwato.[1205][U+000F]\n Cette [E4][NULL][NULL][U+0006]légende urbaine, Kuchisake-onna[E4][NULL][NULL][0002].\n J'ai vu une femme masquée."
-  },
-  {
-    "id": 271,
-    "offset": 312192,
-    "data_size": 210,
-    "slot_size": 214,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
-    "texte_orig": "Dollars[SP]to[SP]donuts[SP]there's[SP]a[SP]huge[SP]mouth,[SP]split\nfrom[SP]ear[SP]to[SP]ear,[SP]under[SP]that[SP]mask.",
-    "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Sous ce masque, une bouche fendue d'une oreille à l'autre."
-  },
-  {
-    "id": 272,
-    "offset": 312406,
-    "data_size": 204,
-    "slot_size": 208,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
-    "texte_orig": "But[SP]my[SP]wife[SP]tells[SP]me[SP]not[SP]to[SP]be[SP]such[SP]a[SP]baby\nand[SP]refuses[SP]to[SP]take[SP]me[SP]seriously.",
-    "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Ma femme dit que j'en fais trop, elle ne me croit pas."
-  },
-  {
-    "id": 273,
-    "offset": 312614,
-    "data_size": 224,
-    "slot_size": 228,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
-    "texte_orig": "K-Kid,[SP]I'm[SP]begging[SP]you.[SP]Could[SP]you[SP]bring[SP]back\nproof[SP]that[SP]Kuchisake-onna's[SP]really[SP]there?",
-    "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Gamin, prouve que Kuchisake-onna est là."
-  },
-  {
-    "id": 274,
-    "offset": 312842,
-    "data_size": 184,
-    "slot_size": 188,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
-    "texte_orig": "Don't[SP]worry,[SP]I'll[SP]be[SP]sure[SP]to[SP]repay[SP]the[SP]favor.\nI'm[SP]counting[SP]on[SP]you!",
-    "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Je te revaudrai ça. Compte sur toi !"
-  },
-  {
-    "id": 275,
-    "offset": 313030,
-    "data_size": 272,
-    "slot_size": 276,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
-    "texte_orig": "Kuchisake-onna[SP]should[SP]still[SP]be[SP]somewhere[SP]on\nMt.[SP]Iwato.[1205][U+000F][SP]I'm[SP]begging[SP]you,[SP]bring[SP]back[SP]proof\nshe's[SP]really[SP]there!",
-    "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Kuchisake-onna est au mont Iwato.[1205][U+000F]\n Prouve qu'elle est là !"
-  },
-  {
-    "id": 276,
-    "offset": 313306,
-    "data_size": 262,
-    "slot_size": 266,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
-    "texte_orig": "Hm?[1205][U+000A][SP]Ohhhhh![1205][U+000F][SP]That's[SP]it![SP][E4][NULL][NULL][U+0006]Kuchisake-onna's[SP]mask[E4][NULL][NULL][0002]![1205][U+000F]\nKid,[SP]I[SP]gotta[SP]thank[SP]you[SP]for[SP]bringing[SP]it[SP]to[SP]me!",
-    "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Ohhhhh ![1205][U+000F] C'est ça !\n [E4][NULL][NULL][U+0006]Le masque de Kuchisake-onna[E4][NULL][NULL][0002] ![1205][U+000F]\n Merci de me l'avoir apporté !"
-  },
-  {
-    "id": 277,
-    "offset": 313572,
-    "data_size": 246,
-    "slot_size": 250,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
-    "texte_orig": "L-Like[SP]I[SP]said,[SP]I'll[SP]repay[SP]you[SP]for[SP]the[SP]favor.\nHere's[SP]a[SP][E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Megido[SP]Card[E4][NULL][NULL][0002].[SP]Go[SP]on,[SP]it's[SP]yours!",
-    "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Comme je l'ai dit, je te revaudrai ça.\n Tiens, une [E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Carte Megido[E4][NULL][NULL][0002].\n Elle est à toi !"
-  },
-  {
-    "id": 278,
-    "offset": 313822,
-    "data_size": 154,
-    "slot_size": 158,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
-    "texte_orig": "My[SP]wife[SP]will[SP]have[SP]to[SP]believe[SP]me[SP]once[SP]she\nsees[SP]this.",
-    "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Ma femme me croira en voyant ça."
-  },
-  {
-    "id": 279,
-    "offset": 313980,
-    "data_size": 200,
-    "slot_size": 204,
-    "_term": [
-      4358,
-      4354,
-      5169
-    ],
-    "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
-    "texte_orig": "...You[SP]know,[SP]though,[SP]that[SP]Kuchisake-onna[SP]did\na[SP]lot[SP]of[SP]mumbling[SP]to[SP]herself.",
-    "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "... Cette Kuchisake-onna se parlait tout le temps toute seule."
-  },
-  {
-    "id": 280,
-    "offset": 314184,
-    "data_size": 328,
-    "slot_size": 332,
-    "_term": [
-      4358,
-      4354,
-      4355,
-      5169
-    ],
-    "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
-    "texte_orig": "Like,[SP][1432][NULL][NULL][0014]I[SP]wonder[SP]if[SP]this[SP]costume's[SP]too[SP]obvious...[1432][NULL][NULL][0014]\nOr[SP][1432][NULL][NULL][0014]Has[SP][1113]-kun[SP]reached[SP]the[SP]detective\nagency[SP]yet?[1432][NULL][NULL][0014][1205][U+000F][SP]What[SP]a[SP]strange[SP]monster...",
-    "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "[1432][NULL][NULL][0014]Déguisement trop voyant ?[1432][NULL][NULL][0014]\n Ou [1432][NULL][NULL][0014][1113]-kun à l'agence ?[1432][NULL][NULL][0014][1205][U+000F]\n Drôle de monstre..."
-  }
+    {
+        "id": 0,
+        "offset": 255626,
+        "data_size": 542,
+        "slot_size": 542,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "Guess[SP]what?[SP]You've[SP]noticed[SP]how[SP]this[SP]place[SP]is[SP]an[NL]island[SP]surrounded[SP]by[SP]the[SP]Tanabata[SP]River,[SP]right?[NL][1106][E2][1431][U+0000][U+0000]\"Housewife[NL]I[SP]was[SP]told[SP]it[SP]got[SP]its[SP]name[SP]because[SP]Rengedai[NL]means[SP][U+1432][U+0000][U+0000][U+0014]lotus[SP]flower.[U+1432][U+0000][U+0000][U+0014][SP]In[SP]the[SP]spring,[SP]it[SP]looks[NL]like[SP]a[SP]lotus[SP]floating[SP]on[SP]the[SP]water[SP]from[SP]above.",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "Cet endroit est une île\n dans la Tanabata, non ?[1106][NL]Rengedai veut dire [1432][NULL][NULL][0014]fleur de lotus.[1432][NULL][NULL][0014] Au printemps, vue d'en haut,\n on dirait un lotus flottant."
+    },
+    {
+        "id": 1,
+        "offset": 256168,
+        "data_size": 304,
+        "slot_size": 304,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "Have[SP]you[SP]been[SP]to[SP]Honmaru[SP]Park?[SP]It's[SP]very[NL]beautiful.[SP]The[SP]perfect[SP]place[SP]for[SP]taking[SP]a[SP]walk.[NL]I[SP]hear[SP]some[SP]strange[SP]rumors[SP]about[SP]it,[SP]though...",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "Tu connais le parc Honmaru ? Très beau pour s'y promener.\n Mais d'étranges rumeurs circulent..."
+    },
+    {
+        "id": 2,
+        "offset": 256472,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "Do[SP]you[SP]know[SP]the[SP]homeless[SP]man[SP]in[SP]Honmaru[SP]Park?[NL]I[SP]hear[SP]he[SP]used[SP]to[SP]be[SP]a[SP]college[SP]professor.[1205][U+000F][NL]I[SP]wonder[SP]how[SP]he[SP]became[SP]homeless...",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "Tu connais le SDF du parc Honmaru ? Ancien prof.\n Comment en est-il arrivé là ?[1205][U+000F]"
+    },
+    {
+        "id": 3,
+        "offset": 256754,
+        "data_size": 264,
+        "slot_size": 264,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "Huh?[1205][U+000A][SP]The[SP]Masked[SP]Circle?[1205][U+000F][SP]Can't[SP]say[SP]I've[SP]ever[NL]heard[SP]of[SP]them,[SP]no.[SP]Is[SP]there[SP]an[SP]organization[SP]in[NL]Sumaru[SP]by[SP]that[SP]name?",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "Hein ? Le Cercle Masqué ?[1205][U+000A] Jamais entendu parler.\n Une organisation à Sumaru porte ce nom ?[1205][U+000F]"
+    },
+    {
+        "id": 4,
+        "offset": 257018,
+        "data_size": 246,
+        "slot_size": 246,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "I[SP]haven't[SP]seen[SP]any[SP]Kasugayama[SP]High[SP]students[NL]around[SP]lately.[1205][U+000F][SP]I[SP]wonder[SP]if[SP]they[SP]all[SP]went[SP]on[NL]a[SP]school[SP]trip...",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "Je n'ai vu aucun élève de Kasugayama ces temps-ci.[1205][U+000F]\n En voyage scolaire ?"
+    },
+    {
+        "id": 5,
+        "offset": 257264,
+        "data_size": 294,
+        "slot_size": 294,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "Muses,[SP]right?[SP]I[SP]hear[SP]they're[SP]pretty[SP]popular.[NL][1106][E2][1431][U+0000][U+0000]\"Housewife[NL]I[SP]guess[SP]they're[SP]already[SP]having[SP]a[SP]concert[SP]at[NL]the[SP]outdoor[SP]concert[SP]hall.",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "Muses, oui. Populaires.[1106][NL]Elles donnent déjà un concert\n à la salle en plein air."
+    },
+    {
+        "id": 6,
+        "offset": 257558,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "I[SP]bet[SP]the[SP]Masked[SP]Circle[SP]are[SP]the[SP]terrorists[NL]here.[1205][U+000F][SP]No[SP]sane[SP]man[SP]would[SP]do[SP]these[SP]things...[NL]So[SP]the[SP]Masked[SP]Circle[SP]was[SP]sinister[SP]after[SP]all.",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "C'est sûrement le Cercle Masqué les terroristes.[1205][U+000F]\n Aucun sain d'esprit ne ferait ça...\n Donc ils étaient sinistres."
+    },
+    {
+        "id": 7,
+        "offset": 257856,
+        "data_size": 312,
+        "slot_size": 312,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "They[SP]posted[SP]the[SP]composite[SP]sketches[SP]of[SP]those[NL]terrorists,[SP]so[SP]I[SP]went[SP]to[SP]see[SP]for[SP]myself.[1205][U+000F][SP]All[SP]five[NL]of[SP]them[SP]were[SP]the[SP]scariest-looking[SP]people...",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "Les portraits-robots des terroristes sont affichés, je suis allée voir.[1205][U+000F]\n Les cinq avaient l'air terrifiant..."
+    },
+    {
+        "id": 8,
+        "offset": 258168,
+        "data_size": 500,
+        "slot_size": 500,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "I[SP]spoke[SP]with[SP]the[SP]woman[SP]next[SP]door,[SP]and[SP]we[SP]think[NL]the[SP]things[SP]in[SP]that[SP]In[SP]Lak'ech[SP]are[SP]all[SP]true.[NL][1106][E2][1431][U+0000][U+0000]\"Housewife[NL]I[SP]mean,[SP]everything[SP]that's[SP]happened[SP]up[SP]to[SP]now[NL]was[SP]foretold[SP]in[SP]it,[SP]right?[1205][U+000F][SP]They[SP]said[SP]so[SP]on[SP]the[NL]news.[SP]That[SP]can't[SP]be[SP]coincidence.",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "Avec la voisine, on pense que tout l'In Lak'ech est vrai.[1106][NL]Tout ce qui est arrivé était prédit, non ?[1205][U+000F]\n Ils l'ont dit aux infos. Pas une coïncidence."
+    },
+    {
+        "id": 9,
+        "offset": 258668,
+        "data_size": 480,
+        "slot_size": 480,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "I-I[SP]almost[SP]got[SP]attacked[SP]by[SP]those[SP]soldiers[SP]just[NL]now...[1205][U+000F][SP]It[SP]was[SP]terrifying...[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Housewife[NL]B-But[SP]then[SP]one[SP]of[SP]the[SP]Masked[SP]Circle[SP]saved[SP]me![1205][U+000F][NL]What's[SP]going[SP]on[SP]here?[NL][1106][E2][1431][U+0000][U+0000]\"Housewife[NL]I[SP]think[SP]I[SP]had[SP]the[SP]wrong[SP]idea[SP]about[SP]them...",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "J'ai failli me faire attaquer par ces soldats...[1205][U+000F]\n Terrible...[1106][NL]Un membre du Cercle Masqué m'a sauvée ![1205][U+000F]\n Que se passe-t-il ?[1106][NL]J'avais mal jugé..."
+    },
+    {
+        "id": 10,
+        "offset": 259148,
+        "data_size": 466,
+        "slot_size": 466,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "Hey![1205][U+000F][SP]S-Some[SP]of[SP]those[SP]Masked[SP]Circle[SP]people[NL]saw[SP]the[SP]shooting[SP]stars[SP]and[SP]said,[SP][U+1432][U+0000][U+0000][U+0014]It's[SP]the[NL]lion's[SP]roar![U+1432][U+0000][U+0000][U+0014][1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Housewife[NL]That's[SP]another[SP]line[SP]from[SP]that[SP]Oracle,[SP]right?[NL]I[SP]knew[SP]it...[SP]The[SP]In[SP]Lak'ech[SP]is[SP]true[SP]after[SP]all!",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "Hé ! Des gens du Cercle Masqué ont dit : [1432][NULL][NULL][0014]C'est le rugissement du lion ![1432][NULL][NULL][0014][1205][U+000F][1106][NL]C'est encore une phrase de l'Oracle, non ?\n L'In Lak'ech est donc vrai !"
+    },
+    {
+        "id": 11,
+        "offset": 259614,
+        "data_size": 240,
+        "slot_size": 240,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "Have[SP]you[SP]been[SP]to[SP]Honmaru[SP]Park[SP]already?[1205][U+000A][SP]They're[NL]having[SP]a[SP]gathering[SP]to[SP]evolve[SP]into[SP]Idealians[NL]right[SP]now!",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "Tu es allé au parc Honmaru ?[1205][U+000A] Ils se rassemblent\n pour devenir Idéaliens là maintenant !"
+    },
+    {
+        "id": 12,
+        "offset": 259854,
+        "data_size": 386,
+        "slot_size": 386,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "H-Hey![1205][U+000A][SP]You're[SP]a[SP]Sevens[SP]student,[SP]right?[1205][U+000A][SP]What's[NL]that[SP]light[SP]coming[SP]out[SP]from[SP]your[SP]school?[NL][1106][E2][1431][U+0000][U+0000]\"Housewife[NL]Is[SP]the[SP]evolution[SP]starting[SP]already?[1205][U+000A][SP]Oh,[SP]no![NL]I'm[SP]not[SP]ready[SP]for[SP]it[SP]yet!",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "Hé ! Tu es de Seven ?[1205][U+000A] C'est quoi cette lumière\n qui sort de ton école ?[1106][NL]L'évolution a déjà commencé ?[1205][U+000A] Oh non,\n je ne suis pas prête !"
+    },
+    {
+        "id": 13,
+        "offset": 260240,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Housewife",
+        "texte_orig": "*sigh*[1205][U+0008][SP]I[SP]wish[SP]they'd[SP]get[SP]this[SP]evolution[SP]thing[NL]over[SP]with...[1205][U+000A][SP]I[SP]feel[SP]like[SP]the[SP]excitement[SP]has[NL]passed[SP]and[SP]I'm[SP]losing[SP]interest.",
+        "nom_fr": "Femme au foyer",
+        "texte_fr": "*soupir*[1205][U+0008] J'aimerais en finir avec cette évolution...[1205][U+000A]\n L'excitation est retombée, ça ne m'intéresse plus."
+    },
+    {
+        "id": 14,
+        "offset": 260524,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "Oh,[SP]don't[SP]you[SP]go[SP]to[SP]Sevens?[SP]Did[SP]something[NL]happen[SP]at[SP]your[SP]school?[SP]It[SP]sounded[SP]like[SP]there[NL]was[SP]some[SP]commotion[SP]on[SP]the[SP]school[SP]grounds.",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "Oh, tu vas à Seven ? Il s'est passé quelque chose dans ton école ?\n On a entendu du bruit dans la cour."
+    },
+    {
+        "id": 15,
+        "offset": 260822,
+        "data_size": 326,
+        "slot_size": 326,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "My[SP]colleagues[SP]have[SP]been[SP]pretty[SP]distant[SP]lately.[NL]They[SP]keep[SP]leaving[SP]before[SP]me[SP]because[SP]they[SP]have[NL]some[SP]meeting[SP]to[SP]attend.[1205][U+000F][SP]Are[SP]they[SP]in[SP]some[SP]union?",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "Mes collègues sont distants. Ils partent avant moi pour une réunion.[1205][U+000F]\n Sont-ils syndiqués ?"
+    },
+    {
+        "id": 16,
+        "offset": 261148,
+        "data_size": 416,
+        "slot_size": 416,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "Wow,[SP]Kasugayama[SP]High's[SP]festival[SP]is[SP]the[SP]talk[SP]of[NL]the[SP]town[SP]over[SP]in[SP]Hirasaka.[NL][1106][E2][1431][U+0000][U+0000]\"Office[SP]worker[NL]I'm[SP]sure[SP]the[SP]people[SP]who[SP]live[SP]there[SP]must[SP]be[SP]glad[NL]the[SP]local[SP]school's[SP]on[SP]the[SP]rise[SP]in[SP]popularity.",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "La fête de Kasugayama fait jaser\n dans tout Hirasaka.[1106][NL]Les habitants sont contents que l'école du coin\n gagne en popularité."
+    },
+    {
+        "id": 17,
+        "offset": 261564,
+        "data_size": 320,
+        "slot_size": 320,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "Do[SP]you[SP]know[SP]who[SP]the[SP]third[SP]member[SP]of[SP]Muses[SP]is?[1205][U+000F][NL]She's[SP]apparently[SP]a[SP]Sevens[SP]student[SP]like[SP]you.[SP]If[NL]you[SP]know[SP]her,[SP]would[SP]you[SP]mind[SP]introducing[SP]me?",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "Tu sais qui est le troisième membre de Muses ?[1205][U+000F]\n Une élève de Seven comme toi. Tu pourrais me la présenter ?"
+    },
+    {
+        "id": 18,
+        "offset": 261884,
+        "data_size": 302,
+        "slot_size": 302,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "They're[SP]going[SP]to[SP]announce[SP]the[SP]third[SP]member[SP]of[NL]Muses[SP]at[SP]the[SP]live[SP]recording[SP]at[SP]Giga[SP]Macho.[1205][U+000F][NL]I[SP]wonder[SP]what[SP]she's[SP]like.[SP]I[SP]can't[SP]wait!",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "Ils annoncent le 3e membre de Muses au live de Giga Macho.[1205][U+000F]\n J'ai hâte de voir à quoi elle ressemble !"
+    },
+    {
+        "id": 19,
+        "offset": 262186,
+        "data_size": 420,
+        "slot_size": 420,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "So[SP]the[SP]third[SP]member's[SP]fluent[SP]in[SP]English...[1205][U+000F][NL]I[SP]see...[NL][1106][E2][1431][U+0000][U+0000]\"Office[SP]worker[NL]A[SP]bilingual[SP]idol,[SP]eh?[1205][U+000F][SP]I[SP]like[SP]that.[SP]It[SP]has[NL]a[SP]nice[SP]intellectual[SP]air[SP]to[SP]it.[SP]I'm[SP]looking[NL]forward[SP]to[SP]hearing[SP]her[SP]solo.",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "La 3e parle anglais couramment...[1205][U+000F]\n Je vois...[1106][NL]Une idole bilingue ?[1205][U+000F] J'aime ça. Ça fait intellectuel.\n J'ai hâte d'entendre son solo."
+    },
+    {
+        "id": 20,
+        "offset": 262606,
+        "data_size": 278,
+        "slot_size": 278,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "Fortunately,[SP]there[SP]were[SP]no[SP]casualties[SP]in[SP]the[NL]concert[SP]hall[SP]fire.[1205][U+000F][SP]But[SP]whose[SP]concert[SP]was[NL]it?[SP]I[SP]can't[SP]really[SP]remember...",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "Heureusement, pas de victimes dans l'incendie.[1205][U+000F]\n C'était le concert de qui ? Je ne me souviens pas."
+    },
+    {
+        "id": 21,
+        "offset": 262884,
+        "data_size": 318,
+        "slot_size": 318,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "Wasn't[SP]that[SP]one[SP]of[SP]the[SP]teachers[SP]at[SP]Sevens...?[1205][U+000F][NL]She[SP]had[SP]this[SP]crazy[SP]expression[SP]and[SP]told[SP]me[SP]that[NL]the[SP]terrorists[SP]were[SP]this[SP]Last...[SP]something.",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "C'était une prof de Seven ?[1205][U+000F] Elle avait l'air folle\n et m'a dit que les terroristes étaient ce... Dernier quelque chose."
+    },
+    {
+        "id": 22,
+        "offset": 263202,
+        "data_size": 328,
+        "slot_size": 328,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "Some[SP]kids[SP]just[SP]now[SP]said[SP]that[SP]the[SP]five[SP]people[SP]in[NL]those[SP]composite[SP]sketches[SP]are[SP]heroes[SP]fighting[SP]the[NL]Masked[SP]Circle.[1205][U+000F][SP]Now[SP]how[SP]would[SP]they[SP]know[SP]that?",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "Des gamins disent que les 5 personnes des portraits sont des héros.[1205][U+000F]\n Comment pourraient-ils savoir ça ?"
+    },
+    {
+        "id": 23,
+        "offset": 263530,
+        "data_size": 286,
+        "slot_size": 286,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "The[SP]Last[SP]Battalion[SP]and[SP]the[SP]Masked[SP]Circle[SP]are[NL]fighting[SP]over[SP]the[SP]secret[SP]treasure[SP]of[SP]Sumaru[NL]City.[SP]It's[SP]all[SP]in[SP]the[SP]In[SP]Lak'ech.",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "Le Dernier Bataillon et le Cercle Masqué se battent\n pour le trésor secret de Sumaru. Tout est dans l'In Lak'ech."
+    },
+    {
+        "id": 24,
+        "offset": 263816,
+        "data_size": 288,
+        "slot_size": 288,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "D-Did[SP]you[SP]see[SP]the[SP]size[SP]of[SP]that[SP]air[SP]fleet?[NL]There[SP]were[SP]20[SP]of[SP]them,[SP]easy![1205][U+000F][SP]Th-They've[SP]come[NL]to[SP]steal[SP]Sumaru's[SP]hidden[SP]treasure!",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "T'as vu cette flotte aérienne ? 20 appareils, facile ![1205][U+000F]\n Ils sont venus voler le trésor caché de Sumaru !"
+    },
+    {
+        "id": 25,
+        "offset": 264104,
+        "data_size": 522,
+        "slot_size": 522,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "These[SP]weird[SP]temples[SP]showed[SP]up[SP]in[SP]the[SP]other[NL]wards,[SP]right?[1205][U+000A][SP]The[SP]Masked[SP]Circle[SP]and[SP]Last[NL]Battalion[SP]were[SP]going[SP]in[SP]to[SP]fight[SP]each[SP]other![NL][1106][E2][1431][U+0000][U+0000]\"Office[SP]worker[NL]But...[SP]why[SP]didn't[SP]one[SP]of[SP]those[SP]temples[SP]appear[NL]here,[SP]too?[1205][U+000F][SP]It[SP]makes[SP]me[SP]sort[SP]of[SP]nervous...",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "Ces étranges temples sont apparus ailleurs, non ?[1205][U+000A]\n Le Cercle Masqué et le Dernier Bataillon y entraient pour se battre ![1106][NL]Mais pourquoi aucun temple n'est apparu ici ?[1205][U+000F]\n Ça m'inquiète..."
+    },
+    {
+        "id": 26,
+        "offset": 264626,
+        "data_size": 252,
+        "slot_size": 252,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "You're[SP]safe?[1205][U+000A][SP]I'd[SP]heard[SP]the[SP]Last[SP]Battalion[NL]captured[SP]all[SP]the[SP]Sevens[SP]students.[1205][U+000F][SP]Did[SP]you[NL]manage[SP]to[SP]escape?",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "Tu es sain et sauf ?[1205][U+000A] Les élèves de Seven ont été capturés.[1205][U+000F]\n Tu t'es échappé ?"
+    },
+    {
+        "id": 27,
+        "offset": 264878,
+        "data_size": 306,
+        "slot_size": 306,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Office[SP]worker",
+        "texte_orig": "I[SP]hear[SP]the[SP]students[SP]at[SP]Sevens[SP]got[SP]rescued.[1205][U+000A][NL]I[SP]don't[SP]know[SP]who[SP]pulled[SP]that[SP]off,[SP]but[SP]they're[NL]some[SP]damn[SP]brave[SP]people,[SP]whoever[SP]they[SP]are.",
+        "nom_fr": "Employé de bureau",
+        "texte_fr": "J'entends que les élèves de Seven ont été secourus.[1205][U+000A]\n Je ne sais pas qui a fait ça, mais ce sont des gens courageux."
+    },
+    {
+        "id": 28,
+        "offset": 265184,
+        "data_size": 458,
+        "slot_size": 458,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Um,[SP]I[SP]hear[SP]a[SP]ramen[SP]shop[SP]sells[SP]guns[SP]and[SP]swords[NL]and[SP]stuff.[SP]I[SP]wonder[SP]if[SP]they[SP]have[SP]a[SP]really[NL]cool[SP]sword.[1106][E2][NL][E3][1431][U+0000][U+0000]\"Boy[NL]Did[SP]the[SP]boys[SP]at[SP]Cuss[SP]High[SP]get[SP]cooler?[1205][U+000F][SP]That's[NL]what[SP]my[SP]sister[SP]said.[SP]How[SP]do[SP]they[SP]do[SP]that?[NL]Do[SP]they[SP]transform?",
+        "nom_fr": "Garçon",
+        "texte_fr": "Un resto de ramen vend des flingues et des épées.\n Ils ont une épée super cool ?[E1][E2]\n[E3][E4][NULL][NULL]\"Garçon\nLes garçons du lycée Cuss sont plus cools ?[1205][U+000F]\n C'est ce que ma sœur a dit. Comment ils font ?\n Ils se transforment ?"
+    },
+    {
+        "id": 29,
+        "offset": 265642,
+        "data_size": 212,
+        "slot_size": 212,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Waaaaah![1205][U+000F][SP]I[SP]wanted[SP]to[SP]go[SP]to[SP]Kasuga[SP]Festival![NL]My[SP]sister[SP]said[SP]kids[SP]can't[SP]go.[1205][U+000F][SP]It's[SP]not[SP]faaaair!",
+        "nom_fr": "Garçon",
+        "texte_fr": "Waaaaah ![1205][U+000F] Je voulais aller au festival Kasuga !\n Les enfants ne peuvent pas.[1205][U+000F] Pas juste !"
+    },
+    {
+        "id": 30,
+        "offset": 265854,
+        "data_size": 144,
+        "slot_size": 144,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy[U+121D][U+0001]",
+        "texte_orig": "I[SP]saw[SP]a[SP]bunch[SP]of[SP]Sevens[SP]people[SP]running[SP]away.[NL]What[SP]happened?",
+        "nom_fr": "",
+        "texte_fr": ""
+    },
+    {
+        "id": 31,
+        "offset": 265998,
+        "data_size": 272,
+        "slot_size": 272,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "My[SP]sister[SP]didn't[SP]come[SP]home[SP]after[SP]the[SP]Kasuga[NL]Festival...[SP]What's[SP]wrong[SP]with[SP]her?[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]Oh[SP]well.[SP]I[SP]wonder[SP]what's[SP]for[SP]dinner.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Ma sœur n'est pas rentrée après le festival...\n Qu'est-ce qu'elle a ?[1106][NL]Tant pis. Quoi manger ?"
+    },
+    {
+        "id": 32,
+        "offset": 266270,
+        "data_size": 310,
+        "slot_size": 310,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Mommy[SP]said[SP]I[SP]shouldn't[SP]go[SP]outside.[SP]She[SP]says[NL]it's[SP]dangerous.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]But[SP]I[SP]think[SP]I[SP]was[SP]waiting[SP]for[SP]someone[SP]here.[1205][U+000F][NL]I[SP]can't[SP]remember[SP]who[SP]though.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Maman dit de ne pas sortir.\n C'est dangereux.[1106][NL]Je crois que j'attendais quelqu'un ici.[1205][U+000F]\n Je ne me souviens plus qui."
+    },
+    {
+        "id": 33,
+        "offset": 266580,
+        "data_size": 178,
+        "slot_size": 178,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Hey[SP]Mister?[SP]What's[SP]a[SP]Last[SP]Battalion?[SP]Are[SP]they[NL]bad[SP]guys[SP]like[SP]the[SP]Masked[SP]Circle?",
+        "nom_fr": "Garçon",
+        "texte_fr": "C'est quoi le Dernier Bataillon ?\n Des méchants comme le Cercle Masqué ?"
+    },
+    {
+        "id": 34,
+        "offset": 266758,
+        "data_size": 206,
+        "slot_size": 206,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "The[SP]people[SP]in[SP]the[SP]drawings[SP]are[SP]heroes[SP]and[NL]they[SP]fight[SP]the[SP]Masked[SP]Circle.[1205][U+000F][SP]My[SP]friend[NL]told[SP]me.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Les dessins montrent des héros combattant le Cercle Masqué.[1205][U+000F]\n Mon ami l'a dit."
+    },
+    {
+        "id": 35,
+        "offset": 266964,
+        "data_size": 150,
+        "slot_size": 150,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "What's[SP]Xibalba[SP]like?[1205][U+000F][SP]Does[SP]it[SP]combine[SP]with[NL]stuff[SP]and[SP]transform?",
+        "nom_fr": "Garçon",
+        "texte_fr": "C'est quoi Xibalba ?[1205][U+000F]\n Ça se combine et ça se transforme ?"
+    },
+    {
+        "id": 36,
+        "offset": 267114,
+        "data_size": 124,
+        "slot_size": 124,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Waaaaaah![SP]Waaaaaah![1205][U+000F][SP]I'm[SP]scaaaared![SP]Mommy![NL]Sister!",
+        "nom_fr": "Garçon",
+        "texte_fr": "Waaaaaah ! J'ai peur !\n Maman ! Ma sœur !"
+    },
+    {
+        "id": 37,
+        "offset": 267238,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Woooow...[SP]The[SP]city's[SP]flying![1205][U+000A][SP]But[SP]the[SP]Earth[SP]is[NL]gonna[SP]get[SP]uh-nye-a-lated[SP]after[SP]the[SP]Grand[SP]Cross.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[U+121D][U+0001][NL]Mister,[SP]what's[SP]uh-nye-a-lated?",
+        "nom_fr": "Garçon",
+        "texte_fr": "Woooow... La ville vole ![1205][U+000A] Mais la Terre va être anéantie\n après la Grande Croix."
+    },
+    {
+        "id": 38,
+        "offset": 267536,
+        "data_size": 318,
+        "slot_size": 318,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Um,[SP]so,[SP]I[SP]heard[SP]the[SP]Earth's[SP]gonna[SP]split[SP]open[NL]after[SP]the[SP]Grand[SP]Cross.[1205][U+000A][SP]That's[SP]how[SP]it[SP]gets[NL]uh-nye-a-lated.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[U+121D][U+0001][NL]But[SP]what's[SP]uh-nye-a-lated[SP]mean?",
+        "nom_fr": "Garçon",
+        "texte_fr": "J'ai entendu que la Terre va se fendre après la Grande Croix.[1205][U+000A]\n C'est comme ça qu'elle est anéantie."
+    },
+    {
+        "id": 39,
+        "offset": 267854,
+        "data_size": 382,
+        "slot_size": 382,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Mommy[SP]says[SP]after[SP]the[SP]Grand[SP]Cross,[SP]there's[SP]gonna[NL]be[SP]a[SP]huge[SP]earthquake[SP]and[SP]the[SP]Earth[SP]down[SP]there[NL]is[SP]gonna[SP]get[SP]uh-nye-a-lated.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]But[SP]no[SP]one[SP]will[SP]tell[SP]me[SP]what[SP]uh-nye-a-lated[SP]is.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Maman dit qu'après la Grande Croix, il y aura un grand tremblement de terre\n et que la Terre sera anéantie.[1106][NL]Personne ne veut me dire anéanti."
+    },
+    {
+        "id": 40,
+        "offset": 268236,
+        "data_size": 368,
+        "slot_size": 368,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "After[SP]the[SP]Grand[SP]Cross,[SP]the[SP]Earth's[SP]gonna[SP]stop[NL]spinning.[1205][U+000A][SP]That's[SP]what[SP]my[SP]daddy[SP]said.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]Is[SP]that[SP]what[SP]uh-nye-a-lated[SP]means?[SP]The[SP]Earth[NL]stops[SP]spinning?[1205][U+000F][SP]I[SP]don't[SP]get[SP]it.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Après la Grande Croix, la Terre va s'arrêter.[1205][U+000A]\n C'est mon papa.[1106][NL]C'est ça, anéanti ? La Terre s'arrête ?[1205][U+000F]\n Je ne comprends pas."
+    },
+    {
+        "id": 41,
+        "offset": 268604,
+        "data_size": 342,
+        "slot_size": 342,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Um,[SP]someone[SP]told[SP]me[SP]there[SP]are[SP]flowers[SP]in[SP]Aoba[NL]Park[SP]that[SP]talk.[SP]But[SP]that[SP]sounds[SP]dumb.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]Flowers[SP]don't[SP]have[SP]mouths,[SP]silly![SP]Can[SP]they[NL]talk[SP]with[SP]their[SP]petals?",
+        "nom_fr": "Garçon",
+        "texte_fr": "Des fleurs qui parlent au parc d'Aoba ?\n Ça me paraît idiot.[1106][NL]Les fleurs n'ont pas de bouche !\n Elles parlent par pétales ?"
+    },
+    {
+        "id": 42,
+        "offset": 268946,
+        "data_size": 424,
+        "slot_size": 424,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Hey,[SP]what's[SP]Zodiac[SP]like?[SP]'Cause[SP]my[SP]friend[SP]said[NL]the[SP]second[SP]floor[SP]is[SP]this[SP]big[SP]dungeon[SP]with[SP]a[NL]lot[SP]of[SP]cool[SP]stuff.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]I[SP]bet[SP]there's[SP]an[SP]archfiend[SP]in[SP]there.[SP]He's[SP]just[NL]waiting[SP]for[SP]the[SP]heroes[SP]to[SP]show[SP]up.",
+        "nom_fr": "Garçon",
+        "texte_fr": "C'est quoi Zodiac ? Mon pote dit que le 2e étage\n est un grand donjon avec des trucs cools.[1106][NL]Il y a un archidémon là-dedans.\n Il attend que les héros viennent."
+    },
+    {
+        "id": 43,
+        "offset": 269370,
+        "data_size": 256,
+        "slot_size": 256,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy[U+121D][U+0001]",
+        "texte_orig": "Hey,[SP]is[SP]that[SP]ghost[SP]Hanako[SP]really[SP]at[SP]Sevens?[NL]Hanako's[SP]scary.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]If[SP]she[SP]sees[SP]you,[SP]she[SP]pulls[SP]you[SP]in[SP]the[SP]toilet.",
+        "nom_fr": "",
+        "texte_fr": "Elle te tire aux toilettes."
+    },
+    {
+        "id": 44,
+        "offset": 269626,
+        "data_size": 236,
+        "slot_size": 236,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Hey,[SP]is[SP]Bukimi[SP]really[SP]at[SP]Cuss[SP]High?[SP]She's[SP]even[NL]scarier[SP]than[SP]Hanako.[SP]You're[SP]a[SP]goner[SP]if[SP]she[NL]sees[SP]you,[SP]Mister.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Bukimi est vraiment au lycée Cuss ?\n Elle fait plus peur qu'Hanako.\n Vous êtes mort si elle vous voit."
+    },
+    {
+        "id": 45,
+        "offset": 269862,
+        "data_size": 294,
+        "slot_size": 294,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Is[SP]there[SP]really[SP]a[SP]ghost[SP]in[SP]the[SP]park[SP]by[SP]the[NL]concert[SP]hall?[SP]Um,[SP]I[SP]heard[SP]it's[SP]an[SP]idol's[SP]ghost.[1205][U+000F][NL]What[SP]do[SP]I[SP]do?[SP]My[SP]treasure's[SP]buried[SP]there...",
+        "nom_fr": "Garçon",
+        "texte_fr": "Il y a vraiment un fantôme dans le parc près de la salle ?\n C'est le fantôme d'une idole.[1205][U+000F] Mon trésor est enterré là..."
+    },
+    {
+        "id": 46,
+        "offset": 270156,
+        "data_size": 222,
+        "slot_size": 222,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Guess[SP]what?[SP]There's[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the[NL]abandoned[SP]factory.[SP]I[SP]bet[SP]you'll[SP]get[SP]cursed[NL]if[SP]you[SP]equip[SP]it.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Devine quoi ? Il y a un Taxi Maudit à l'usine abandonnée.\n Tu seras maudit si tu l'équipes."
+    },
+    {
+        "id": 47,
+        "offset": 270378,
+        "data_size": 234,
+        "slot_size": 234,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Hey,[SP]you[SP]know[SP]what?[SP]There's[SP]a[SP]Cursed[SP]Escort[SP]at[NL]the[SP]abandoned[SP]factory.[SP]I[SP]bet[SP]your[SP]HP[SP]drops[SP]if[NL]you[SP]equip[SP]it.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Il y a une Escorte Maudite à l'usine abandonnée.\n Tes PV baissent si tu l'équipes."
+    },
+    {
+        "id": 48,
+        "offset": 270612,
+        "data_size": 306,
+        "slot_size": 306,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "What[SP]do[SP]I[SP]do...?[SP]I[SP]heard[SP]Kuchisake-onna[SP]is[NL]at[SP]Mt.[SP]Iwato.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]And[SP]my[SP]teacher[SP]says[SP]it[SP]chases[SP]kids[SP]who[SP]don't[NL]go[SP]straight[SP]home[SP]after[SP]school.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Je fais quoi ? Kuchisake-onna est au mont Iwato.[1106][NL]Mon prof dit qu'elle poursuit ceux qui ne rentrent pas."
+    },
+    {
+        "id": 49,
+        "offset": 270918,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Um,[SP]I[SP]heard[SP]Jumping[SP]Geezer[SP]is[SP]at[NL]Mt.[SP]Katatsumuri.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]Jumping[SP]Geezer's[SP]this[SP]guy[SP]who[SP]chases[SP]after[SP]you[NL]and[SP]stomps[SP]on[SP]your[SP]head.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Le Sauteur Vieux est au mont Katatsumuri.[1106][NL]Le Sauteur Vieux, un type qui te court après\n et te piétine la tête."
+    },
+    {
+        "id": 50,
+        "offset": 271202,
+        "data_size": 210,
+        "slot_size": 210,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Waaaaaah![SP]Waaaaah![SP]I'm[SP]scaaaared![NL]U-Um,[SP]Kudan's[SP]at[SP]the[SP]abandoned[SP]factory...[NL]Waaaaaah![SP]Waaaaah!",
+        "nom_fr": "Garçon",
+        "texte_fr": "Waaaaah ! J'ai peur !\n Kudan est à l'usine abandonnée...\n Waaaaah !"
+    },
+    {
+        "id": 51,
+        "offset": 271412,
+        "data_size": 240,
+        "slot_size": 240,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Hey,[SP]I[SP]heard[SP]Giga[SP]Macho[SP]sells[SP]a[SP]secret[SP]CD.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]It's[SP]like[SP]a[SP]secret[SP]item[SP]in[SP]a[SP]game,[SP]huh?[NL]That's[SP]so[SP]weird.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Giga Macho vend un CD secret.[1106][NL]C'est comme un objet secret de jeu, non ?\n Bizarre."
+    },
+    {
+        "id": 52,
+        "offset": 271652,
+        "data_size": 322,
+        "slot_size": 322,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]wonder[SP]if[SP]Dresser[SP]Hag[SP]is[SP]the[SP]monster[SP]my[NL]friend[SP]Chii[SP]was[SP]talking[SP]about.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]So[SP]he[SP]wasn't[SP]lying[SP]when[SP]he[SP]said[SP]he[SP]saw[SP]it[SP]at[NL]the[SP]abandoned[SP]factory!",
+        "nom_fr": "Garçon",
+        "texte_fr": "La Sorcière du Buffet, c'est le monstre\n dont mon pote Chii parlait ?[1106][NL]Donc il ne mentait pas en disant l'avoir vue à l'usine !"
+    },
+    {
+        "id": 53,
+        "offset": 271974,
+        "data_size": 244,
+        "slot_size": 244,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "If[SP]you[SP]go[SP]to[SP]Time[SP]Castle,[SP]you[SP]can[SP]buy[NL]real[SP]weapons![NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]Um,[SP]I[SP]heard[SP]they're[SP]okay[SP]and[SP]the[SP]price[NL]is[SP]normal.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Au Château du Temps, de vraies armes ![1106][NL]Elles sont correctes et le prix est normal."
+    },
+    {
+        "id": 54,
+        "offset": 272218,
+        "data_size": 244,
+        "slot_size": 244,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "If[SP]you[SP]go[SP]to[SP]Time[SP]Castle,[SP]you[SP]can[SP]buy[NL]real[SP]weapons![NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]Um,[SP]I[SP]heard[SP]they're[SP]good,[SP]but[SP]they[SP]cost[NL]too[SP]much.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Au Château du Temps, de vraies armes ![1106][NL]Elles sont bonnes mais trop chères."
+    },
+    {
+        "id": 55,
+        "offset": 272462,
+        "data_size": 252,
+        "slot_size": 252,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "If[SP]you[SP]go[SP]to[SP]Time[SP]Castle,[SP]you[SP]can[SP]buy[NL]real[SP]weapons![NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]Um,[SP]I[SP]heard[SP]they're[SP]cheap,[SP]but[SP]they're[NL]not[SP]that[SP]good.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Au Château du Temps, de vraies armes ![1106][NL]Bon marché mais pas terribles."
+    },
+    {
+        "id": 56,
+        "offset": 272714,
+        "data_size": 296,
+        "slot_size": 296,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]heard[SP]about[SP]a[SP]weapon[SP]store[SP]in[SP]Yumezaki[NL]called[SP]Tony's[SP]Shop.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]They[SP]sell[SP]a[SP]bunch[SP]of[SP]stuff,[SP]but[SP]they[SP]don't[NL]pay[SP]you[SP]much[SP]for[SP]sales.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop.[1106][NL]Ils vendent plein de trucs, mais reprennent pas cher."
+    },
+    {
+        "id": 57,
+        "offset": 273010,
+        "data_size": 260,
+        "slot_size": 260,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]heard[SP]about[SP]a[SP]weapon[SP]store[SP]in[SP]Yumezaki[NL]called[SP]Tony's[SP]Shop.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]They're[SP]cheap,[SP]but[SP]their[SP]stuff's[SP]not[NL]that[SP]great.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop.[1106][NL]Bon marché, mais qualité moyenne."
+    },
+    {
+        "id": 58,
+        "offset": 273270,
+        "data_size": 254,
+        "slot_size": 254,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]heard[SP]about[SP]a[SP]weapon[SP]store[SP]in[SP]Yumezaki[NL]called[SP]Tony's[SP]Shop.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]Their[SP]stuff[SP]is[SP]okay.[SP]The[SP]prices[SP]are[SP]okay[SP]too.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop.[1106][NL]Trucs corrects, prix corrects."
+    },
+    {
+        "id": 59,
+        "offset": 273524,
+        "data_size": 246,
+        "slot_size": 246,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]heard[SP]about[SP]a[SP]weapon[SP]store[SP]in[SP]Yumezaki[NL]called[SP]Tony's[SP]Shop.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]They[SP]have[SP]nice[SP]stuff,[SP]but[SP]it[SP]costs[SP]a[SP]lot.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop.[1106][NL]Beaux trucs, mais chers."
+    },
+    {
+        "id": 60,
+        "offset": 273770,
+        "data_size": 288,
+        "slot_size": 288,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]This[SP]lady[SP]said[SP]they[SP]don't[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[NL]but[SP]their[SP]trade-ins[SP]are[SP]good.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Un resto à Aoba vend des armes, vrai ?[1106][NL]Cette dame a dit qu'ils ont peu de choix,\n mais reprennent bien."
+    },
+    {
+        "id": 61,
+        "offset": 274058,
+        "data_size": 260,
+        "slot_size": 260,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]This[SP]lady[SP]said[SP]they're[SP]cheap,[SP]but[SP]they[SP]don't[NL]have[SP]great[SP]stuff.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Un resto à Aoba vend des armes, vrai ?[1106][NL]Bon marché, mais pas de super trucs,\n dit cette dame."
+    },
+    {
+        "id": 62,
+        "offset": 274318,
+        "data_size": 250,
+        "slot_size": 250,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]This[SP]lady[SP]said[SP]they[SP]sell[SP]nice[SP]things,[SP]but[SP]it[NL]costs[SP]a[SP]lot.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Un resto à Aoba vend des armes, vrai ?[1106][NL]Belles choses, mais cher."
+    },
+    {
+        "id": 63,
+        "offset": 274568,
+        "data_size": 278,
+        "slot_size": 278,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]This[SP]lady[SP]said[SP]they[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[NL]but[SP]their[SP]trade-ins[SP]are[SP]cheap.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Un resto à Aoba vend des armes, vrai ?[1106][NL]Cette dame a dit beaucoup de choix,\n mais reprises bas prix."
+    },
+    {
+        "id": 64,
+        "offset": 274846,
+        "data_size": 274,
+        "slot_size": 274,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Is[SP]it[SP]true[SP]a[SP]restaurant[SP]in[SP]Aoba[SP]sells[SP]weapons?[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]This[SP]cool[SP]lady[SP]said[SP]their[SP]stuff[SP]is[SP]okay[SP]and[NL]their[SP]prices[SP]were[SP]normal.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Un resto à Aoba vend des armes, vrai ?[1106][NL]Cette dame sympa a dit : trucs corrects,\n prix normaux."
+    },
+    {
+        "id": 65,
+        "offset": 275120,
+        "data_size": 302,
+        "slot_size": 302,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a[NL]boat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]I[SP]heard[SP]their[SP]stuff[SP]is[SP]okay.[SP]And[SP]their[SP]prices[NL]are[SP]normal.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes.[1106][NL]Leurs trucs sont corrects,\n prix normaux."
+    },
+    {
+        "id": 66,
+        "offset": 275422,
+        "data_size": 322,
+        "slot_size": 322,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a[NL]boat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]I[SP]heard[SP]they're[SP]cheap,[SP]but[SP]they[SP]don't[SP]have[NL]great[SP]stuff[SP]or[SP]anything.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes.[1106][NL]Bon marché, mais pas de super trucs."
+    },
+    {
+        "id": 67,
+        "offset": 275744,
+        "data_size": 332,
+        "slot_size": 332,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a[NL]boat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]I[SP]heard[SP]they[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]they[NL]don't[SP]pay[SP]you[SP]much[SP]for[SP]yours.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes.[1106][NL]Beaucoup de choix, mais tes reprises\n sont mal payées."
+    },
+    {
+        "id": 68,
+        "offset": 276076,
+        "data_size": 330,
+        "slot_size": 330,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a[NL]boat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]I[SP]heard[SP]they[SP]don't[SP]have[SP]much[SP]stuff,[SP]so[SP]they'll[NL]pay[SP]you[SP]a[SP]lot[SP]for[SP]yours.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes.[1106][NL]Peu de choix, donc ils reprennent cher."
+    },
+    {
+        "id": 69,
+        "offset": 276406,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Guess[SP]what?[SP]If[SP]you[SP]go[SP]to[SP]the[SP]shop[SP]with[SP]a[NL]boat,[SP]you[SP]can[SP]buy[SP]real[SP]weapons.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]I[SP]heard[SP]their[SP]stuff[SP]is[SP]great.[SP]But[SP]it[SP]costs[NL]a[SP]whole[SP]lot.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Devine : au magasin avec un bateau,\n on achète de vraies armes.[1106][NL]Trucs géniaux, mais très chers."
+    },
+    {
+        "id": 70,
+        "offset": 276704,
+        "data_size": 286,
+        "slot_size": 286,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]didn't[SP]know[SP]Rosa[SP]Candida[SP]was[SP]an[SP]armor[SP]store.[NL]I[SP]wonder[SP]if[SP]they[SP]sell[SP]Orichalcum[SP]shields...[NL]Their[SP]defense[SP]and[SP]price[SP]is[SP]normal,[SP]right?",
+        "nom_fr": "Garçon",
+        "texte_fr": "Je ne savais pas que Rosa Candida vendait des armures.\n Des boucliers en orichalque ? Défense et prix normaux, non ?"
+    },
+    {
+        "id": 71,
+        "offset": 276990,
+        "data_size": 276,
+        "slot_size": 276,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]didn't[SP]know[SP]Rosa[SP]Candida[SP]was[SP]an[SP]armor[SP]store.[NL]I[SP]wonder[SP]if[SP]they[SP]sell[SP]Orichalcum[SP]shields...[NL]They're[SP]not[SP]great,[SP]but[SP]cheap,[SP]right?",
+        "nom_fr": "Garçon",
+        "texte_fr": "Rosa Candida vend des armures ? Des boucliers en orichalque ?\n Pas géniaux mais bon marché ?"
+    },
+    {
+        "id": 72,
+        "offset": 277266,
+        "data_size": 296,
+        "slot_size": 296,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]didn't[SP]know[SP]Rosa[SP]Candida[SP]was[SP]an[SP]armor[SP]store.[NL]I[SP]wonder[SP]if[SP]they[SP]sell[SP]Orichalcum[SP]shields...[NL]They[SP]sell[SP]good[SP]stuff,[SP]but[SP]it's[SP]expensive,[SP]huh?",
+        "nom_fr": "Garçon",
+        "texte_fr": "Rosa Candida est un magasin d'armures ? Des boucliers en orichalque ?\n Bonne qualité mais cher, hein ?"
+    },
+    {
+        "id": 73,
+        "offset": 277562,
+        "data_size": 272,
+        "slot_size": 272,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Um,[SP]I[SP]heard[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[NL]real[SP]armor.[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]A[SP]lady[SP]said[SP]their[SP]stuff[SP]is[SP]okay[SP]and[SP]the[SP]prices[NL]were[SP]normal.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures.[1106][NL]Une dame a dit : trucs corrects,\n prix normaux."
+    },
+    {
+        "id": 74,
+        "offset": 277834,
+        "data_size": 240,
+        "slot_size": 240,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Um,[SP]I[SP]heard[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[NL]real[SP]armor.[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]A[SP]lady[SP]said[SP]it's[SP]cheap,[SP]but[SP]not[SP]that[SP]great.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures.[1106][NL]Bon marché, pas terrible."
+    },
+    {
+        "id": 75,
+        "offset": 278074,
+        "data_size": 286,
+        "slot_size": 286,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Um,[SP]I[SP]heard[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[NL]real[SP]armor.[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]A[SP]lady[SP]said[SP]they[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]the[NL]trade-ins[SP]are[SP]cheap.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures.[1106][NL]Une dame a dit beaucoup de choix,\n mais reprises bon marché."
+    },
+    {
+        "id": 76,
+        "offset": 278360,
+        "data_size": 256,
+        "slot_size": 256,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Um,[SP]I[SP]heard[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells[NL]real[SP]armor.[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]A[SP]lady[SP]said[SP]they[SP]had[SP]good[SP]stuff,[SP]but[SP]it[NL]cost[SP]a[SP]lot.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures.[1106][NL]Une dame a dit de bonnes choses,\n mais cher."
+    },
+    {
+        "id": 77,
+        "offset": 278616,
+        "data_size": 324,
+        "slot_size": 324,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.[NL]Aren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]Someone[SP]said[SP]they[SP]don't[SP]have[SP]a[SP]lot,[SP]but[NL]their[SP]trade-ins[SP]are[SP]good.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Il y a aussi un Rosa Candida à Aoba.\n C'est un magasin d'armures, non ?[1106][NL]Quelqu'un a dit peu de choix,\n mais bonnes reprises."
+    },
+    {
+        "id": 78,
+        "offset": 278940,
+        "data_size": 298,
+        "slot_size": 298,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.[NL]Aren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][U+000F][SP]Someone[SP]said[NL]their[SP]stuff's[SP]okay[SP]and[SP]their[SP]prices[SP]are[SP]normal.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Rosa Candida à Aoba, c'est aussi un magasin d'armures ?[1205][U+000F]\n Quelqu'un a dit trucs corrects, prix normaux."
+    },
+    {
+        "id": 79,
+        "offset": 279238,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.[NL]Aren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][U+000F][SP]Someone[SP]said[NL]their[SP]stuff's[SP]great,[SP]but[SP]it[SP]costs[SP]a[SP]lot.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Rosa Candida à Aoba, armurerie ?[1205][U+000F]\n Quelqu'un a dit trucs géniaux, mais cher."
+    },
+    {
+        "id": 80,
+        "offset": 279522,
+        "data_size": 290,
+        "slot_size": 290,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.[NL]Aren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][U+000F][SP]Someone[SP]said[NL]they're[SP]cheap,[SP]but[SP]their[SP]stuff's[SP]kinda[SP]bad.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Rosa Candida à Aoba, magasin d'armures ?[1205][U+000F]\n Quelqu'un a dit bon marché, mais qualité bof."
+    },
+    {
+        "id": 81,
+        "offset": 279812,
+        "data_size": 278,
+        "slot_size": 278,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.[NL]Aren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][U+000F][SP]They[SP]have[SP]a[NL]lot[SP]of[SP]stuff,[SP]but[SP]trade-ins[SP]are[SP]cheap.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Rosa Candida à Aoba, armures ?[1205][U+000F]\n Beaucoup de choix, mais reprises bon marché."
+    },
+    {
+        "id": 82,
+        "offset": 280090,
+        "data_size": 222,
+        "slot_size": 222,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady[NL]said[SP]they[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]trade-ins[NL]are[SP]cheap.",
+        "nom_fr": "Garçon",
+        "texte_fr": "London Clothier fait aussi des armures ?[1205][U+000F]\n Beaucoup de choix, reprises pas chères."
+    },
+    {
+        "id": 83,
+        "offset": 280312,
+        "data_size": 218,
+        "slot_size": 218,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady[NL]said[SP]they're[SP]cheap,[SP]but[SP]their[SP]stuff[SP]isn't[NL]that[SP]great.",
+        "nom_fr": "Garçon",
+        "texte_fr": "London Clothier, armures ?[1205][U+000F]\n Bon marché, qualité moyenne."
+    },
+    {
+        "id": 84,
+        "offset": 280530,
+        "data_size": 202,
+        "slot_size": 202,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady[NL]said[SP]their[SP]stuff[SP]is[SP]nice,[SP]but[SP]it's[SP]expensive.",
+        "nom_fr": "Garçon",
+        "texte_fr": "London Clothier vend des armures ?[1205][U+000F]\n Joli mais cher."
+    },
+    {
+        "id": 85,
+        "offset": 280732,
+        "data_size": 246,
+        "slot_size": 246,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady[NL]said[SP]their[SP]stuff[SP]is[SP]okay.[SP]And[SP]she[SP]said[SP]their[NL]prices[SP]are[SP]normal[SP]too.",
+        "nom_fr": "Garçon",
+        "texte_fr": "London Clothier, armures ?[1205][U+000F]\n Trucs corrects, prix normaux."
+    },
+    {
+        "id": 86,
+        "offset": 280978,
+        "data_size": 244,
+        "slot_size": 244,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][U+000F][SP]This[SP]lady[NL]said[SP]they[SP]don't[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]their[NL]trade-ins[SP]are[SP]good.",
+        "nom_fr": "Garçon",
+        "texte_fr": "London Clothier fait des armures ?[1205][U+000F]\n Peu de choix, mais bonnes reprises."
+    },
+    {
+        "id": 87,
+        "offset": 281222,
+        "data_size": 356,
+        "slot_size": 356,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Do[SP]you[SP]know[SP]about[SP]magazine[SP]contests?[1205][U+000F][SP]I[SP]heard[SP]if[NL]you[SP]win[SP]one,[SP]you[SP]get[SP]real[SP]weapons[SP]and[SP]stuff.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]You[SP]don't[SP]win[SP]too[SP]often,[SP]but[SP]when[SP]you[SP]do,[SP]the[NL]prizes[SP]are[SP]nice.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Tu connais les concours de magazines ?\n Si on gagne, on a des vraies armes.[1106][NL]On gagne rarement, mais les lots sont sympas."
+    },
+    {
+        "id": 88,
+        "offset": 281578,
+        "data_size": 374,
+        "slot_size": 374,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Do[SP]you[SP]know[SP]about[SP]magazine[SP]contests?[1205][U+000F][SP]I[SP]heard[SP]if[NL]you[SP]win[SP]one,[SP]you[SP]get[SP]real[SP]weapons[SP]and[SP]stuff.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]You[SP]hardly[SP]ever[SP]win,[SP]but[SP]when[SP]you[SP]do,[SP]the[NL]prizes[SP]are[SP]really[SP]rare[SP]stuff.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Tu connais les concours de magazines ?\n Si on gagne, on a des vraies armes.[1106][NL]On gagne rarement, mais les lots sont très rares."
+    },
+    {
+        "id": 89,
+        "offset": 281952,
+        "data_size": 344,
+        "slot_size": 344,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Do[SP]you[SP]know[SP]about[SP]magazine[SP]contests?[1205][U+000F][SP]I[SP]heard[SP]if[NL]you[SP]win[SP]one,[SP]you[SP]get[SP]real[SP]weapons[SP]and[SP]stuff.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]People[SP]win[SP]all[SP]the[SP]time.[SP]But[SP]they[SP]only[SP]get[NL]boring[SP]stuff.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Tu connais les concours de magazines ?\n Si on gagne, on a des vraies armes.[1106][NL]On gagne souvent, des trucs ennuyeux."
+    },
+    {
+        "id": 90,
+        "offset": 282296,
+        "data_size": 356,
+        "slot_size": 356,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]know[SP]what[SP]a[SP]casino[SP]is![SP]They[SP]have[SP]stuff[SP]like[NL]slots[SP]and[SP]races.[SP]Mu[SP]has[SP]one,[SP]right?[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]They[SP]say[SP]poker's[SP]the[SP]best[SP]game[SP]there.[SP]I[SP]dunno[NL]how[SP]to[SP]play[SP]that[SP]one,[SP]though.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Je sais ce qu'est un casino !\n Machines à sous, courses. Mu en a un, non ?[1106][NL]Le poker est le meilleur jeu là-bas,\n mais je ne sais pas y jouer."
+    },
+    {
+        "id": 91,
+        "offset": 282652,
+        "data_size": 386,
+        "slot_size": 386,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]know[SP]what[SP]a[SP]casino[SP]is![SP]They[SP]have[SP]stuff[SP]like[NL]slots[SP]and[SP]races.[SP]Mu[SP]has[SP]one,[SP]right?[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]Slots[SP]are[SP]the[SP]best.[SP]I[SP]know[SP]how[SP]to[SP]play[SP]those![NL]Um,[SP]I[SP]heard[SP]you[SP]can[SP]win[SP]a[SP]lot[SP]on[SP]machine[SP]#1.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Je sais ce qu'est un casino !\n Machines à sous, courses. Mu en a un, non ?[1106][NL]Machines à sous : le top. Je sais y jouer !\n Grosse gagne sur la n°1."
+    },
+    {
+        "id": 92,
+        "offset": 283038,
+        "data_size": 390,
+        "slot_size": 390,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]know[SP]what[SP]a[SP]casino[SP]is![SP]They[SP]have[SP]stuff[SP]like[NL]slots[SP]and[SP]races.[SP]Mu[SP]has[SP]one,[SP]right?[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]Um,[SP]I[SP]heard[SP]it's[SP]good[SP]to[SP]play[SP]blackjack[SP]there,[NL]but[SP]I[SP]dunno[SP]how[SP]to[SP]play[SP]that.[SP]Do[SP]you,[SP]Mister?",
+        "nom_fr": "Garçon",
+        "texte_fr": "Je sais ce qu'est un casino !\n Machines à sous, courses. Mu en a un, non ?[1106][NL]Blackjack est bon là-bas, mais je ne sais pas.\n Vous savez, monsieur ?"
+    },
+    {
+        "id": 93,
+        "offset": 283428,
+        "data_size": 278,
+        "slot_size": 278,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Is[SP]there[SP]really[SP]a[SP]legendary[SP]weapon[SP]at[SP]the[SP]ramen[NL]shop?[1205][U+000F][SP]Some[SP]lady[SP]said[SP]so[SP]a[SP]minute[SP]ago.[SP]Wow,[SP]I[NL]didn't[SP]know[SP]those[SP]really[SP]existed!",
+        "nom_fr": "Garçon",
+        "texte_fr": "Une arme légendaire au resto de ramen ?\n Une dame vient de le dire. Je ne savais pas que ça existait !"
+    },
+    {
+        "id": 94,
+        "offset": 283706,
+        "data_size": 208,
+        "slot_size": 208,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Is[SP]it[SP]true[SP]there's[SP]a[SP]legendary[SP]weapon[SP]at[SP]the[NL]restaurant[SP]in[SP]Aoba?[1205][U+000F][SP]Would[SP]it[SP]be[SP]in[SP]a[SP]dresser?[NL]",
+        "nom_fr": "Garçon",
+        "texte_fr": "Une arme légendaire dans le resto d'Aoba ?\n Dans un buffet ?"
+    },
+    {
+        "id": 95,
+        "offset": 283914,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Why[SP]would[SP]the[SP]man[SP]at[SP]Time[SP]Castle[SP]lie[SP]about[NL]having[SP]a[SP]legendary[SP]weapon?[1205][U+000F][SP]I[SP]heard[SP]it's[SP]'cause[NL]he's[SP]trying[SP]to[SP]charge[SP]a[SP]lot...[NL]",
+        "nom_fr": "Garçon",
+        "texte_fr": "Pourquoi le gars du Château du Temps mentirait\n sur une arme légendaire ?[1205][U+000F] Pour faire monter les prix..."
+    },
+    {
+        "id": 96,
+        "offset": 284182,
+        "data_size": 310,
+        "slot_size": 310,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]wonder[SP]why[SP]the[SP]man[SP]at[SP]Time[SP]Castle[SP]won't[SP]go[NL]get[SP]his[SP]legendary[SP]weapon.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]He[SP]should[SP]just[SP]beat[SP]up[SP]those[SP]monsters[SP]at[SP]the[NL]abandoned[SP]factory.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Pourquoi ne pas chercher son arme légendaire ?[1106][NL]Il n'a qu'à battre les monstres\n à l'usine abandonnée."
+    },
+    {
+        "id": 97,
+        "offset": 284492,
+        "data_size": 218,
+        "slot_size": 218,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]heard[SP]the[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle[NL]got[SP]stolen.[SP]I[SP]bet[SP]it[SP]was[SP]the[SP]minions[SP]of[SP]the[NL]archfiend.",
+        "nom_fr": "Garçon",
+        "texte_fr": "L'arme légendaire du Château du Temps a été volée.\n Ce sont les sbires de l'archidémon."
+    },
+    {
+        "id": 98,
+        "offset": 284710,
+        "data_size": 410,
+        "slot_size": 410,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "I[SP]heard[SP]a[SP]lady[SP]bought[SP]the[SP]legendary[SP]weapon[NL]at[SP]Time[SP]Castle.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]I[SP]bet[SP]her[SP]kid's[SP]all[SP]grown[SP]up[SP]now[SP]and[SP]going[SP]on[NL]a[SP]journey,[SP]so[SP]she's[SP]gonna[SP]give[SP]it[SP]to[SP]him[SP]as[SP]a[NL]present.[SP]That's[SP]how[SP]it[SP]always[SP]is.",
+        "nom_fr": "Garçon",
+        "texte_fr": "Une dame a acheté l'arme légendaire.[1106][NL]Son fils a grandi et part en voyage,\n alors elle va la lui donner en cadeau.\n C'est toujours comme ça."
+    },
+    {
+        "id": 99,
+        "offset": 285120,
+        "data_size": 422,
+        "slot_size": 422,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Boy",
+        "texte_orig": "Um,[SP]I[SP]heard[SP]the[SP]man[SP]at[SP]Time[SP]Castle[SP]gave[SP]his[NL]legendary[SP]weapon[SP]to[SP]a[SP]lady[SP]with[SP]short[SP]hair.[NL][1106][E2][1431][U+0000][U+0000]\"Boy[NL]I[SP]bet...[SP]she's[SP]actually[SP]a[SP]princess,[SP]and[SP]she's[NL]gonna[SP]hold[SP]onto[SP]it[SP]until[SP]the[SP]hero[SP]comes.[NL]Right,[SP]Mister?[NL]",
+        "nom_fr": "Garçon",
+        "texte_fr": "Le gars du Château du Temps a donné son arme\n à une dame aux cheveux courts.[1106][NL]Je parie que c'est une princesse, elle garde l'arme\n pour le héros. C'est ça, monsieur ?"
+    },
+    {
+        "id": 100,
+        "offset": 285542,
+        "data_size": 308,
+        "slot_size": 308,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "The[SP]principal's[SP]statue[SP]at[SP]Sevens[SP]doesn't[SP]like[NL]to[SP]be[SP]seen[SP]walking[SP]around...[1205][U+000F][SP]But[SP]there[SP]aren't[NL]many[SP]foxes[SP]around[SP]these[SP]days.[SP]Is[SP]it[SP]possible?",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "La statue du proviseur à Seven n'aime pas qu'on la voie se promener...[1205][U+000F]\n Mais il n'y a plus beaucoup de renards. Est-ce possible ?"
+    },
+    {
+        "id": 101,
+        "offset": 285850,
+        "data_size": 260,
+        "slot_size": 260,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I've[SP]stopped[SP]seeing[SP]young[SP]girls[SP]around[SP]here[NL]lately.[1205][U+000F][SP]Is[SP]the[SP]bloom[SP]off[SP]the[SP]rose[SP]for[SP]Sevens[NL]because[SP]of[SP]that[SP]disease?",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Je ne vois plus de jeunes filles par ici.[1205][U+000F]\n Seven a-t-il perdu son attrait à cause de cette maladie ?"
+    },
+    {
+        "id": 102,
+        "offset": 286110,
+        "data_size": 292,
+        "slot_size": 292,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "It[SP]seems[SP]Kasugayama[SP]High's[SP]holding[SP]a[SP]masquerade[NL]as[SP]part[SP]of[SP]their[SP]school[SP]festival.[SP]Is[SP]that[SP]some[NL]kind[SP]of[SP]grape?[SP]It's[SP]all[SP]Greek[SP]to[SP]me.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Kasugayama organise un bal masqué pour sa fête.\n Une sorte de raisin ? C'est du chinois pour moi."
+    },
+    {
+        "id": 103,
+        "offset": 286402,
+        "data_size": 628,
+        "slot_size": 628,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I[SP]heard[SP]at[SP]Honmaru[SP]Park[SP]that[SP]a[SP]store[SP]in[SP]Yumezaki[NL]sells[SP]real[SP]armor[SP]alongside[SP]regular[SP]clothes.[NL]What[SP]a[SP]dangerous[SP]place[SP]this[SP]world's[SP]become...[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]If[SP]you[SP]want[SP]to[SP]know[SP]more[SP]about[SP]it,[SP]I'd[SP]say[SP]you[NL]should[SP]start[SP]by[SP]visiting[SP]Honmaru[SP]Park.[1205][U+000F][NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]I[SP]heard[SP]the[SP]story[SP]from[SP]a[SP]homeless[SP]man[SP]there.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "J'ai entendu au parc Honmaru qu'un magasin à Yumezaki\n vend des armures avec des vêtements. Dans quel monde dangereux on vit...[1106][NL]Si tu veux en savoir plus, commence par visiter le parc Honmaru.[1106][NL]J'ai entendu cette histoire d'un SDF."
+    },
+    {
+        "id": 104,
+        "offset": 287030,
+        "data_size": 292,
+        "slot_size": 292,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Do[SP]you[SP]know[SP]the[SP]Masked[SP]Circle?[SP]There's[SP]some[NL]group[SP]by[SP]that[SP]name,[SP]apparently.[SP]It[SP]reminds[SP]me[NL]of[SP]those[SP]bandits[SP]you[SP]see[SP]in[SP]period[SP]films.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Tu connais le Cercle Masqué ? Il paraît qu'il y a un groupe de ce nom.\n Ça me rappelle les bandits des films d'époque."
+    },
+    {
+        "id": 105,
+        "offset": 287322,
+        "data_size": 332,
+        "slot_size": 332,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man[U+121D][U+0001]",
+        "texte_orig": "Well,[SP]it[SP]appears[SP]this[SP]Masked[SP]Circle[SP]is[SP]quite[NL]the[SP]frightening[SP]group.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]I'd[SP]rather[SP]steer[SP]clear[SP]of[SP]such[SP]folk[SP]at[SP]my[SP]age.[1205][U+000F][NL]Fingers[SP]crossed...",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Eh bien, ce Cercle Masqué est un groupe assez effrayant.[1106][NL]À mon âge, je préfère éviter ces gens.\n Croisons les doigts..."
+    },
+    {
+        "id": 106,
+        "offset": 287654,
+        "data_size": 310,
+        "slot_size": 310,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Sounds[SP]like[SP]it[SP]was[SP]the[SP]Masked[SP]Circle[SP]who[SP]burned[NL]down[SP]the[SP]outdoor[SP]concert[SP]hall.[1205][U+000F][SP]What's[SP]this[SP]world[NL]coming[SP]to[SP]if[SP]such[SP]people[SP]really[SP]exist...?",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "On dirait que c'est le Cercle Masqué qui a brûlé la salle de concert.[1205][U+000F]\n Où va le monde si de telles personnes existent vraiment ?"
+    },
+    {
+        "id": 107,
+        "offset": 287964,
+        "data_size": 262,
+        "slot_size": 262,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Turns[SP]out[SP]the[SP]real[SP]culprit[SP]was[SP]a[SP]gang[SP]of[SP]five[NL]terrorists.[1205][U+000F][SP]That's[SP]more[SP]plausible[SP]than[SP]the[NL]Masked[SP]Circle,[SP]I'd[SP]say...",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Le vrai coupable était une bande de cinq terroristes.[1205][U+000F]\n Plus plausible que le Cercle Masqué, je dirais..."
+    },
+    {
+        "id": 108,
+        "offset": 288226,
+        "data_size": 286,
+        "slot_size": 286,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "There[SP]was[SP]a[SP]fella[SP]I[SP]used[SP]to[SP]play[SP]Go[SP]with...[1205][U+000F][NL]Haven't[SP]seen[SP]him[SP]around[SP]lately.[1205][U+000F][SP]He[SP]seemed[NL]awful[SP]depressed,[SP]so[SP]I[SP]worry[SP]about[SP]him.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Il y avait un type avec qui je jouais au go...[1205][U+000F]\n Je ne l'ai pas vu récemment.[1205][U+000F] Il avait l'air très déprimé,\n je m'inquiète."
+    },
+    {
+        "id": 109,
+        "offset": 288512,
+        "data_size": 382,
+        "slot_size": 382,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "If[SP]folks[SP]like[SP]that[SP]are[SP]really[SP]here,[SP]does[SP]that[NL]mean[SP]there[SP]is[SP]such[SP]a[SP]thing[SP]as[SP]Xibalba[SP]under[NL]this[SP]city?[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]I've[SP]lived[SP]here[SP]for[SP]ages,[SP]but[SP]I've[SP]never[SP]seen[NL]any[SP]such[SP]thing.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Si des gens comme ça sont ici, cela signifie-t-il\n qu'il existe un Xibalba sous cette ville ?[1106][NL]Jamais rien vu de tel ici."
+    },
+    {
+        "id": 110,
+        "offset": 288894,
+        "data_size": 460,
+        "slot_size": 460,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I'm[SP]too[SP]old[SP]to[SP]evolve![1205][U+000A][SP]I'm[SP]more[SP]worried[SP]about[NL]what's[SP]happening[SP]down[SP]there.[1205][U+000A][SP]It'll[SP]all[SP]be[NL]destroyed[SP]when[SP]the[SP]stars[SP]align,[SP]no?[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]I[SP]have[SP]friends[SP]down[SP]there...[1205][U+000F][SP]Isn't[SP]there[NL]anything[SP]I[SP]can[SP]do[SP]for[SP]them...?",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Je suis trop vieux pour évoluer ![1205][U+000A]\n Je m'inquiète pour en bas.[1205][U+000A] Destruction quand les étoiles s'alignent, non ?[1106][NL]J'ai des amis en bas...[1205][U+000F]\n Rien que je puisse faire pour eux ?"
+    },
+    {
+        "id": 111,
+        "offset": 289354,
+        "data_size": 482,
+        "slot_size": 482,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "The[SP]people[SP]in[SP]this[SP]city[SP]are[SP]appalling.[1205][U+000A][SP]They[NL]know[SP]they're[SP]safe,[SP]so[SP]they're[SP]imagining[SP]what[NL]might[SP]destroy[SP]the[SP]Earth[SP]below.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]What[SP]good[SP]will[SP]it[SP]do[SP]mankind[SP]if[SP]folks[SP]like[NL]them[SP]evolve...?[1205][U+000F][SP]I[SP]don't[SP]hold[SP]out[SP]much[SP]hope...",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Les gens sont épouvantables.[1205][U+000A]\n En sécurité, ils imaginent la destruction de la Terre.[1106][NL]À quoi bon si des gens comme eux évoluent ?[1205][U+000F]\n Je n'ai pas beaucoup d'espoir..."
+    },
+    {
+        "id": 112,
+        "offset": 289836,
+        "data_size": 314,
+        "slot_size": 314,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Sounds[SP]like[SP]the[SP]Earth's[SP]air[SP]will[SP]evaporate[SP]when[NL]the[SP]stars[SP]align.[1205][U+000F][SP]Criminy...[SP]The[SP]things[SP]those[NL]kids[SP]think[SP]up[SP]lately[SP]scares[SP]the[SP]life[SP]out[SP]of[SP]me.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "L'air de la Terre va s'évaporer quand les étoiles s'aligneront.[1205][U+000F]\n Bon sang... Ce que ces gosses inventent me fait une peur bleue."
+    },
+    {
+        "id": 113,
+        "offset": 290150,
+        "data_size": 374,
+        "slot_size": 374,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Sounds[SP]like[SP]the[SP]Earth's[SP]rotation[SP]will[SP]stop[SP]when[NL]the[SP]stars[SP]align...[1205][U+000A][SP]Everything[SP]on[SP]Earth[SP]will[SP]get[NL]blasted[SP]away...[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]Why[SP]is[SP]God[SP]doing[SP]such[SP]horrible[SP]things[SP]to[SP]us?",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "La Terre va s'arrêter quand les étoiles s'aligneront...[1205][U+000A]\n Tout sera pulvérisé...[1106][NL]Pourquoi Dieu nous fait-il ça ?"
+    },
+    {
+        "id": 114,
+        "offset": 290524,
+        "data_size": 374,
+        "slot_size": 374,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Sounds[SP]like[SP]the[SP]Earth's[SP]rotation[SP]will[SP]stop[SP]when[NL]the[SP]stars[SP]align...[1205][U+000A][SP]Everything[SP]on[SP]Earth[SP]will[SP]get[NL]blasted[SP]away...[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]Why[SP]is[SP]God[SP]doing[SP]such[SP]horrible[SP]things[SP]to[SP]us?",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "La Terre va s'arrêter quand les étoiles s'aligneront...[1205][U+000A]\n Tout sera pulvérisé...[1106][NL]Pourquoi Dieu nous fait-il ça ?"
+    },
+    {
+        "id": 115,
+        "offset": 290898,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I[SP]heard[SP]there's[SP]talking[SP]flowers[SP]in[SP]Aoba[SP]Park.[NL]I'd[SP]have[SP]dismissed[SP]it[SP]when[SP]I[SP]was[SP]young,[SP]but[NL]who[SP]can[SP]say[SP]in[SP]today's[SP]world?",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Des fleurs qui parlent au parc d'Aoba ?\n Je l'aurais rejeté avant, mais de nos jours, qui sait ?"
+    },
+    {
+        "id": 116,
+        "offset": 291166,
+        "data_size": 550,
+        "slot_size": 550,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "It[SP]seems[SP]that[SP]club[SP]called[SP]Zodiac[SP]is[SP]one[SP]big[NL]monster's[SP]den[SP]now.[SP]Some[SP]young'uns[SP]were[SP]getting[NL]excited[SP]to[SP]venture[SP]in[SP]there.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]They[SP]talked[SP]about[SP]some[SP]treasure...[1205][U+000F][SP]But[SP]the[NL]more[SP]you[SP]find,[SP]the[SP]greater[SP]the[SP]danger.[NL]I[SP]wouldn't[SP]go[SP]in[SP]carelessly[SP]if[SP]I[SP]were[SP]you.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Le club Zodiac est devenu un antre de monstres.\n Des jeunes étaient tout excités à l'idée d'y aller.[1106][NL]Un trésor...[1205][U+000F] Plus on en trouve, plus grand danger.\n N'y va pas imprudemment."
+    },
+    {
+        "id": 117,
+        "offset": 291716,
+        "data_size": 396,
+        "slot_size": 396,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "From[SP]what[SP]I've[SP]heard,[SP]that[SP]ghost[SP]Hanako[SP]is[NL]at[SP]Sevens.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]First[SP]that[SP]strange[SP]disease,[SP]then[SP]the[SP]principal's[NL]statue[SP]gets[SP]up[SP]and[SP]walks,[SP]and[SP]now[SP]this?[NL]It's[SP]the[SP]damnedest[SP]school.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Hanako est à Seven.[1106][NL]Maladie étrange, statue qui marche, et ça ?\n C'est la pire école."
+    },
+    {
+        "id": 118,
+        "offset": 292112,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Did[SP]you[SP]hear?[SP]There's[SP]a[SP]ghost[SP]by[SP]the[SP]name[SP]of[NL]Bukimi[SP]hanging[SP]around[SP]Kasugayama[SP]High.[SP]Wonder[NL]if[SP]that[SP]school's[SP]been[SP]cursed[SP]now...",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Tu as entendu ? Un fantôme nommé Bukimi traîne au lycée Kasugayama.\n Je me demande si cette école a été maudite..."
+    },
+    {
+        "id": 119,
+        "offset": 292394,
+        "data_size": 388,
+        "slot_size": 388,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "People[SP]who[SP]die[SP]with[SP]attachments[SP]to[SP]this[SP]world[NL]can't[SP]find[SP]peace[SP]and[SP]end[SP]up[SP]wandering[SP]the[SP]Earth.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]That's[SP]probably[SP]what[SP]happened[SP]to[SP]the[SP]idol[SP]whose[NL]ghost[SP]is[SP]at[SP]Aoba[SP]Park.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Ceux qui meurent avec des attaches n'ont pas la paix\n et errent.[1106][NL]L'idole dont le fantôme est au parc d'Aoba, c'est ça."
+    },
+    {
+        "id": 120,
+        "offset": 292782,
+        "data_size": 368,
+        "slot_size": 368,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I[SP]wouldn't[SP]go[SP]near[SP]the[SP]abandoned[SP]factory[SP]if[NL]I[SP]was[SP]you,[SP]boy.[SP]There's[SP]a[SP]Cursed[SP]Taxi[SP]parked[NL]there.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]They[SP]say[SP]to[SP]let[SP]sleeping[SP]dogs[SP]lie...[NL]You[SP]should[SP]be[SP]careful.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "N'approche pas l'usine abandonnée.\n Un Taxi Maudit y est garé.[1106][NL]Ne réveille pas le chat qui dort...\n Sois prudent."
+    },
+    {
+        "id": 121,
+        "offset": 293150,
+        "data_size": 390,
+        "slot_size": 390,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Sounds[SP]like[SP]there's[SP]a[SP]monster[SP]called[SP]a[SP]Cursed[NL]Escort[SP]at[SP]the[SP]abandoned[SP]factory.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]The[SP]rumor[SP]goes[SP]that[SP]it[SP]runs[SP]over[SP]people[SP]night[NL]after[SP]night...[SP]Terrible,[SP]just[SP]terrible...",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Il y a un monstre appelé Escorte Maudite\n à l'usine abandonnée.[1106][NL]On dit qu'elle renverse les gens nuit après nuit...\n Terrible."
+    },
+    {
+        "id": 122,
+        "offset": 293540,
+        "data_size": 276,
+        "slot_size": 276,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Hohoho,[SP]I[SP]used[SP]to[SP]be[SP]scared[SP]that[SP]Kuchisake-onna[NL]would[SP]come[SP]after[SP]me[SP]when[SP]I[SP]was[SP]a[SP]kid.[SP]I[SP]didn't[NL]know[SP]she[SP]lives[SP]at[SP]Mt.[SP]Iwato.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Hohoho, j'avais peur de Kuchisake-onna enfant.\n Elle vit au mont Iwato."
+    },
+    {
+        "id": 123,
+        "offset": 293816,
+        "data_size": 278,
+        "slot_size": 278,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Just[SP]because[SP]there's[SP]a[SP]spy[SP]old[SP]man[SP]at[SP]Mt.[NL]Katatsumuri[SP]is[SP]no[SP]reason[SP]to[SP]think[SP]he's[SP]the[NL]Jumping[SP]Geezer![SP]Don't[SP]mock[SP]the[SP]elderly!",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Un vieil homme espion au mont Katatsumuri n'est pas le Sauteur Vieux !\n Ne moquez pas les personnes âgées !"
+    },
+    {
+        "id": 124,
+        "offset": 294094,
+        "data_size": 264,
+        "slot_size": 264,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I-I[SP]can't[SP]believe[SP]it...[SP]My[SP]heart[SP]almost[SP]gave[NL]out[SP]when[SP]I[SP]heard...[1205][U+000F][SP]Kudan[SP]is...[1205][U+000F][SP]Kid,[SP]you[SP]must[NL]never[SP]go[SP]near[SP]a[SP]Kudan!",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "J'y crois pas... Crise cardiaque...[1205][U+000F] Kudan...[1205][U+000F]\n Ne t'approche jamais d'un Kudan, gamin !"
+    },
+    {
+        "id": 125,
+        "offset": 294358,
+        "data_size": 308,
+        "slot_size": 308,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I[SP]like[SP]the[SP]sound[SP]of[SP]albums[SP]from[SP]back[SP]in[SP]the[SP]day.[NL]Something[SP]about[SP]these[SP]CDs[SP]and[SP]their[SP]glitz...[NL]There's[SP]even[SP]a[SP]secret[SP]CD[SP]out[SP]there[SP]somewhere.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "J'aime le son des albums d'autrefois.\n Quelque chose à propos des CD et de leur clinquant...\n Il y a même un CD secret quelque part."
+    },
+    {
+        "id": 126,
+        "offset": 294666,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "There's[SP]no[SP]call[SP]to[SP]pick[SP]on[SP]the[SP]elderly[SP]like[NL]this![SP]Just[SP]'cause[SP]an[SP]old[SP]lady[SP]has[SP]a[SP]dresser,[NL]they[SP]call[SP]her[SP]the[SP]Dresser[SP]Hag!?",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Pourquoi s'en prendre aux vieux ?\n Une dame avec un buffet, la Sorcière du Buffet !?"
+    },
+    {
+        "id": 127,
+        "offset": 294936,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Time[SP]Castle[SP]sells[SP]weapons[SP]too?[SP]I[SP]always[SP]thought[NL]they[SP]seemed[SP]crooked.[SP]Sounds[SP]like[SP]their[SP]quality[NL]and[SP]prices[SP]are[SP]average.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Château du Temps vend des armes ? Louche.\n Qualité et prix moyens."
+    },
+    {
+        "id": 128,
+        "offset": 295202,
+        "data_size": 276,
+        "slot_size": 276,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Time[SP]Castle[SP]sells[SP]weapons[SP]too?[SP]I[SP]always[SP]thought[NL]they[SP]seemed[SP]crooked.[SP]Sounds[SP]like[SP]their[SP]quality[NL]is[SP]good,[SP]but[SP]it's[SP]expensive.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Le Château du Temps vend des armes ? Louche,\n mais qualité bonne et cher."
+    },
+    {
+        "id": 129,
+        "offset": 295478,
+        "data_size": 254,
+        "slot_size": 254,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Time[SP]Castle[SP]sells[SP]weapons[SP]too?[SP]I[SP]always[SP]thought[NL]they[SP]seemed[SP]crooked.[SP]Sounds[SP]like[SP]they're[SP]cheap,[NL]but[SP]bad[SP]quality.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Le Château du Temps vend des armes ? Louche,\n bon marché mais mauvaise qualité."
+    },
+    {
+        "id": 130,
+        "offset": 295732,
+        "data_size": 344,
+        "slot_size": 344,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "That[SP]young'un[SP]Tony[SP]was[SP]selling[SP]weapons[NL]after[SP]all![NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]People[SP]like[SP]him[SP]are[SP]good[SP]for[SP]nothing.[SP]He[SP]has[NL]a[SP]good[SP]selection,[SP]but[SP]his[SP]resale[SP]prices[NL]are[SP]low.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Ce jeune Tony vendait donc des armes ![1106][NL]Les gens comme lui ne valent rien.\n Bon choix, reprises basses."
+    },
+    {
+        "id": 131,
+        "offset": 296076,
+        "data_size": 316,
+        "slot_size": 316,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "That[SP]young'un[SP]Tony[SP]was[SP]selling[SP]weapons[NL]after[SP]all![NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]People[SP]like[SP]him[SP]are[SP]good[SP]for[SP]nothing.[SP]He[SP]has[NL]low[SP]prices,[SP]but[SP]his[SP]stuff[SP]is[SP]junk.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Ce jeune Tony vendait donc des armes ![1106][NL]Les gens comme lui ne valent rien.\n Prix bas, camelote."
+    },
+    {
+        "id": 132,
+        "offset": 296392,
+        "data_size": 302,
+        "slot_size": 302,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "That[SP]young'un[SP]Tony[SP]was[SP]selling[SP]weapons[NL]after[SP]all![NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]People[SP]like[SP]him[SP]are[SP]good[SP]for[SP]nothing.[SP]He[SP]has[NL]average[SP]quality[SP]and[SP]prices.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Ce jeune Tony vendait donc des armes ![1106][NL]Les gens comme lui ne valent rien.\n Qualité et prix moyens."
+    },
+    {
+        "id": 133,
+        "offset": 296694,
+        "data_size": 316,
+        "slot_size": 316,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "That[SP]young'un[SP]Tony[SP]was[SP]selling[SP]weapons[NL]after[SP]all![NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]People[SP]like[SP]him[SP]are[SP]good[SP]for[SP]nothing.[SP]He[SP]has[NL]quality[SP]stuff,[SP]but[SP]it's[SP]expensive.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Ce jeune Tony vendait donc des armes ![1106][NL]Les gens comme lui ne valent rien.\n Qualité mais cher."
+    },
+    {
+        "id": 134,
+        "offset": 297010,
+        "data_size": 256,
+        "slot_size": 256,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?[NL]I've[SP]heard[SP]their[SP]selection[SP]is[SP]bad,[SP]but[SP]the[NL]resale[SP]prices[SP]are[SP]good.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Ma parole, même les restos d'Aoba vendent des armes ?\n Peu de choix, mais bonnes reprises."
+    },
+    {
+        "id": 135,
+        "offset": 297266,
+        "data_size": 236,
+        "slot_size": 236,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?[NL]I've[SP]heard[SP]they're[SP]cheap,[SP]but[SP]the[SP]quality[SP]is[NL]not[SP]so[SP]hot.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Les restos d'Aoba vendent des armes ?\n Bon marché, qualité bof."
+    },
+    {
+        "id": 136,
+        "offset": 297502,
+        "data_size": 252,
+        "slot_size": 252,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?[NL]I've[SP]heard[SP]their[SP]quality[SP]is[SP]top-notch,[SP]but[SP]it's[NL]expensive[SP]stuff.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Les restos d'Aoba vendent des armes ?\n Qualité excellente, mais cher."
+    },
+    {
+        "id": 137,
+        "offset": 297754,
+        "data_size": 258,
+        "slot_size": 258,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?[NL]I've[SP]heard[SP]their[SP]selection[SP]is[SP]great,[SP]but[SP]the[NL]resale[SP]prices[SP]are[SP]low.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Restos d'Aoba vendent des armes ?\n Excellent choix, reprises basses."
+    },
+    {
+        "id": 138,
+        "offset": 298012,
+        "data_size": 242,
+        "slot_size": 242,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "My,[SP]even[SP]the[SP]restaurants[SP]in[SP]Aoba[SP]sell[SP]weapons?[NL]I've[SP]heard[SP]the[SP]quality[SP]and[SP]prices[SP]are[SP]both[NL]fairly[SP]standard.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Restos d'Aoba vendent des armes ?\n Qualité et prix standards."
+    },
+    {
+        "id": 139,
+        "offset": 298254,
+        "data_size": 414,
+        "slot_size": 414,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit[NL]Jolly[SP]Roger[SP]in[SP]Kounan.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]I[SP]hear[SP]the[SP]quality[SP]and[SP]prices[SP]are[SP]ordinary,[NL]but[SP]if[SP]you[SP]ask[SP]me,[SP]there's[SP]nothing[SP]ordinary[NL]about[SP]selling[SP]weapons.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes.[1106][NL]Qualité et prix ordinaires, mais vendre des armes\n n'a rien d'ordinaire."
+    },
+    {
+        "id": 140,
+        "offset": 298668,
+        "data_size": 354,
+        "slot_size": 354,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit[NL]Jolly[SP]Roger[SP]in[SP]Kounan.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]The[SP]prices[SP]are[SP]supposedly[SP]right,[SP]but[SP]the[SP]quality[NL]leaves[SP]something[SP]to[SP]be[SP]desired.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes.[1106][NL]Prix corrects, mais qualité à désirer."
+    },
+    {
+        "id": 141,
+        "offset": 299022,
+        "data_size": 348,
+        "slot_size": 348,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit[NL]Jolly[SP]Roger[SP]in[SP]Kounan.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]The[SP]selection[SP]is[SP]supposed[SP]to[SP]be[SP]pretty[SP]good,[NL]but[SP]the[SP]resale[SP]prices[SP]are[SP]cheap.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes.[1106][NL]Bon choix, reprises bon marché."
+    },
+    {
+        "id": 142,
+        "offset": 299370,
+        "data_size": 350,
+        "slot_size": 350,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit[NL]Jolly[SP]Roger[SP]in[SP]Kounan.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]The[SP]selection[SP]isn't[SP]supposed[SP]to[SP]be[SP]that[SP]great,[NL]but[SP]the[SP]resale[SP]prices[SP]are[SP]high.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes.[1106][NL]Peu de choix, reprises élevées."
+    },
+    {
+        "id": 143,
+        "offset": 299720,
+        "data_size": 318,
+        "slot_size": 318,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]visit[NL]Jolly[SP]Roger[SP]in[SP]Kounan.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]The[SP]quality[SP]is[SP]supposed[SP]to[SP]be[SP]great,[SP]but[SP]it's[NL]expensive[SP]stuff.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Au Jolly Roger à Kounan, on peut acheter de vraies armes.[1106][NL]Qualité excellente, mais cher."
+    },
+    {
+        "id": 144,
+        "offset": 300038,
+        "data_size": 348,
+        "slot_size": 348,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]sells[SP]real[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]That[SP]means[SP]things[SP]like[SP]helmets[SP]and[SP]chestplates[NL]and[SP]such,[SP]right?[SP]I[SP]hear[SP]their[SP]quality[SP]and[NL]prices[SP]are[SP]average.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Rosa Candida vend des armures.[1106][NL]Des casques, plastrons, etc.\n Qualité et prix moyens."
+    },
+    {
+        "id": 145,
+        "offset": 300386,
+        "data_size": 374,
+        "slot_size": 374,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]sells[SP]real[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]That[SP]means[SP]things[SP]like[SP]helmets[SP]and[SP]chestplates[NL]and[SP]such,[SP]right?[SP]I[SP]hear[SP]their[SP]prices[SP]are[NL]great,[SP]but[SP]the[SP]quality's[SP]lacking.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Rosa Candida vend des armures.[1106][NL]Des casques, plastrons... Prix super,\n qualité manquante."
+    },
+    {
+        "id": 146,
+        "offset": 300760,
+        "data_size": 378,
+        "slot_size": 378,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]sells[SP]real[SP]armor.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]That[SP]means[SP]things[SP]like[SP]helmets[SP]and[SP]chestplates[NL]and[SP]such,[SP]right?[SP]I[SP]hear[SP]their[SP]quality[SP]is[NL]great,[SP]but[SP]the[SP]prices[SP]are[SP]sky-high.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Rosa Candida vend des armures.[1106][NL]Casques, plastrons... Qualité excellente,\n prix exorbitants."
+    },
+    {
+        "id": 147,
+        "offset": 301138,
+        "data_size": 370,
+        "slot_size": 370,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I've[SP]heard[SP]you[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima[NL]Mundi[SP]in[SP]Yumezaki.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[NL]Their[SP]quality[SP]and[SP]prices[SP]are[SP]normal...[SP]But[SP]just[NL]what's[SP]normal[SP]about[SP]wearing[SP]armor[SP]around[SP]town?",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "On peut acheter des armures à Anima Mundi, Yumezaki.[1106][NL]Qualité et prix normaux... Mais porter une armure en ville,\n rien de normal."
+    },
+    {
+        "id": 148,
+        "offset": 301508,
+        "data_size": 232,
+        "slot_size": 232,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I've[SP]heard[SP]you[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima[NL]Mundi[SP]in[SP]Yumezaki.[SP]It[SP]seems[SP]cheap,[SP]but[SP]pretty[NL]low[SP]quality.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Anima Mundi vend des armures.\n Bon marché mais basse qualité."
+    },
+    {
+        "id": 149,
+        "offset": 301740,
+        "data_size": 272,
+        "slot_size": 272,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I've[SP]heard[SP]you[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima[NL]Mundi[SP]in[SP]Yumezaki.[SP]The[SP]selection[SP]seems[SP]great,[NL]but[SP]the[SP]resale[SP]prices[SP]are[SP]cheap.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Anima Mundi à Yumezaki : excellent choix,\n reprises basses."
+    },
+    {
+        "id": 150,
+        "offset": 302012,
+        "data_size": 260,
+        "slot_size": 260,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I've[SP]heard[SP]you[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima[NL]Mundi[SP]in[SP]Yumezaki.[SP]It[SP]seems[SP]high[SP]quality,[NL]but[SP]you'll[SP]pay[SP]a[SP]pretty[SP]penny.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Anima Mundi : haute qualité,\n mais ça coûte un bras."
+    },
+    {
+        "id": 151,
+        "offset": 302272,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they[NL]sell[SP]real[SP]armor.[SP]Their[SP]selection[SP]isn't[SP]great,[NL]but[SP]their[SP]resale[SP]prices[SP]are[SP]nice.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Rosa Candida à Aoba vend des armures.\n Peu de choix, mais bonnes reprises."
+    },
+    {
+        "id": 152,
+        "offset": 302554,
+        "data_size": 258,
+        "slot_size": 258,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they[NL]sell[SP]real[SP]armor.[SP]The[SP]quality[SP]and[SP]prices[SP]of[NL]their[SP]stuff[SP]are[SP]average.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Rosa Candida à Aoba : armures,\n qualité et prix moyens."
+    },
+    {
+        "id": 153,
+        "offset": 302812,
+        "data_size": 264,
+        "slot_size": 264,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they[NL]sell[SP]real[SP]armor.[SP]The[SP]quality[SP]of[SP]their[SP]stock[NL]is[SP]great,[SP]but[SP]it's[SP]pricey.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Rosa Candida à Aoba : excellente qualité,\n mais cher."
+    },
+    {
+        "id": 154,
+        "offset": 303076,
+        "data_size": 260,
+        "slot_size": 260,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they[NL]sell[SP]real[SP]armor.[SP]The[SP]prices[SP]are[SP]right,[SP]but[SP]you[NL]get[SP]what[SP]you[SP]pay[SP]for.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Rosa Candida à Aoba : prix corrects,\n mais tu en as pour ton argent."
+    },
+    {
+        "id": 155,
+        "offset": 303336,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "There's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too,[SP]where[SP]they[NL]sell[SP]real[SP]armor.[SP]Their[SP]selection[SP]is[SP]great,[NL]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Rosa Candida à Aoba : excellent choix,\n reprises basses."
+    },
+    {
+        "id": 156,
+        "offset": 303606,
+        "data_size": 304,
+        "slot_size": 304,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the[NL]scamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]selection[NL]is[SP]great,[SP]but[SP]his[SP]resale[SP]prices[SP]are[SP]cheap.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Hoho, le gars chez London Clothier est un sacré coquin.\n Il fait des armures ! Beau choix, reprises basses."
+    },
+    {
+        "id": 157,
+        "offset": 303910,
+        "data_size": 264,
+        "slot_size": 264,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the[NL]scamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]stuff[NL]is[SP]cheap,[SP]but[SP]low[SP]quality.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "London Clothier : ce coquin vend des armures.\n Bon marché, mauvaise qualité."
+    },
+    {
+        "id": 158,
+        "offset": 304174,
+        "data_size": 270,
+        "slot_size": 270,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the[NL]scamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]stuff[NL]is[SP]great,[SP]but[SP]very[SP]expensive.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "London Clothier : ce coquin vend des armures.\n Excellente qualité, très cher."
+    },
+    {
+        "id": 159,
+        "offset": 304444,
+        "data_size": 278,
+        "slot_size": 278,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the[NL]scamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]prices[NL]and[SP]quality[SP]are[SP]average,[SP]I[SP]hear.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "London Clothier : ce coquin fait des armures.\n Prix et qualité moyens, parait-il."
+    },
+    {
+        "id": 160,
+        "offset": 304722,
+        "data_size": 306,
+        "slot_size": 306,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Hoho,[SP]the[SP]gent[SP]at[SP]London[SP]Clothier's[SP]quite[SP]the[NL]scamp.[SP]I[SP]never[SP]knew[SP]he[SP]made[SP]armor.[SP]His[SP]selection[NL]is[SP]limited,[SP]but[SP]his[SP]resale[SP]prices[SP]are[SP]high.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "London Clothier : ce coquin vend des armures.\n Choix limité, reprises élevées."
+    },
+    {
+        "id": 161,
+        "offset": 305028,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Lately,[SP]the[SP]magazines[SP]have[SP]been[SP]giving[SP]out[NL]real[SP]weapons[SP]and[SP]items[SP]in[SP]contests.[SP]They're[NL]hard[SP]to[SP]win,[SP]but[SP]you[SP]can[SP]get[SP]nice[SP]stuff.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Les magazines offrent des armes et objets dans des concours.\n Durs à gagner, mais beaux lots."
+    },
+    {
+        "id": 162,
+        "offset": 305312,
+        "data_size": 294,
+        "slot_size": 294,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Lately,[SP]the[SP]magazines[SP]have[SP]been[SP]giving[SP]out[NL]real[SP]weapons[SP]and[SP]items[SP]in[SP]contests.[SP]They're[NL]nearly[SP]impossible[SP]to[SP]win,[SP]but[SP]those[SP]prizes...",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Magazines donnent des armes dans des concours.\n Presque impossibles à gagner, mais ces lots..."
+    },
+    {
+        "id": 163,
+        "offset": 305606,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Lately,[SP]the[SP]magazines[SP]have[SP]been[SP]giving[SP]out[NL]real[SP]weapons[SP]and[SP]items[SP]in[SP]contests.[SP]They're[NL]easy[SP]to[SP]win,[SP]but[SP]why[SP]would[SP]you[SP]want[SP]to?",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Concours de magazines faciles à gagner,\n mais pourquoi voudrais-tu ?"
+    },
+    {
+        "id": 164,
+        "offset": 305888,
+        "data_size": 252,
+        "slot_size": 252,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "A[SP]casino...[SP]like[SP]a[SP]gambling[SP]parlor,[SP]right?[NL]And[SP]Mu[SP]has[SP]one[SP]now?[SP]I[SP]hear[SP]a[SP]certain[SP]poker[NL]machine[SP]is[SP]your[SP]best[SP]bet.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Un casino, une salle de jeu ? Mu en a un ?\n Une machine de poker est ton meilleur choix."
+    },
+    {
+        "id": 165,
+        "offset": 306140,
+        "data_size": 250,
+        "slot_size": 250,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "A[SP]casino...[SP]like[SP]a[SP]gambling[SP]parlor,[SP]right?[NL]And[SP]Mu[SP]has[SP]one[SP]now?[SP]I[SP]hear[SP]a[SP]certain[SP]slot[NL]machine[SP]is[SP]your[SP]best[SP]bet.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Un casino ? Mu en a un ?\n Une machine à sous est ton meilleur choix."
+    },
+    {
+        "id": 166,
+        "offset": 306390,
+        "data_size": 236,
+        "slot_size": 236,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "A[SP]casino...[SP]like[SP]a[SP]gambling[SP]parlor,[SP]right?[NL]And[SP]Mu[SP]has[SP]one[SP]now?[SP]I[SP]hear[SP]it's[SP]easiest[SP]to[NL]win[SP]at[SP]blackjack.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Un casino ? Mu en a un ?\n Le plus facile pour gagner, c'est le blackjack."
+    },
+    {
+        "id": 167,
+        "offset": 306626,
+        "data_size": 238,
+        "slot_size": 238,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Does[SP]Shiraishi[SP]Ramen[SP]in[SP]Hirasaka[SP]really[SP]have[NL]a[SP]legendary[SP]weapon?[SP]The[SP]things[SP]they[SP]say[SP]about[NL]that[SP]place...",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Le Shiraishi Ramen à Hirasaka a vraiment une arme légendaire ?\n Ce qu'on raconte sur cet endroit..."
+    },
+    {
+        "id": 168,
+        "offset": 306864,
+        "data_size": 252,
+        "slot_size": 252,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Are[SP]you[SP]searching[SP]for[SP]a[SP]legendary[SP]weapon?[NL]Then[SP]try[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I've[SP]heard[NL]rumors[SP]that[SP]they[SP]have[SP]one.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Tu cherches une arme légendaire ?\n Essaye Clair de Lune à Aoba. J'ai entendu qu'ils en ont une."
+    },
+    {
+        "id": 169,
+        "offset": 307116,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "Lying[SP]about[SP]your[SP]store[SP]to[SP]drive[SP]up[SP]the[SP]price![NL]The[SP]very[SP]idea![SP]It[SP]seems[SP]you[SP]can't[SP]put[SP]that[NL]past[SP]the[SP]owner[SP]of[SP]Time[SP]Castle.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Mentir sur son magasin pour faire monter les prix !\n L'idée ! C'est le proprio du Château du Temps."
+    },
+    {
+        "id": 170,
+        "offset": 307384,
+        "data_size": 310,
+        "slot_size": 310,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "I[SP]hear[SP]Time[SP]Castle's[SP]legendary[SP]weapons[SP]is[SP]still[NL]with[SP]the[SP]seller[SP]at[SP]the[SP]abandoned[SP]factory.[SP]He's[NL]still[SP]waiting[SP]for[SP]the[SP]owner[SP]to[SP]come[SP]claim[SP]it.",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "L'arme légendaire du Château du Temps est toujours chez le vendeur\n à l'usine abandonnée. Il attend que le proprio vienne la réclamer."
+    },
+    {
+        "id": 171,
+        "offset": 307694,
+        "data_size": 216,
+        "slot_size": 216,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "It[SP]seems[SP]demons[SP]have[SP]stolen[SP]the[SP]legendary[NL]weapon[SP]from[SP]Time[SP]Castle.[SP]How[SP]is[SP]that[SP]even[NL]possible?",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Des démons ont volé l'arme légendaire du Château du Temps.\n Comment est-ce possible ?"
+    },
+    {
+        "id": 172,
+        "offset": 307910,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "The[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle[SP]got[SP]sold.[NL]Rumor[SP]has[SP]it[SP]an[SP]unlucky[SP]woman[SP]bought[SP]it,[SP]but[NL]who[SP]knows[SP]what[SP]she'll[SP]use[SP]it[SP]for...[NL]",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "L'arme légendaire a été vendue.\n Une femme malchanceuse l'aurait achetée.\n Qui sait ce qu'elle en fera..."
+    },
+    {
+        "id": 173,
+        "offset": 308194,
+        "data_size": 282,
+        "slot_size": 282,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man",
+        "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle[SP]gave[SP]his[SP]legendary[NL]weapon[SP]away[SP]to[SP]a[SP]girl[SP]with[SP]short[SP]hair.[SP]Now[NL]what[SP]would[SP]she[SP]want[SP]with[SP]such[SP]a[SP]thing?[NL]",
+        "nom_fr": "Vieil homme",
+        "texte_fr": "Le proprio du Château du Temps a donné son arme légendaire\n à une fille aux cheveux courts. Que veut-elle en faire ?"
+    },
+    {
+        "id": 174,
+        "offset": 308476,
+        "data_size": 286,
+        "slot_size": 286,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Masked[SP]Circle[SP]member",
+        "texte_orig": "J-Joker[SP]told[SP]us[SP]to[SP]protect[SP]the[SP]city,[SP]but[NL]there's[SP]no[SP]way[SP]we[SP]can[SP]beat[SP]guys[SP]like[SP]that![1205][U+000F][NL]This[SP]wasn't[SP]part[SP]of[SP]the[SP]deal!",
+        "nom_fr": "Membre du Cercle Masqué",
+        "texte_fr": "Joker nous a dit de protéger la ville,\n mais pas possible ![1205][U+000F] Pas dans le contrat !"
+    },
+    {
+        "id": 175,
+        "offset": 308762,
+        "data_size": 216,
+        "slot_size": 216,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Last[SP]Battalion",
+        "texte_orig": "Mt.[SP]Katatsumuri[SP]is[SP]already[SP]ours.[1205][U+000F][SP]To[SP]resist[NL]is[SP]futile.[1205][U+000F][SP]Those[SP]who[SP]do[SP]will[SP]be[SP]killed.",
+        "nom_fr": "Dernier Bataillon",
+        "texte_fr": "Le mont Katatsumuri est à nous.[1205][U+000F]\n Résister est futile.[1205][U+000F] Les résistants tués."
+    },
+    {
+        "id": 176,
+        "offset": 308978,
+        "data_size": 200,
+        "slot_size": 200,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "I[SP]wonder[SP]if[SP]Kozy's[SP]got[SP]some[SP]info[SP]for[SP]us.[NL]Hey,[SP][1113],[SP]let's[SP]head[SP]to[SP]Peace[SP]Diner[NL]in[SP]Yumezaki.",
+        "nom_fr": "Ginko",
+        "texte_fr": "Kozy a des infos pour nous ?\n Hé, [1113], allons au Peace Diner à Yumezaki."
+    },
+    {
+        "id": 177,
+        "offset": 309178,
+        "data_size": 180,
+        "slot_size": 180,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "Looks[SP]like[SP]the[SP]curse[SP]has[SP]been[SP]lifted,[SP]so[SP]things[NL]should[SP]be[SP]fine[SP]at[SP]Sevens[SP]now.",
+        "nom_fr": "Ginko",
+        "texte_fr": "La malédiction est levée,\n tout devrait aller bien à Seven maintenant."
+    },
+    {
+        "id": 178,
+        "offset": 309358,
+        "data_size": 250,
+        "slot_size": 250,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "I[SP]feel[SP]bad[SP]for[SP]what[SP]I[SP]did[SP]to[SP]the[SP]guys[SP]here...[NL]Yo[SP][1113],[SP]let's[SP]go[SP]to[SP]Kasugayama[SP]High.[SP]I'll[NL]make[SP]that[SP]president[SP]pay!",
+        "nom_fr": "Michel",
+        "texte_fr": "Je me sens mal... Yo [1113], allons à Kasugayama.\n Ce président va payer !"
+    },
+    {
+        "id": 179,
+        "offset": 309608,
+        "data_size": 110,
+        "slot_size": 110,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "This[SP]place[SP]should[SP]be[SP]fine.[SP]C'mon,[SP]let's[SP]go.",
+        "nom_fr": "Maya",
+        "texte_fr": "Cet endroit devrait aller. Allez, on y va."
+    },
+    {
+        "id": 180,
+        "offset": 309718,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "I[SP]know[SP]you're[SP]worried[SP]about[SP]your[SP]school,[SP]but[SP]I[NL]don't[SP]think[SP]they'll[SP]strike[SP]here.[SP]We[SP]don't[SP]have[NL]much[SP]time,[SP]man.[SP]Let's[SP]go.",
+        "nom_fr": "Michel",
+        "texte_fr": "Je sais que tu t'inquiètes, mais pas ici.\n On a peu de temps. Allons-y."
+    },
+    {
+        "id": 181,
+        "offset": 309986,
+        "data_size": 268,
+        "slot_size": 268,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "I[SP]already[SP]miss[SP]the[SP]regular[SP]school[SP]days...[NL]Hey,[SP][1113],[SP]will[SP]things[SP]ever[SP]go[SP]back[SP]to[NL]normal?[SP]Will[SP]Sheba[SP]and[SP]Mee-ho[SP]come[SP]back...?",
+        "nom_fr": "Ginko",
+        "texte_fr": "Les jours normaux me manquent...\n Hé, [1113], tout redeviendra normal ?\n Sheba et Mee-ho ?"
+    },
+    {
+        "id": 182,
+        "offset": 310254,
+        "data_size": 200,
+        "slot_size": 200,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Looks[SP]like[SP]those[SP]soldiers[SP]haven't[SP]made[SP]it[SP]this[NL]far[SP]yet...[SP]Are[SP]the[SP]students[SP]still[SP]inside?",
+        "nom_fr": "Maya",
+        "texte_fr": "Ces soldats ne sont pas allés aussi loin...\n Les élèves sont-ils encore à l'intérieur ?"
+    },
+    {
+        "id": 183,
+        "offset": 310454,
+        "data_size": 284,
+        "slot_size": 284,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Eikichi",
+        "texte_orig": "Mt.[SP]Iwato...[SP]That's[SP]weird...[SP]I've[SP]seen[SP]it[SP]in[NL]my[SP]dreams...[SP]Is[SP]this[SP]deja[SP]vu[SP]or[SP]something?[NL]We[SP]don't[SP]have[SP]any[SP]business[SP]here,[SP]right?",
+        "nom_fr": "Michel",
+        "texte_fr": "Mont Iwato... C'est bizarre... Je l'ai vu dans mes rêves...\n Du déjà-vu ? On n'a rien à faire ici, non ?"
+    },
+    {
+        "id": 184,
+        "offset": 310738,
+        "data_size": 86,
+        "slot_size": 86,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "This[SP]is...[1205][U+000F][SP]It's[SP]Mt.[SP]Iwato...",
+        "nom_fr": "Ginko",
+        "texte_fr": "C'est... le mont Iwato..."
+    },
+    {
+        "id": 185,
+        "offset": 310824,
+        "data_size": 148,
+        "slot_size": 148,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "H-Hey,[SP][1113]?[SP]I[SP]don't[SP]like[SP]it[SP]here...[1205][U+000F][NL]Can[SP]we[SP]go[SP]somewhere[SP]else?",
+        "nom_fr": "Ginko",
+        "texte_fr": "Hé, [1113] ? J'aime pas ici...[1205][U+000F]\n Ailleurs ?"
+    },
+    {
+        "id": 186,
+        "offset": 310972,
+        "data_size": 224,
+        "slot_size": 224,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Maya",
+        "texte_orig": "Mt.[SP]Iwato?[SP]What's[SP]this[SP]feeling...?[SP]Like...[NL]Nostalgia,[SP]but[SP]bittersweet...[SP]I[SP]guess[SP]now[NL]isn't[SP]the[SP]time.",
+        "nom_fr": "Maya",
+        "texte_fr": "Mont Iwato ? Quel est ce sentiment... ?\n De la nostalgie, mais douce-amère...\n Pas le moment."
+    },
+    {
+        "id": 187,
+        "offset": 311196,
+        "data_size": 266,
+        "slot_size": 266,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "It's[SP]been[SP]ten[SP]years...[SP]Why[SP]now...?[SP]Let's[SP]stay[NL]away[SP]from[SP]here[SP]for[SP]now,[SP][1113].[SP]There's[NL]something[SP]I[SP]need[SP]to[SP]be[SP]sure[SP]of[SP]first...",
+        "nom_fr": "Ginko",
+        "texte_fr": "Dix ans... Pourquoi maintenant ?\n Restons loin, [1113]. Je dois d'abord vérifier."
+    },
+    {
+        "id": 188,
+        "offset": 311462,
+        "data_size": 224,
+        "slot_size": 224,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Ginko",
+        "texte_orig": "I[SP]was[SP]scared[SP]of[SP]this[SP]place[SP]for[SP]a[SP]long[SP]time.[NL]But[SP]I'm[SP]okay[SP]now.[SP]I[SP]won't[SP]run[SP]anymore,[NL]from[SP]anything...",
+        "nom_fr": "Ginko",
+        "texte_fr": "Peur longtemps. Maintenant ça va.\n Je ne fuirai plus."
+    },
+    {
+        "id": 189,
+        "offset": 311686,
+        "data_size": 188,
+        "slot_size": 188,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Jun",
+        "texte_orig": "Our[SP]secret[SP]hideout...[SP]It[SP]feels[SP]a[SP]little[SP]odd[NL]to[SP]be[SP]able[SP]to[SP]come[SP]here[SP]with[SP][1113][SP]again...",
+        "nom_fr": "Jun",
+        "texte_fr": "Notre cachette secrète...\n Ça fait étrange de pouvoir venir ici avec [1113] à nouveau..."
+    },
+    {
+        "id": 190,
+        "offset": 311874,
+        "data_size": 1156,
+        "slot_size": 1156,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
+        "texte_orig": "I[SP]saw[SP]her[SP]at[SP]Mt.[SP]Iwato.[1205][U+000F][SP]You[SP]know[SP]who[SP]I[SP]mean...[NL]That[SP][1431][U+0000][U+0000][U+0006]urban[SP]legend,[SP]Kuchisake-onna[1431][U+0000][U+0000][U+0002].[SP]I[SP]saw[SP]a[NL]woman[SP]wearing[SP]a[SP]mask[SP]out[SP]there.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[SP]playing[SP]dumb[NL]Dollars[SP]to[SP]donuts[SP]there's[SP]a[SP]huge[SP]mouth,[SP]split[NL]from[SP]ear[SP]to[SP]ear,[SP]under[SP]that[SP]mask.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[SP]playing[SP]dumb[NL]But[SP]my[SP]wife[SP]tells[SP]me[SP]not[SP]to[SP]be[SP]such[SP]a[SP]baby[NL]and[SP]refuses[SP]to[SP]take[SP]me[SP]seriously.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[SP]playing[SP]dumb[NL]K-Kid,[SP]I'm[SP]begging[SP]you.[SP]Could[SP]you[SP]bring[SP]back[NL]proof[SP]that[SP]Kuchisake-onna's[SP]really[SP]there?[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[SP]playing[SP]dumb[NL]Don't[SP]worry,[SP]I'll[SP]be[SP]sure[SP]to[SP]repay[SP]the[SP]favor.[NL]I'm[SP]counting[SP]on[SP]you!",
+        "nom_fr": "Vieil homme qui fait le sourd",
+        "texte_fr": "Je l'ai vue au mont Iwato.[1205][U+000F]\n Cette [E4][NULL][NULL][U+0006]légende urbaine, Kuchisake-onna[E4][NULL][NULL][0002].\n J'ai vu une femme masquée.[1106][NL]Sous ce masque, une bouche fendue d'une oreille à l'autre.[1106][NL]Ma femme dit que j'en fais trop, elle ne me croit pas.[1106][NL]Gamin, prouve que Kuchisake-onna est là.[1106][NL]Je te revaudrai ça. Compte sur toi !"
+    },
+    {
+        "id": 191,
+        "offset": 313030,
+        "data_size": 276,
+        "slot_size": 276,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
+        "texte_orig": "Kuchisake-onna[SP]should[SP]still[SP]be[SP]somewhere[SP]on[NL]Mt.[SP]Iwato.[1205][U+000F][SP]I'm[SP]begging[SP]you,[SP]bring[SP]back[SP]proof[NL]she's[SP]really[SP]there!",
+        "nom_fr": "Vieil homme qui fait le sourd",
+        "texte_fr": "Kuchisake-onna est au mont Iwato.[1205][U+000F]\n Prouve qu'elle est là !"
+    },
+    {
+        "id": 192,
+        "offset": 313306,
+        "data_size": 516,
+        "slot_size": 516,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
+        "texte_orig": "Hm?[1205][U+000A][SP]Ohhhhh![1205][U+000F][SP]That's[SP]it![SP][1431][U+0000][U+0000][U+0006]Kuchisake-onna's[SP]mask[1431][U+0000][U+0000][U+0002]![1205][U+000F][NL]Kid,[SP]I[SP]gotta[SP]thank[SP]you[SP]for[SP]bringing[SP]it[SP]to[SP]me![NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[SP]playing[SP]dumb[NL]L-Like[SP]I[SP]said,[SP]I'll[SP]repay[SP]you[SP]for[SP]the[SP]favor.[NL]Here's[SP]a[SP][1431][U+0000][U+0000][U+0004][U+1433][U+0000][U+0000][U+0004]Megido[SP]Card[1431][U+0000][U+0000][U+0002].[SP]Go[SP]on,[SP]it's[SP]yours!",
+        "nom_fr": "Vieil homme qui fait le sourd",
+        "texte_fr": "Ohhhhh ![1205][U+000F] C'est ça !\n [E4][NULL][NULL][U+0006]Le masque de Kuchisake-onna[E4][NULL][NULL][0002] ![1205][U+000F]\n Merci de me l'avoir apporté ![1106][NL]Comme je l'ai dit, je te revaudrai ça.\n Tiens, une [E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Carte Megido[E4][NULL][NULL][0002].\n Elle est à toi !"
+    },
+    {
+        "id": 193,
+        "offset": 313822,
+        "data_size": 694,
+        "slot_size": 694,
+        "_term": [
+            4358,
+            4354,
+            4355,
+            5169,
+            0,
+            0
+        ],
+        "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
+        "texte_orig": "My[SP]wife[SP]will[SP]have[SP]to[SP]believe[SP]me[SP]once[SP]she[NL]sees[SP]this.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[SP]playing[SP]dumb[NL]...You[SP]know,[SP]though,[SP]that[SP]Kuchisake-onna[SP]did[NL]a[SP]lot[SP]of[SP]mumbling[SP]to[SP]herself.[NL][1106][E2][1431][U+0000][U+0000]\"Old[SP]man[SP]playing[SP]dumb[NL]Like,[SP][U+1432][U+0000][U+0000][U+0014]I[SP]wonder[SP]if[SP]this[SP]costume's[SP]too[SP]obvious...[U+1432][U+0000][U+0000][U+0014][NL]Or[SP][U+1432][U+0000][U+0000][U+0014]Has[SP][1113]-kun[SP]reached[SP]the[SP]detective[NL]agency[SP]yet?[U+1432][U+0000][U+0000][U+0014][1205][U+000F][SP]What[SP]a[SP]strange[SP]monster...",
+        "nom_fr": "Vieil homme qui fait le sourd",
+        "texte_fr": "Ma femme me croira en voyant ça.[1106][NL]... Cette Kuchisake-onna se parlait tout le temps toute seule.[1106][NL][1432][NULL][NULL][0014]Déguisement trop voyant ?[1432][NULL][NULL][0014]\n Ou [1432][NULL][NULL][0014][1113]-kun à l'agence ?[1432][NULL][NULL][0014][1205][U+000F]\n Drôle de monstre..."
+    }
 ]


### PR DESCRIPTION
## Description de la Pull Request

Cette PR règle définitivement le problème d'écran noir (crash / freeze) sur la Town Map !

**Explications des changements :**
1. **Fusion intelligente des JSON MMAP** : Les JSON présents sur GitHub utilisaient un ancien format (par exemple `MMAP05.json` avait des `slot_size` de 270 octets) car l'ancien parseur coupait mal les dialogues. Ce PR remplace ces fichiers par les JSON originaux de 606 octets et a automatiquement fusionné tes traductions pour qu'elles soient préservées dans la bonne structure !
2. **Correctif de `mmap_encoder.py`** : L'encodeur ajoutait automatiquement un saut de ligne (`[NL]`) à tort à la fin de tous les dialogues, ce qui décalait la mémoire, tronquait massivement les textes, et plantait l'affichage de la carte (d'où l'écran noir sans possibilité de marcher). Ce bug est maintenant entièrement corrigé, et le padding de sécurité se fait au bon endroit, proprement.

Maintenant, tout devrait fonctionner et s'encoder correctement.