### PR TITLE
fix(traduction): v0.2.2 - fix 4313 tag swaps, pagination, glossary an…

### DIFF
--- a/traduction/CD_SHOP.json
+++ b/traduction/CD_SHOP.json
@@ -12,7 +12,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Hellooooo![1205][000F][SP]Welcome[SP]to[SP]the[SP]record[SP]store\nGIGA[SP]MACHOOOO![SP]State[SP]your[SP]business!\n[1208][0004]Buy[SP]CDs\nTalk[SP]to[SP]employee\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Employé",
-    "texte_fr": "Salut![1205][000F] Bienvenue au disquaire GIGA\nMACHO! Que voulez-vous!\n[1208][0004]Acheter des CDs\nParler\nLaisse tomber\nQuitter",
+    "texte_fr": "Salut![000F][1205] Bienvenue au disquaire GIGA\nMACHO! Que voulez-vous!\n[1208][0004]Acheter des CDs\nParler\nLaisse tomber\nQuitter",
     "question_orig": "Hellooooo![1205][000F][SP]Welcome[SP]to[SP]the[SP]record[SP]store\nGIGA[SP]MACHOOOO![SP]State[SP]your[SP]business!",
     "choix_orig": [
       "Buy[SP]CDs",
@@ -115,7 +115,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Heeeey...[SP]Does[SP]that[SP]blonde[SP]girl[SP]with[SP]you[SP]happen\nto[SP]be[SP]Lisa-san[SP]from[SP]Muses?[1205][000F][SP]Whoa![SP]She's[SP]the[SP]real\ndeal!",
     "nom_fr": "Employé",
-    "texte_fr": "Hé... La blonde là, c'est pas Lisa-san\ndu groupe Muses?[1205][000F] C'est vraiment elle!"
+    "texte_fr": "Hé... La blonde là, c'est pas Lisa-san\ndu groupe Muses?[000F][1205] C'est vraiment elle!"
   },
   {
     "id": 5,
@@ -130,7 +130,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Huh?[SP]Wait,[SP]what[SP]about[SP]the[SP]other[SP]girls?[1205][000F][SP]Weren't\nthere...[1205][000F][SP]Weird.[SP]I[SP]can't[SP]remember...",
     "nom_fr": "Employé",
-    "texte_fr": "Attends, et les autres?[1205][000F] Y'avait...\n[1205][000F]Bizarre. Je m'en souviens pas..."
+    "texte_fr": "Attends, et les autres?[000F][1205] Y'avait...\n[000F][1205]Bizarre. Je m'en souviens pas..."
   },
   {
     "id": 6,
@@ -145,7 +145,7 @@
     "nom_orig": "Employee",
     "texte_orig": "*sigh*[1205][000F][SP]We've[SP]lost[SP]so[SP]many[SP]customers[SP]to[SP]this\nawful[SP]terror[SP]wave...[1205][000F][SP]I[SP]should[SP]sue[SP]for\nobstruction[SP]of[SP]business.",
     "nom_fr": "Employé",
-    "texte_fr": "Pff...[1205][000F] On a perdu des clients à\ncause de la terreur...[1205][000F] *soupir*."
+    "texte_fr": "Pff...[000F][1205] On a perdu des clients à\ncause de la terreur...[000F][1205] *soupir*."
   },
   {
     "id": 7,
@@ -175,7 +175,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Hey,[SP]what[SP]do[SP]you[SP]think[SP]of[SP]the[SP]In[SP]Lak'ech?\nThink[SP]it's[SP]true?[1205][000F][SP]Well,[SP]I[SP]don't[SP]really[SP]care.",
     "nom_fr": "Employé",
-    "texte_fr": "Tu crois que In Lak'ech\nexiste?[1205][000F][SP] Bof, je m'en fiche."
+    "texte_fr": "Tu crois que In Lak'ech\nexiste?[000F][1205][SP] Bof, je m'en fiche."
   },
   {
     "id": 9,
@@ -190,7 +190,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Man,[SP]you[SP]always[SP]have[SP]the[SP]best[SP]timing.[SP]We[SP]juuust\ngot[SP]in[SP]some[SP]new[SP]singles[SP]in[SP]the[SP]Terzo[SP]corner.[1205][000F]\nHere,[SP]come[SP]take[SP]a[SP]look.",
     "nom_fr": "Employé",
-    "texte_fr": "T'as toujours le bon timing. On viens\nde recevoir Des nouveaux singles dans\nle coin Terzo.[1205][000F] Viens voir."
+    "texte_fr": "T'as toujours le bon timing. On viens\nde recevoir Des nouveaux singles dans\nle coin Terzo.[000F][1205] Viens voir."
   },
   {
     "id": 10,
@@ -205,7 +205,7 @@
     "nom_orig": "Employee",
     "texte_orig": "The[SP]city's[SP]a[SP]mess[SP]right[SP]now,[SP]but[SP]we[SP]did[SP]get\nour[SP]scheduled[SP]delivery[SP]of[SP]new[SP]material.[1205][000F][SP]I've\nfinally[SP]put[SP]together[SP]a[SP]Quarto[SP]corner.",
     "nom_fr": "Employé",
-    "texte_fr": "La ville est dans le chaos, mais\non a recu les nouveaux morceaux.[1205][000F]\nJ'ai enfin monté un coin Quarto."
+    "texte_fr": "La ville est dans le chaos, mais\non a recu les nouveaux morceaux.[000F][1205]\nJ'ai enfin monté un coin Quarto."
   },
   {
     "id": 11,
@@ -220,7 +220,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Geez,[SP]we're[SP]getting[SP]in[SP]so[SP]much[SP]new[SP]music[SP]these\ndays,[SP]I'm[SP]running[SP]out[SP]of[SP]rack[SP]space[SP]for[SP]it[SP]all.[1205][000F]\nAaaanyways,[SP]we[SP]have[SP]a[SP]Quinto[SP]corner[SP]at[SP]last.",
     "nom_fr": "Employé",
-    "texte_fr": "Pff, on recoit tellement de nouveaux\ndisques que je manque de place.[1205][000F]\nBref, on a enfin un coin Quarto."
+    "texte_fr": "Pff, on recoit tellement de nouveaux\ndisques que je manque de place.[000F][1205]\nBref, on a enfin un coin Quarto."
   },
   {
     "id": 12,
@@ -235,7 +235,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Now[SP]that's[SP]weird...[1205][000F][SP]Did[SP]we[SP]used[SP]to[SP]carry[SP]this\n[1432][NULL][NULL][0014]secret[SP]CD[1432][NULL][NULL][0014]?[1205][000F][SP]Huh,[SP]well,[SP]I[SP]see[SP]we[SP]have[SP]it[SP]in\nstock...[SP]so[SP]I[SP]guess[SP]we[SP]carry[SP]it[SP]now!",
     "nom_fr": "Employé",
-    "texte_fr": "Bizarre...[1205][000F] On avait ce[1432][NULL][NULL][0014]CD\nsecret[1432][NULL][NULL][0014]?[1205][000F] Bon, On l'a maintenant!"
+    "texte_fr": "Bizarre...[000F][1205] On avait ce[1432][NULL][NULL][0014]CD\nsecret[1432][NULL][NULL][0014]?[000F][1205] Bon, On l'a maintenant!"
   },
   {
     "id": 13,
@@ -250,7 +250,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Something[SP]seems[SP]fishy[SP]about[SP]this,[SP]but...\nOh[SP]well.[1205][000F][SP]Anyway,[SP]I[SP]put[SP]it[SP]in[SP]the[SP]Quarto\ncorner.[SP]Take[SP]it[SP]off[SP]my[SP]hands,[SP]will[SP]ya?",
     "nom_fr": "Employé",
-    "texte_fr": "C'est louche, mais.... Bon.[1205][000F] Peu\nimporte, je l'ai mit dans le coin\nQuarto. Débarasse-moi de ca."
+    "texte_fr": "C'est louche, mais.... Bon.[000F][1205] Peu\nimporte, je l'ai mit dans le coin\nQuarto. Débarasse-moi de ca."
   },
   {
     "id": 14,
@@ -265,7 +265,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Whoops,[SP]we're[SP]completely[SP]out[SP]of[SP]CDs[SP]right[SP]now![1205][000F]\nHuh?[SP]Oh,[SP]those[SP]ones[SP]on[SP]the[SP]shelves?[1205][000F][SP]Yeah,[SP]those\nare[SP]just[SP]for[SP]show.[SP]So[SP]sorry!",
     "nom_fr": "Employé",
-    "texte_fr": "Oups, on a plus de CDs![1205][000F] Ceux sur les\nétagères? [1205][000F]C'est juste pour décorer, désolé!"
+    "texte_fr": "Oups, on a plus de CDs![000F][1205] Ceux sur les\nétagères? [000F][1205]C'est juste pour décorer, désolé!"
   },
   {
     "id": 15,
@@ -280,7 +280,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Wow,[SP]you're[SP]something[SP]else.[1205][000F][SP]You've[SP]bought[SP]up\nevery[SP]CD[SP]in[SP]the[SP]shop![SP]Thanks,[SP]thanks,[SP]and[SP]in\ncase[SP]I[SP]forget,[SP]thanks!",
     "nom_fr": "Employé",
-    "texte_fr": "T'es dingue.[1205][000F] T'as acheté tout les\nCDs disponibles! Merci infiniment!"
+    "texte_fr": "T'es dingue.[000F][1205] T'as acheté tout les\nCDs disponibles! Merci infiniment!"
   },
   {
     "id": 16,
@@ -426,7 +426,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Hmm?[1205][000F][SP]The[SP]Quarto[SP]corner's[SP]sold[SP]out?[1205][000F][SP]That[SP]was...\ndisappointingly[SP]quick...[1205][000F][SP]But[SP]I[SP]won't[SP]complain!",
     "nom_fr": "Employé",
-    "texte_fr": "Hm?[1205][000F] Le coin Quarto est épuisé?[1205][000F] C'était...\nDécevamment rapide...[1205][000F] Mais je me plains pas!"
+    "texte_fr": "Hm?[000F][1205] Le coin Quarto est épuisé?[000F][1205] C'était...\nDécevamment rapide...[000F][1205] Mais je me plains pas!"
   },
   {
     "id": 25,
@@ -486,6 +486,6 @@
     "nom_orig": "Employee",
     "texte_orig": "Thanks![1205][000F][SP]Come[SP]again!",
     "nom_fr": "",
-    "texte_fr": "Merci ![1205][000F] Revenez nous voir !"
+    "texte_fr": "Merci ![000F][1205] Revenez nous voir !"
   }
 ]

--- a/traduction/EBOOT_decoupe/EBOOT_Part1.json
+++ b/traduction/EBOOT_decoupe/EBOOT_Part1.json
@@ -85,7 +85,7 @@
     "data_size": 118,
     "slot_size": 118,
     "texte_orig": "Saving[SP]system[SP]data<0004>[SP]Please[SP]do[SP]not<FF03>remove[SP]the[SP]Memory[SP]Stick<04B1><0004>",
-    "texte_fr": "Sauvegarde donnees syst.<0004> Ne pas<FF03> retirer carte mem.<04B1><0004>"
+    "texte_fr": "Sauvegarde donnees syst<0004> Ne pas<FF03> retirer carte mem<04B1><0004>"
   },
   {
     "id": 11,
@@ -1093,7 +1093,7 @@
     "data_size": 98,
     "slot_size": 98,
     "texte_orig": "Installing[SP]data<0004><FF03>Do[SP]not[SP]remove[SP]the[SP]Memory[SP]Stick<04B1><0004>",
-    "texte_fr": "Installation<0004><FF03> Ne retirez pas la carte mem.<04B1><0004>"
+    "texte_fr": "Installation<0004><FF03> Ne retirez pas la carte mem<04B1><0004>"
   },
   {
     "id": 137,

--- a/traduction/MMAP01.json
+++ b/traduction/MMAP01.json
@@ -72,7 +72,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "The[SP]students[SP]there[SP]have[SP]settled[SP]down[SP]lately,\nand[SP]I[SP]like[SP]this[SP]neighborhood's[SP]working-class\nfeel.",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Le festival de Kasuga ? Je crois bien que c'est\nune première pour le lycée Kakasu. Ils gagnent en\ncrédibilité.[1106][NL]Je viens d'ici, donc voir ça me rend heureux.[1205][U+000F]\nAh, les années lycée."
+    "texte_fr": "Le festival de Kasuga ? Je crois bien que c'est\nune première pour le lycée Kakasu. Ils gagnent en\ncrédibilité.[1106][NL]Je viens d'ici, donc voir ça me rend heureux.[1205][U+000F] Ah, les années lycée."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Hah...[SP]The[SP]Kasuga[SP]Festival,[SP]eh?[SP]I[SP]think[SP]this[SP]is\nthe[SP]first[SP]time[SP]Cuss[SP]High[SP]has[SP]ever[SP]had[SP]an[SP]actual\nschool[SP]festival.[SP]They're[SP]moving[SP]up[SP]in[SP]the[SP]world.",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Le festival de Kasuga ? Je crois bien que c'est\nune première pour le lycée Kakasu. Ils gagnent en\ncrédibilité.[NL]Je viens d'ici, donc voir ça me rend heureux.\nAh, les années lycée."
+    "texte_fr": "Le festival de Kasuga ? Je crois bien que c'est\nune première pour le lycée Kakasu. Ils gagnent en\ncrédibilité.[NL]Je viens d'ici, donc voir ça me rend heureux. Ah, les années lycée."
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Huh?[SP]That's[SP]weird...[1205][000F][SP]I[SP]haven't[SP]seen[SP]Cuss[SP]High\nstudents[SP]around[SP]lately.[SP]Did[SP]their[SP]enrollment\nnumbers[SP]drop?[1205][000F][SP]Nah,[SP]that[SP]can't[SP]be[SP]it...",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Bizarre...[1205][000F] Pas d'élèves du lycée\nKakasu récemment. Moins d'inscrits ?[1205][000F]\nNan, impossible..."
+    "texte_fr": "Bizarre...[000F][1205] Pas d'élèves du lycée\nKakasu récemment. Moins d'inscrits ?[000F][1205]\nNan, impossible..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "You[SP]can[SP]buy[SP]CDs[SP]at[SP]Giga[SP]Macho[SP]in[SP]Yumezaki.[1205][000F]\nI[SP]go[SP]there[SP]all[SP]the[SP]time.",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Achète tes CD à Giga Macho\nà Yumezaki.[1205][000F] J'y vais tout le temps."
+    "texte_fr": "Achète tes CD à Giga Macho\nà Yumezaki.[000F][1205] J'y vais tout le temps."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "This[SP]terrorism[SP]wave's[SP]the[SP]talk[SP]of[SP]the[SP]city.\nHonestly,[SP]I'm[SP]scared[SP]too.[1205][000F][SP]Even[SP]the[SP]police\nstation[SP]and[SP]fire[SP]department[SP]got[SP]hit.",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Cette vague terroriste fait parler.\nJ'ai peur aussi.[1205][000F] Même la police\net les pompiers sont touchés.[NL]Qui reste-t-il pour protéger cette ville et\néteindre les feux ?[NL]On est coincés à attendre\nla prochaine attaque !"
+    "texte_fr": "Cette vague terroriste fait parler.\nJ'ai peur aussi.[000F][1205] Même la police\net les pompiers sont touchés.[NL]Qui reste-t-il pour protéger cette ville et éteindre les feux ?[NL]On est coincés à attendre la prochaine attaque !"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Who's[SP]left[SP]to[SP]protect[SP]this[SP]city[SP]or[SP]put[SP]out\nany[SP]fires[SP]that[SP]get[SP]started?",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "C'est encore cette fille ?[1205][U+000F] Celle que j'ai vu sortir\nde Smile Hirasaka en courant.[1205][U+000F][1106][NL]Et cette fois, elle était accompagnée\nd'une bande de gamins...[1106][NL]Ils disent que les cinq personnes dans le journal\nsont en fait des héros qui combattent le cercle masqué.[1205][U+000F]\nC'est vrai, ça ?"
+    "texte_fr": "C'est encore cette fille ?[1205][U+000F] Celle que j'ai vu sortir\nde Smile Hirasaka en courant.[1205][U+000F][1106][NL]Et cette fois, elle était accompagnée\nd'une bande de gamins...[1106][NL]Ils disent que les cinq personnes dans le journal sont en fait des héros qui combattent le cercle masqué.[1205][U+000F] C'est vrai, ça ?"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "We're[SP]just[SP]stuck[SP]waiting[SP]for[SP]the[SP]terrorists\nto[SP]strike[SP]again!",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Cette fille bouge beaucoup.\nVue aux infos.[1205][U+000F][1106][NL]Elle dit que ces 5 suspects\nsont des héros...[1106][NL]Elle a peut-être raison...[1205][U+000F] Hah ?\nEh, ne te fais pas d'idées !"
+    "texte_fr": "Cette fille bouge beaucoup.\nVue aux infos.[1205][U+000F][1106][NL]Elle dit que ces 5 suspects\nsont des héros...[1106][NL]Elle a peut-être raison...[1205][U+000F] Hah ? Eh, ne te fais pas d'idées !"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Now[SP]that[SP]was[SP]strange...[1205][000F][SP]This[SP]girl[SP]in[SP]crazy\nclothes[SP]just[SP]ran[SP]out[SP]of[SP]Smile[SP]Hirasaka.",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Étrange...[1205][000F] Cette fille en\ntenue folle a fui de Smile Hirasaka.[NL]Je crois que je l'ai entendu dire un truc comme\n[NULL][NULL]Tu vas le regretter ![NULL][NULL]"
+    "texte_fr": "Étrange...[000F][1205] Cette fille en\ntenue folle a fui de Smile Hirasaka.[NL]Je crois que je l'ai entendu dire un truc comme\n[NULL][NULL]Tu vas le regretter ![NULL][NULL]"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "I[SP]think[SP]I[SP]heard[SP]her[SP]say[SP]something[SP]like,[SP][1432][NULL][NULL][0014]You'll\npay[SP]for[SP]this![1432][NULL][NULL][0014][SP]as[SP]she[SP]went...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Que se passe-t-il !?[1205][U+0008][1106][NL]D'abord ce temple bizarre, puis\nle Bataillon et le Cercle masqué\nl'envahissent ![1106][NL]Ils y sont entrés...[1205][U+000A] J'entends des tirs\nà l'intérieur.[1205][U+000F] Ils se battent encore ?[1432][NULL][NULL][0014][1432][NULL][NULL][0014]"
+    "texte_fr": "Que se passe-t-il !?[1205][U+0008][1106][NL]D'abord ce temple bizarre, puis\nle Bataillon et le Cercle masqué\nl'envahissent ![1106][NL]Ils y sont entrés...[1205][U+000A] J'entends des tirs à l'intérieur.[1205][U+000F] Ils se battent encore ?[1432][NULL][NULL][0014][1432][NULL][NULL][0014]"
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Now[SP]that[SP]was[SP]strange...[1205][000F][SP]This[SP]girl[SP]with[SP]crazy\nclothes[SP]and[SP]a[SP]burning[SP]ass[SP]ran[SP]out[SP]of[SP]Smile\nHirasaka[SP]when[SP]it[SP]was[SP]on[SP]fire[SP]just[SP]now.",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "C'est étrange...[1205][000F] Cette fille habillée\nbizarrement vient de sortir de Smile Hirasaka qui flambait\nen courant.[NL]Je crois que je l'ai entendu dire un truc comme\n[NULL][NULL]C'était pas censé se passer comme ça ![NULL][NULL]"
+    "texte_fr": "C'est étrange...[000F][1205] Cette fille habillée\nbizarrement vient de sortir de Smile Hirasaka qui flambait\nen courant.[NL]Je crois que je l'ai entendu dire un truc comme [NULL][NULL]C'était pas censé se passer comme ça ![NULL][NULL]"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "I[SP]think[SP]I[SP]heard[SP]her[SP]say[SP]something[SP]like,\n[1432][NULL][NULL][0014]This[SP]wasn't[SP]how[SP]it[SP]was[SP]supposed[SP]to[SP]go![1432][NULL][NULL][0014]\nas[SP]she[SP]went...",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le lycée Kakasu ? Pas mon truc.\nMais ces temps-ci, ils ont eu plein\nde beaux garçons, non ?[1106][NL]Donc je vais voir leurs shows à la Prison.\nT'es mignon, mais t'es juste\nun élève de Seven.[1432][NULL][NULL][0014][1432][NULL][NULL][0014]"
+    "texte_fr": "Le lycée Kakasu ? Pas mon truc.\nMais ces temps-ci, ils ont eu plein\nde beaux garçons, non ?[1106][NL]Donc je vais voir leurs shows à la Prison. T'es mignon, mais t'es juste un élève de Seven.[1432][NULL][NULL][0014][1432][NULL][NULL][0014]"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Huh?[SP]It's[SP]that[SP]girl[SP]again...[1205][000F][SP]I[SP]mean[SP]the[SP]one[SP]in\nthe[SP]weird[SP]getup[SP]who[SP]ran[SP]out[SP]of[SP]Smile[SP]Hirasaka\nbefore.[1205][000F]",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "C'est encore cette fille ?[1205][000F] Celle que j'ai vu sortir\nde Smile Hirasaka en courant.[1205][000F][NL]Et cette fois, elle était accompagnée\nd'une bande de gamins...[NL]Ils disent que les cinq personnes dans le journal\nsont en fait des héros qui combattent le cercle masqué.\nC'est vrai, ça ?"
+    "texte_fr": "C'est encore cette fille ?[000F][1205] Celle que j'ai vu sortir\nde Smile Hirasaka en courant.[000F][1205][NL]Et cette fois, elle était accompagnée\nd'une bande de gamins...[NL]Ils disent que les cinq personnes dans le journal sont en fait des héros qui combattent le cercle masqué. C'est vrai, ça ?"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "And[SP]it[SP]seemed[SP]like[SP]there[SP]were[SP]a[SP]bunch[SP]of[SP]kids\nwith[SP]her[SP]this[SP]time...",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le président du BDE est si cool. Il a\norganisé un bal masqué pour notre\nfestival.[1205][U+000F] J'ai eu un billet direct.[1106][NL]Il me faut juste un mec cool de Kakasu.[1205][U+000F]\nOu tu veux venir avec moi ? T'es plutôt\nmignon, ça m'irait."
+    "texte_fr": "Le président du BDE est si cool. Il a\norganisé un bal masqué pour notre\nfestival.[1205][U+000F] J'ai eu un billet direct.[1106][NL]Il me faut juste un mec cool de Kakasu.[1205][U+000F] Ou tu veux venir avec moi ? T'es plutôt mignon, ça m'irait."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "They[SP]said[SP]something[SP]about[SP]how[SP]the[SP]five[SP]people\non[SP]the[SP]news[SP]are[SP]actually[SP]heroes[SP]fighting\nagainst[SP]the[SP]Masked[SP]Circle...[1205][000F][SP]Is[SP]that[SP]true?",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le bal masqué ?[1205][U+000F] Oh, ce vieux truc ?[1205][U+000F]\nJ'ai zappé, j'avais d'autres trucs à faire.\nBref, la nouveauté c'est les Muses ![1106][NL]Tu sais, le trio d'idoles produit\npar Ginji Sasaki ?[1205][U+000F] Je me demande comment\nelles sont... Vivement leurs débuts ![000F]"
+    "texte_fr": "Le bal masqué ?[1205][U+000F] Oh, ce vieux truc ?[1205][U+000F]\nJ'ai zappé, j'avais d'autres trucs à faire.\nBref, la nouveauté c'est les Muses ![1106][NL]Tu sais, le trio d'idoles produit par Ginji Sasaki ?[1205][U+000F] Je me demande comment elles sont... Vivement leurs débuts ![000F]"
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "That[SP]girl[SP]gets[SP]around.[SP]I[SP]just[SP]saw[SP]her[SP]on\nthe[SP]news.[1205][000F]",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Cette fille bouge beaucoup.\nVue aux infos.[1205][000F][NL]Elle dit que ces 5 suspects\nsont des héros...[NL]Elle a peut-être raison... Hah ?\nEh, ne te fais pas d'idées !"
+    "texte_fr": "Cette fille bouge beaucoup.\nVue aux infos.[000F][1205][NL]Elle dit que ces 5 suspects\nsont des héros...[NL]Elle a peut-être raison... Hah ? Eh, ne te fais pas d'idées !"
   },
   {
     "id": 20,
@@ -342,7 +342,7 @@
     "nom_orig": "Healthy[SP]young[SP]man",
     "texte_orig": "Wh-Where[SP]are[SP]those[SP]soldiers[SP]going?[1205][000F][SP]There's\nnothing[SP]over[SP]there[SP]but[SP]Mt.[SP]Katatsumuri.[1205][000F][SP]What\nare[SP]they[SP]doing[SP]there[SP]with[SP]all[SP]those[SP]guns?",
     "nom_fr": "Jeune homme vigoureux",
-    "texte_fr": "Où vont ces soldats ?[1205][000F] Il n'y a rien là-bas\nà part le Mt Katatsumuri.[1205][000F] Qu'est-ce qu'ils\nfont avec tous ces flingues ?"
+    "texte_fr": "Où vont ces soldats ?[000F][1205] Il n'y a rien là-bas\nà part le Mt Katatsumuri.[000F][1205] Qu'est-ce qu'ils\nfont avec tous ces flingues ?"
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Dude,[SP]what's[SP]going[SP]on!?[1205][0008]",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Que se passe-t-il !?[1205][0008][NL]D'abord ce temple bizarre, puis\nle Bataillon et le Cercle masqué\nl'envahissent ![NL]Ils y sont entrés... J'entends des tirs\nà l'intérieur. Ils se battent encore ?"
+    "texte_fr": "Que se passe-t-il !?[0008][1205][NL]D'abord ce temple bizarre, puis\nle Bataillon et le Cercle masqué\nl'envahissent ![NL]Ils y sont entrés... J'entends des tirs à l'intérieur. Ils se battent encore ?"
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "First[SP]that[SP]weird[SP]temple[SP]shows[SP]up,[SP]then[SP]the\nLast[SP]Battalion[SP]and[SP]Masked[SP]Circle[SP]goons[SP]show\nup[SP]and[SP]swarm[SP]into[SP]it!",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Hein ? T'as pas vu les portraits-robots ?[1205][U+000F]\nY en a un qui a tes cheveux, et son\nvisage te ressemble...[1106][NL]Son nez...[1205][U+000A] Comme le tien...[1205][U+000F] Et sa bouche...[1205][U+000A]\nOuais, ça colle...[1205][U+000F] Tu vois ?\nIl a l'air si maléfique."
+    "texte_fr": "Hein ? T'as pas vu les portraits-robots ?[1205][U+000F]\nY en a un qui a tes cheveux, et son\nvisage te ressemble...[1106][NL]Son nez...[1205][U+000A] Comme le tien...[1205][U+000F] Et sa bouche...[1205][U+000A] Ouais, ça colle...[1205][U+000F] Tu vois ? Il a l'air si maléfique."
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "They[SP]all[SP]went[SP]inside...[1205][000A][SP]I[SP]can[SP]hear[SP]gunshots[SP]and\nstuff[SP]from[SP]in[SP]there.[1205][000F][SP]Are[SP]they[SP]still[SP]fighting?",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Je me suis demandé en lisant l'In Lak'ech...\nLe Bataillon a-t-il fait sauter des trucs\npour trouver le trésor de Sumaru ?[1205][000A][1205][000F]"
+    "texte_fr": "Je me suis demandé en lisant l'In Lak'ech...\nLe Bataillon a-t-il fait sauter des trucs\npour trouver le trésor de Sumaru ?[000A][1205][000F][1205]"
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Looks[SP]like[SP]the[SP]war[SP]between[SP]the[SP]Masked[SP]Circle\nand[SP]the[SP]Last[SP]Battalion's[SP]being[SP]fought[SP]in[SP]that\ntemple...[1205][000F][SP]Will[SP]they[SP]fight[SP]to[SP]the[SP]death?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "La guerre entre le Cercle masqué\net le Bataillon a lieu dans ce\ntemple...[1205][000F] S'entretueront-ils ?"
+    "texte_fr": "La guerre entre le Cercle masqué\net le Bataillon a lieu dans ce\ntemple...[000F][1205] S'entretueront-ils ?"
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "I[SP]was[SP]like,[SP]Cuss[SP]High?[SP]Totally[SP]not[SP]my[SP]thing.\nBut[SP]then[SP]lately[SP]they've[SP]been[SP]getting[SP]these\nhot[SP]guys?",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le lycée Kakasu ? Pas mon truc.\nMais ces temps-ci, ils ont eu plein\nde beaux garçons, non ?[NL]Donc je vais voir leurs shows à la Prison.\nT'es mignon, mais t'es juste\nun élève de Seven."
+    "texte_fr": "Le lycée Kakasu ? Pas mon truc.\nMais ces temps-ci, ils ont eu plein\nde beaux garçons, non ?[NL]Donc je vais voir leurs shows à la Prison. T'es mignon, mais t'es juste un élève de Seven."
   },
   {
     "id": 28,
@@ -447,7 +447,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "So[SP]like,[SP]the[SP]new[SP]Leader[SP]of[SP]Cuss[SP]High[SP]was\ndecided?[1205][000F][SP]He's[SP]waaaay[SP]better.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le nouveau chef de Kakasu a\nété choisi ?[1205][000F] Il est carrément mieux.[NL]Boss Calbute ? Pitié. En plus de son\nnom, il n'arrêtait pas d'imposer des règles.[NL]Franchement, il était chiant. Et le\nnouveau chef a l'air bien plus fort !\nOuais ! Écrase ce vieux Boss !"
+    "texte_fr": "Le nouveau chef de Kakasu a\nété choisi ?[000F][1205] Il est carrément mieux.[NL]Boss Calbute ? Pitié. En plus de son\nnom, il n'arrêtait pas d'imposer des règles.[NL]Franchement, il était chiant. Et le nouveau chef a l'air bien plus fort ! Ouais ! Écrase ce vieux Boss !"
   },
   {
     "id": 30,
@@ -477,7 +477,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Honestly,[SP]he[SP]was[SP]a[SP]total[SP]drag.[1205][000F][SP]Plus[SP]the[SP]new\nLeader[SP]seems,[SP]like,[SP]way[SP]stronger?[SP]It's[SP]like,\nyeah![SP]Go[SP]crush[SP]that[SP]old[SP]Boss!",
     "nom_fr": "Homme",
-    "texte_fr": "Il paraît que la dame de Shiraishi Ramen\nest une espionne russe.[1106][NL]Si tu commandes des ramens au porc et à la\nbanane, elle te vend des armes ![1205][U+000F]\nDrôle de monde, hein ?[000F]"
+    "texte_fr": "Il paraît que la dame de Shiraishi Ramen\nest une espionne russe.[1106][NL]Si tu commandes des ramens au porc et à la\nbanane, elle te vend des armes ![1205][U+000F] Drôle de monde, hein ?[000F]"
   },
   {
     "id": 32,
@@ -492,7 +492,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "The[SP]new[SP]student[SP]council[SP]president's[SP]so[SP]cool\nthat[SP]he[SP]set[SP]up[SP]a[SP]masquerade[SP]at[SP]our[SP]school\nfestival.[1205][000F][SP]I[SP]got[SP]a[SP]ticket,[SP]like,[SP]day[SP]one.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le président du BDE est si cool. Il a\norganisé un bal masqué pour notre\nfestival.[1205][000F] J'ai eu un billet direct.[NL]Il me faut juste un mec cool de Kakasu.\nOu tu veux venir avec moi ? T'es plutôt\nmignon, ça m'irait."
+    "texte_fr": "Le président du BDE est si cool. Il a\norganisé un bal masqué pour notre\nfestival.[000F][1205] J'ai eu un billet direct.[NL]Il me faut juste un mec cool de Kakasu. Ou tu veux venir avec moi ? T'es plutôt mignon, ça m'irait."
   },
   {
     "id": 33,
@@ -522,7 +522,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Masquerade?[1205][000F][SP]Oh,[SP]that[SP]old[SP]thing?[1205][000F][SP]I[SP]like,[SP]ditched\non[SP]it[SP]'cause[SP]I[SP]had[SP]other[SP]stuff[SP]to[SP]do?[SP]Anyway,\nthe[SP]new[SP]hotness[SP]is[SP]Muses!",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le bal masqué ?[1205][000F] Oh, ce vieux truc ?[1205][000F]\nJ'ai zappé, j'avais d'autres trucs à faire.\nBref, la nouveauté c'est les Muses ![NL]Tu sais, le trio d'idoles produit\npar Ginji Sasaki ? Je me demande comment\nelles sont... Vivement leurs débuts !"
+    "texte_fr": "Le bal masqué ?[000F][1205] Oh, ce vieux truc ?[000F][1205]\nJ'ai zappé, j'avais d'autres trucs à faire.\nBref, la nouveauté c'est les Muses ![NL]Tu sais, le trio d'idoles produit par Ginji Sasaki ? Je me demande comment elles sont... Vivement leurs débuts !"
   },
   {
     "id": 35,
@@ -552,7 +552,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "The[SP]girls[SP]that[SP]got[SP]picked[SP]for[SP]Muses[SP]are[SP]soooo\nlucky.[1205][000F][SP]I[SP]mean,[SP]Ginji[SP]Sasaki[SP]producing[SP]you?\nThere's[SP]like,[SP]no[SP]way[SP]they[SP]won't[SP]be[SP]huge.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Les filles choisies pour Muses ont trop\nde chance.[1205][000F] Être produite par Ginji\nSasaki ? C'est sûr qu'elles vont percer."
+    "texte_fr": "Les filles choisies pour Muses ont trop\nde chance.[000F][1205] Être produite par Ginji\nSasaki ? C'est sûr qu'elles vont percer."
   },
   {
     "id": 37,
@@ -582,7 +582,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "I[SP]went[SP]to[SP]go[SP]buy[SP]concert[SP]tickets,[SP]and[SP]they[SP]were\nlike,[SP][1432][NULL][NULL][0014]Durrr,[SP]we're[SP]sold[SP]out.[1432][NULL][NULL][0014][1205][000F][SP]That[SP]receptionist\nwas[SP]such[SP]a[SP]bitch!",
     "nom_fr": "Homme",
-    "texte_fr": "Bon sang ! Smile Hirasaka a pris feu sous mes\nyeux ! Où sont les pompiers !? Il se passe quoi !?[1432][NULL][NULL][0014][1432][NULL][NULL][0014][1205][000F]"
+    "texte_fr": "Bon sang ! Smile Hirasaka a pris feu sous mes\nyeux ! Où sont les pompiers !? Il se passe quoi !?[1432][NULL][NULL][0014][1432][NULL][NULL][0014][000F][1205]"
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "The[SP]Masked[SP]Circle's[SP]behind[SP]this[SP]terrorist[SP]stuff,\nright?[1205][000F][SP]Some[SP]of[SP]their[SP]members[SP]were[SP]making[SP]trouble\nin[SP]the[SP]city,[SP]too.[SP]They're[SP]some[SP]real[SP]bad[SP]guys.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le Cercle masqué est derrière ces attaques,\nnon ?[1205][000F] Certains membres ont fait du\ngrabuge en ville. Ce sont de vrais méchants."
+    "texte_fr": "Le Cercle masqué est derrière ces attaques,\nnon ?[000F][1205] Certains membres ont fait du\ngrabuge en ville. Ce sont de vrais méchants."
   },
   {
     "id": 40,
@@ -612,7 +612,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "What[SP]the[SP]hell!?[SP]Why[SP]did[SP]the[SP]terrorists[SP]go\nafter[SP]Smile[SP]Hirasaka?[SP]Why[SP]target[SP]a[SP]station\nbuilding[SP]like[SP]that!?",
     "nom_fr": "Jeune fille",
-    "texte_fr": "C'est quoi ce bordel !? Pourquoi les\nterroristes ont attaqué Smile Hirasaka ?\nPourquoi viser ça !?[NL]Est-ce un [NULL][NULL]acte de violence\ngratuite[NULL][NULL] dont on parle ?\nParce que là, c'est pas drôle !"
+    "texte_fr": "C'est quoi ce bordel !? Pourquoi les\nterroristes ont attaqué Smile Hirasaka ?\nPourquoi viser ça !?[NL]Est-ce un [NULL][NULL]acte de violence gratuite[NULL][NULL] dont on parle ? Parce que là, c'est pas drôle !"
   },
   {
     "id": 41,
@@ -627,7 +627,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Is[SP]this,[SP]like,[SP]one[SP]of[SP]those[SP][1432][NULL][NULL][0014]random[SP]acts[SP]of\nviolence[1432][NULL][NULL][0014][SP]they[SP]talk[SP]about?[1205][000F][SP]'Cause[SP]like,[SP]this\nisn't[SP]funny!",
     "nom_fr": "Homme",
-    "texte_fr": "Waouh, c'était quoi !? Une armée de types avec\ndes lances vient de passer en trombe ![1106][NL]Je savais pas que le Bataillon avait des gars comme ça ![1432][NULL][NULL][0014][1432][NULL][NULL][0014][1205][000F]"
+    "texte_fr": "Waouh, c'était quoi !? Une armée de types avec\ndes lances vient de passer en trombe ![1106][NL]Je savais pas que le Bataillon avait des gars comme ça ![1432][NULL][NULL][0014][1432][NULL][NULL][0014][000F][1205]"
   },
   {
     "id": 42,
@@ -642,7 +642,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "I-Is[SP]this[SP]some[SP]kind[SP]of[SP]joke?[SP]Why'd[SP]those\nterrorists[SP]blow[SP]up[SP]Smile[SP]Hirasaka!?[1205][000F][SP]Bombing\na[SP]place[SP]like[SP]that[SP]doesn't[SP]get[SP]them[SP]anything!",
     "nom_fr": "Jeune fille",
-    "texte_fr": "C'est une blague ? Pourquoi ces terroristes\nont fait sauter Smile Hirasaka !?[1205][000F] Cibler\nun tel endroit ne leur apporte rien ![NL]Urgh, à quoi pense le Cercle masqué !?\nPourquoi faire ça !?"
+    "texte_fr": "C'est une blague ? Pourquoi ces terroristes\nont fait sauter Smile Hirasaka !?[000F][1205] Cibler\nun tel endroit ne leur apporte rien ![NL]Urgh, à quoi pense le Cercle masqué !? Pourquoi faire ça !?"
   },
   {
     "id": 43,
@@ -657,7 +657,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Geez,[SP]what's[SP]the[SP]Masked[SP]Circle[SP]thinking!?[1205][000F]\nWhy[SP]would[SP]they[SP]do[SP]this!?",
     "nom_fr": "Homme",
-    "texte_fr": "Tout le monde dit que c'est la fin du monde ![1205][U+000A][1106][NL]Inondations, météores... Dès que cette Grande\nJe-Sais-Pas-Quoi arrivera...[1106][NL]Ce que je pige pas, c'est que ça va tous les tuer\nen bas, non ? Quel intérêt de prédire comment\nils vont mourir ?[000F]"
+    "texte_fr": "Tout le monde dit que c'est la fin du monde ![1205][U+000A][1106][NL]Inondations, météores... Dès que cette Grande\nJe-Sais-Pas-Quoi arrivera...[1106][NL]Ce que je pige pas, c'est que ça va tous les tuer\nen bas, non ? Quel intérêt de prédire comment ils vont mourir ?[000F]"
   },
   {
     "id": 44,
@@ -672,7 +672,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Huh?[SP]You[SP]haven't[SP]seen[SP]the[SP]composite[SP]sketches[SP]yet?[1205][000F]\nWell,[SP]one[SP]of[SP]them[SP]had[SP]hair[SP]like[SP]yours,[SP]and[SP]his\nface[SP]looked[SP]kinda[SP]like[SP]you[SP]too...",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Hein ? T'as pas vu les portraits-robots ?[1205][000F]\nY en a un qui a tes cheveux, et son\nvisage te ressemble...[NL]Son nez... Comme le tien... Et sa bouche...\nOuais, ça colle... Tu vois ?\nIl a l'air si maléfique."
+    "texte_fr": "Hein ? T'as pas vu les portraits-robots ?[000F][1205]\nY en a un qui a tes cheveux, et son\nvisage te ressemble...[NL]Son nez... Comme le tien... Et sa bouche... Ouais, ça colle... Tu vois ? Il a l'air si maléfique."
   },
   {
     "id": 45,
@@ -687,7 +687,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "His[SP]nose...[1205][000A][SP]was[SP]like[SP]yours...[1205][000F][SP]And[SP]his[SP]mouth...[1205][000A]\nYeah,[SP]that[SP]matches[SP]too...[1205][000F][SP]See?[SP]Doesn't[SP]he[SP]seem\ntotally[SP]evil?",
     "nom_fr": "Homme",
-    "texte_fr": "J'ai entendu dire que la Terre arrêtera de tourner\navec la Croix.[1205][U+000A] Un truc sur la gravité...\nÇa me dépasse.[1106][NL]À quel point ce serait grave si ça arrivait ?\nJ'en sais rien...[000A][1205][1205][000F][000A][1205][000F]"
+    "texte_fr": "J'ai entendu dire que la Terre arrêtera de tourner\navec la Croix.[1205][U+000A] Un truc sur la gravité...\nÇa me dépasse.[1106][NL]À quel point ce serait grave si ça arrivait ? J'en sais rien...[000A][1205][000F][1205][000A][000F][1205]"
   },
   {
     "id": 46,
@@ -717,7 +717,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Those[SP]soldiers[SP]a[SP]moment[SP]ago[SP]saw[SP]me![SP]But[SP]then,\nlike,[SP]some[SP]Masked[SP]Circle[SP]guys[SP]totally[SP]saved\nmy[SP]bacon.",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Ces soldats m'ont vue ! Mais ensuite,\ndes gars du Cercle masqué m'ont sauvée.[NL]Ils disaient : [NULL][NULL]Le Joker a ordonné de\nprotéger les civils ![NULL][NULL] Je me\nsuis peut-être trompée sur lui.[NL]C'est peut-être l'ange gardien de Sumaru."
+    "texte_fr": "Ces soldats m'ont vue ! Mais ensuite,\ndes gars du Cercle masqué m'ont sauvée.[NL]Ils disaient : [NULL][NULL]Le Joker a ordonné de\nprotéger les civils ![NULL][NULL] Je me suis peut-être trompée sur lui.[NL]C'est peut-être l'ange gardien de Sumaru."
   },
   {
     "id": 48,
@@ -762,7 +762,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "I[SP]almost[SP]got[SP]attacked[SP]again[SP]by[SP]some[SP]more[SP]Last\nBattalion[SP]thugs...[1205][000F][SP]And[SP]this[SP]time[SP]a[SP]couple[SP]of\nwomen[SP]saved[SP]me!",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Le Bataillon a failli m'attaquer de\nnouveau...[1205][000F] Et cette fois,\ndes femmes m'ont sauvée ![NL]Elles étaient si cool... Je dois me\nreprendre."
+    "texte_fr": "Le Bataillon a failli m'attaquer de\nnouveau...[000F][1205] Et cette fois,\ndes femmes m'ont sauvée ![NL]Elles étaient si cool... Je dois me reprendre."
   },
   {
     "id": 51,
@@ -777,7 +777,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "They[SP]were[SP]so[SP]cool...[1205][000A][SP]I[SP]gotta[SP]get[SP]my[SP]act\ntogether[SP]too.",
     "nom_fr": "Homme",
-    "texte_fr": "Un Taxi Maudit ? Y en a un à l'usine abandonnée ?\nQuels genres de passagers il espère\nprendre là-bas ?[1205][000A]"
+    "texte_fr": "Un Taxi Maudit ? Y en a un à l'usine abandonnée ?\nQuels genres de passagers il espère\nprendre là-bas ?[000A][1205]"
   },
   {
     "id": 52,
@@ -792,7 +792,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "Some[SP]Last[SP]Battalion[SP]guys[SP]with[SP]long[SP]spears[SP]went\ninto[SP]that[SP]temple[SP]a[SP]minute[SP]ago.[1205][000F][SP]They[SP]were\ncarrying[SP]something[SP]shiny,[SP]too...",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Des gars du Bataillon avec de longues\nlances sont entrés là-dedans.[1205][000F]\nIls portaient un objet brillant..."
+    "texte_fr": "Des gars du Bataillon avec de longues\nlances sont entrés là-dedans.[000F][1205]\nIls portaient un objet brillant..."
   },
   {
     "id": 53,
@@ -807,7 +807,7 @@
     "nom_orig": "Young[SP]girl",
     "texte_orig": "I-I[SP]just[SP]saw[SP]them[SP]pulling[SP]a[SP]woman[SP]out[SP]of[SP]the\ndetective[SP]agency![1205][000F][SP]Were[SP]they[SP]kidnapping[SP]her...?",
     "nom_fr": "Jeune fille",
-    "texte_fr": "Je les ai vus sortir une femme de l'agence\nde détectives ![1205][000F] Ils la kidnappaient... ?"
+    "texte_fr": "Je les ai vus sortir une femme de l'agence\nde détectives ![000F][1205] Ils la kidnappaient... ?"
   },
   {
     "id": 54,
@@ -852,7 +852,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]the[SP]lady[SP]at[SP]Shiraishi[SP]Ramen\nwas[SP]really[SP]a[SP]Russian[SP]spy.",
     "nom_fr": "Homme",
-    "texte_fr": "Il paraît que la dame de Shiraishi Ramen\nest une espionne russe.[NL]Si tu commandes des ramens au porc et à la\nbanane, elle te vend des armes !\nDrôle de monde, hein ?"
+    "texte_fr": "Il paraît que la dame de Shiraishi Ramen\nest une espionne russe.[NL]Si tu commandes des ramens au porc et à la\nbanane, elle te vend des armes ! Drôle de monde, hein ?"
   },
   {
     "id": 57,
@@ -867,7 +867,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "You[SP]can[SP]tell[SP]because[SP]she'll[SP]sell[SP]you[SP]real\nweapons[SP]if[SP]you[SP]order[SP]banana[SP]char[SP]siu[SP]ramen![1205][000F]\nFunny[SP]old[SP]world,[SP]huh?",
     "nom_fr": "Homme",
-    "texte_fr": "Il paraît qu'il y a un monstre Mégère à Commode\nà l'usine... Vraiment ?\n[1432][NULL][NULL][0014]Mégère à Commode[1432][NULL][NULL][0014] ?[1106][NL]C'est pas une commode avec des bras et\ndes jambes, si ? Pfff. Ces monstres ont de ces noms...[1205][000F]"
+    "texte_fr": "Il paraît qu'il y a un monstre Mégère à Commode\nà l'usine... Vraiment ?\n[1432][NULL][NULL][0014]Mégère à Commode[1432][NULL][NULL][0014] ?[1106][NL]C'est pas une commode avec des bras et des jambes, si ? Pfff. Ces monstres ont de ces noms...[000F][1205]"
   },
   {
     "id": 58,
@@ -882,7 +882,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]the[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High\nwasn't[SP]stronger[SP]than[SP]Eikichi[SP]at[SP]all.[1205][000F][SP]But[SP]then,\nwho[SP]is[SP]stronger[SP]than[SP]that[SP]kid?",
     "nom_fr": "Homme",
-    "texte_fr": "Le nouveau chef de Kakasu n'est pas plus\nfort qu'Eikichi.[1205][000F] Mais qui est plus fort\nque ce gamin ?[NL]Le Boss Calbute n'a pas perdu la main."
+    "texte_fr": "Le nouveau chef de Kakasu n'est pas plus\nfort qu'Eikichi.[000F][1205] Mais qui est plus fort\nque ce gamin ?[NL]Le Boss Calbute n'a pas perdu la main."
   },
   {
     "id": 59,
@@ -912,7 +912,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "You[SP]can[SP]buy[SP]real[SP]shooters[SP]and[SP]blades[SP]at[SP]this\nguy[SP]Tony's[SP]shop[SP]in[SP]Yumezaki?[1205][000F][SP]Damn...[SP]sounds\ndangerous,[SP]if[SP]you[SP]ask[SP]me.",
     "nom_fr": "Homme",
-    "texte_fr": "On peut acheter des armes à feu et des lames\nchez Tony à Yumezaki ?[1205][000F] Mince... ça craint.[NL]Je l'ai appris du gros Toro à Gatten Sushi.\nSi tu veux en savoir plus, va lui demander."
+    "texte_fr": "On peut acheter des armes à feu et des lames\nchez Tony à Yumezaki ?[000F][1205] Mince... ça craint.[NL]Je l'ai appris du gros Toro à Gatten Sushi.\nSi tu veux en savoir plus, va lui demander."
   },
   {
     "id": 61,
@@ -927,7 +927,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]just[SP]heard[SP]it[SP]from[SP]this[SP]porker[SP]called[SP]Toro\nat[SP]Gatten[SP]Sushi.[1205][000F][SP]If[SP]you[SP]wanna[SP]know[SP]more,[SP]go\nask[SP]him.",
     "nom_fr": "Homme",
-    "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce.[1106][NL]Son choix est bon, mais son prix de rachat est naze.[1205][000F]"
+    "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce.[1106][NL]Son choix est bon, mais son prix de rachat est naze.[000F][1205]"
   },
   {
     "id": 62,
@@ -942,7 +942,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]guess[SP]people[SP]are[SP]pretty[SP]worked[SP]up[SP]over[SP]this\nnew[SP]singer.[1205][000F][SP]Me,[SP]I[SP]prefer[SP]enka.",
     "nom_fr": "Homme",
-    "texte_fr": "Les gens sont à fond sur cette nouvelle\nchanteuse.[1205][000F] Moi, je préfère l'enka.[NL]Il n'y a pas un événement live en ce moment à\nGiga Macho ? Quoi, tu vas pas y aller ?"
+    "texte_fr": "Les gens sont à fond sur cette nouvelle\nchanteuse.[000F][1205] Moi, je préfère l'enka.[NL]Il n'y a pas un événement live en ce moment à\nGiga Macho ? Quoi, tu vas pas y aller ?"
   },
   {
     "id": 63,
@@ -957,7 +957,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Aren't[SP]they[SP]doing[SP]some[SP]live[SP]event[SP]right[SP]now[SP]at\nthat[SP]Giga[SP]Macho[SP]place?[1205][000F][SP]What,[SP]you're[SP]not\ngonna[SP]go[SP]check[SP]it[SP]out?",
     "nom_fr": "Homme",
-    "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce.[1106][NL]La qualité et le prix de ses trucs sont dans la moyenne.[1205][000F]"
+    "texte_fr": "On dirait que ce poseur de Tony vend\nde vraies armes en douce.[1106][NL]La qualité et le prix de ses trucs sont dans la moyenne.[000F][1205]"
   },
   {
     "id": 64,
@@ -972,7 +972,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "You[SP]one[SP]of[SP]them[SP]guys[SP]that[SP]missed[SP]out[SP]on[SP]the\nconcert?[SP]I[SP]heard[SP]there[SP]weren't[SP]enough[SP]tickets.[1205][000F]\nMan[SP]like[SP]you[SP]didn't[SP]need[SP]to[SP]be[SP]there[SP]anyway.",
     "nom_fr": "Homme",
-    "texte_fr": "T'es un de ceux qui ont raté le concert ? J'ai\nentendu qu'il manquait de billets.[1205][000F] Un gars\ncomme toi n'avait rien à y faire de toute façon."
+    "texte_fr": "T'es un de ceux qui ont raté le concert ? J'ai\nentendu qu'il manquait de billets.[000F][1205] Un gars\ncomme toi n'avait rien à y faire de toute façon."
   },
   {
     "id": 65,
@@ -1047,7 +1047,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Huh?[1205][000F][SP]D-Did[SP]you[SP]just[SP]get[SP]here?[SP]Coulda[SP]sworn[SP]I\njust[SP]saw[SP]you[SP]go[SP]that[SP]way...[1205][000F][SP]H-Hahaha,[SP]I[SP]must\nbe[SP]seein'[SP]things...",
     "nom_fr": "Homme",
-    "texte_fr": "Hein ?[1205][000F] T-Tu viens d'arriver ? J'aurais juré\nt'avoir vu passer par là...[1205][000F] H-Hahaha, je\ndois halluciner..."
+    "texte_fr": "Hein ?[000F][1205] T-Tu viens d'arriver ? J'aurais juré\nt'avoir vu passer par là...[000F][1205] H-Hahaha, je\ndois halluciner..."
   },
   {
     "id": 70,
@@ -1137,7 +1137,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Well,[SP]I'll[SP]be[SP]damned![1205][000F][SP]That[SP]Xibalba[SP]thing[SP]was\nthis[SP]big!?[1205][000A][SP]Not[SP]too[SP]many[SP]people[SP]can[SP]say[SP]they\nlive[SP]in[SP]a[SP]city[SP]in[SP]the[SP]sky.",
     "nom_fr": "Homme",
-    "texte_fr": "Nom d'un chien ![1205][000F] Ce Xibalba était aussi grand !?[1205][000A]\nPeu de gens peuvent dire qu'ils vivent\ndans une ville dans le ciel.[NL]Mais je ne crois pas à cette histoire de fin\ndu monde. Tu peux rien y faire, petit !?"
+    "texte_fr": "Nom d'un chien ![000F][1205] Ce Xibalba était aussi grand !?[000A][1205]\nPeu de gens peuvent dire qu'ils vivent\ndans une ville dans le ciel.[NL]Mais je ne crois pas à cette histoire de fin du monde. Tu peux rien y faire, petit !?"
   },
   {
     "id": 76,
@@ -1167,7 +1167,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Everyone[SP]I[SP]know's[SP]talkin'[SP]about[SP]how[SP]the[SP]world's\ngonna[SP]end![1205][000A]",
     "nom_fr": "Homme",
-    "texte_fr": "Tout le monde dit que c'est la fin du monde ![1205][000A][NL]Inondations, météores... Dès que cette Grande\nJe-Sais-Pas-Quoi arrivera...[NL]Ce que je pige pas, c'est que ça va tous les tuer\nen bas, non ? Quel intérêt de prédire comment\nils vont mourir ?"
+    "texte_fr": "Tout le monde dit que c'est la fin du monde ![000A][1205][NL]Inondations, météores... Dès que cette Grande\nJe-Sais-Pas-Quoi arrivera...[NL]Ce que je pige pas, c'est que ça va tous les tuer\nen bas, non ? Quel intérêt de prédire comment ils vont mourir ?"
   },
   {
     "id": 78,
@@ -1212,7 +1212,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]when[SP]the[SP]Grand[SP]Cross[SP]is[SP]done,\nthe[SP]gravity[SP]of[SP]the[SP]stars[SP]is[SP]gonna[SP]pulverize[SP]the\nEarth.[1205][000F][SP]Is[SP]that[SP]how[SP]the[SP]world's[SP]gonna[SP]end?",
     "nom_fr": "Homme",
-    "texte_fr": "Quand la Croix Cosmique sera finie, la gravité des\nétoiles va pulvériser la Terre.[1205][000F]\nC'est ça la fin du monde ?"
+    "texte_fr": "Quand la Croix Cosmique sera finie, la gravité des\nétoiles va pulvériser la Terre.[000F][1205]\nC'est ça la fin du monde ?"
   },
   {
     "id": 81,
@@ -1227,7 +1227,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]I[SP]heard[SP]the[SP]world[SP]will[SP]stop[SP]spinning[SP]if\nthe[SP]Grand[SP]Cross[SP]happens.[1205][000A][SP]Somethin'[SP]about[SP]the\nbalance[SP]of[SP]gravity[SP]and[SP]stuff...[SP]Over[SP]my[SP]head.",
     "nom_fr": "Homme",
-    "texte_fr": "J'ai entendu dire que la Terre arrêtera de tourner\navec la Croix.[1205][000A] Un truc sur la gravité...\nÇa me dépasse.[NL]À quel point ce serait grave si ça arrivait ?\nJ'en sais rien..."
+    "texte_fr": "J'ai entendu dire que la Terre arrêtera de tourner\navec la Croix.[000A][1205] Un truc sur la gravité...\nÇa me dépasse.[NL]À quel point ce serait grave si ça arrivait ? J'en sais rien..."
   },
   {
     "id": 82,
@@ -1272,7 +1272,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]kid.[SP]Ya[SP]know[SP]that[SP]club[SP]Zodiac?[SP]People[SP]say\nthe[SP]second[SP]floor's[SP]a[SP]huge[SP]dungeon,[SP]packed[SP]with\ngreat[SP]stuff.",
     "nom_fr": "Homme",
-    "texte_fr": "Hé, petit. Tu connais le Zodiac ? On dit que\nle 2e étage est un immense donjon rempli\nde super trucs.[NL]Pourquoi tu vas pas fouiner ? Montre tes talents\net je parie que ta copine va te sauter dessus.\nHahahaha !"
+    "texte_fr": "Hé, petit. Tu connais le Zodiac ? On dit que\nle 2e étage est un immense donjon rempli\nde super trucs.[NL]Pourquoi tu vas pas fouiner ? Montre tes talents et je parie que ta copine va te sauter dessus. Hahahaha !"
   },
   {
     "id": 85,
@@ -1302,7 +1302,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]there's[SP]a[SP]ghost[SP]girl[SP]called\nHanako[SP]at[SP]Sevens.[1205][000F][SP]First[SP]a[SP]curse,[SP]and[SP]now[SP]a\nghost?[SP]That[SP]school,[SP]I[SP]tell[SP]ya.",
     "nom_fr": "Homme",
-    "texte_fr": "J'ai ouï-dire qu'un fantôme nommé Hanako\nest à Seven.[1205][000F] D'abord une malédiction, puis un\nfantôme ? Cette école, sérieux."
+    "texte_fr": "J'ai ouï-dire qu'un fantôme nommé Hanako\nest à Seven.[000F][1205] D'abord une malédiction, puis un\nfantôme ? Cette école, sérieux."
   },
   {
     "id": 87,
@@ -1422,7 +1422,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]guess[SP]kids[SP]your[SP]age[SP]wouldn't[SP]know[SP]about\nKuchisake-onna,[SP]huh?",
     "nom_fr": "Homme",
-    "texte_fr": "Les gosses de ton âge connaissent pas\nKuchisake-onna, hein ?[NL]Elle vient te voir la bouche couverte et te\ndemande si tu la trouves jolie...[NL]La rumeur dit que Kuchisake-onna est\napparue au Mt Iwato.[NL]Faut avouer que ce genre d'histoires me donnait\nla chair de poule quand j'étais gosse."
+    "texte_fr": "Les gosses de ton âge connaissent pas\nKuchisake-onna, hein ?[NL]Elle vient te voir la bouche couverte et te\ndemande si tu la trouves jolie...[NL]La rumeur dit que Kuchisake-onna est apparue au Mt Iwato.[NL]Faut avouer que ce genre d'histoires me donnait la chair de poule quand j'étais gosse."
   },
   {
     "id": 95,
@@ -1557,7 +1557,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "From[SP]what[SP]I[SP]heard,[SP]there's[SP]this[SP]Dresser[SP]Hag\nmonster[SP]at[SP]the[SP]abandoned[SP]factory...[SP]Really,\nnow?[SP][1432][NULL][NULL][0014]Dresser[SP]Hag[1432][NULL][NULL][0014]?",
     "nom_fr": "Homme",
-    "texte_fr": "Il paraît qu'il y a un monstre Mégère à Commode\nà l'usine... Vraiment ?\n[1432][NULL][NULL][0014]Mégère à Commode[1432][NULL][NULL][0014] ?[NL]C'est pas une commode avec des bras et\ndes jambes, si ? Pfff. Ces monstres ont de ces noms..."
+    "texte_fr": "Il paraît qu'il y a un monstre Mégère à Commode\nà l'usine... Vraiment ?\n[1432][NULL][NULL][0014]Mégère à Commode[1432][NULL][NULL][0014] ?[NL]C'est pas une commode avec des bras et des jambes, si ? Pfff. Ces monstres ont de ces noms..."
   },
   {
     "id": 104,
@@ -1572,7 +1572,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "It's[SP]not[SP]like[SP]it's[SP]a[SP]dresser[SP]with[SP]arms[SP]and\nlegs,[SP]is[SP]it?[SP]Sheesh.[SP]All[SP]these[SP]monsters[SP]got\nthe[SP]worst[SP]names,[SP]I[SP]tell[SP]ya.",
     "nom_fr": "Homme",
-    "texte_fr": "Hé, t'as entendu ? Le boss de Time Castle a\ndistribué son arme légendaire à une fille\naux cheveux courts.[1106][NL]Hahaha, plutôt généreux, non ? C'est ça\nun vrai homme."
+    "texte_fr": "Hé, t'as entendu ? Le boss de Time Castle a\ndistribué son arme légendaire à une fille\naux cheveux courts.[1106][NL]Hahaha, plutôt généreux, non ? C'est ça un vrai homme."
   },
   {
     "id": 105,
@@ -1602,7 +1602,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "It's[SP]a[SP]dangerous[SP]world[SP]we[SP]live[SP]in,[SP]I[SP]tell[SP]ya.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] C'était juste une rumeur ?[1205][U+000F] On\nparle d'une statue vivante à Seven...\n[1205][U+000F]Aime le pécheur, hais le péché ![1106][NL]Avoir une telle statue à l'école doit\ngêner sérieusement l'éducation de ces\nélèves.[1205][U+000F][1106][NL]En tant qu'étudiant, j'apporterai le châtiment\ndivin à cette statue ! Éventuellement..."
+    "texte_fr": "Hyaaaah ![1205][U+000F] C'était juste une rumeur ?[1205][U+000F] On\nparle d'une statue vivante à Seven...\n[1205][U+000F]Aime le pécheur, hais le péché ![1106][NL]Avoir une telle statue à l'école doit gêner sérieusement l'éducation de ces élèves.[1205][U+000F][1106][NL]En tant qu'étudiant, j'apporterai le châtiment divin à cette statue ! Éventuellement..."
   },
   {
     "id": 107,
@@ -1632,7 +1632,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "It's[SP]a[SP]dangerous[SP]world[SP]we[SP]live[SP]in,[SP]I[SP]tell[SP]ya.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! J'arrive pas à croire que j'ai\ngobé une rumeur infondée ![1205][U+000F] Quoi ? Tu\nveux en savoir plus sur ma folie ?[1106][NL]J'ai entendu une rumeur disant qu'il y avait\nde vraies armures à Anima Mundi à Yumezaki.[1106][NL]Mais en fait, il n'y avait rien de tel !\nLes employés se sont même moqués de moi ![1106][NL]Mais mes infos étaient peut-être fausses...[1205][U+000F]\nCe grand costaud sait peut-être\nquelque chose.[1205][U+000F] Il s'appelle Toro,\net adore le thon gras."
+    "texte_fr": "Hyaaaah ! J'arrive pas à croire que j'ai\ngobé une rumeur infondée ![1205][U+000F] Quoi ? Tu\nveux en savoir plus sur ma folie ?[1106][NL]J'ai entendu une rumeur disant qu'il y avait de vraies armures à Anima Mundi à Yumezaki.[1106][NL]Mais en fait, il n'y avait rien de tel ! Les employés se sont même moqués de moi ![1106][NL]Mais mes infos étaient peut-être fausses...[1205][U+000F] Ce grand costaud sait peut-être quelque chose.[1205][U+000F] Il s'appelle Toro, et adore le thon gras."
   },
   {
     "id": 109,
@@ -1662,7 +1662,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "It's[SP]a[SP]dangerous[SP]world[SP]we[SP]live[SP]in,[SP]I[SP]tell[SP]ya.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] J'aime Ginji Sasaki moi aussi ![1205][U+000F]\nJe ne les écoute pas vraiment, mais j'ai acheté\ntout ce qu'il a produit ! Même sa compil ![1106][NL]Mais je hais qu'il entraîne des filles\ninnocentes devant étudier dans cette\nindustrie tape-à-l'œil ![1106][NL]Bien que je ne déteste pas vraiment sa musique.[1205][U+000F]\nEst-ce que je me contredis ?[1205][U+000F] Oui, n'est-ce pas... ?"
+    "texte_fr": "Hyaaaah ![1205][U+000F] J'aime Ginji Sasaki moi aussi ![1205][U+000F]\nJe ne les écoute pas vraiment, mais j'ai acheté\ntout ce qu'il a produit ! Même sa compil ![1106][NL]Mais je hais qu'il entraîne des filles innocentes devant étudier dans cette industrie tape-à-l'œil ![1106][NL]Bien que je ne déteste pas vraiment sa musique.[1205][U+000F] Est-ce que je me contredis ?[1205][U+000F] Oui, n'est-ce pas... ?"
   },
   {
     "id": 111,
@@ -1692,7 +1692,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]hear[SP]his[SP]selection's[SP]good,[SP]but[SP]his[SP]resale\nprice[SP]ain't[SP]so[SP]hot.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] On parle de terrorisme par-ci\npar-là, mais on devrait connaître leurs\nrevendications maintenant.[1106][NL]Pourtant, aucune n'a été faite. C'est peut-être\nl'œuvre de quelqu'un qui s'amuse...[1205][U+000F]\nMa colère ne s'apaisera jamais !"
+    "texte_fr": "Hyaaaah ![1205][U+000F] On parle de terrorisme par-ci\npar-là, mais on devrait connaître leurs\nrevendications maintenant.[1106][NL]Pourtant, aucune n'a été faite. C'est peut-être l'œuvre de quelqu'un qui s'amuse...[1205][U+000F] Ma colère ne s'apaisera jamais !"
   },
   {
     "id": 113,
@@ -1722,7 +1722,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]hear[SP]his[SP]stuff's[SP]cheap,[SP]but[SP]not[SP]what[SP]you'd\ncall[SP]quality.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Hmm, si mes souvenirs du lycée\nsont exacts, cette dame d'il y a un\ninstant était de Seven...[1106][NL]Il s'est passé un truc pour qu'elle se rue\nainsi à l'agence de détectives ?[1205][U+000F]\n*gasp* Non ! Quelle pensée affreuse ![1106][NL]C'est terriblement vulgaire de s'immiscer dans\nla vie privée des autres.[1205][U+000F] Je dois me faire une\nraison ![1205][U+000F] Je vais copier le code civil !"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Hmm, si mes souvenirs du lycée\nsont exacts, cette dame d'il y a un\ninstant était de Seven...[1106][NL]Il s'est passé un truc pour qu'elle se rue ainsi à l'agence de détectives ?[1205][U+000F] *gasp* Non ! Quelle pensée affreuse ![1106][NL]C'est terriblement vulgaire de s'immiscer dans la vie privée des autres.[1205][U+000F] Je dois me faire une raison ![1205][U+000F] Je vais copier le code civil !"
   },
   {
     "id": 115,
@@ -1752,7 +1752,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "I[SP]hear[SP]the[SP]quality[SP]and[SP]price[SP]of[SP]his[SP]stuff\nis[SP]pretty[SP]average.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] L'invasion du Bataillon est un\ngrave problème, mais l'In Lak'ech est\nencore plus sérieux ![1106][NL]S'il dit vrai, le monde fera face à\nune destruction totale bientôt.[1106][NL]Si ça arrive, que deviendra mon rêve !?[1205][U+000F]\nComment intégrer la meilleure université\ndu pays si le pays est détruit !?"
+    "texte_fr": "Hyaaaah ![1205][U+000F] L'invasion du Bataillon est un\ngrave problème, mais l'In Lak'ech est\nencore plus sérieux ![1106][NL]S'il dit vrai, le monde fera face à une destruction totale bientôt.[1106][NL]Si ça arrive, que deviendra mon rêve !?[1205][U+000F] Comment intégrer la meilleure université du pays si le pays est détruit !?"
   },
   {
     "id": 117,
@@ -1797,7 +1797,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][000F][SP]Their[SP]selection[SP]sucks,\nbut[SP]their[SP]resale[SP]prices[SP]are[SP]high.",
     "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][000F]\nLeur choix craint, mais leurs prix de rachat sont élevés."
+    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[000F][1205]\nLeur choix craint, mais leurs prix de rachat sont élevés."
   },
   {
     "id": 120,
@@ -1812,7 +1812,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][000F][SP]They're[SP]cheap,[SP]but\nthe[SP]quality[SP]sucks.",
     "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][000F]\nC'est pas cher, mais la qualité est nulle."
+    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[000F][1205]\nC'est pas cher, mais la qualité est nulle."
   },
   {
     "id": 121,
@@ -1827,7 +1827,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][000F][SP]The[SP]quality's[SP]good,\nbut[SP]the[SP]prices[SP]are[SP]high.",
     "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][000F]\nLa qualité est là, mais les prix sont élevés."
+    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[000F][1205]\nLa qualité est là, mais les prix sont élevés."
   },
   {
     "id": 122,
@@ -1842,7 +1842,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][000F][SP]Their[SP]selection's\ngood,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]the[SP]pits.",
     "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][000F]\nLe choix est bon, mais les prix de rachat sont à chier."
+    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[000F][1205]\nLe choix est bon, mais les prix de rachat sont à chier."
   },
   {
     "id": 123,
@@ -1857,7 +1857,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Looks[SP]like[SP]that[SP]Clair[SP]de[SP]Lune[SP]place[SP]in[SP]Aoba\nsells[SP]real[SP]weapons.[1205][000F][SP]Their[SP]quality[SP]and\nprice[SP]are[SP]basically[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[1205][000F]\nLeur qualité et leurs prix sont dans la moyenne."
+    "texte_fr": "Clair de Lune à Aoba vend de vraies armes.[000F][1205]\nLeur qualité et leurs prix sont dans la moyenne."
   },
   {
     "id": 124,
@@ -1872,7 +1872,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][000F][SP]I[SP]hear[SP]their[SP]quality[SP]and[SP]price\nis[SP]just[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][000F]\nIl paraît que la qualité et les prix sont moyens."
+    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[000F][1205]\nIl paraît que la qualité et les prix sont moyens."
   },
   {
     "id": 125,
@@ -1887,7 +1887,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][000F][SP]I[SP]hear[SP]they're[SP]cheap,[SP]but[SP]not\nexactly[SP]quality[SP]stuff.",
     "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][000F]\nC'est pas cher, mais c'est pas de la top qualité."
+    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[000F][1205]\nC'est pas cher, mais c'est pas de la top qualité."
   },
   {
     "id": 126,
@@ -1902,7 +1902,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][000F][SP]I[SP]hear[SP]his[SP]selection's[SP]good,\nbut[SP]his[SP]resale[SP]value[SP]sucks.",
     "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][000F]\nIl a du choix, mais les prix de rachat sont nuls."
+    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[000F][1205]\nIl a du choix, mais les prix de rachat sont nuls."
   },
   {
     "id": 127,
@@ -1917,7 +1917,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][000F][SP]I[SP]hear[SP]his[SP]selection[SP]sucks,\nbut[SP]his[SP]resale[SP]prices[SP]are[SP]great.",
     "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][000F]\nLe choix craint, mais les prix de rachat sont super."
+    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[000F][1205]\nLe choix craint, mais les prix de rachat sont super."
   },
   {
     "id": 128,
@@ -1932,7 +1932,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "So[SP]the[SP]old[SP]man[SP]at[SP]Jolly[SP]Roger[SP]even[SP]sells\nweapons...[1205][000F][SP]I[SP]hear[SP]their[SP]quality's[SP]good,\nbut[SP]the[SP]prices[SP]are[SP]high.",
     "nom_fr": "Homme",
-    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[1205][000F]\nLa qualité est bonne, mais les prix sont élevés."
+    "texte_fr": "Même le vieux de Jolly Roger vend des armes...[000F][1205]\nLa qualité est bonne, mais les prix sont élevés."
   },
   {
     "id": 129,
@@ -1947,7 +1947,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "It[SP]takes[SP]balls[SP]to[SP]sell[SP]armor[SP]at[SP]a[SP]fancy\nboutique[SP]like[SP]Rosa[SP]Candida[SP]at[SP]Rengedai.[1205][000F]\nTheir[SP]quality[SP]and[SP]price[SP]is[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[1205][000F] Qualité et prix moyens."
+    "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[000F][1205] Qualité et prix moyens."
   },
   {
     "id": 130,
@@ -1962,7 +1962,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "It[SP]takes[SP]balls[SP]to[SP]sell[SP]armor[SP]at[SP]a[SP]fancy\nboutique[SP]like[SP]Rosa[SP]Candida[SP]at[SP]Rengedai.[1205][000F]\nIt's[SP]cheap,[SP]but[SP]low[SP]quality.",
     "nom_fr": "Homme",
-    "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[1205][000F] Pas cher, mais qualité nulle."
+    "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[000F][1205] Pas cher, mais qualité nulle."
   },
   {
     "id": 131,
@@ -1977,7 +1977,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "It[SP]takes[SP]balls[SP]to[SP]sell[SP]armor[SP]at[SP]a[SP]fancy\nboutique[SP]like[SP]Rosa[SP]Candida[SP]at[SP]Rengedai.[1205][000F]\nIt's[SP]good[SP]quality,[SP]but[SP]expensive.",
     "nom_fr": "Homme",
-    "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[1205][000F] Bonne qualité, mais cher."
+    "texte_fr": "Faut oser vendre des armures dans une boutique chic\ncomme Rosa Candida.[000F][1205] Bonne qualité, mais cher."
   },
   {
     "id": 132,
@@ -2052,7 +2052,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][000F][SP]I[SP]hear[SP]their[SP]selection's[SP]the\npits,[SP]but[SP]they[SP]have[SP]great[SP]resale[SP]prices.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][000F]\nLe choix craint, mais les prix de rachat sont excellents."
+    "texte_fr": "Rosa Candida à Aoba vend des armures ?[000F][1205]\nLe choix craint, mais les prix de rachat sont excellents."
   },
   {
     "id": 137,
@@ -2067,7 +2067,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][000F][SP]I[SP]hear[SP]their[SP]quality[SP]and\nprices[SP]are[SP]just[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][000F]\nLa qualité et les prix sont très moyens."
+    "texte_fr": "Rosa Candida à Aoba vend des armures ?[000F][1205]\nLa qualité et les prix sont très moyens."
   },
   {
     "id": 138,
@@ -2082,7 +2082,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][000F][SP]I[SP]hear[SP]their[SP]stuff[SP]is[SP]top-\nnotch,[SP]but[SP]it's[SP]expensive.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][000F]\nC'est du matos top niveau, mais c'est cher."
+    "texte_fr": "Rosa Candida à Aoba vend des armures ?[000F][1205]\nC'est du matos top niveau, mais c'est cher."
   },
   {
     "id": 139,
@@ -2097,7 +2097,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][000F][SP]I[SP]hear[SP]their[SP]prices[SP]are\nlow,[SP]but[SP]so's[SP]the[SP]quality.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][000F]\nC'est pas cher, mais la qualité suit."
+    "texte_fr": "Rosa Candida à Aoba vend des armures ?[000F][1205]\nC'est pas cher, mais la qualité suit."
   },
   {
     "id": 140,
@@ -2112,7 +2112,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]did[SP]you[SP]know[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells\nreal[SP]armor?[1205][000F][SP]I[SP]hear[SP]their[SP]selection's[SP]good,\nbut[SP]their[SP]resale[SP]value[SP]is[SP]awful.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida à Aoba vend des armures ?[1205][000F]\nBon choix, mais le prix de rachat est affreux."
+    "texte_fr": "Rosa Candida à Aoba vend des armures ?[000F][1205]\nBon choix, mais le prix de rachat est affreux."
   },
   {
     "id": 141,
@@ -2127,7 +2127,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][000F][SP]I[SP]hear[SP]their[SP]selection\nis[SP]great,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]low.",
     "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures ?[1205][000F]\nLe choix est super, mais le prix de rachat est bas."
+    "texte_fr": "London Clothier fait même des armures ?[000F][1205]\nLe choix est super, mais le prix de rachat est bas."
   },
   {
     "id": 142,
@@ -2142,7 +2142,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][000F][SP]I[SP]hear[SP]their[SP]stuff\nis[SP]cheap,[SP]but[SP]really[SP]low[SP]quality.",
     "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures ?[1205][000F]\nC'est pas cher, mais de mauvaise qualité."
+    "texte_fr": "London Clothier fait même des armures ?[000F][1205]\nC'est pas cher, mais de mauvaise qualité."
   },
   {
     "id": 143,
@@ -2157,7 +2157,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][000F][SP]I[SP]hear[SP]their[SP]quality's\ngreat,[SP]if[SP]you[SP]can[SP]afford[SP]it.",
     "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures ?[1205][000F]\nLa qualité est top, si tu peux te le permettre."
+    "texte_fr": "London Clothier fait même des armures ?[000F][1205]\nLa qualité est top, si tu peux te le permettre."
   },
   {
     "id": 144,
@@ -2172,7 +2172,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][000F][SP]I[SP]hear[SP]their[SP]quality\nand[SP]prices[SP]are[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures ?[1205][000F]\nLa qualité et les prix sont moyens."
+    "texte_fr": "London Clothier fait même des armures ?[000F][1205]\nLa qualité et les prix sont moyens."
   },
   {
     "id": 145,
@@ -2187,7 +2187,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Whoa,[SP]so[SP]London[SP]Clothier[SP]makes[SP]anything[SP]you\ncan[SP]wear,[SP]even[SP]armor?[1205][000F][SP]I[SP]hear[SP]their[SP]selection\nis[SP]terrible,[SP]but[SP]the[SP]resale[SP]value[SP]is[SP]great.",
     "nom_fr": "Homme",
-    "texte_fr": "London Clothier fait même des armures ?[1205][000F]\nLe choix est nul, mais le prix de rachat est excellent."
+    "texte_fr": "London Clothier fait même des armures ?[000F][1205]\nLe choix est nul, mais le prix de rachat est excellent."
   },
   {
     "id": 146,
@@ -2382,7 +2382,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "What[SP]a[SP]load[SP]of[SP]it.[1205][000F][SP]Then[SP]again,[SP]lately[SP]it[SP]seems\nlike[SP]anything[SP]goes...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leurs marchandises\nsont bonnes, mais chères.[1205][000F]"
+    "texte_fr": "Rosa Candida à Aoba vend des armures. Ces sœurs ne\nsont pas des marchandes ordinaires... Leurs marchandises\nsont bonnes, mais chères.[000F][1205]"
   },
   {
     "id": 159,
@@ -2427,7 +2427,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hey,[SP]did[SP]ya[SP]hear?[SP]The[SP]owner[SP]of[SP]Time[SP]Castle[SP]gave\nthat[SP]legendary[SP]weapon[SP]to[SP]some[SP]girl[SP]with[SP]short\nhair.",
     "nom_fr": "Homme",
-    "texte_fr": "Hé, t'as entendu ? Le boss de Time Castle a\ndistribué son arme légendaire à une fille\naux cheveux courts.[NL]Hahaha, plutôt généreux, non ? C'est ça\nun vrai homme."
+    "texte_fr": "Hé, t'as entendu ? Le boss de Time Castle a\ndistribué son arme légendaire à une fille\naux cheveux courts.[NL]Hahaha, plutôt généreux, non ? C'est ça un vrai homme."
   },
   {
     "id": 162,
@@ -2442,7 +2442,7 @@
     "nom_orig": "Blue-collar[SP]man",
     "texte_orig": "Hahaha,[SP]pretty[SP]generous[SP]of[SP]him,[SP]huh?[SP]Now[SP]there's\na[SP]man[SP]for[SP]you.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[1106][NL]Leurs prix sont bas, mais leurs biens sont\nde mauvaise qualité."
+    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[1106][NL]Leurs prix sont bas, mais leurs biens sont de mauvaise qualité."
   },
   {
     "id": 163,
@@ -2457,7 +2457,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaaah![SP]I'm[SP]not[SP]a[SP]Cuss[SP]High[SP]student[SP]anymore.\nI[SP]used[SP]to[SP]be[SP]one,[SP]but[SP]no[SP]longer.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaaah ! Je ne suis plus à Kakasu.\nJ'y étais, mais plus maintenant.[NL]Maintenant, j'étudie dur pour intégrer\nla meilleure université du pays ![NL]Cependant ! L'afflux de femmes ici est troublant !\nMon école est populaire, mais ça me distrait !"
+    "texte_fr": "Hyaaaaah ! Je ne suis plus à Kakasu.\nJ'y étais, mais plus maintenant.[NL]Maintenant, j'étudie dur pour intégrer\nla meilleure université du pays ![NL]Cependant ! L'afflux de femmes ici est troublant ! Mon école est populaire, mais ça me distrait !"
   },
   {
     "id": 164,
@@ -2487,7 +2487,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "However![SP]The[SP]recent[SP]influx[SP]of[SP]women[SP]into[SP]this\ncity[SP]is[SP]troubling![SP]While[SP]I'm[SP]happy[SP]my[SP]alma[SP]mater\nis[SP]gaining[SP]popularity,[SP]they're[SP]distracting!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[1106][NL]Leur sélection est pauvre, mais les prix\nde rachat qu'ils offrent sont généreux."
+    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[1106][NL]Leur sélection est pauvre, mais les prix de rachat qu'ils offrent sont généreux."
   },
   {
     "id": 166,
@@ -2502,7 +2502,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Was[SP]it[SP]only[SP]a[SP]groundless[SP]rumor?[1205][000F][SP]I[SP]hear\ntell[SP]of[SP]a[SP]walking[SP]statue[SP]at[SP]Sevens,[SP]my[SP]alma\nmater's[SP]rival...[1205][000F][SP]Hate[SP]the[SP]sin,[SP]love[SP]the[SP]sinner!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] C'était juste une rumeur ?[1205][000F] On\nparle d'une statue vivante à Seven...\n[1205][000F]Aime le pécheur, hais le péché ![NL]Avoir une telle statue à l'école doit\ngêner sérieusement l'éducation de ces\nélèves.[NL]En tant qu'étudiant, j'apporterai le châtiment\ndivin à cette statue ! Éventuellement..."
+    "texte_fr": "Hyaaaah ![000F][1205] C'était juste une rumeur ?[000F][1205] On\nparle d'une statue vivante à Seven...\n[000F][1205]Aime le pécheur, hais le péché ![NL]Avoir une telle statue à l'école doit gêner sérieusement l'éducation de ces élèves.[NL]En tant qu'étudiant, j'apporterai le châtiment divin à cette statue ! Éventuellement..."
   },
   {
     "id": 167,
@@ -2547,7 +2547,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "H-Hyaaaah...![1205][000F][SP]My[SP]vision[SP]is[SP]blurry[SP]with[SP]tears...\nThe[SP]students[SP]at[SP]my[SP]alma[SP]mater[SP]are[SP]incredible!",
     "nom_fr": "Étudiant",
-    "texte_fr": "H-Hyaaaah... ![1205][000F] J'ai les larmes aux yeux...\nLes élèves de mon école sont incroyables ![NL]Vous êtes de brillants exemples !\nJ'ai longtemps attendu une telle chose ![NL]Le festival montre les fruits de l'éducation\net des traditions scolaires ![NL]Faire un bal masqué comme ça prouve\nvotre esprit international ![NL]C'est dans la nature de la jeunesse d'être\nimprudent au nom de la liberté ![NL]Les gouttes d'eau usent la pierre ! Faites de\nvotre mieux pour votre avenir, et des\nlendemains radieux vous attendent !"
+    "texte_fr": "H-Hyaaaah... ![000F][1205] J'ai les larmes aux yeux...\nLes élèves de mon école sont incroyables ![NL]Vous êtes de brillants exemples !\nJ'ai longtemps attendu une telle chose ![NL]Le festival montre les fruits de l'éducation et des traditions scolaires ![NL]Faire un bal masqué comme ça prouve votre esprit international ![NL]C'est dans la nature de la jeunesse d'être imprudent au nom de la liberté ![NL]Les gouttes d'eau usent la pierre ! Faites de votre mieux pour votre avenir, et des lendemains radieux vous attendent !"
   },
   {
     "id": 170,
@@ -2562,7 +2562,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "You[SP]are[SP]all[SP]shining[SP]examples![1205][000F][SP]I[SP]have[SP]long\nawaited[SP]such[SP]a[SP]sight!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent ![1106][NL]...Cependant, il ne faut pas négliger le monde réel.\nJ'entends qu'on peut gagner gros à la\nmachine #1...[1205][U+000F] Ça ne ferait pas de mal d'essayer.[000F]"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent ![1106][NL]...Cependant, il ne faut pas négliger le monde réel. J'entends qu'on peut gagner gros à la machine #1...[1205][U+000F] Ça ne ferait pas de mal d'essayer.[000F]"
   },
   {
     "id": 171,
@@ -2577,7 +2577,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "A[SP]school[SP]festival[SP]is[SP]an[SP]important[SP]event[SP]that\nshows[SP]the[SP]fruits[SP]of[SP]daily[SP]education[SP]and[SP]school\ntraditions![1205][000F]",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent ![1106][NL]Mais le blackjack est une exception. Je n'aime pas ça,\npas vraiment, mais il paraît qu'on peut y gagner\ngros. Mes études ne sont pas gratuites ![000F]"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent ![1106][NL]Mais le blackjack est une exception. Je n'aime pas ça, pas vraiment, mais il paraît qu'on peut y gagner gros. Mes études ne sont pas gratuites ![000F]"
   },
   {
     "id": 172,
@@ -2622,7 +2622,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Even[SP]drops[SP]of[SP]water[SP]wear[SP]away[SP]at[SP]stone![1205][000F][SP]Do[SP]your\nbest[SP]to[SP]work[SP]towards[SP]your[SP]future,[SP]and[SP]a[SP]bright\ntomorrow[SP]will[SP]await[SP]you[SP]all!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Ce propriétaire de Time Castle... Prétendre\nne pas avoir ce qu'il a en fait, dans le but\nde faire monter son prix, est impardonnable.[1106][NL]Mais Time Castle a-t-il vraiment une arme\nlégendaire, pour commencer ?[000F]"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Ce propriétaire de Time Castle... Prétendre\nne pas avoir ce qu'il a en fait, dans le but\nde faire monter son prix, est impardonnable.[1106][NL]Mais Time Castle a-t-il vraiment une arme légendaire, pour commencer ?[000F]"
   },
   {
     "id": 175,
@@ -2637,7 +2637,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![SP]I[SP]can't[SP]believe[SP]I[SP]let[SP]myself[SP]be[SP]taken\nin[SP]by[SP]a[SP]groundless[SP]rumor![1205][000F][SP]What?[SP]You[SP]wish[SP]to\nknow[SP]more[SP]of[SP]my[SP]folly?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! J'arrive pas à croire que j'ai\ngobé une rumeur infondée ![1205][000F] Quoi ? Tu\nveux en savoir plus sur ma folie ?[NL]J'ai entendu une rumeur disant qu'il y avait\nde vraies armures à Anima Mundi à Yumezaki.[NL]Mais en fait, il n'y avait rien de tel !\nLes employés se sont même moqués de moi ![NL]Mais mes infos étaient peut-être fausses...\nCe grand costaud sait peut-être\nquelque chose. Il s'appelle Toro,\net adore le thon gras."
+    "texte_fr": "Hyaaaah ! J'arrive pas à croire que j'ai\ngobé une rumeur infondée ![000F][1205] Quoi ? Tu\nveux en savoir plus sur ma folie ?[NL]J'ai entendu une rumeur disant qu'il y avait de vraies armures à Anima Mundi à Yumezaki.[NL]Mais en fait, il n'y avait rien de tel ! Les employés se sont même moqués de moi ![NL]Mais mes infos étaient peut-être fausses... Ce grand costaud sait peut-être quelque chose. Il s'appelle Toro, et adore le thon gras."
   },
   {
     "id": 176,
@@ -2667,7 +2667,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "But[SP]in[SP]truth,[SP]there[SP]was[SP]nothing[SP]of[SP]the[SP]kind!\nThe[SP]employees[SP]there[SP]even[SP]mocked[SP]me[SP]for[SP]asking!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] L'arme légendaire de\nTime Castle a été vendue ! J'entends qu'une femme\nparticulièrement malchanceuse l'a achetée.[1106][NL]Hrghhh... Quel culot ! Et si elle l'utilisait pour\nmettre fin à ses jours !? S'il me l'avait\nconfiée, j'en aurais fait bon usage..."
+    "texte_fr": "Hyaaaah ![1205][U+000F] L'arme légendaire de\nTime Castle a été vendue ! J'entends qu'une femme\nparticulièrement malchanceuse l'a achetée.[1106][NL]Hrghhh... Quel culot ! Et si elle l'utilisait pour mettre fin à ses jours !? S'il me l'avait confiée, j'en aurais fait bon usage..."
   },
   {
     "id": 178,
@@ -2682,7 +2682,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "But[SP]perhaps[SP]my[SP]information[SP]was[SP]bad...[1205][000F][SP]Maybe\nthat[SP]stout[SP]man[SP]knows[SP]something.[1205][000F][SP]I[SP]believe[SP]his\nname[SP]is[SP]Toro,[SP]and[SP]he[SP]loves[SP]fatty[SP]tuna.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][U+000F] Ce lâche propriétaire de Time Castle !\nIl a donné l'arme légendaire à une femme\naux cheveux courts ! Comment a-t-il pu !?[1106][NL]Eh ? Quel genre de femme était-ce ? B-Belle, je\nsuppose...[1205][U+000F] J-Je ne suis pas envieux, pas du tout ![000F][000F]"
+    "texte_fr": "Hyaaaah ![1205][U+000F] Ce lâche propriétaire de Time Castle !\nIl a donné l'arme légendaire à une femme\naux cheveux courts ! Comment a-t-il pu !?[1106][NL]Eh ? Quel genre de femme était-ce ? B-Belle, je suppose...[1205][U+000F] J-Je ne suis pas envieux, pas du tout ![000F][000F]"
   },
   {
     "id": 179,
@@ -2697,7 +2697,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]I[SP]heard[SP]that[SP]the[SP]members[SP]of[SP]Muses[SP]are\nall[SP]still[SP]in[SP]high[SP]school!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] J'ai entendu dire que les membres de\nMuses sont toutes encore au lycée ![NL]Qu'en est-il de leurs études !? Et leurs\nexamens d'entrée à la fac !? Avez-vous\nseulement passé vos examens finaux !?[NL]La beauté seule ne suffit pas !\nComment osent-elles se laisser éblouir par le show-biz !?\nLe premier devoir d'un étudiant est d'étudier !"
+    "texte_fr": "Hyaaaah ![000F][1205] J'ai entendu dire que les membres de\nMuses sont toutes encore au lycée ![NL]Qu'en est-il de leurs études !? Et leurs\nexamens d'entrée à la fac !? Avez-vous seulement passé vos examens finaux !?[NL]La beauté seule ne suffit pas ! Comment osent-elles se laisser éblouir par le show-biz !? Le premier devoir d'un étudiant est d'étudier !"
   },
   {
     "id": 180,
@@ -2712,7 +2712,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "What[SP]about[SP]their[SP]studies!?[1205][000A][SP]What[SP]about[SP]their\ncollege[SP]entrance[SP]exams!?[1205][000A][SP]Have[SP]you[SP]even[SP]taken\nyour[SP]finals[SP]yet!?",
     "nom_fr": "Bataillon",
-    "texte_fr": "Notre Führer a atteint sa destination.[1205][U+000F]\nLes civils à proximité doivent se rendre.[000A][1205][000A]"
+    "texte_fr": "Notre Führer a atteint sa destination.[1205][U+000F]\nLes civils à proximité doivent se rendre.[000A][000A][1205]"
   },
   {
     "id": 181,
@@ -2727,7 +2727,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "One's[SP]good[SP]looks[SP]will[SP]not[SP]keep[SP]one[SP]afloat![1205][000F]\nHow[SP]dare[SP]they[SP]be[SP]dazzled[SP]by[SP]show[SP]business!?\nA[SP]student's[SP]first[SP]duty[SP]is[SP]studying!",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est le lycée Kasu, l'école du grand\nMichel ! On aura bientôt un festival.[1205][000F]"
+    "texte_fr": "C'est le lycée Kasu, l'école du grand\nMichel ! On aura bientôt un festival.[000F][1205]"
   },
   {
     "id": 182,
@@ -2742,7 +2742,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]I[SP]like[SP]Ginji[SP]Sasaki[SP]too![1205][000F][SP]I[SP]don't[SP]really\nlisten[SP]to[SP]them,[SP]but[SP]I've[SP]bought[SP]everything[SP]he's\nproduced![SP]Even[SP]his[SP]compilation[SP]album!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] J'aime Ginji Sasaki moi aussi ![1205][000F]\nJe ne les écoute pas vraiment, mais j'ai acheté\ntout ce qu'il a produit ! Même sa compil ![NL]Mais je hais qu'il entraîne des filles\ninnocentes devant étudier dans cette\nindustrie tape-à-l'œil ![NL]Bien que je ne déteste pas vraiment sa musique.\nEst-ce que je me contredis ? Oui, n'est-ce pas... ?"
+    "texte_fr": "Hyaaaah ![000F][1205] J'aime Ginji Sasaki moi aussi ![000F][1205]\nJe ne les écoute pas vraiment, mais j'ai acheté\ntout ce qu'il a produit ! Même sa compil ![NL]Mais je hais qu'il entraîne des filles innocentes devant étudier dans cette industrie tape-à-l'œil ![NL]Bien que je ne déteste pas vraiment sa musique. Est-ce que je me contredis ? Oui, n'est-ce pas... ?"
   },
   {
     "id": 183,
@@ -2772,7 +2772,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Though[SP]I[SP]don't[SP]necessarily[SP]hate[SP]his[SP]music.[1205][000F]\nAm[SP]I[SP]contradicting[SP]myself?[1205][000F][SP]I[SP]am,[SP]aren't[SP]I...?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Viens [1113], on y va ![1205][1205][000F][000F]"
+    "texte_fr": "Viens [1113], on y va ![1205][000F][1205][000F]"
   },
   {
     "id": 185,
@@ -2787,7 +2787,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]I[SP]don't[SP]know[SP]if[SP]it[SP]was[SP]actually[SP]a\nterrorism[SP]wave,[SP]but[SP]my[SP]cram[SP]school[SP]was[SP]shut\ndown[SP]because[SP]of[SP]fools[SP]playing[SP]with[SP]fire!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Je ne sais pas s'il y a vraiment\nune vague de terrorisme, mais ma prépa a\nfermé à cause d'idiots qui jouent avec le feu ![NL]Rien ne m'empêchera d'étudier !\nLa plume est plus forte que l'épée !\nJe ferai tomber le Cercle masqué ! Bientôt..."
+    "texte_fr": "Hyaaaah ![000F][1205] Je ne sais pas s'il y a vraiment\nune vague de terrorisme, mais ma prépa a\nfermé à cause d'idiots qui jouent avec le feu ![NL]Rien ne m'empêchera d'étudier ! La plume est plus forte que l'épée ! Je ferai tomber le Cercle masqué ! Bientôt..."
   },
   {
     "id": 186,
@@ -2802,7 +2802,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Nothing[SP]will[SP]get[SP]in[SP]the[SP]way[SP]of[SP]my[SP]studies!\nThe[SP]pen[SP]is[SP]mightier[SP]than[SP]the[SP]sword![SP]I'll[SP]bring\ndown[SP]the[SP]Masked[SP]Circle![1205][000F][SP]Eventually...",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est comme si l'école était morte... Y a personne\net je n'entends aucune voix, non plus...\nC'est vraiment mon lycée Kasu ?[1205][000F]"
+    "texte_fr": "C'est comme si l'école était morte... Y a personne\net je n'entends aucune voix, non plus...\nC'est vraiment mon lycée Kasu ?[000F][1205]"
   },
   {
     "id": 187,
@@ -2817,7 +2817,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]People[SP]talk[SP]about[SP]terrorism[SP]this[SP]and\nterrorism[SP]that,[SP]but[SP]if[SP]this[SP]is[SP]the[SP]work[SP]of\nterrorists,[SP]we[SP]should[SP]know[SP]their[SP]demands[SP]now.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] On parle de terrorisme par-ci\npar-là, mais on devrait connaître leurs\nrevendications maintenant.[NL]Pourtant, aucune n'a été faite. C'est peut-être\nl'œuvre de quelqu'un qui s'amuse...\nMa colère ne s'apaisera jamais !"
+    "texte_fr": "Hyaaaah ![000F][1205] On parle de terrorisme par-ci\npar-là, mais on devrait connaître leurs\nrevendications maintenant.[NL]Pourtant, aucune n'a été faite. C'est peut-être l'œuvre de quelqu'un qui s'amuse... Ma colère ne s'apaisera jamais !"
   },
   {
     "id": 188,
@@ -2832,7 +2832,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Yet[SP]none[SP]have[SP]been[SP]made.[SP]It's[SP]possible[SP]that\nthis[SP]is[SP]being[SP]perpetrated[SP]for[SP]someone's[SP]sick\namusement...[1205][000F][SP]My[SP]anger[SP]will[SP]never[SP]be[SP]stilled!",
     "nom_fr": "Lisa",
-    "texte_fr": "Zappons ce trou et allons plutôt à Zodiac ![1205][000F]"
+    "texte_fr": "Zappons ce trou et allons plutôt à Zodiac ![000F][1205]"
   },
   {
     "id": 189,
@@ -2847,7 +2847,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]People[SP]talk[SP]about[SP]terrorism[SP]this[SP]and\nterrorism[SP]that,[SP]but[SP]if[SP]this[SP]is[SP]the[SP]work[SP]of\nterrorists,[SP]we[SP]should[SP]know[SP]their[SP]demands[SP]now.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] On parle de terrorisme par-ci\npar-là, mais on devrait connaître leurs\nrevendications maintenant.[NL]Pourtant, aucune n'a été faite. C'est peut-être\nl'œuvre de quelqu'un qui s'amuse...\nMa colère ne s'apaisera jamais !"
+    "texte_fr": "Hyaaaah ![000F][1205] On parle de terrorisme par-ci\npar-là, mais on devrait connaître leurs\nrevendications maintenant.[NL]Pourtant, aucune n'a été faite. C'est peut-être l'œuvre de quelqu'un qui s'amuse... Ma colère ne s'apaisera jamais !"
   },
   {
     "id": 190,
@@ -2862,7 +2862,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Yet[SP]none[SP]have[SP]been[SP]made.[SP]It's[SP]possible[SP]that\nthis[SP]is[SP]being[SP]perpetrated[SP]for[SP]someone's[SP]sick\namusement...[1205][000F][SP]My[SP]anger[SP]will[SP]never[SP]be[SP]stilled!",
     "nom_fr": "Ginko",
-    "texte_fr": "Zappons ce trou et allons plutôt à Zodiac ![1205][000F]"
+    "texte_fr": "Zappons ce trou et allons plutôt à Zodiac ![000F][1205]"
   },
   {
     "id": 191,
@@ -2877,7 +2877,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Hmm,[SP]if[SP]my[SP]high[SP]school[SP]memories[SP]are\naccurate,[SP]that[SP]lady[SP]a[SP]moment[SP]ago[SP]was[SP]Sevens'...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Hmm, si mes souvenirs du lycée\nsont exacts, cette dame d'il y a un\ninstant était de Seven...[NL]Il s'est passé un truc pour qu'elle se rue\nainsi à l'agence de détectives ?\n*gasp* Non ! Quelle pensée affreuse ![NL]C'est terriblement vulgaire de s'immiscer dans\nla vie privée des autres. Je dois me faire une\nraison ! Je vais copier le code civil !"
+    "texte_fr": "Hyaaaah ![000F][1205] Hmm, si mes souvenirs du lycée\nsont exacts, cette dame d'il y a un\ninstant était de Seven...[NL]Il s'est passé un truc pour qu'elle se rue ainsi à l'agence de détectives ? *gasp* Non ! Quelle pensée affreuse ![NL]C'est terriblement vulgaire de s'immiscer dans la vie privée des autres. Je dois me faire une raison ! Je vais copier le code civil !"
   },
   {
     "id": 192,
@@ -2892,7 +2892,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Did[SP]something[SP]happen[SP]for[SP]her[SP]to[SP]rush[SP]into[SP]the\ndetective[SP]agency[SP]like[SP]that?[1205][000F][SP]*gasp*[SP]No![SP]What[SP]an\nawful[SP]thought!",
     "nom_fr": "Maya",
-    "texte_fr": "Je viens souvent ici avec mon amie. Hm ? De qui\nje parle ? Haha... Je te la présenterai bientôt.[1205][000F]"
+    "texte_fr": "Je viens souvent ici avec mon amie. Hm ? De qui\nje parle ? Haha... Je te la présenterai bientôt.[000F][1205]"
   },
   {
     "id": 193,
@@ -2907,7 +2907,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "It's[SP]terribly[SP]vulgar[SP]to[SP]pry[SP]into[SP]the[SP]privacy[SP]of\nothers.[1205][000F][SP]I[SP]must[SP]admonish[SP]myself![1205][000F][SP]Time[SP]to[SP]copy\nall[SP]the[SP]pages[SP]of[SP]the[SP]Compendium[SP]of[SP]Laws!",
     "nom_fr": "Maya",
-    "texte_fr": "Smile Hirasaka...[1205][U+000F] Est-ce la cible ?\nOu... ?[1205][000F][000F]"
+    "texte_fr": "Smile Hirasaka...[1205][U+000F] Est-ce la cible ?\nOu... ?[000F][1205][000F]"
   },
   {
     "id": 194,
@@ -2922,7 +2922,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Fear[SP]makes[SP]men[SP]panic[SP]and[SP]become\nconfused![SP]What[SP]is[SP]right[SP]and[SP]what[SP]is[SP]wrong...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaah![1205][000F] La peur fait paniquer\nles hommes et les rend confus ! Ce qui\nest bien et ce qui est mal...[NL]Ça doit être clarifié, ou l'homme continuera\nà faire des erreurs stupides. Calmons-nous\ntous... et faisons confiance à l'In Lak'ech."
+    "texte_fr": "Hyaaah![000F][1205] La peur fait paniquer\nles hommes et les rend confus ! Ce qui\nest bien et ce qui est mal...[NL]Ça doit être clarifié, ou l'homme continuera à faire des erreurs stupides. Calmons-nous tous... et faisons confiance à l'In Lak'ech."
   },
   {
     "id": 195,
@@ -2937,7 +2937,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "That[SP]must[SP]be[SP]made[SP]clear,[SP]or[SP]man[SP]will[SP]continue\nto[SP]make[SP]foolish[SP]mistakes.[1205][000F][SP]Let[SP]us[SP]all[SP]calm\nourselves...[1205][000F][SP]and[SP]trust[SP]in[SP]the[SP]In[SP]Lak'ech.",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun ?[1205][U+000F] On devrait chercher par ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, jetons un œil.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas le bon endroit.[1432][NULL][NULL][0014][1106][NL]Ok. Si c'est décidé, dépêchons-nous.\nOn a peu de temps à perdre.[1205][000F][000F]"
+    "texte_fr": "[1113]-kun ?[1205][U+000F] On devrait chercher par ici ?\n[1208][0002][1432][NULL][NULL][0014]Ouais, jetons un œil.[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Non, c'est pas le bon endroit.[1432][NULL][NULL][0014][1106][NL]Ok. Si c'est décidé, dépêchons-nous.\nOn a peu de temps à perdre.[000F][1205][000F]"
   },
   {
     "id": 196,
@@ -2952,7 +2952,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]The[SP]Last[SP]Battalion's[SP]invasion[SP]is[SP]a\nserious[SP]problem,[SP]but[SP]even[SP]more[SP]serious[SP]is[SP]the\nIn[SP]Lak'ech!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] L'invasion du Bataillon est un\ngrave problème, mais l'In Lak'ech est\nencore plus sérieux ![NL]S'il dit vrai, le monde fera face à\nune destruction totale bientôt.[NL]Si ça arrive, que deviendra mon rêve !?\nComment intégrer la meilleure université\ndu pays si le pays est détruit !?"
+    "texte_fr": "Hyaaaah ![000F][1205] L'invasion du Bataillon est un\ngrave problème, mais l'In Lak'ech est\nencore plus sérieux ![NL]S'il dit vrai, le monde fera face à une destruction totale bientôt.[NL]Si ça arrive, que deviendra mon rêve !? Comment intégrer la meilleure université du pays si le pays est détruit !?"
   },
   {
     "id": 197,
@@ -2967,7 +2967,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "If[SP]it[SP]speaks[SP]truly,[SP]the[SP]world[SP]will[SP]face[SP]utter\ndestruction[SP]soon.",
     "nom_fr": "Maya",
-    "texte_fr": "Cet endroit est sain et sauf.\nMais où est la prochaine cible... ?\nGOLD ou Pachinko Silver ?[1106][NL]C'est à toi de voir, [1113]-kun. Mais on a\npeu de temps, alors en route."
+    "texte_fr": "Cet endroit est sain et sauf.\nMais où est la prochaine cible... ?\nGOLD ou Pachinko Silver ?[1106][NL]C'est à toi de voir, [1113]-kun. Mais on a peu de temps, alors en route."
   },
   {
     "id": 198,
@@ -2982,7 +2982,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "If[SP]that[SP]happens,[SP]what[SP]will[SP]become[SP]of[SP]my[SP]dream!?[1205][000F]\nHow[SP]will[SP]I[SP]make[SP]it[SP]into[SP]the[SP]best[SP]university[SP]in\nthe[SP]country[SP]if[SP]the[SP]country[SP]is[SP]destroyed!?",
     "nom_fr": "Maya",
-    "texte_fr": "C'est pas vrai... ? Il devait y avoir tant\nde gens à l'intérieur... Les flammes\nôtent encore des vies...[1205][000F]"
+    "texte_fr": "C'est pas vrai... ? Il devait y avoir tant\nde gens à l'intérieur... Les flammes\nôtent encore des vies...[000F][1205]"
   },
   {
     "id": 199,
@@ -2997,7 +2997,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][0008][SP]What[SP]should[SP]I[SP]do?[1205][000A][SP]A[SP]city[SP]soaring[SP]in\nthe[SP]sky[SP]is[SP]the[SP]epitome[SP]of[SP]absurdity![1205][000A][SP]Worse,\nthere[SP]are[SP]no[SP]colleges[SP]in[SP]Sumaru[SP]City!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][0008] Que dois-je faire ?[1205][000A] Une ville dans\nle ciel, c'est le comble de l'absurdité ![1205][000A] Pire,\nil n'y a pas de facultés à Sumaru ![NL]Hrrrgh... Si le monde s'arrête, à quoi tout ce\ntravail aura-t-il servi... ? Rien que\nd'y penser, ça me brise le cœur !"
+    "texte_fr": "Hyaaaah ![0008][1205] Que dois-je faire ?[000A][1205] Une ville dans\nle ciel, c'est le comble de l'absurdité ![000A][1205] Pire,\nil n'y a pas de facultés à Sumaru ![NL]Hrrrgh... Si le monde s'arrête, à quoi tout ce travail aura-t-il servi... ? Rien que d'y penser, ça me brise le cœur !"
   },
   {
     "id": 200,
@@ -3012,7 +3012,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hrrrgh...[1205][000A][SP]If[SP]the[SP]world[SP]does[SP]end,[SP]what[SP]was[SP]all\nmy[SP]hard[SP]work[SP]for...?[1205][000F][SP]It[SP]pains[SP]my[SP]heart[SP]to[SP]even\nthink[SP]about[SP]it!",
     "nom_fr": "Maya",
-    "texte_fr": "Fâché que j'aie laissé fuir Ixquic ?\nC'est dans ma nature... Désolée si ça\nt'a contrarié.[1205][000A][1205][000F]"
+    "texte_fr": "Fâché que j'aie laissé fuir Ixquic ?\nC'est dans ma nature... Désolée si ça\nt'a contrarié.[000A][1205][000F][1205]"
   },
   {
     "id": 201,
@@ -3027,7 +3027,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][0008][SP]Making[SP]it[SP]into[SP]a[SP]top[SP]college,[SP]working\nfor[SP]the[SP]best[SP]company...[1205][000A][SP]This[SP]has[SP]been[SP]my[SP]dream\nfor[SP]31[SP]years...[1205][000F][SP]Now[SP]neither[SP]will[SP]come[SP]true...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][0008] Entrer dans une grande faculté, bosser\npour la meilleure boîte...[1205][000A] C'est mon rêve\ndepuis 31 ans...[1205][000F] Aucun ne se réalisera...[NL]Au moins, je verrai la fin de notre\nTerre, puisque ma vie sera épargnée.\nFaut-il oublier les vieilles connaissances...\n*sniff*[E1][E2]\n[E3][E4][NULL][NULL]\"Étudiant\nHyaaaah ! J'entends dire que quand la Croix\nCosmique sera terminée, un trou noir va se\nformer au centre et engloutir cette planète.[NL]Mais si ça arrivait, alors nous ne\nserions pas non plus en sécurité.\nÇa ressemble à un canular."
+    "texte_fr": "Hyaaaah ![0008][1205] Entrer dans une grande faculté, bosser\npour la meilleure boîte...[000A][1205] C'est mon rêve\ndepuis 31 ans...[000F][1205] Aucun ne se réalisera...[NL]Au moins, je verrai la fin de notre\nTerre, puisque ma vie sera épargnée.\nFaut-il oublier les vieilles connaissances...\n*sniff*[E1][E2]\n[E3][E4][NULL][NULL]\"Étudiant\nHyaaaah ! J'entends dire que quand la Croix\nCosmique sera terminée, un trou noir va se\nformer au centre et engloutir cette planète.[NL]Mais si ça arrivait, alors nous ne\nserions pas non plus en sécurité.\nÇa ressemble à un canular."
   },
   {
     "id": 202,
@@ -3042,7 +3042,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "At[SP]the[SP]very[SP]least,[SP]I'll[SP]witness[SP]the[SP]end[SP]of\nMother[SP]Earth,[SP]since[SP]my[SP]life[SP]will[SP]be[SP]spared.[1205][000F]\nShould[SP]auld[SP]acquaintance[SP]be[SP]forgot...[1205][000A][SP]*sniff*[E1][E2]\n[E3][E4][NULL][NULL]\"Fighting[SP]washout[SP]student\nHyaaaah![1205][0008][SP]I[SP]hear[SP]tell[SP]that[SP]when[SP]the[SP]Grand[SP]Cross\nis[SP]complete,[SP]a[SP]black[SP]hole[SP]will[SP]form[SP]at[SP]its\ncenter[SP]and[SP]swallow[SP]this[SP]planet[SP]whole.",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est horrible... Est-ce leur volonté aussi ?\nSi oui... Que va-t-on faire... ?[1205][1205][000F][000A][E1][E2][E3][E4][NULL][NULL][1205][0008]"
+    "texte_fr": "C'est horrible... Est-ce leur volonté aussi ?\nSi oui... Que va-t-on faire... ?[1205][000F][1205][000A][E1][E2][E3][E4][NULL][NULL][0008][1205]"
   },
   {
     "id": 203,
@@ -3057,7 +3057,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "But[SP]if[SP]that[SP]were[SP]to[SP]happen,[SP]then[SP]we[SP]won't[SP]be\nsafe,[SP]either.[1205][000A][SP]It[SP]sounds[SP]like[SP]a[SP]hoax.",
     "nom_fr": "Maya",
-    "texte_fr": "Ce n'est pas le genre de Jun-kun de souhaiter\nune telle chose. Attends-moi... Je viens\nte chercher cette fois...[NULL][NULL]\"Eikichi\nLe Bâtiment Sakanoue ?[1205][U+000A] Pourquoi on irait là-bas ?[1205][U+000A]\nAllez, allons ailleurs.[000A]"
+    "texte_fr": "Ce n'est pas le genre de Jun-kun de souhaiter\nune telle chose. Attends-moi... Je viens\nte chercher cette fois...[NULL][NULL]\"Eikichi Le Bâtiment Sakanoue ?[1205][U+000A] Pourquoi on irait là-bas ?[1205][U+000A] Allez, allons ailleurs.[000A]"
   },
   {
     "id": 204,
@@ -3072,7 +3072,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][0008][SP]I[SP]doubt[SP]any[SP]severe[SP]natural[SP]disaster\nbut[SP]this[SP]one[SP]could[SP]happen![1205][000A][SP]It[SP]seems[SP]that[SP]the\nEarth's[SP]rotation[SP]will[SP]suddenly[SP]halt.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][0008] Je doute qu'une autre catastrophe\nnaturelle puisse se produire ![1205][000A] Il semble\nque la Terre va soudainement s'arrêter.[NL]Tel est l'effet de la Croix Cosmique.\nPersonne ne défie la volonté de\nl'espace... Triste pensée, en effet."
+    "texte_fr": "Hyaaaah ![0008][1205] Je doute qu'une autre catastrophe\nnaturelle puisse se produire ![000A][1205] Il semble\nque la Terre va soudainement s'arrêter.[NL]Tel est l'effet de la Croix Cosmique. Personne ne défie la volonté de l'espace... Triste pensée, en effet."
   },
   {
     "id": 205,
@@ -3087,7 +3087,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Such[SP]is[SP]the[SP]effect[SP]of[SP]the[SP]Grand[SP]Cross.[1205][000A]\nNo[SP]one[SP]can[SP]defy[SP]the[SP]will[SP]of[SP]space...[1205][000F]\nA[SP]sad[SP]thought[SP]indeed.",
     "nom_fr": "Maya",
-    "texte_fr": "Bâtiment Sakanoue...[1205][U+000F] Est-ce la prochaine\ncible... ?[000A][1205][000F]"
+    "texte_fr": "Bâtiment Sakanoue...[1205][U+000F] Est-ce la prochaine\ncible... ?[000A][000F][1205]"
   },
   {
     "id": 206,
@@ -3102,7 +3102,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][0008][SP]What[SP]strange[SP]news![SP]It[SP]seems[SP]there[SP]are\nflowers[SP]in[SP]Aoba[SP]Park[SP]who[SP]talk.[SP]Perhaps[SP]the\nmystery[SP]of[SP]the[SP]plants[SP]will[SP]be[SP]revealed...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][0008] Quelle étrange nouvelle ! Il\nsemble y avoir des fleurs au parc Aoba qui\nparlent. Peut-être que le mystère sera révélé...[NL]Ce doit être un signe de Dieu, m'indiquant\nle chemin du prix Nobel de la paix !\n...Ou c'est ce que je croyais. Je suis pas scientifique."
+    "texte_fr": "Hyaaaah ![0008][1205] Quelle étrange nouvelle ! Il\nsemble y avoir des fleurs au parc Aoba qui\nparlent. Peut-être que le mystère sera révélé...[NL]Ce doit être un signe de Dieu, m'indiquant le chemin du prix Nobel de la paix ! ...Ou c'est ce que je croyais. Je suis pas scientifique."
   },
   {
     "id": 207,
@@ -3132,7 +3132,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][0008][SP]Did[SP]you[SP]hear?[SP]Club[SP]Zodiac's[SP]second\nfloor[SP]is[SP]undergoing[SP]extensive[SP]remodeling![1205][000A]\nIt's[SP]now[SP]an[SP]item-filled[SP]labyrinth.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][0008] Tu as entendu ? Le deuxième\nétage du club Zodiac est en rénovation ![1205][000A]\nC'est maintenant un labyrinthe rempli d'objets.[NL]Hmm, cette épreuve a sûrement été faite pour moi...\nMais je suis trop pris par mes études. Je serai\ngénéreux et te permettrai de la relever !"
+    "texte_fr": "Hyaaaah ![0008][1205] Tu as entendu ? Le deuxième\nétage du club Zodiac est en rénovation ![000A][1205]\nC'est maintenant un labyrinthe rempli d'objets.[NL]Hmm, cette épreuve a sûrement été faite pour moi... Mais je suis trop pris par mes études. Je serai généreux et te permettrai de la relever !"
   },
   {
     "id": 209,
@@ -3147,7 +3147,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hmm,[SP]this[SP]ordeal[SP]must[SP]have[SP]been[SP]made[SP]for[SP]me...[1205][000A]\nBut[SP]I'm[SP]too[SP]busy[SP]with[SP]my[SP]studies.[SP]I[SP]will[SP]be\ngenerous[SP]and[SP]allow[SP]you[SP]to[SP]challenge[SP]it!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Si on avait choisi ici, Smile Hirasaka\nserait en cendres... Pfiou, y penser\nme donne des frissons.[1205][000A]"
+    "texte_fr": "Si on avait choisi ici, Smile Hirasaka\nserait en cendres... Pfiou, y penser\nme donne des frissons.[000A][1205]"
   },
   {
     "id": 210,
@@ -3162,7 +3162,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]So[SP]even[SP]the[SP]ghost[SP]Hanako[SP]is[SP]appearing\nat[SP]Sevens!?[SP]What[SP]an[SP]ill-fated[SP]institution.\nI[SP]pity[SP]its[SP]students.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Même le fantôme Hanako apparaît\nà Seven !? Quelle institution\nmaudite. J'ai pitié de ses étudiants."
+    "texte_fr": "Hyaaaah ![000F][1205] Même le fantôme Hanako apparaît\nà Seven !? Quelle institution\nmaudite. J'ai pitié de ses étudiants."
   },
   {
     "id": 211,
@@ -3177,7 +3177,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]This[SP]is[SP]serious[SP]indeed![SP]It[SP]seems[SP]the\nghost[SP]of[SP]Bukimi[SP]is[SP]haunting[SP]my[SP]beloved[SP]alma\nmater,[SP]Kasugayama[SP]High!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] C'est vraiment sérieux ! Il\nsemble que le fantôme de Bukimi hante\nmon école adorée, le lycée Kasugayama ![NL]Ahh, mais ne craignez rien, mes amis...\nEn tant qu'ancien de Kasugayama, je me\ndébarrasserai de Bukimi ! Éventuellement..."
+    "texte_fr": "Hyaaaah ![000F][1205] C'est vraiment sérieux ! Il\nsemble que le fantôme de Bukimi hante\nmon école adorée, le lycée Kasugayama ![NL]Ahh, mais ne craignez rien, mes amis... En tant qu'ancien de Kasugayama, je me débarrasserai de Bukimi ! Éventuellement..."
   },
   {
     "id": 212,
@@ -3207,7 +3207,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![SP]It[SP]seems[SP]the[SP]ghost[SP]of[SP]a[SP]former[SP]idol\nis[SP]haunting[SP]Aoba[SP]Park...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! Il semble que le fantôme d'une\nancienne idole hante le parc Aoba...[NL]C'est dommage, vraiment, mais c'est le\ndestin de beaucoup de gens tentés\npar le show-biz."
+    "texte_fr": "Hyaaaah ! Il semble que le fantôme d'une\nancienne idole hante le parc Aoba...[NL]C'est dommage, vraiment, mais c'est le\ndestin de beaucoup de gens tentés par le show-biz."
   },
   {
     "id": 214,
@@ -3237,7 +3237,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Apparently,[SP]a[SP]monster[SP]known[SP]as[SP]a\nCursed[SP]Taxi[SP]is[SP]menacing[SP]the[SP]abandoned[SP]factory.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Apparemment, un monstre connu sous le\nnom de Taxi Maudit menace l'usine abandonnée.[NL]Normalement, je ne laisserais pas vivre un\ntel monstre, mais je suis\noccupé aujourd'hui."
+    "texte_fr": "Hyaaaah ![000F][1205] Apparemment, un monstre connu sous le\nnom de Taxi Maudit menace l'usine abandonnée.[NL]Normalement, je ne laisserais pas vivre un\ntel monstre, mais je suis occupé aujourd'hui."
   },
   {
     "id": 216,
@@ -3267,7 +3267,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Dear[SP]me...[SP]So[SP]it[SP]was[SP]a[SP]Cursed[SP]Escort,\nand[SP]not[SP]a[SP]Cursed[SP]Taxi,[SP]that[SP]made[SP]the[SP]abandoned\nfactory[SP]its[SP]home...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Mon Dieu... C'était donc une Escorte\nMaudite, et non un Taxi Maudit, qui a élu domicile\nà l'usine abandonnée...[NL]Euh, quelle est la différence entre les deux ?"
+    "texte_fr": "Hyaaaah ![000F][1205] Mon Dieu... C'était donc une Escorte\nMaudite, et non un Taxi Maudit, qui a élu domicile\nà l'usine abandonnée...[NL]Euh, quelle est la différence entre les deux ?"
   },
   {
     "id": 218,
@@ -3282,7 +3282,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Er,[SP]what[SP]is[SP]the[SP]difference[SP]between[SP]the[SP]two?",
     "nom_fr": "Voix d'Elly",
-    "texte_fr": "Allô ?[1205][U+000F] C'est moi, Elly.[1205][U+000F] J'ai réduit la\nprochaine cible. Cet indice est aussi lié à\nl'astrologie...[1106][NL]C'est au nord-nord-est de Seven.\nLes seuls trucs là-bas sont Pachinko Silver\net GOLD à Yumezaki. La prochaine cible est--"
+    "texte_fr": "Allô ?[1205][U+000F] C'est moi, Elly.[1205][U+000F] J'ai réduit la\nprochaine cible. Cet indice est aussi lié à\nl'astrologie...[1106][NL]C'est au nord-nord-est de Seven. Les seuls trucs là-bas sont Pachinko Silver et GOLD à Yumezaki. La prochaine cible est--"
   },
   {
     "id": 219,
@@ -3297,7 +3297,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]So[SP]Kuchisake-onna[SP]is[SP]at[SP]Mt.[SP]Iwato?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Kuchisake-onna est au Mt Iwato ?[NL]J'ai eu mon lot de problèmes avec des légendes\nurbaines comme elle dans ma jeunesse. Elle chassait\nles enfants qui ne rentraient pas direct à la maison.[NL]En y repensant, ces contes étaient utiles pour\nmettre en garde les enfants contre les mauvais\ncomportements... J'ignorerai Kuchisake-onna."
+    "texte_fr": "Hyaaaah ![000F][1205] Kuchisake-onna est au Mt Iwato ?[NL]J'ai eu mon lot de problèmes avec des légendes\nurbaines comme elle dans ma jeunesse. Elle chassait\nles enfants qui ne rentraient pas direct à la maison.[NL]En y repensant, ces contes étaient utiles pour mettre en garde les enfants contre les mauvais comportements... J'ignorerai Kuchisake-onna."
   },
   {
     "id": 220,
@@ -3342,7 +3342,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]An[SP]oddity[SP]by[SP]the[SP]name[SP]of[SP]Jumping\nGeezer[SP]has[SP]been[SP]sighted[SP]at[SP]Mt.[SP]Katatsumuri.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Une bizarrerie nommée Vieux\nSauteur a été aperçue au Mt Katatsumuri.[NL]Pourquoi un homme de quatre-vingt-dix ans\nsauterait-il partout... ?"
+    "texte_fr": "Hyaaaah ![000F][1205] Une bizarrerie nommée Vieux\nSauteur a été aperçue au Mt Katatsumuri.[NL]Pourquoi un homme de quatre-vingt-dix ans\nsauterait-il partout... ?"
   },
   {
     "id": 223,
@@ -3372,7 +3372,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "H-Hyaa...aaah...[1205][000F][SP]Oh,[SP]who[SP]am[SP]I[SP]kidding?[1205][000F][SP]I'm[SP]so\nfrightened,[SP]my[SP]legs[SP]won't[SP]stop[SP]shaking.[1205][000F]\nK-Kudan...[SP]It's[SP]at[SP]the[SP]abandoned[SP]factory...",
     "nom_fr": "Étudiant",
-    "texte_fr": "H-Hyaa...aaah...[1205][000F] Oh, à qui je veux faire\ncroire ça ?[1205][000F] J'ai tellement peur que mes jambes\nne s'arrêtent pas de trembler.[1205][000F] Kudan... À l'usine..."
+    "texte_fr": "H-Hyaa...aaah...[000F][1205] Oh, à qui je veux faire\ncroire ça ?[000F][1205] J'ai tellement peur que mes jambes\nne s'arrêtent pas de trembler.[000F][1205] Kudan... À l'usine..."
   },
   {
     "id": 225,
@@ -3387,7 +3387,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]How[SP]dare[SP]a[SP]merchant[SP]hide[SP]his[SP]own\nmerchandise!?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Comment un marchand ose-t-il\ncacher sa propre marchandise !?[NL]Et un CD secret, en plus !? À quoi\npense le propriétaire de Giga Macho ?"
+    "texte_fr": "Hyaaaah ![000F][1205] Comment un marchand ose-t-il\ncacher sa propre marchandise !?[NL]Et un CD secret, en plus !? À quoi\npense le propriétaire de Giga Macho ?"
   },
   {
     "id": 226,
@@ -3417,7 +3417,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]It[SP]seems[SP]there's[SP]a[SP]creature[SP]known[SP]as\na[SP]Dresser[SP]Hag[SP]at[SP]the[SP]abandoned[SP]factory.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Il semble qu'il y ait une créature\nconnue sous le nom de Mégère à Commode à l'usine.[NL]Cet endroit a engendré tellement de rumeurs.\nIls devraient faire ce qu'il faut et condamner\ncet endroit."
+    "texte_fr": "Hyaaaah ![000F][1205] Il semble qu'il y ait une créature\nconnue sous le nom de Mégère à Commode à l'usine.[NL]Cet endroit a engendré tellement de rumeurs.\nIls devraient faire ce qu'il faut et condamner cet endroit."
   },
   {
     "id": 228,
@@ -3432,7 +3432,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "That[SP]place[SP]has[SP]spawned[SP]so[SP]many[SP]rumors.[1205][000F]\nThey[SP]should[SP]do[SP]what[SP]needs[SP]doing[SP]and[SP]condemn\nthe[SP]place.",
     "nom_fr": "Ginko",
-    "texte_fr": "Attends Chinyan ! On n'a pas encore le crâne\ndu temple taureau. On devrait y passer d'abord.[1205][000F]"
+    "texte_fr": "Attends Chinyan ! On n'a pas encore le crâne\ndu temple taureau. On devrait y passer d'abord.[000F][1205]"
   },
   {
     "id": 229,
@@ -3447,7 +3447,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Selling[SP]weapons[SP]at[SP]an[SP]antique[SP]shop...[1205][000F]\nTime[SP]Castle's[SP]owner[SP]is[SP]no[SP]ordinary[SP]man.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Vendre des armes chez un antiquaire...[1205][000F]\nLe propriétaire de Time Castle est audacieux.[NL]La qualité et le prix de ses biens semblent\ncependant être dans la moyenne."
+    "texte_fr": "Hyaaaah ![000F][1205] Vendre des armes chez un antiquaire...[000F][1205]\nLe propriétaire de Time Castle est audacieux.[NL]La qualité et le prix de ses biens semblent\ncependant être dans la moyenne."
   },
   {
     "id": 230,
@@ -3477,7 +3477,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Selling[SP]weapons[SP]at[SP]an[SP]antique[SP]shop...[1205][000F]\nTime[SP]Castle's[SP]owner[SP]is[SP]no[SP]ordinary[SP]man.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Vendre des armes chez un antiquaire...[1205][000F]\nLe propriétaire de Time Castle est audacieux.[NL]La qualité de ses biens est superbe, mais ses\nprix sont très élevés."
+    "texte_fr": "Hyaaaah ![000F][1205] Vendre des armes chez un antiquaire...[000F][1205]\nLe propriétaire de Time Castle est audacieux.[NL]La qualité de ses biens est superbe, mais ses\nprix sont très élevés."
   },
   {
     "id": 232,
@@ -3507,7 +3507,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Selling[SP]weapons[SP]at[SP]an[SP]antique[SP]shop...[1205][000F]\nTime[SP]Castle's[SP]owner[SP]is[SP]no[SP]ordinary[SP]man.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Vendre des armes chez un antiquaire...[1205][000F]\nLe propriétaire de Time Castle est audacieux.[NL]On m'a dit que le prix est correct, mais\nque la qualité laisse à désirer."
+    "texte_fr": "Hyaaaah ![000F][1205] Vendre des armes chez un antiquaire...[000F][1205]\nLe propriétaire de Time Castle est audacieux.[NL]On m'a dit que le prix est correct, mais\nque la qualité laisse à désirer."
   },
   {
     "id": 234,
@@ -3537,7 +3537,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street\nvendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in\nreal[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes.[NL]On m'a dit que son choix est très varié,\nmais que ses prix de rachat sont bas."
+    "texte_fr": "Hyaaaah ![000F][1205] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes.[NL]On m'a dit que son choix est très varié, mais que ses prix de rachat sont bas."
   },
   {
     "id": 236,
@@ -3567,7 +3567,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street\nvendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in\nreal[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes.[NL]Moins cher, mais de mauvaise qualité."
+    "texte_fr": "Hyaaaah ![000F][1205] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes.[NL]Moins cher, mais de mauvaise qualité."
   },
   {
     "id": 238,
@@ -3597,7 +3597,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street\nvendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in\nreal[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes.[NL]Il semble que la qualité et le prix de\nses biens soient tous deux moyens."
+    "texte_fr": "Hyaaaah ![000F][1205] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes.[NL]Il semble que la qualité et le prix de ses biens soient tous deux moyens."
   },
   {
     "id": 240,
@@ -3627,7 +3627,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]That[SP]man[SP]Tony[SP]who[SP]works[SP]as[SP]a[SP]street\nvendor[SP]in[SP]Yumezaki[SP]seems[SP]to[SP]traffic[SP]in\nreal[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes.[NL]On m'a dit que la qualité était superbe,\nmais que les prix étaient élevés."
+    "texte_fr": "Hyaaaah ![000F][1205] Ce Tony, qui travaille comme\nvendeur ambulant à Yumezaki, semble\ntrafiquer de vraies armes.[NL]On m'a dit que la qualité était superbe, mais que les prix étaient élevés."
   },
   {
     "id": 242,
@@ -3657,7 +3657,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[NL]Leur choix semble être limité, mais au\nmoins leurs prix de rachat sont bons."
+    "texte_fr": "Hyaaaah ![000F][1205] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[NL]Leur choix semble être limité, mais au moins leurs prix de rachat sont bons."
   },
   {
     "id": 244,
@@ -3687,7 +3687,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[NL]Leurs biens sont bon marché, mais manquent de qualité."
+    "texte_fr": "Hyaaaah ![000F][1205] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[NL]Leurs biens sont bon marché, mais manquent de qualité."
   },
   {
     "id": 246,
@@ -3717,7 +3717,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[NL]La qualité de leurs produits est élevée,\nmais cela a un prix."
+    "texte_fr": "Hyaaaah ![000F][1205] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[NL]La qualité de leurs produits est élevée, mais cela a un prix."
   },
   {
     "id": 248,
@@ -3747,7 +3747,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[NL]Ils semblent avoir un grand choix de produits,\nmais leurs prix de rachat sont bas."
+    "texte_fr": "Hyaaaah ![000F][1205] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[NL]Ils semblent avoir un grand choix de produits, mais leurs prix de rachat sont bas."
   },
   {
     "id": 250,
@@ -3777,7 +3777,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]I[SP]hear[SP]that[SP]real[SP]weapons[SP]are[SP]now[SP]for\nsale[SP]at[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba.[SP]I[SP]can[SP]scarcely\nbelieve[SP]it...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[NL]La qualité et le prix de leurs produits\nsont tout juste moyens."
+    "texte_fr": "Hyaaaah ![000F][1205] J'ai entendu que de vraies armes\nsont en vente chez Clair de Lune à Aoba.\nJ'ai du mal à y croire...[NL]La qualité et le prix de leurs produits sont tout juste moyens."
   },
   {
     "id": 252,
@@ -3807,7 +3807,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[NL]La qualité et le prix de leurs articles\nsemblent plutôt moyens."
+    "texte_fr": "Hyaaaah ![000F][1205] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[NL]La qualité et le prix de leurs articles\nsemblent plutôt moyens."
   },
   {
     "id": 254,
@@ -3837,7 +3837,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[NL]Leurs produits sont bon marché, mais manquent\nmalheureusement de qualité."
+    "texte_fr": "Hyaaaah ![000F][1205] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[NL]Leurs produits sont bon marché, mais manquent\nmalheureusement de qualité."
   },
   {
     "id": 256,
@@ -3867,7 +3867,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[NL]Leur choix est excellent, mais leurs prix de\nrachat semblent être bas."
+    "texte_fr": "Hyaaaah ![000F][1205] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[NL]Leur choix est excellent, mais leurs prix de\nrachat semblent être bas."
   },
   {
     "id": 258,
@@ -3897,7 +3897,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[NL]Leur sélection est assez pauvre, mais je suppose\nque leurs prix de rachat sont bons."
+    "texte_fr": "Hyaaaah ![000F][1205] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[NL]Leur sélection est assez pauvre, mais je suppose\nque leurs prix de rachat sont bons."
   },
   {
     "id": 260,
@@ -3927,7 +3927,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Call[SP]it[SP]a[SP]rumor,[SP]a[SP]hoax,[SP]or[SP]what-have-\nyou,[SP]but[SP]it[SP]appears[SP]that[SP]Jolly[SP]Roger[SP]in[SP]Kounan\nsells[SP]weapons.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[NL]La qualité de leurs produits est excellente,\nmais elle est très chère."
+    "texte_fr": "Hyaaaah ![000F][1205] Rumeur ou pas, il semble que\nJolly Roger à Kounan vende des armes.[NL]La qualité de leurs produits est excellente,\nmais elle est très chère."
   },
   {
     "id": 262,
@@ -3957,7 +3957,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]That[SP]reminds[SP]me,[SP]I[SP]heard[SP]an[SP]interesting\nrumor[SP]that[SP]Rosa[SP]Candida[SP]sells[SP]armor.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures.[NL]J'ai entendu récemment que la qualité et le prix\nde leur stock sont moyens."
+    "texte_fr": "Hyaaaah ![000F][1205] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures.[NL]J'ai entendu récemment que la qualité et le prix\nde leur stock sont moyens."
   },
   {
     "id": 264,
@@ -3987,7 +3987,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]That[SP]reminds[SP]me,[SP]I[SP]heard[SP]an[SP]interesting\nrumor[SP]that[SP]Rosa[SP]Candida[SP]sells[SP]armor.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures.[NL]J'ai entendu récemment que leurs biens sont\nbon marché, mais de piètre qualité."
+    "texte_fr": "Hyaaaah ![000F][1205] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures.[NL]J'ai entendu récemment que leurs biens sont\nbon marché, mais de piètre qualité."
   },
   {
     "id": 266,
@@ -4017,7 +4017,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]That[SP]reminds[SP]me,[SP]I[SP]heard[SP]an[SP]interesting\nrumor[SP]that[SP]Rosa[SP]Candida[SP]sells[SP]armor.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures.[NL]J'ai entendu récemment que la qualité de leur\nstock est élevée, mais que c'est cher."
+    "texte_fr": "Hyaaaah ![000F][1205] Ça me rappelle, j'ai entendu la rumeur\nintéressante que Rosa Candida vend des armures.[NL]J'ai entendu récemment que la qualité de leur\nstock est élevée, mais que c'est cher."
   },
   {
     "id": 268,
@@ -4047,7 +4047,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi\nsells[SP]armor!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Donc il est VRAI qu'Anima Mundi\nvend des armures ![NL]J'entends dire que leur qualité et leurs prix\nsont dans la moyenne, cela dit."
+    "texte_fr": "Hyaaaah ![000F][1205] Donc il est VRAI qu'Anima Mundi\nvend des armures ![NL]J'entends dire que leur qualité et leurs prix\nsont dans la moyenne, cela dit."
   },
   {
     "id": 270,
@@ -4077,7 +4077,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi\nsells[SP]armor!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Donc il est VRAI qu'Anima Mundi\nvend des armures ![NL]Leur matos est pas cher,\nmais de mauvaise qualité."
+    "texte_fr": "Hyaaaah ![000F][1205] Donc il est VRAI qu'Anima Mundi\nvend des armures ![NL]Leur matos est pas cher,\nmais de mauvaise qualité."
   },
   {
     "id": 272,
@@ -4107,7 +4107,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi\nsells[SP]armor!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Donc il est VRAI qu'Anima Mundi\nvend des armures ![NL]J'entends dire que leur sélection est belle,\nmais que leurs prix de rachat sont bas."
+    "texte_fr": "Hyaaaah ![000F][1205] Donc il est VRAI qu'Anima Mundi\nvend des armures ![NL]J'entends dire que leur sélection est belle,\nmais que leurs prix de rachat sont bas."
   },
   {
     "id": 274,
@@ -4137,7 +4137,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]So[SP]it[SP]IS[SP]true[SP]that[SP]Anima[SP]Mundi\nsells[SP]armor!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Donc il est VRAI qu'Anima Mundi\nvend des armures ![NL]Leur qualité semble élevée en effet,\nmais peu peuvent se le permettre."
+    "texte_fr": "Hyaaaah ![000F][1205] Donc il est VRAI qu'Anima Mundi\nvend des armures ![NL]Leur qualité semble élevée en effet,\nmais peu peuvent se le permettre."
   },
   {
     "id": 276,
@@ -4242,7 +4242,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[NL]Ils semblent avoir un choix impressionnant,\nmais leurs prix de rachat sont bas."
+    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[NL]Ils semblent avoir un choix impressionnant, mais leurs prix de rachat sont bas."
   },
   {
     "id": 283,
@@ -4272,7 +4272,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[NL]Leurs prix sont bas, mais leurs biens sont\nde mauvaise qualité."
+    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[NL]Leurs prix sont bas, mais leurs biens sont de mauvaise qualité."
   },
   {
     "id": 285,
@@ -4302,7 +4302,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[NL]La qualité de leurs biens est de premier ordre,\nmais c'est assez cher."
+    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[NL]La qualité de leurs biens est de premier ordre, mais c'est assez cher."
   },
   {
     "id": 287,
@@ -4362,7 +4362,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![SP]Do[SP]tailors[SP]make[SP]even[SP]armor[SP]nowadays?\nI[SP]hear[SP]you[SP]can[SP]buy[SP]such[SP]things[SP]from[SP]the[SP]man\nat[SP]London[SP]Clothier.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[NL]Leur sélection est pauvre, mais les prix\nde rachat qu'ils offrent sont généreux."
+    "texte_fr": "Hyaaaah ! Les tailleurs fabriquent même des armures ?\nOn peut apparemment en acheter\nà London Clothier.[NL]Leur sélection est pauvre, mais les prix de rachat qu'ils offrent sont généreux."
   },
   {
     "id": 291,
@@ -4392,7 +4392,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Is[SP]it[SP]true[SP]one[SP]may[SP]win[SP]real[SP]weapons\nin[SP]a[SP]magazine[SP]sweepstakes?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?[NL]Il n'est pas facile de gagner, mais on reçoit\nde beaux objets en récompense."
+    "texte_fr": "Hyaaaah ![000F][1205] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?[NL]Il n'est pas facile de gagner, mais on reçoit\nde beaux objets en récompense."
   },
   {
     "id": 293,
@@ -4422,7 +4422,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Is[SP]it[SP]true[SP]one[SP]may[SP]win[SP]real[SP]weapons\nin[SP]a[SP]magazine[SP]sweepstakes?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?[NL]On gagne très rarement, mais les prix\npour ceux qui y parviennent sont exquis."
+    "texte_fr": "Hyaaaah ![000F][1205] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?[NL]On gagne très rarement, mais les prix\npour ceux qui y parviennent sont exquis."
   },
   {
     "id": 295,
@@ -4452,7 +4452,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Is[SP]it[SP]true[SP]one[SP]may[SP]win[SP]real[SP]weapons\nin[SP]a[SP]magazine[SP]sweepstakes?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?[NL]Il n'est pas difficile de gagner, mais on peut\nse demander pourquoi on a pris la peine."
+    "texte_fr": "Hyaaaah ![000F][1205] Est-il vrai qu'on peut gagner de vraies armes\ndans un concours de magazine ?[NL]Il n'est pas difficile de gagner, mais on peut\nse demander pourquoi on a pris la peine."
   },
   {
     "id": 297,
@@ -4482,7 +4482,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]I[SP]am[SP]a[SP]mere[SP]student[SP]striving[SP]to[SP]make\nit[SP]into[SP]the[SP]country's[SP]best[SP]college.[SP]I[SP]have[SP]no\ntime[SP]to[SP]fritter[SP]away[SP]on[SP]gambling!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent ![NL]...Cependant, il ne faut pas négliger le monde réel.\nJ'entends qu'on peut gagner gros à la\nmachine #5... Ça ne ferait pas de mal d'essayer."
+    "texte_fr": "Hyaaaah ![000F][1205] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent ![NL]...Cependant, il ne faut pas négliger le monde réel. J'entends qu'on peut gagner gros à la machine #5... Ça ne ferait pas de mal d'essayer."
   },
   {
     "id": 299,
@@ -4512,7 +4512,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]I[SP]am[SP]a[SP]mere[SP]student[SP]striving[SP]to[SP]make\nit[SP]into[SP]the[SP]country's[SP]best[SP]college.[SP]I[SP]have[SP]no\ntime[SP]to[SP]fritter[SP]away[SP]on[SP]gambling!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent ![NL]...Cependant, il ne faut pas négliger le monde réel.\nJ'entends qu'on peut gagner gros à la\nmachine #1... Ça ne ferait pas de mal d'essayer."
+    "texte_fr": "Hyaaaah ![000F][1205] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent ![NL]...Cependant, il ne faut pas négliger le monde réel. J'entends qu'on peut gagner gros à la machine #1... Ça ne ferait pas de mal d'essayer."
   },
   {
     "id": 301,
@@ -4542,7 +4542,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]I[SP]am[SP]a[SP]mere[SP]student[SP]striving[SP]to[SP]make\nit[SP]into[SP]the[SP]country's[SP]best[SP]college.[SP]I[SP]have[SP]no\ntime[SP]to[SP]fritter[SP]away[SP]on[SP]gambling!",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent ![NL]Mais le blackjack est une exception. Je n'aime pas ça,\npas vraiment, mais il paraît qu'on peut y gagner\ngros. Mes études ne sont pas gratuites !"
+    "texte_fr": "Hyaaaah ![000F][1205] Je suis un simple étudiant voulant intégrer\nla meilleure faculté. Je n'ai pas de temps à perdre\ndans les jeux d'argent ![NL]Mais le blackjack est une exception. Je n'aime pas ça, pas vraiment, mais il paraît qu'on peut y gagner gros. Mes études ne sont pas gratuites !"
   },
   {
     "id": 303,
@@ -4572,7 +4572,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]A[SP]legendary[SP]weapon...[SP]They[SP]have[SP]such\na[SP]thing[SP]at[SP]Shiraishi[SP]Ramen...[SP]I'd[SP]like[SP]to[SP]see\nit[SP]for[SP]myself,[SP]just[SP]once.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Une arme légendaire... Ils ont ça\nchez Shiraishi Ramen... J'aimerais la voir\nde mes propres yeux, juste une fois."
+    "texte_fr": "Hyaaaah ![000F][1205] Une arme légendaire... Ils ont ça\nchez Shiraishi Ramen... J'aimerais la voir\nde mes propres yeux, juste une fois."
   },
   {
     "id": 305,
@@ -4587,7 +4587,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]Is[SP]there[SP]really[SP]a[SP]legendary[SP]weapon\nin[SP]stock[SP]at[SP]Clair[SP]de[SP]Lune?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Y a-t-il vraiment une arme légendaire\nen stock chez Clair de Lune ?[NL]Bah ! Les armes d'un étudiant sont les stylos\net les livres ! Cela ne me concerne pas."
+    "texte_fr": "Hyaaaah ![000F][1205] Y a-t-il vraiment une arme légendaire\nen stock chez Clair de Lune ?[NL]Bah ! Les armes d'un étudiant sont les stylos\net les livres ! Cela ne me concerne pas."
   },
   {
     "id": 306,
@@ -4617,7 +4617,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]That[SP]owner[SP]at[SP]Time[SP]Castle...[SP]Claiming\nnot[SP]to[SP]have[SP]what[SP]he[SP]in[SP]fact[SP]does,[SP]in[SP]a[SP]bid[SP]to\ndrive[SP]up[SP]its[SP]price,[SP]is[SP]unforgivable.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Ce propriétaire de Time Castle... Prétendre\nne pas avoir ce qu'il a en fait, dans le but\nde faire monter son prix, est impardonnable.[NL]Mais Time Castle a-t-il vraiment une arme\nlégendaire, pour commencer ?"
+    "texte_fr": "Hyaaaah ![000F][1205] Ce propriétaire de Time Castle... Prétendre\nne pas avoir ce qu'il a en fait, dans le but\nde faire monter son prix, est impardonnable.[NL]Mais Time Castle a-t-il vraiment une arme légendaire, pour commencer ?"
   },
   {
     "id": 308,
@@ -4647,7 +4647,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]A[SP]merchant[SP]should[SP]meet[SP]the[SP]needs[SP]of\nhis[SP]customers[SP]even[SP]at[SP]the[SP]risk[SP]of[SP]his[SP]own[SP]life!\nYet[SP]that[SP]owner[SP]at[SP]Time[SP]Castle...",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Un marchand doit répondre aux besoins\nde ses clients au péril de sa vie !\nPourtant ce propriétaire...[NL]Il n'a pas encore réclamé son arme légendaire.\nMême maintenant, le vendeur attend à l'usine\nabandonnée que le propriétaire vienne.[NL]Mais il a trop peur des monstres pour sortir !\nC'est pitoyable ! J'aimerais que quelqu'un d'autre\naille acheter l'arme à sa place."
+    "texte_fr": "Hyaaaah ![000F][1205] Un marchand doit répondre aux besoins\nde ses clients au péril de sa vie !\nPourtant ce propriétaire...[NL]Il n'a pas encore réclamé son arme légendaire. Même maintenant, le vendeur attend à l'usine abandonnée que le propriétaire vienne.[NL]Mais il a trop peur des monstres pour sortir ! C'est pitoyable ! J'aimerais que quelqu'un d'autre aille acheter l'arme à sa place."
   },
   {
     "id": 310,
@@ -4722,7 +4722,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]It[SP]seems[SP]the[SP]legendary[SP]weapon[SP]at\nTime[SP]Castle[SP]has[SP]been[SP]sold![SP]I[SP]hear[SP]that[SP]an\nunusually[SP]unlucky[SP]woman[SP]bought[SP]it.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] L'arme légendaire de\nTime Castle a été vendue ! J'entends qu'une femme\nparticulièrement malchanceuse l'a achetée.[NL]Hrghhh... Quel culot ! Et si elle l'utilisait pour\nmettre fin à ses jours !? S'il me l'avait\nconfiée, j'en aurais fait bon usage..."
+    "texte_fr": "Hyaaaah ![000F][1205] L'arme légendaire de\nTime Castle a été vendue ! J'entends qu'une femme\nparticulièrement malchanceuse l'a achetée.[NL]Hrghhh... Quel culot ! Et si elle l'utilisait pour mettre fin à ses jours !? S'il me l'avait confiée, j'en aurais fait bon usage..."
   },
   {
     "id": 315,
@@ -4752,7 +4752,7 @@
     "nom_orig": "Fighting[SP]washout[SP]student",
     "texte_orig": "Hyaaaah![1205][000F][SP]That[SP]dastardly[SP]owner[SP]of[SP]Time[SP]Castle!\nHe[SP]gave[SP]the[SP]legendary[SP]weapon[SP]to[SP]a[SP]woman[SP]with\nshort[SP]hair![SP]How[SP]dare[SP]he[SP]become[SP]so[SP]smitten!?",
     "nom_fr": "Étudiant",
-    "texte_fr": "Hyaaaah ![1205][000F] Ce lâche propriétaire de Time Castle !\nIl a donné l'arme légendaire à une femme\naux cheveux courts ! Comment a-t-il pu !?[NL]Eh ? Quel genre de femme était-ce ? B-Belle, je\nsuppose... J-Je ne suis pas envieux, pas du tout !"
+    "texte_fr": "Hyaaaah ![000F][1205] Ce lâche propriétaire de Time Castle !\nIl a donné l'arme légendaire à une femme\naux cheveux courts ! Comment a-t-il pu !?[NL]Eh ? Quel genre de femme était-ce ? B-Belle, je suppose... J-Je ne suis pas envieux, pas du tout !"
   },
   {
     "id": 317,
@@ -4782,7 +4782,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Many[SP]of[SP]my[SP]comrades[SP]are[SP]complaining,[SP]but[SP]I\nintend[SP]to[SP]follow[SP]Joker's[SP]orders![1205][000F][SP]This[SP]is[SP]our\ncity,[SP]after[SP]all!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Beaucoup de camarades se plaignent,\nmais j'obéirai au Joker ![1205][000F] C'est\nnotre ville, après tout !"
+    "texte_fr": "Beaucoup de camarades se plaignent,\nmais j'obéirai au Joker ![000F][1205] C'est\nnotre ville, après tout !"
   },
   {
     "id": 319,
@@ -4797,7 +4797,7 @@
     "nom_orig": "Last[SP]Battalion[SP]soldier",
     "texte_orig": "Our[SP]Fuhrer[SP]has[SP]already[SP]reached[SP]his[SP]destination.[1205][000F]\nAll[SP]nearby[SP]civilians[SP]must[SP]surrender[SP]immediately.",
     "nom_fr": "Bataillon",
-    "texte_fr": "Notre Führer a atteint sa destination.[1205][000F]\nLes civils à proximité doivent se rendre."
+    "texte_fr": "Notre Führer a atteint sa destination.[000F][1205]\nLes civils à proximité doivent se rendre."
   },
   {
     "id": 320,
@@ -4992,7 +4992,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Smile[SP]Hirasaka...[1205][000F][SP]Is[SP]this[SP]the[SP]target?\nOr...?",
     "nom_fr": "Maya",
-    "texte_fr": "Smile Hirasaka...[1205][000F] Est-ce la cible ?\nOu... ?"
+    "texte_fr": "Smile Hirasaka...[000F][1205] Est-ce la cible ?\nOu... ?"
   },
   {
     "id": 333,
@@ -5007,7 +5007,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We[SP]can't[SP]overthink[SP]this.[1205][000F][SP]Let's[SP]just[SP]hurry[SP]up\nand[SP]get[SP]inside.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Faut pas trop y penser.[1205][000F] Dépêchons-nous\nd'entrer."
+    "texte_fr": "Faut pas trop y penser.[000F][1205] Dépêchons-nous\nd'entrer."
   },
   {
     "id": 334,
@@ -5022,7 +5022,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun?[1205][000F][SP]Should[SP]we[SP]search[SP]through[SP]here?",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun ?[1205][000F] On devrait chercher par ici ?\n[NULL][NULL]Ouais, jetons un œil.[NULL][NULL]\n[NULL][NULL]Non, c'est pas le bon endroit.[NULL][NULL][NL]Ok. Si c'est décidé, dépêchons-nous.\nOn a peu de temps à perdre."
+    "texte_fr": "[1113]-kun ?[000F][1205] On devrait chercher par ici ?\n[NULL][NULL]Ouais, jetons un œil.[NULL][NULL]\n[NULL][NULL]Non, c'est pas le bon endroit.[NULL][NULL][NL]Ok. Si c'est décidé, dépêchons-nous. On a peu de temps à perdre."
   },
   {
     "id": 335,
@@ -5067,7 +5067,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]place[SP]is[SP]safe[SP]and[SP]sound.\nQuestion[SP]is,[SP]where's[SP]the[SP]next[SP]target...?\nGOLD[SP]or[SP]Pachinko[SP]Silver?",
     "nom_fr": "Maya",
-    "texte_fr": "Cet endroit est sain et sauf.\nMais où est la prochaine cible... ?\nGOLD ou Pachinko Silver ?[NL]C'est à toi de voir, -kun. Mais on a\npeu de temps, alors en route."
+    "texte_fr": "Cet endroit est sain et sauf.\nMais où est la prochaine cible... ?\nGOLD ou Pachinko Silver ?[NL]C'est à toi de voir, -kun. Mais on a peu de temps, alors en route."
   },
   {
     "id": 338,
@@ -5172,7 +5172,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]not[SP]like[SP]Jun-kun[SP]to[SP]wish[SP]for[SP]something\nlike[SP]this.[SP]Wait[SP]for[SP]me...[SP]I'm[SP]coming[SP]to[SP]get\nyou[SP]this[SP]time...[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nThe[SP]Sakanoue[SP]Building?[1205][000A][SP]Why[SP]would[SP]we[SP]go[SP]there?[1205][000A]\nC'mon,[SP]let's[SP]go[SP]somewhere[SP]else.",
     "nom_fr": "Maya",
-    "texte_fr": "Ce n'est pas le genre de Jun-kun de souhaiter\nune telle chose. Attends-moi... Je viens\nte chercher cette fois...[NULL][NULL]\"Eikichi\nLe Bâtiment Sakanoue ?[1205][000A] Pourquoi on irait là-bas ?[1205][000A]\nAllez, allons ailleurs.[E1][E2][E3][E4]"
+    "texte_fr": "Ce n'est pas le genre de Jun-kun de souhaiter\nune telle chose. Attends-moi... Je viens\nte chercher cette fois...[NULL][NULL]\"Eikichi\nLe Bâtiment Sakanoue ?[000A][1205] Pourquoi on irait là-bas ?[000A][1205]\nAllez, allons ailleurs.[E1][E2][E3][E4]"
   },
   {
     "id": 345,
@@ -5202,7 +5202,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]Sakanoue[SP]Building...[1205][000F][SP]Is[SP]this[SP]the[SP]next\ntarget...?",
     "nom_fr": "Maya",
-    "texte_fr": "Bâtiment Sakanoue...[1205][000F] Est-ce la prochaine\ncible... ?"
+    "texte_fr": "Bâtiment Sakanoue...[000F][1205] Est-ce la prochaine\ncible... ?"
   },
   {
     "id": 347,
@@ -5217,7 +5217,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Let's[SP]worry[SP]about[SP]that[SP]later.[1205][000F][SP]We[SP]gotta[SP]hurry\nand[SP]take[SP]care[SP]of[SP]those[SP]bombs!",
     "nom_fr": "Eikichi",
-    "texte_fr": "On s'en souciera plus tard.[1205][000F] Faut se dépêcher\nde s'occuper de ces bombes !"
+    "texte_fr": "On s'en souciera plus tard.[000F][1205] Faut se dépêcher\nde s'occuper de ces bombes !"
   },
   {
     "id": 348,
@@ -5232,7 +5232,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun?[1205][000F][SP]Should[SP]we[SP]search[SP]through[SP]here?",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun ?[1205][000F] On devrait chercher par ici ?\n[NULL][NULL]Ouais, jetons un œil.[NULL][NULL]\n[NULL][NULL]Non, c'est pas le bon endroit.[NULL][NULL][NL]Ok. Si c'est décidé, dépêchons-nous.\nOn n'a pas de temps à perdre."
+    "texte_fr": "[1113]-kun ?[000F][1205] On devrait chercher par ici ?\n[NULL][NULL]Ouais, jetons un œil.[NULL][NULL]\n[NULL][NULL]Non, c'est pas le bon endroit.[NULL][NULL][NL]Ok. Si c'est décidé, dépêchons-nous. On n'a pas de temps à perdre."
   },
   {
     "id": 349,
@@ -5322,7 +5322,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Huh?[SP]It's[SP]locked.[SP]Guess[SP]we[SP]can't[SP]get[SP]in.[1205][000F]\nOh[SP]well,[SP]let's[SP]go[SP]somewhere[SP]else.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hein ? C'est fermé, on ne peut pas\nentrer.[1205][000F] Tant pis, allons ailleurs."
+    "texte_fr": "Hein ? C'est fermé, on ne peut pas\nentrer.[000F][1205] Tant pis, allons ailleurs."
   },
   {
     "id": 355,
@@ -5367,7 +5367,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "S-Smile[SP]Hirasaka...[1205][000F][SP]No...",
     "nom_fr": "Ginko",
-    "texte_fr": "Smile Hirasaka...[1205][000F] Non..."
+    "texte_fr": "Smile Hirasaka...[000F][1205] Non..."
   },
   {
     "id": 358,
@@ -5382,7 +5382,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Holy[SP]shit...[1205][000F][SP]We[SP]were[SP]so[SP]close!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Merde...[1205][000F] On y était presque !"
+    "texte_fr": "Merde...[000F][1205] On y était presque !"
   },
   {
     "id": 359,
@@ -5412,7 +5412,7 @@
     "nom_orig": "Elly's[SP]voice",
     "texte_orig": "Hello?[1205][000F][SP]It's[SP]me,[SP]Elly.[1205][000F][SP]I've[SP]narrowed[SP]down[SP]the\nnext[SP]target.[SP]This[SP]clue's[SP]also[SP]related[SP]to\nastrology...",
     "nom_fr": "Voix d'Elly",
-    "texte_fr": "Allô ?[1205][000F] C'est moi, Elly.[1205][000F] J'ai réduit la\nprochaine cible. Cet indice est aussi lié à\nl'astrologie...[NL]C'est au nord-nord-est de Seven.\nLes seuls trucs là-bas sont Pachinko Silver\net GOLD à Yumezaki. La prochaine cible est--"
+    "texte_fr": "Allô ?[000F][1205] C'est moi, Elly.[000F][1205] J'ai réduit la\nprochaine cible. Cet indice est aussi lié à\nl'astrologie...[NL]C'est au nord-nord-est de Seven. Les seuls trucs là-bas sont Pachinko Silver et GOLD à Yumezaki. La prochaine cible est--"
   },
   {
     "id": 361,
@@ -5442,7 +5442,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Elly-san,[SP]please![SP]Can[SP]you[SP]be[SP]more[SP]specific\nabout[SP]the[SP]location?[1205][000F][SP]Which[SP]one[SP]is[SP]King[SP]Leo's\nnext[SP]target?",
     "nom_fr": "Maya",
-    "texte_fr": "Elly-san ! Sois plus précise\nsur le lieu.[1205][000F] Quelle est la\nprochaine cible du Roi Lion ?"
+    "texte_fr": "Elly-san ! Sois plus précise\nsur le lieu.[000F][1205] Quelle est la\nprochaine cible du Roi Lion ?"
   },
   {
     "id": 363,
@@ -5457,7 +5457,7 @@
     "nom_orig": "Elly's[SP]voice",
     "texte_orig": "Then...[1205][000F][SP]You...[1205][000F][SP]You[SP]couldn't[SP]prevent[SP]the\nfire...[1205][000F][SP]I-I'm[SP]sorry...[1205][000F][SP]There's[SP]not[SP]much[SP]more\nI[SP]can[SP]tell[SP]you...",
     "nom_fr": "Voix d'Elly",
-    "texte_fr": "Alors...[1205][000F] Vous...[1205][000F] N'avez pas pu stopper\nl'incendie...[1205][000F] Désolée...[1205][000F] Je ne peux\nvous en dire plus..."
+    "texte_fr": "Alors...[000F][1205] Vous...[000F][1205] N'avez pas pu stopper\nl'incendie...[000F][1205] Désolée...[000F][1205] Je ne peux\nvous en dire plus..."
   },
   {
     "id": 364,
@@ -5487,7 +5487,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Look[SP]alive,[SP]people![SP]This[SP]is[SP]not[SP]the[SP]time[SP]for\nmoping![SP]We[SP]have[SP]to[SP]get[SP]a[SP]grip[SP]if[SP]we[SP]want[SP]to\nstop[SP]any[SP]more[SP]deaths!",
     "nom_fr": "Yukino",
-    "texte_fr": "Réveillez-vous ! Ce n'est pas le moment\nde broyer du noir ! Reprenons-nous si on veut\néviter d'autres morts ![NL]Tenez bon ! Courage ! La prochaine cible est\nGOLD ou Pachinko Silver à Yumezaki ![NL]Il LE faut, sinon la prochaine\nbombe explosera ! , ne\nnous égare pas !"
+    "texte_fr": "Réveillez-vous ! Ce n'est pas le moment\nde broyer du noir ! Reprenons-nous si on veut\néviter d'autres morts ![NL]Tenez bon ! Courage ! La prochaine cible est GOLD ou Pachinko Silver à Yumezaki ![NL]Il LE faut, sinon la prochaine bombe explosera ! , ne nous égare pas !"
   },
   {
     "id": 366,

--- a/traduction/MMAP02.json
+++ b/traduction/MMAP02.json
@@ -12,7 +12,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Yo,[SP]you[SP]here[SP]to[SP]have[SP]some[SP]fun[SP]too?[1205][000F][SP]'Course[SP]you\nare.[SP]Yumezaki's[SP]the[SP]district[SP]for[SP]kids![SP]Wall-to-\nwall[SP]entertainment!",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Yo, tu viens t'amuser aussi ?[1205][000F] Bien sûr.\nYumezaki est pour les jeunes !\nDu divertissement partout ![NL]Mu, le meilleur centre de jeux. Giga Macho,\nun disquaire avec studio. Anima Mundi,\nle temple de la mode.[NL]Un gars de mon âge peut passer toute la\njournée ici sans s'ennuyer.[NL]Les filles ici... Ouf ! Heheh."
+    "texte_fr": "Yo, tu viens t'amuser aussi ?[000F][1205] Bien sûr.\nYumezaki est pour les jeunes !\nDu divertissement partout ![NL]Mu, le meilleur centre de jeux. Giga Macho, un disquaire avec studio. Anima Mundi, le temple de la mode.[NL]Un gars de mon âge peut passer toute la journée ici sans s'ennuyer.[NL]Les filles ici... Ouf ! Heheh."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Mu,[SP]the[SP]hottest[SP]amusement[SP]center.[1205][000F][SP]Giga[SP]Macho,\na[SP]record[SP]store[SP]with[SP]a[SP]recording[SP]studio.[1205][000F][SP]Anima\nMundi,[SP]home[SP]of[SP]the[SP]latest[SP]fashions.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "On dirait qu'il y a un nouveau chef à Kakasu.[1205][U+000F]\nPlus fort que l'ancien, non ?[1205][000F][000F]"
+    "texte_fr": "On dirait qu'il y a un nouveau chef à Kakasu.[1205][U+000F]\nPlus fort que l'ancien, non ?[000F][1205][000F]"
   },
   {
     "id": 2,
@@ -72,7 +72,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Looks[SP]like[SP]there's[SP]a[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High.[1205][000F]\nHe's[SP]stronger[SP]than[SP]the[SP]old[SP]Boss,[SP]right?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "On dirait qu'il y a un nouveau chef à Kakasu.[1205][000F]\nPlus fort que l'ancien, non ?"
+    "texte_fr": "On dirait qu'il y a un nouveau chef à Kakasu.[000F][1205]\nPlus fort que l'ancien, non ?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Heh,[SP]they're[SP]having[SP]a[SP]masquerade[SP]as[SP]part[SP]of\ntheir[SP]school[SP]festival.[SP]Cuss[SP]High[SP]sure[SP]knows\nhow[SP]to[SP]draw[SP]a[SP]crowd.[1205][000F][SP]All[SP]my[SP]friends[SP]are[SP]going.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ils font un bal masqué pour leur festival.\nLe lycée Kakasu sait comment attirer la\nfoule.[1205][000F] Tous mes potes y vont."
+    "texte_fr": "Ils font un bal masqué pour leur festival.\nLe lycée Kakasu sait comment attirer la\nfoule.[000F][1205] Tous mes potes y vont."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Ooh,[SP]you[SP]on[SP]your[SP]way[SP]to[SP]Mu?[1205][000F][SP]We[SP]might[SP]catch[SP]a\nglimpse[SP]of[SP]the[SP]Muses[SP]live![SP]I[SP]better[SP]get[SP]going.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ooh, tu vas à Mu ?[1205][000F] On pourrait voir les\nMuses en direct ! Il faut que j'y aille."
+    "texte_fr": "Ooh, tu vas à Mu ?[000F][1205] On pourrait voir les\nMuses en direct ! Il faut que j'y aille."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Ugh,[SP]I[SP]was[SP]just[SP]at[SP]Giga[SP]Macho,[SP]and[SP]it[SP]was[SP]packed\nwith[SP]guys[SP]trying[SP]to[SP]scope[SP]out[SP]the[SP]Muses[SP]event.[1205][000F]\nBandwagon-hopping[SP]bastards...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ugh, j'étais à Giga Macho, c'était rempli de\ngars voulant voir l'événement des Muses.[1205][000F]\nBande de moutons...[NL]Ça va puer si d'autres nazes se pointent.\nJe suis fan depuis bien avant que ce soit cool."
+    "texte_fr": "Ugh, j'étais à Giga Macho, c'était rempli de\ngars voulant voir l'événement des Muses.[000F][1205]\nBande de moutons...[NL]Ça va puer si d'autres nazes se pointent. Je suis fan depuis bien avant que ce soit cool."
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Dude,[SP]everyone[SP]went[SP]to[SP]go[SP]see[SP]the[SP]concert\nin[SP]Aoba...[1205][000F][SP]Am[SP]I[SP]the[SP]only[SP]one[SP]who[SP]didn't[SP]go?[1205][000F]\nLame...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Tous sont allés voir le concert à Aoba...[1205][000F]\nJe suis le seul à pas y être allé ?[1205][000F] Nul..."
+    "texte_fr": "Tous sont allés voir le concert à Aoba...[000F][1205]\nJe suis le seul à pas y être allé ?[000F][1205] Nul..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Hey,[SP]what's[SP]the[SP]Masked[SP]Circle?[1205][000F][SP]They're[SP]the[SP]ones\nwho[SP]set[SP]fire[SP]to[SP]the[SP]concert[SP]hall,[SP]right?[SP]That's\nwhat[SP]my[SP]friend's[SP]friend[SP]said.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Hé, c'est quoi le Cercle masqué ?[1205][000F] Ce sont\neux qui ont incendié la salle de concert,\nnon ? C'est ce qu'un pote a dit.[NL]Même leur nom est louche. S'ils font\nvraiment ce genre de trucs, ils doivent\nêtre hyper dangereux."
+    "texte_fr": "Hé, c'est quoi le Cercle masqué ?[000F][1205] Ce sont\neux qui ont incendié la salle de concert,\nnon ? C'est ce qu'un pote a dit.[NL]Même leur nom est louche. S'ils font vraiment ce genre de trucs, ils doivent être hyper dangereux."
   },
   {
     "id": 11,
@@ -222,7 +222,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Is[SP]it[SP]true[SP]the[SP]terrorists[SP]bombed[SP]Smile\nHirasaka?[SP]Dude,[SP]seriously...?[1205][000A][SP]They[SP]could\nhit[SP]here[SP]next![1205][000F][SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]run.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ils ont vraiment bombardé Smile Hirasaka ?\nSérieux ?[1205][000A] Ils pourraient viser ici !\n[1205][000F]Je devrais fuir."
+    "texte_fr": "Ils ont vraiment bombardé Smile Hirasaka ?\nSérieux ?[000A][1205] Ils pourraient viser ici !\n[000F][1205]Je devrais fuir."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "What,[SP]they[SP]even[SP]targeted[SP]GOLD!?[1205][000F][SP]Does[SP]that[SP]mean\nYumezaki's[SP]not[SP]safe[SP]either!?[SP]When[SP]will[SP]someone\ndo[SP]something[SP]about[SP]this...?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Quoi, ils ont même ciblé GOLD !?[1205][000F] Ça\nveut dire que Yumezaki n'est pas sûr\nnon plus !? Quand vont-ils agir... ?"
+    "texte_fr": "Quoi, ils ont même ciblé GOLD !?[000F][1205] Ça\nveut dire que Yumezaki n'est pas sûr\nnon plus !? Quand vont-ils agir... ?"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "O-Oh[SP]shit,[SP]they[SP]got[SP]GOLD[SP]too...[1205][000F][SP]H-Hey,[SP]where\nare[SP]they[SP]gonna[SP]strike[SP]next!?[1205][000F][SP]If[SP]I[SP]don't[SP]know\nthat...[SP]I[SP]don't[SP]know[SP]where[SP]to[SP]run[SP]to...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "M-Merde, ils ont eu GOLD aussi...[1205][000F] H-Hé,\noù vont-ils frapper ensuite !?[1205][000F] Si je ne le\nsais pas... je ne sais pas où fuir..."
+    "texte_fr": "M-Merde, ils ont eu GOLD aussi...[000F][1205] H-Hé,\noù vont-ils frapper ensuite !?[000F][1205] Si je ne le\nsais pas... je ne sais pas où fuir..."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "They've[SP]posted[SP]composite[SP]sketches[SP]of[SP]the[SP]suspects,\nright?[1205][000F][SP]Looks[SP]like[SP]crime[SP]doesn't[SP]pay[SP]after[SP]all.\nBut[SP]wasn't[SP]it[SP]the[SP]Masked[SP]Circle[SP]who[SP]did[SP]this?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ils ont publié les portraits-robots des\nsuspects, non ?[1205][000F] Le crime ne paie pas.\nMais n'était-ce pas le Cercle masqué ?"
+    "texte_fr": "Ils ont publié les portraits-robots des\nsuspects, non ?[000F][1205] Le crime ne paie pas.\nMais n'était-ce pas le Cercle masqué ?"
   },
   {
     "id": 18,
@@ -297,7 +297,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Are[SP]those[SP]guys[SP]not[SP]the[SP]culprits?[1205][000F][SP]Or[SP]are[SP]they\nreally[SP]terrorists[SP]after[SP]all?",
     "nom_fr": "Femme active",
-    "texte_fr": "Muses garde toujours sa troisième membre\nsecrète ?[1205][U+000F] Je sais que c'est du marketing,\nmais j'aimerais qu'ils arrêtent ce teasing.[1106][NL]Ou comptent-ils faire une annonce\npendant l'enregistrement aujourd'hui ?[000F]"
+    "texte_fr": "Muses garde toujours sa troisième membre\nsecrète ?[1205][U+000F] Je sais que c'est du marketing,\nmais j'aimerais qu'ils arrêtent ce teasing.[1106][NL]Ou comptent-ils faire une annonce pendant l'enregistrement aujourd'hui ?[000F]"
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Dude,[SP]shit[SP]keeps[SP]going[SP]down[SP]right[SP]and[SP]left!\nWhat's[SP]going[SP]on!?[1205][000F][SP]Were[SP]those[SP]guys[SP]terrorists\nor[SP]not!?[SP]What[SP]are[SP]they[SP]doing[SP]to[SP]our[SP]city!?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Mec, c'est le bordel de partout !\nIl se passe quoi !?[1205][000F] Ces gars étaient des\nterroristes ou pas !? Ils font quoi ici !?"
+    "texte_fr": "Mec, c'est le bordel de partout !\nIl se passe quoi !?[000F][1205] Ces gars étaient des\nterroristes ou pas !? Ils font quoi ici !?"
   },
   {
     "id": 21,
@@ -342,7 +342,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Was[SP]he[SP]a[SP]Cuss[SP]High[SP]student?[SP]He[SP]had[SP]a[SP]really\ncute[SP]girl[SP]with[SP]him,[SP]though...",
     "nom_fr": "Femme active",
-    "texte_fr": "J'irais à la campagne si je le pouvais.[1205][U+000F]\nMalheureusement, ce n'est pas possible.[1106][NL]J'ai une tonne de boulot en retard et\nrien n'indique qu'il y aura une bombe ici.[1106][NL]Mais je regretterai s'il y A une bombe ici.[1106][NL]Je me demande si je suis trop habituée\nà la paix pour pouvoir me décider."
+    "texte_fr": "J'irais à la campagne si je le pouvais.[1205][U+000F]\nMalheureusement, ce n'est pas possible.[1106][NL]J'ai une tonne de boulot en retard et\nrien n'indique qu'il y aura une bombe ici.[1106][NL]Mais je regretterai s'il y A une bombe ici.[1106][NL]Je me demande si je suis trop habituée à la paix pour pouvoir me décider."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Hm?[SP]Are[SP]you[SP]hitting[SP]on[SP]me?[1205][000F][SP]If[SP]you[SP]are,[SP]I[SP]hate\nto[SP]break[SP]it[SP]to[SP]you,[SP]but[SP]I'm[SP]a[SP]little[SP]busy.",
     "nom_fr": "Femme active",
-    "texte_fr": "Hm ? Tu me dragues ?[1205][000F] Si c'est le cas,\ndésolée de te décevoir, mais je suis occupée.[NL]Oh, ce n'était pas ça ? Haha, désolée.\nÇa me rappelle, tu vas au lycée Kakasu ?[NL]J'ai vu un groupe de Kakasu entrer dans\nZodiac. Tu sais ce qu'ils y font ?"
+    "texte_fr": "Hm ? Tu me dragues ?[000F][1205] Si c'est le cas,\ndésolée de te décevoir, mais je suis occupée.[NL]Oh, ce n'était pas ça ? Haha, désolée.\nÇa me rappelle, tu vas au lycée Kakasu ?[NL]J'ai vu un groupe de Kakasu entrer dans Zodiac. Tu sais ce qu'ils y font ?"
   },
   {
     "id": 24,
@@ -387,7 +387,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Because[SP]I[SP]saw[SP]a[SP]group[SP]of[SP]Cuss[SP]High[SP]kids[SP]going\ninto[SP]Zodiac[SP]a[SP]moment[SP]ago.[1205][000F][SP]Do[SP]you[SP]know[SP]what\nthey're[SP]up[SP]to[SP]in[SP]there?",
     "nom_fr": "Femme active",
-    "texte_fr": "Huh.[1205][U+000F] Ces jeunes étaient trempés et disaient\nque les gars aux infos étaient des héros\ncontre le Cercle masqué...[1205][0014] Qui croire ?[000F]"
+    "texte_fr": "Huh.[1205][U+000F] Ces jeunes étaient trempés et disaient\nque les gars aux infos étaient des héros\ncontre le Cercle masqué...[0014][1205] Qui croire ?[000F]"
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "That[SP]reminds[SP]me,[SP]rumor[SP]has[SP]it[SP]there's[SP]a[SP]secret\nlounge[SP]deep[SP]inside[SP]Zodiac.[1205][000F][SP]I've[SP]never[SP]gone[SP]to\nsee[SP]it,[SP]though...",
     "nom_fr": "Femme active",
-    "texte_fr": "D'ailleurs, la rumeur dit qu'il y a un salon\nsecret au fond de Zodiac.[1205][000F] Je n'y suis\njamais allée, par contre..."
+    "texte_fr": "D'ailleurs, la rumeur dit qu'il y a un salon\nsecret au fond de Zodiac.[000F][1205] Je n'y suis\njamais allée, par contre..."
   },
   {
     "id": 27,
@@ -447,7 +447,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Young[SP]kids[SP]tend[SP]to[SP]gather[SP]here,[SP]so[SP]TV[SP]stations\nsend[SP]reporters[SP]to[SP]interview[SP]them[SP]and[SP]hold\nevents.[1205][000F][SP]Aren't[SP]they[SP]having[SP]one[SP]at[SP]Mu[SP]today?",
     "nom_fr": "Femme active",
-    "texte_fr": "Les jeunes traînent ici, donc la télé\nenvoie des reporters pour les interviewer\net faire des trucs.[1205][000F] C'est à Mu aujourd'hui ?"
+    "texte_fr": "Les jeunes traînent ici, donc la télé\nenvoie des reporters pour les interviewer\net faire des trucs.[000F][1205] C'est à Mu aujourd'hui ?"
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Is[SP]Muses[SP]still[SP]keeping[SP]their[SP]third[SP]member[SP]a\nsecret?[1205][000F][SP]I[SP]know[SP]it's[SP]a[SP]marketing[SP]strategy,[SP]but\nI[SP]wish[SP]they'd[SP]stop[SP]fanning[SP]the[SP]flames.",
     "nom_fr": "Femme active",
-    "texte_fr": "Muses garde toujours sa troisième membre\nsecrète ?[1205][000F] Je sais que c'est du marketing,\nmais j'aimerais qu'ils arrêtent ce teasing.[NL]Ou comptent-ils faire une annonce\npendant l'enregistrement aujourd'hui ?"
+    "texte_fr": "Muses garde toujours sa troisième membre\nsecrète ?[000F][1205] Je sais que c'est du marketing,\nmais j'aimerais qu'ils arrêtent ce teasing.[NL]Ou comptent-ils faire une annonce pendant l'enregistrement aujourd'hui ?"
   },
   {
     "id": 31,
@@ -492,7 +492,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "They[SP]just[SP]revealed[SP]the[SP]third[SP]member,[SP]and[SP]they're\nalready[SP]giving[SP]a[SP]concert?[1205][000F][SP]That's[SP]pretty[SP]sudden.",
     "nom_fr": "Femme active",
-    "texte_fr": "Ils viennent de révéler la troisième membre\net ils donnent déjà un concert ?[1205][000F] Rapide.[NL]Soit ce Ginji Sasaki est très doué,\nsoit il est extrêmement pressé."
+    "texte_fr": "Ils viennent de révéler la troisième membre\net ils donnent déjà un concert ?[000F][1205] Rapide.[NL]Soit ce Ginji Sasaki est très doué,\nsoit il est extrêmement pressé."
   },
   {
     "id": 33,
@@ -522,7 +522,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "They[SP]say[SP]these[SP]bombings[SP]are[SP]part[SP]of[SP]a[SP]wave\nof[SP]terror.[1205][000F][SP]There's[SP]no[SP]knowing[SP]where[SP]they'll\nstrike[SP]next.",
     "nom_fr": "Femme active",
-    "texte_fr": "Ces attentats sont une vague de terreur.[1205][000F]\nImpossible de savoir où ils frapperont.[NL]Ils n'attaqueront pas ici, non... ?\nÇa m'inquiète beaucoup."
+    "texte_fr": "Ces attentats sont une vague de terreur.[000F][1205]\nImpossible de savoir où ils frapperont.[NL]Ils n'attaqueront pas ici, non... ?\nÇa m'inquiète beaucoup."
   },
   {
     "id": 35,
@@ -537,7 +537,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "They[SP]won't[SP]attack[SP]here,[SP]right...?[1205][000F][SP]I[SP]worry\nabout[SP]that[SP]a[SP]lot.",
     "nom_fr": "Homme",
-    "texte_fr": "La salle en plein air est pleine.[1106][NL]J'envie leur succès... C'est dur pour nous\nqui avons traversé des crises.[1205][000F]"
+    "texte_fr": "La salle en plein air est pleine.[1106][NL]J'envie leur succès... C'est dur pour nous\nqui avons traversé des crises.[000F][1205]"
   },
   {
     "id": 36,
@@ -552,7 +552,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "I'd[SP]evacuate[SP]to[SP]the[SP]countryside[SP]if[SP]I[SP]could.[1205][000F]\nUnfortunately,[SP]that's[SP]not[SP]an[SP]option.",
     "nom_fr": "Femme active",
-    "texte_fr": "J'irais à la campagne si je le pouvais.[1205][000F]\nMalheureusement, ce n'est pas possible.[NL]J'ai une tonne de boulot en retard et\nrien n'indique qu'il y aura une bombe ici.[NL]Mais je regretterai s'il y A une bombe ici.[NL]Je me demande si je suis trop habituée\nà la paix pour pouvoir me décider."
+    "texte_fr": "J'irais à la campagne si je le pouvais.[000F][1205]\nMalheureusement, ce n'est pas possible.[NL]J'ai une tonne de boulot en retard et\nrien n'indique qu'il y aura une bombe ici.[NL]Mais je regretterai s'il y A une bombe ici.[NL]Je me demande si je suis trop habituée à la paix pour pouvoir me décider."
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "I've[SP]got[SP]a[SP]huge[SP]backlog[SP]at[SP]work[SP]and[SP]there's\nno[SP]sign[SP]that[SP]this[SP]place[SP]will[SP]be[SP]bombed.",
     "nom_fr": "Homme",
-    "texte_fr": "Le Cercle masqué et le groupe...[1205][U+000F]\nTous deux sont suspects, mais sans preuves...[1106][NL]C'est une situation dangereuse. Les gens ici\nveulent que ça se termine vite, alors\nils sont pressés de jeter le blâme...[1106][NL]Un pas de travers, et tu pourrais être\nétiqueté comme suspect aussi.[1205][U+000F] C'est une\npure chasse aux sorcières. Quelle époque..."
+    "texte_fr": "Le Cercle masqué et le groupe...[1205][U+000F]\nTous deux sont suspects, mais sans preuves...[1106][NL]C'est une situation dangereuse. Les gens ici\nveulent que ça se termine vite, alors ils sont pressés de jeter le blâme...[1106][NL]Un pas de travers, et tu pourrais être étiqueté comme suspect aussi.[1205][U+000F] C'est une pure chasse aux sorcières. Quelle époque..."
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "But[SP]I[SP]know[SP]I'll[SP]regret[SP]it[SP]immediately[SP]if[SP]there\nIS[SP]a[SP]bombing[SP]here.",
     "nom_fr": "Homme",
-    "texte_fr": "On dit que les terroristes sont une unité\nappelée le Bataillon.[1205][U+000F][1106][NL]Quand la panique s'installe, les\ngens croient n'importe quoi.[1106][NL]Tu devrais quitter cette ville avant d'être\nqualifié de coupable aussi.[1205][U+000F] Les gens qui se\ncroient victimes sont les plus dangereux."
+    "texte_fr": "On dit que les terroristes sont une unité\nappelée le Bataillon.[1205][U+000F][1106][NL]Quand la panique s'installe, les\ngens croient n'importe quoi.[1106][NL]Tu devrais quitter cette ville avant d'être qualifié de coupable aussi.[1205][U+000F] Les gens qui se croient victimes sont les plus dangereux."
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "I[SP]wonder[SP]if[SP]I'm[SP]just[SP]too[SP]used[SP]to[SP]everything\nbeing[SP]peaceful[SP]that[SP]I[SP]can't[SP]make[SP]up[SP]my[SP]mind.",
     "nom_fr": "Homme",
-    "texte_fr": "J'ai entendu dire qu'ils avaient publié\nles portraits-robots, alors je suis allé\nvoir...[1205][U+000F] Des visages familiers, en effet.[1106][NL]Oh, je comprends que ce sont\nde fausses accusations, juste des gens\nau mauvais endroit.[1106][NL]Mais tu dois comprendre.[1205][U+000F] Peu importe à quel\npoint on se dit réalistes, l'homme n'a pas\nchangé depuis les procès-spectacles.[1106][NL]J'espère qu'ils les attraperont, je prierai."
+    "texte_fr": "J'ai entendu dire qu'ils avaient publié\nles portraits-robots, alors je suis allé\nvoir...[1205][U+000F] Des visages familiers, en effet.[1106][NL]Oh, je comprends que ce sont de fausses accusations, juste des gens au mauvais endroit.[1106][NL]Mais tu dois comprendre.[1205][U+000F] Peu importe à quel point on se dit réalistes, l'homme n'a pas changé depuis les procès-spectacles.[1106][NL]J'espère qu'ils les attraperont, je prierai."
   },
   {
     "id": 40,
@@ -672,7 +672,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Huh.[1205][000F][SP]Those[SP]kids[SP]were[SP]soaking[SP]wet[SP]and[SP]said[SP]the\npeople[SP]in[SP]the[SP]news[SP]were[SP]heroes[SP]fighting[SP]the\nMasked[SP]Circle...[1205][0014][SP]Who[SP]do[SP]I[SP]believe?",
     "nom_fr": "Femme active",
-    "texte_fr": "Huh.[1205][000F] Ces jeunes étaient trempés et disaient\nque les gars aux infos étaient des héros\ncontre le Cercle masqué...[1205][0014] Qui croire ?"
+    "texte_fr": "Huh.[000F][1205] Ces jeunes étaient trempés et disaient\nque les gars aux infos étaient des héros\ncontre le Cercle masqué...[0014][1205] Qui croire ?"
   },
   {
     "id": 45,
@@ -687,7 +687,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "I[SP]wonder[SP]if[SP]the[SP]stuff[SP]in[SP]the[SP]In[SP]Lak'ech[SP]is\ntrue[SP]after[SP]all.[1205][000F][SP]I[SP]heard[SP]even[SP]the[SP]recent[SP]wave\nof[SP]terror[SP]is[SP]mentioned[SP]in[SP]there...",
     "nom_fr": "Femme active",
-    "texte_fr": "Je me demande si les trucs de l'In Lak'ech\nsont vrais.[1205][000F] J'ai entendu dire que la vague\nde terreur y est même mentionnée..."
+    "texte_fr": "Je me demande si les trucs de l'In Lak'ech\nsont vrais.[000F][1205] J'ai entendu dire que la vague\nde terreur y est même mentionnée..."
   },
   {
     "id": 46,
@@ -702,7 +702,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "If[SP]they're[SP]here,[SP]then[SP]the[SP]secret[SP]treasure[SP]of\nSumaru[SP]City[SP]must[SP]also[SP]exist.[1205][000F][SP]Which[SP]means[SP]that\nOracle[SP]thing[SP]is[SP]true...",
     "nom_fr": "Femme active",
-    "texte_fr": "S'ils sont là, le trésor secret de Sumaru\ndoit aussi exister.[1205][000F] Ce qui signifie que\ncet Oracle dit vrai...[NL]La suite c'était : [NULL][NULL]Le rugissement\ndu lion résonne[NULL][NULL] ?\nÇa veut dire quoi ? Je pige pas..."
+    "texte_fr": "S'ils sont là, le trésor secret de Sumaru\ndoit aussi exister.[000F][1205] Ce qui signifie que\ncet Oracle dit vrai...[NL]La suite c'était : [NULL][NULL]Le rugissement du lion résonne[NULL][NULL] ? Ça veut dire quoi ? Je pige pas..."
   },
   {
     "id": 47,
@@ -717,7 +717,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "The[SP]next[SP]line[SP]was,[SP][1432][NULL][NULL][0014]The[SP]lion's[SP]roar[SP]echoes[SP]far\nand[SP]wide,[1432][NULL][NULL][0014][SP]right?[1205][000F][SP]Wh-What's[SP]that[SP]supposed[SP]to\nmean?[1205][000F][SP]I[SP]don't[SP]understand...",
     "nom_fr": "Homme",
-    "texte_fr": "Ça dégénère... J'entends dire maintenant\nque le deuxième étage de Zodiac est devenu\nun gigantesque donjon.[1106][NL]Y a plein de super objets dedans, mais\nexplorer un club ? Ça ne choque même plus.[1432][NULL][NULL][0014][1432][NULL][NULL][0014][1205][1205][000F][000F]"
+    "texte_fr": "Ça dégénère... J'entends dire maintenant\nque le deuxième étage de Zodiac est devenu\nun gigantesque donjon.[1106][NL]Y a plein de super objets dedans, mais explorer un club ? Ça ne choque même plus.[1432][NULL][NULL][0014][1432][NULL][NULL][0014][1205][000F][1205][000F]"
   },
   {
     "id": 48,
@@ -732,7 +732,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "D-Did[SP]you[SP]see[SP]those[SP]meteors?[1205][000F][SP]One[SP]of[SP]the[SP]Masked\nCircle[SP]said[SP]they[SP]were[SP]the[SP][1432][NULL][NULL][0014]lion's[SP]roar[1432][NULL][NULL][0014]![1205][000F][SP]That's\nwhat[SP]that[SP]line[SP]in[SP]the[SP]Oracle[SP]was[SP]about!",
     "nom_fr": "Femme active",
-    "texte_fr": "T-Tu as vu ces météores ?[1205][000F] Quelqu'un du Cercle\na dit que c'était le [1432][NULL][NULL][0014]rugissement du lion[1432][NULL][NULL][0014] ![1205][000F]\nC'est de ça que parlait l'Oracle !"
+    "texte_fr": "T-Tu as vu ces météores ?[000F][1205] Quelqu'un du Cercle\na dit que c'était le [1432][NULL][NULL][0014]rugissement du lion[1432][NULL][NULL][0014] ![000F][1205]\nC'est de ça que parlait l'Oracle !"
   },
   {
     "id": 49,
@@ -777,7 +777,7 @@
     "nom_orig": "Man",
     "texte_orig": "A[SP]city[SP]for[SP]the[SP]young...[1205][000F][SP]That's[SP]what[SP]those\nlayabouts[SP]think.[SP]For[SP]us[SP]men[SP]making[SP]an[SP]honest\nday's[SP]pay,[SP]this[SP]place[SP]is[SP]part[SP]of[SP]society[SP]too.",
     "nom_fr": "Homme",
-    "texte_fr": "Une ville pour jeunes...[1205][000F] C'est ce que\npensent ces fainéants. Pour nous qui bossons,\nça fait partie de la société.[NL]Au fait, tu viens du lycée Kakasu ?\nC'est souvent plein de gamins de Seven ici,\nmais je les vois rarement désormais."
+    "texte_fr": "Une ville pour jeunes...[000F][1205] C'est ce que\npensent ces fainéants. Pour nous qui bossons,\nça fait partie de la société.[NL]Au fait, tu viens du lycée Kakasu ? C'est souvent plein de gamins de Seven ici, mais je les vois rarement désormais."
   },
   {
     "id": 52,
@@ -792,7 +792,7 @@
     "nom_orig": "Man",
     "texte_orig": "By[SP]the[SP]way,[SP]are[SP]you[SP]from[SP]Kasugayama[SP]High?[1205][000F]\nThis[SP]place[SP]is[SP]usually[SP]packed[SP]with[SP]Sevens[SP]kids,\nbut[SP]I[SP]rarely[SP]see[SP]them[SP]anymore.",
     "nom_fr": "Homme",
-    "texte_fr": "*soupir* D'abord un Taxi Maudit, maintenant\nune Escorte Maudite... Les rumeurs gonflent,\nmais je me demande si celle-ci est vraie.[1205][000F]"
+    "texte_fr": "*soupir* D'abord un Taxi Maudit, maintenant\nune Escorte Maudite... Les rumeurs gonflent,\nmais je me demande si celle-ci est vraie.[000F][1205]"
   },
   {
     "id": 53,
@@ -807,7 +807,7 @@
     "nom_orig": "Man",
     "texte_orig": "A[SP]secret[SP]lounge?[1205][000F][SP]Oh,[SP]you[SP]mean[SP]the[SP]place[SP]you\ncan't[SP]get[SP]into[SP]without[SP]one[SP]of[SP]those[SP]masks?",
     "nom_fr": "Homme",
-    "texte_fr": "Un salon secret ?[1205][000F] Oh, tu parles de l'endroit\noù on ne peut pas entrer sans masque ?[NL]J'ai entendu des rumeurs... Ça a l'air louche."
+    "texte_fr": "Un salon secret ?[000F][1205] Oh, tu parles de l'endroit\noù on ne peut pas entrer sans masque ?[NL]J'ai entendu des rumeurs... Ça a l'air louche."
   },
   {
     "id": 54,
@@ -822,7 +822,7 @@
     "nom_orig": "Man",
     "texte_orig": "I've[SP]heard[SP]rumors[SP]about[SP]it...[1205][000F][SP]But[SP]it[SP]sounds[SP]like\na[SP]pretty[SP]shady[SP]place.",
     "nom_fr": "Homme",
-    "texte_fr": "Maintenant on dit que le Vieux Sauteur est une\nvraie chose qui poursuit les voitures en\nmontagne. Y a-t-il ça au Mt Katatsumuri ?[1205][000F]"
+    "texte_fr": "Maintenant on dit que le Vieux Sauteur est une\nvraie chose qui poursuit les voitures en\nmontagne. Y a-t-il ça au Mt Katatsumuri ?[000F][1205]"
   },
   {
     "id": 55,
@@ -942,7 +942,7 @@
     "nom_orig": "Man",
     "texte_orig": "Some[SP]people[SP]are[SP]saying[SP]the[SP]Masked[SP]Circle[SP]is[SP]to\nblame[SP]for[SP]the[SP]chaos,[SP]but[SP]are[SP]they[SP]really[SP]the\nculprits[SP]here?[1205][000F][SP]Granted,[SP]they're[SP]suspicious...",
     "nom_fr": "Homme",
-    "texte_fr": "Certains accusent le Cercle masqué pour\nce chaos, mais sont-ils vraiment les\ncoupables ?[1205][000F] Certes, ils sont louches...[NL]Mais ces cinq personnes vues devant la salle\nde concert m'inquiètent plus. Beaucoup\npensent que ce sont les vrais coupables."
+    "texte_fr": "Certains accusent le Cercle masqué pour\nce chaos, mais sont-ils vraiment les\ncoupables ?[000F][1205] Certes, ils sont louches...[NL]Mais ces cinq personnes vues devant la salle de concert m'inquiètent plus. Beaucoup pensent que ce sont les vrais coupables."
   },
   {
     "id": 63,
@@ -972,7 +972,7 @@
     "nom_orig": "Man",
     "texte_orig": "The[SP]Masked[SP]Circle[SP]and[SP]the[SP]group[SP]of[SP]five...[1205][000F]\nThey're[SP]both[SP]suspects[SP]behind[SP]the[SP]terrorist\nattacks,[SP]but[SP]there's[SP]no[SP]proof...",
     "nom_fr": "Homme",
-    "texte_fr": "Le Cercle masqué et le groupe...[1205][000F]\nTous deux sont suspects, mais sans preuves...[NL]C'est une situation dangereuse. Les gens ici\nveulent que ça se termine vite, alors\nils sont pressés de jeter le blâme...[NL]Un pas de travers, et tu pourrais être\nétiqueté comme suspect aussi. C'est une\npure chasse aux sorcières. Quelle époque..."
+    "texte_fr": "Le Cercle masqué et le groupe...[000F][1205]\nTous deux sont suspects, mais sans preuves...[NL]C'est une situation dangereuse. Les gens ici\nveulent que ça se termine vite, alors ils sont pressés de jeter le blâme...[NL]Un pas de travers, et tu pourrais être étiqueté comme suspect aussi. C'est une pure chasse aux sorcières. Quelle époque..."
   },
   {
     "id": 65,
@@ -1017,7 +1017,7 @@
     "nom_orig": "Man",
     "texte_orig": "Now[SP]people[SP]are[SP]saying[SP]the[SP]terrorists[SP]behind\nthese[SP]attacks[SP]are[SP]a[SP]special[SP]unit[SP]called[SP]the\nLast[SP]Battalion.[1205][000F]",
     "nom_fr": "Homme",
-    "texte_fr": "On dit que les terroristes sont une unité\nappelée le Bataillon.[1205][000F][NL]Quand la panique s'installe, les\ngens croient n'importe quoi.[NL]Tu devrais quitter cette ville avant d'être\nqualifié de coupable aussi. Les gens qui se\ncroient victimes sont les plus dangereux."
+    "texte_fr": "On dit que les terroristes sont une unité\nappelée le Bataillon.[000F][1205][NL]Quand la panique s'installe, les\ngens croient n'importe quoi.[NL]Tu devrais quitter cette ville avant d'être qualifié de coupable aussi. Les gens qui se croient victimes sont les plus dangereux."
   },
   {
     "id": 68,
@@ -1062,7 +1062,7 @@
     "nom_orig": "Man",
     "texte_orig": "I[SP]heard[SP]they[SP]released[SP]the[SP]composite[SP]sketches[SP]of\nthe[SP]suspects,[SP]so[SP]I[SP]went[SP]to[SP]check[SP]'em[SP]out...[1205][000F]\nThose[SP]were[SP]some[SP]familiar[SP]faces,[SP]all[SP]right.",
     "nom_fr": "Homme",
-    "texte_fr": "J'ai entendu dire qu'ils avaient publié\nles portraits-robots, alors je suis allé\nvoir...[1205][000F] Des visages familiers, en effet.[NL]Oh, je comprends que ce sont\nde fausses accusations, juste des gens\nau mauvais endroit.[NL]Mais tu dois comprendre. Peu importe à quel\npoint on se dit réalistes, l'homme n'a pas\nchangé depuis les procès-spectacles.[NL]J'espère qu'ils les attraperont, je prierai."
+    "texte_fr": "J'ai entendu dire qu'ils avaient publié\nles portraits-robots, alors je suis allé\nvoir...[000F][1205] Des visages familiers, en effet.[NL]Oh, je comprends que ce sont de fausses accusations, juste des gens au mauvais endroit.[NL]Mais tu dois comprendre. Peu importe à quel point on se dit réalistes, l'homme n'a pas changé depuis les procès-spectacles.[NL]J'espère qu'ils les attraperont, je prierai."
   },
   {
     "id": 71,
@@ -1092,7 +1092,7 @@
     "nom_orig": "Man",
     "texte_orig": "But[SP]you[SP]gotta[SP]understand.[1205][000F][SP]No[SP]matter[SP]how[SP]much\npeople[SP]like[SP]to[SP]think[SP]they're[SP]realists,[SP]man\nhasn't[SP]changed[SP]since[SP]the[SP]days[SP]of[SP]show[SP]trials.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Jolly Roger vend des armes.\nLe rachat est bas, mais super sélection.[1205][000F]"
+    "texte_fr": "Même Jolly Roger vend des armes.\nLe rachat est bas, mais super sélection.[000F][1205]"
   },
   {
     "id": 73,
@@ -1122,7 +1122,7 @@
     "nom_orig": "Man",
     "texte_orig": "The[SP]new[SP]rumor[SP]is[SP]that[SP]the[SP]group[SP]of[SP]five[SP]is\nactually[SP]fighting[SP]against[SP]the[SP]Masked[SP]Circle.\nDid[SP]you[SP]guys[SP]spread[SP]that[SP]one?[1205][000F][SP]Very[SP]clever.",
     "nom_fr": "Homme",
-    "texte_fr": "La nouvelle rumeur dit que le groupe de cinq\ncombat en fait le Cercle masqué.\nC'est vous qui l'avez lancée ?[1205][000F] Très malin."
+    "texte_fr": "La nouvelle rumeur dit que le groupe de cinq\ncombat en fait le Cercle masqué.\nC'est vous qui l'avez lancée ?[000F][1205] Très malin."
   },
   {
     "id": 75,
@@ -1137,7 +1137,7 @@
     "nom_orig": "Man",
     "texte_orig": "This[SP]feels[SP]a[SP]lot[SP]like[SP]the[SP]final[SP]push.[1205][000F][SP]I[SP]don't\nthink[SP]anyone[SP]doubts[SP]the[SP]In[SP]Lak'ech[SP]anymore.",
     "nom_fr": "Homme",
-    "texte_fr": "Ça sent la fin.[1205][000F] Plus personne ne doute\nde l'In Lak'ech."
+    "texte_fr": "Ça sent la fin.[000F][1205] Plus personne ne doute\nde l'In Lak'ech."
   },
   {
     "id": 76,
@@ -1152,7 +1152,7 @@
     "nom_orig": "Man",
     "texte_orig": "Now[SP]where[SP]did[SP]that[SP]monstrosity[SP]come[SP]from...?[1205][000A]\nThe[SP]Masked[SP]Circle[SP]and[SP]the[SP]Last[SP]Battalion[SP]are\nhaving[SP]it[SP]out[SP]in[SP]there[SP]now.",
     "nom_fr": "Homme",
-    "texte_fr": "D'où sort cette monstruosité... ?[1205][000A]\nLe Cercle masqué et le Bataillon se\nbattent là-dedans maintenant.[NL]Se battre en haut, détruire en bas...\nPlus personne ne se soucie d'ici ?"
+    "texte_fr": "D'où sort cette monstruosité... ?[000A][1205]\nLe Cercle masqué et le Bataillon se\nbattent là-dedans maintenant.[NL]Se battre en haut, détruire en bas... Plus personne ne se soucie d'ici ?"
   },
   {
     "id": 77,
@@ -1212,7 +1212,7 @@
     "nom_orig": "Man",
     "texte_orig": "I'm[SP]sure[SP]you[SP]know[SP]already,[SP]but[SP]there[SP]are\nseveral[SP]theories[SP]in[SP]Sumaru[SP]about[SP]how[SP]life\ndown[SP]there[SP]on[SP]Earth[SP]will[SP]end.",
     "nom_fr": "Homme",
-    "texte_fr": "Tu le sais, mais il y a\nplusieurs théories sur la fin du monde.[NL]Tant qu'il y a des théories divergentes,\nça va. C'est quand tous\nsont d'accord que ça craint..."
+    "texte_fr": "Tu le sais, mais il y a\nplusieurs théories sur la fin du monde.[NL]Tant qu'il y a des théories divergentes,\nça va. C'est quand tous sont d'accord que ça craint..."
   },
   {
     "id": 81,
@@ -1242,7 +1242,7 @@
     "nom_orig": "Man",
     "texte_orig": "*sigh*[SP]More[SP]and[SP]more,[SP]it's[SP]getting[SP]unanimous\nas[SP]to[SP]how[SP]the[SP]Earth[SP]will[SP]meet[SP]its[SP]end.",
     "nom_fr": "Homme",
-    "texte_fr": "*soupir* De plus en plus, l'unanimité se\nfait sur la façon dont la Terre finira.[NL]Tout le monde dit maintenant que la rotation\nde la Terre s'arrêtera avec la Croix...[NL]Une phrase de l'In Lak'ech le dit,\ndonc c'est acté."
+    "texte_fr": "*soupir* De plus en plus, l'unanimité se\nfait sur la façon dont la Terre finira.[NL]Tout le monde dit maintenant que la rotation\nde la Terre s'arrêtera avec la Croix...[NL]Une phrase de l'In Lak'ech le dit, donc c'est acté."
   },
   {
     "id": 83,
@@ -1302,7 +1302,7 @@
     "nom_orig": "Man",
     "texte_orig": "Things[SP]are[SP]getting[SP]out[SP]of[SP]hand...[SP]I'm[SP]hearing\nnow[SP]that[SP]the[SP]second[SP]floor[SP]of[SP]Zodiac[SP]has[SP]become\na[SP]gigantic[SP]dungeon.",
     "nom_fr": "Homme",
-    "texte_fr": "Ça dégénère... J'entends dire maintenant\nque le deuxième étage de Zodiac est devenu\nun gigantesque donjon.[NL]Y a plein de super objets dedans, mais\nexplorer un club ? Ça ne choque même plus."
+    "texte_fr": "Ça dégénère... J'entends dire maintenant\nque le deuxième étage de Zodiac est devenu\nun gigantesque donjon.[NL]Y a plein de super objets dedans, mais explorer un club ? Ça ne choque même plus."
   },
   {
     "id": 87,
@@ -1332,7 +1332,7 @@
     "nom_orig": "Man",
     "texte_orig": "It[SP]never[SP]rains[SP]but[SP]it[SP]pours...[1205][000F][SP]That's[SP]how[SP]the\nsaying[SP]goes,[SP]but[SP]come[SP]on.[1205][000F][SP]Hanako[SP]now?[SP]This[SP]has\nbeen[SP]one[SP]unlucky[SP]year[SP]for[SP]Sevens.",
     "nom_fr": "Homme",
-    "texte_fr": "Un malheur n'arrive jamais seul.[1205][000F]..[1205][000F] Hanako ?\nC'est une année noire pour Seven."
+    "texte_fr": "Un malheur n'arrive jamais seul.[000F][1205]..[000F][1205] Hanako ?\nC'est une année noire pour Seven."
   },
   {
     "id": 89,
@@ -1377,7 +1377,7 @@
     "nom_orig": "Man",
     "texte_orig": "I[SP]doubt[SP]there's[SP]actually[SP]any[SP]such[SP]thing[SP]over\nthere.[1205][000F][SP]R-Right?",
     "nom_fr": "Homme",
-    "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Mauvais choix, bon rachat.[1205][000F]"
+    "texte_fr": "Des armures chez London Clothier ?\nPatron malin. Mauvais choix, bon rachat.[000F][1205]"
   },
   {
     "id": 92,
@@ -1392,7 +1392,7 @@
     "nom_orig": "Man",
     "texte_orig": "Rumor[SP]has[SP]it[SP]the[SP]ghost[SP]of[SP]an[SP]idol[SP]has[SP]been\nseen[SP]at[SP]Aoba[SP]Park...[1205][000F][SP]But[SP]if[SP]memory[SP]serves,\nthat[SP]idol[SP]is[SP]still[SP]alive[SP]and[SP]well.",
     "nom_fr": "Homme",
-    "texte_fr": "On a vu le fantôme d'une idole au parc...[1205][000F]\nMais cette idole est bien vivante."
+    "texte_fr": "On a vu le fantôme d'une idole au parc...[000F][1205]\nMais cette idole est bien vivante."
   },
   {
     "id": 93,
@@ -1422,7 +1422,7 @@
     "nom_orig": "Man",
     "texte_orig": "But[SP]I[SP]doubt[SP]it's[SP]this[SP]one.[1205][000F][SP]R-Right?",
     "nom_fr": "Homme",
-    "texte_fr": "Fais les concours\ndes magazines un jour.[1106][NL]On y gagne des armes et objets.\nC'est facile de gagner, mais c'est pas ouf.[1205][000F]"
+    "texte_fr": "Fais les concours\ndes magazines un jour.[1106][NL]On y gagne des armes et objets.\nC'est facile de gagner, mais c'est pas ouf.[000F][1205]"
   },
   {
     "id": 95,
@@ -1557,7 +1557,7 @@
     "nom_orig": "Man",
     "texte_orig": "As[SP]I[SP]recall,[SP]word[SP]is[SP]their[SP]quality[SP]and[SP]prices\nare[SP]average.[1205][000F][SP]Me,[SP]I[SP]think[SP]it's[SP]an[SP]ingenious\nway[SP]to[SP]do[SP]business.",
     "nom_fr": "Homme",
-    "texte_fr": "Time Castle a vendu son arme légendaire.\nUne femme malchanceuse l'a achetée...[1205][000F]"
+    "texte_fr": "Time Castle a vendu son arme légendaire.\nUne femme malchanceuse l'a achetée...[000F][1205]"
   },
   {
     "id": 104,
@@ -1632,7 +1632,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]Tony's[SP]Shop[SP]was[SP]selling[SP]weapons[SP]after[SP]all...[1205][000F]\nI'd[SP]heard[SP]rumors.[SP]Something[SP]about[SP]his[SP]selection\nbeing[SP]good,[SP]but[SP]having[SP]low[SP]resale[SP]value.",
     "nom_fr": "Homme",
-    "texte_fr": "Donc la boutique de Tony vendait des armes\nfinalement...[1205][000F] J'avais entendu des rumeurs.\nBon choix, mais faible valeur de revente."
+    "texte_fr": "Donc la boutique de Tony vendait des armes\nfinalement...[000F][1205] J'avais entendu des rumeurs.\nBon choix, mais faible valeur de revente."
   },
   {
     "id": 109,
@@ -1647,7 +1647,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]Tony's[SP]Shop[SP]was[SP]selling[SP]weapons[SP]after[SP]all...[1205][000F]\nI'd[SP]heard[SP]rumors.[SP]Something[SP]about[SP]his[SP]stuff\nbeing[SP]cheap,[SP]but[SP]low[SP]quality.",
     "nom_fr": "Homme",
-    "texte_fr": "La boutique de Tony vendait des armes...[1205][000F]\nBon marché, mais mauvaise qualité."
+    "texte_fr": "La boutique de Tony vendait des armes...[000F][1205]\nBon marché, mais mauvaise qualité."
   },
   {
     "id": 110,
@@ -1662,7 +1662,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]Tony's[SP]Shop[SP]was[SP]selling[SP]weapons[SP]after[SP]all...[1205][000F]\nI'd[SP]heard[SP]rumors.[SP]Something[SP]about[SP]his[SP]prices\nand[SP]quality[SP]being[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "La boutique de Tony vendait des armes...[1205][000F]\nRapport qualité-prix dans la moyenne."
+    "texte_fr": "La boutique de Tony vendait des armes...[000F][1205]\nRapport qualité-prix dans la moyenne."
   },
   {
     "id": 111,
@@ -1677,7 +1677,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]Tony's[SP]Shop[SP]was[SP]selling[SP]weapons[SP]after[SP]all...[1205][000F]\nI'd[SP]heard[SP]rumors.[SP]Something[SP]about[SP]the[SP]quality\nbeing[SP]good,[SP]but[SP]his[SP]prices[SP]being[SP]high.",
     "nom_fr": "Homme",
-    "texte_fr": "Donc la boutique de Tony vendait des armes\nfinalement...[1205][000F] J'avais entendu des rumeurs.\nDe la bonne qualité, mais à des prix élevés."
+    "texte_fr": "Donc la boutique de Tony vendait des armes\nfinalement...[000F][1205] J'avais entendu des rumeurs.\nDe la bonne qualité, mais à des prix élevés."
   },
   {
     "id": 112,
@@ -1692,7 +1692,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][000F][SP]Their[SP]selection\nis[SP]bad,[SP]but[SP]the[SP]buyback[SP]prices[SP]are[SP]great.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes...[1205][000F]\nIls ont des difficultés financières aussi ?[1205][000F] Choix\nlimité, mais d'excellents prix de rachat."
+    "texte_fr": "Même Clair de Lune vend des armes...[000F][1205]\nIls ont des difficultés financières aussi ?[000F][1205] Choix\nlimité, mais d'excellents prix de rachat."
   },
   {
     "id": 113,
@@ -1707,7 +1707,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][000F][SP]Their[SP]prices\nare[SP]just[SP]right,[SP]but[SP]the[SP]quality[SP]is[SP]so-so.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes.[1205][000F]..[1205][000F]\nLes prix sont corrects, mais la qualité est moyenne."
+    "texte_fr": "Même Clair de Lune vend des armes.[000F][1205]..[000F][1205]\nLes prix sont corrects, mais la qualité est moyenne."
   },
   {
     "id": 114,
@@ -1722,7 +1722,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][000F][SP]Their[SP]quality\nis[SP]great,[SP]but[SP]the[SP]prices[SP]are[SP]pretty[SP]high.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes.[1205][000F]..[1205][000F]\nLa qualité est top, mais les prix sont élevés."
+    "texte_fr": "Même Clair de Lune vend des armes.[000F][1205]..[000F][1205]\nLa qualité est top, mais les prix sont élevés."
   },
   {
     "id": 115,
@@ -1737,7 +1737,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][000F][SP]Their[SP]selection\nis[SP]great,[SP]but[SP]the[SP]buyback[SP]prices[SP]aren't[SP]much.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes...[1205][000F]\nIls ont des difficultés financières aussi ?[1205][000F] Choix\nexcellent, mais prix de rachat dérisoires."
+    "texte_fr": "Même Clair de Lune vend des armes...[000F][1205]\nIls ont des difficultés financières aussi ?[000F][1205] Choix\nexcellent, mais prix de rachat dérisoires."
   },
   {
     "id": 116,
@@ -1752,7 +1752,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]even[SP]Clair[SP]de[SP]Lune[SP]is[SP]selling[SP]weapons...[1205][000F]\nAre[SP]they[SP]having[SP]hard[SP]times[SP]too?[1205][000F][SP]Their[SP]quality\nand[SP]prices[SP]are[SP]average,[SP]I[SP]hear.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Clair de Lune vend des armes.[1205][000F]..[1205][000F]\nLa qualité et les prix sont moyens, paraît-il."
+    "texte_fr": "Même Clair de Lune vend des armes.[000F][1205]..[000F][1205]\nLa qualité et les prix sont moyens, paraît-il."
   },
   {
     "id": 117,
@@ -1842,7 +1842,7 @@
     "nom_orig": "Man",
     "texte_orig": "Huh,[SP]so[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]is[SP]getting[SP]in\non[SP]the[SP]armor[SP]market.[1205][000F][SP]It[SP]seems[SP]their[SP]quality\nand[SP]prices[SP]are[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida se lance dans les\narmures.[1205][000F] Qualité et prix moyens."
+    "texte_fr": "Rosa Candida se lance dans les\narmures.[000F][1205] Qualité et prix moyens."
   },
   {
     "id": 123,
@@ -1857,7 +1857,7 @@
     "nom_orig": "Man",
     "texte_orig": "Huh,[SP]so[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]is[SP]getting[SP]in\non[SP]the[SP]armor[SP]market.[1205][000F][SP]It[SP]seems[SP]the[SP]quality\nis[SP]low,[SP]but[SP]it's[SP]cheap,[SP]at[SP]least.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida se lance dans les\narmures.[1205][000F] Qualité faible, mais c'est pas cher."
+    "texte_fr": "Rosa Candida se lance dans les\narmures.[000F][1205] Qualité faible, mais c'est pas cher."
   },
   {
     "id": 124,
@@ -1872,7 +1872,7 @@
     "nom_orig": "Man",
     "texte_orig": "Huh,[SP]so[SP]Rosa[SP]Candida[SP]in[SP]Rengedai[SP]is[SP]getting[SP]in\non[SP]the[SP]armor[SP]market.[1205][000F][SP]It[SP]seems[SP]the[SP]quality\nis[SP]great,[SP]but[SP]you[SP]pay[SP]through[SP]the[SP]nose.",
     "nom_fr": "Homme",
-    "texte_fr": "Rosa Candida se lance dans les\narmures.[1205][000F] Qualité top, mais ça coûte un bras."
+    "texte_fr": "Rosa Candida se lance dans les\narmures.[000F][1205] Qualité top, mais ça coûte un bras."
   },
   {
     "id": 125,
@@ -1887,7 +1887,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][000F][SP]I'm\nsurprised,[SP]I[SP]admit.[SP]They[SP]say[SP]their[SP]quality[SP]and\nprices[SP]are[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Donc Anima Mundi vend des armures...[1205][000F]\nJe suis surpris. Qualité et prix moyens."
+    "texte_fr": "Donc Anima Mundi vend des armures...[000F][1205]\nJe suis surpris. Qualité et prix moyens."
   },
   {
     "id": 126,
@@ -1902,7 +1902,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][000F][SP]I'm\nsurprised,[SP]I[SP]admit.[SP]They[SP]say[SP]their[SP]stuff[SP]is\ncheap,[SP]but[SP]not[SP]very[SP]good.",
     "nom_fr": "Homme",
-    "texte_fr": "Donc Anima Mundi vend des armures...[1205][000F]\nSurpris. C'est pas cher, mais mauvais."
+    "texte_fr": "Donc Anima Mundi vend des armures...[000F][1205]\nSurpris. C'est pas cher, mais mauvais."
   },
   {
     "id": 127,
@@ -1917,7 +1917,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][000F][SP]I'm\nsurprised,[SP]I[SP]admit.[SP]They[SP]say[SP]their[SP]selection[SP]is\nfantastic,[SP]but[SP]their[SP]buyback[SP]prices[SP]are[SP]low.",
     "nom_fr": "Homme",
-    "texte_fr": "Anima Mundi vend des armures...[1205][000F]\nChoix fantastique, mais prix de rachat bas."
+    "texte_fr": "Anima Mundi vend des armures...[000F][1205]\nChoix fantastique, mais prix de rachat bas."
   },
   {
     "id": 128,
@@ -1932,7 +1932,7 @@
     "nom_orig": "Man",
     "texte_orig": "So[SP]Anima[SP]Mundi[SP]really[SP]does[SP]sell[SP]armor...[1205][000F][SP]I'm\nsurprised,[SP]I[SP]admit.[SP]They[SP]say[SP]the[SP]quality[SP]is\ngreat,[SP]but[SP]it's[SP]expensive[SP]stuff.",
     "nom_fr": "Homme",
-    "texte_fr": "Anima Mundi vend des armures...[1205][000F]\nQualité super, mais matos hors de prix."
+    "texte_fr": "Anima Mundi vend des armures...[000F][1205]\nQualité super, mais matos hors de prix."
   },
   {
     "id": 129,
@@ -1947,7 +1947,7 @@
     "nom_orig": "Man",
     "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][000F][SP]I've[SP]heard[SP]their[SP]selection[SP]is[SP]bad,\nbut[SP]they[SP]have[SP]high[SP]buyback[SP]prices.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][000F] Mauvais choix, mais bon rachat."
+    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[000F][1205] Mauvais choix, mais bon rachat."
   },
   {
     "id": 130,
@@ -1962,7 +1962,7 @@
     "nom_orig": "Man",
     "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][000F][SP]I've[SP]heard[SP]their[SP]quality[SP]and\nprices[SP]are[SP]average.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][000F] Qualité et prix dans la moyenne."
+    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[000F][1205] Qualité et prix dans la moyenne."
   },
   {
     "id": 131,
@@ -1977,7 +1977,7 @@
     "nom_orig": "Man",
     "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][000F][SP]I've[SP]heard[SP]their[SP]quality[SP]is[SP]great,\nbut[SP]their[SP]prices[SP]are[SP]pretty[SP]high.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][000F] Qualité géniale, mais très cher."
+    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[000F][1205] Qualité géniale, mais très cher."
   },
   {
     "id": 132,
@@ -1992,7 +1992,7 @@
     "nom_orig": "Man",
     "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][000F][SP]I've[SP]heard[SP]their[SP]stuff[SP]is[SP]cheap,\nbut[SP]not[SP]the[SP]best[SP]quality.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][000F] Pas cher, mais de mauvaise qualité."
+    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[000F][1205] Pas cher, mais de mauvaise qualité."
   },
   {
     "id": 133,
@@ -2007,7 +2007,7 @@
     "nom_orig": "Man",
     "texte_orig": "Sheesh,[SP]even[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]handles\narmor?[1205][000F][SP]I've[SP]heard[SP]their[SP]selection[SP]is[SP]pretty\ngood,[SP]but[SP]they[SP]have[SP]low[SP]buyback[SP]prices.",
     "nom_fr": "Homme",
-    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[1205][000F] Bon choix, mais rachat bas."
+    "texte_fr": "Même Rosa Candida fait dans les\narmures ?[000F][1205] Bon choix, mais rachat bas."
   },
   {
     "id": 134,
@@ -2112,7 +2112,7 @@
     "nom_orig": "Man",
     "texte_orig": "Winners[SP]get[SP]real[SP]weapons[SP]and[SP]items.[SP]As[SP]I\nrecall,[SP]it's[SP]hard[SP]to[SP]win,[SP]but[SP]you[SP]can[SP]get\nsome[SP]nice[SP]stuff[SP]if[SP]you[SP]do.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup.[1106][NL]Il a de bons trucs, mais c'est une arnaque.[1205][U+000F]\nÇa lui ressemble tout à fait."
+    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][U+000F]\nJe le savais.[1205][U+000F] Je sentais qu'il préparait un\nmauvais coup.[1106][NL]Il a de bons trucs, mais c'est une arnaque.[1205][U+000F] Ça lui ressemble tout à fait."
   },
   {
     "id": 141,
@@ -2142,7 +2142,7 @@
     "nom_orig": "Man",
     "texte_orig": "Winners[SP]get[SP]real[SP]weapons[SP]and[SP]items.[SP]As[SP]I\nrecall,[SP]you[SP]rarely[SP]win,[SP]but[SP]you[SP]can[SP]get\nsome[SP]rare[SP]stuff[SP]if[SP]you[SP]do.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[1106][NL]Je le savais...[1205][0014] C'est le genre\nd'endroit où on trouverait des mafieux.[1106][NL]Pas cher, mais de mauvaise qualité. Les flics\nsévissent, ils vendent tout pour amasser de l'argent."
+    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[1106][NL]Je le savais...[0014][1205] C'est le genre\nd'endroit où on trouverait des mafieux.[1106][NL]Pas cher, mais de mauvaise qualité. Les flics sévissent, ils vendent tout pour amasser de l'argent."
   },
   {
     "id": 143,
@@ -2172,7 +2172,7 @@
     "nom_orig": "Man",
     "texte_orig": "Winners[SP]get[SP]real[SP]weapons[SP]and[SP]items.[SP]As[SP]I\nrecall,[SP]it's[SP]not[SP]hard[SP]to[SP]win,[SP]but[SP]you[SP]won't\nget[SP]anything[SP]good.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[1106][NL]Je le savais...[1205][0014] C'est le genre\nd'endroit où on trouverait des mafieux.[1106][NL]Leur sélection est bonne, mais ils paient mal.\nC'est louche, à mon avis."
+    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[1106][NL]Je le savais...[0014][1205] C'est le genre\nd'endroit où on trouverait des mafieux.[1106][NL]Leur sélection est bonne, mais ils paient mal. C'est louche, à mon avis."
   },
   {
     "id": 145,
@@ -2337,7 +2337,7 @@
     "nom_orig": "Man",
     "texte_orig": "Giving[SP]a[SP]weapon[SP]to[SP]a[SP]lady[SP]as[SP]a[SP]present...[1205][000F]\nThese[SP]are[SP]crazy[SP]times[SP]we[SP]live[SP]in.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Anima Mundi vend des armures ? J'y vais tout le\ntemps sans le savoir. Pas cher, mais qualité nulle.[1205][000F]"
+    "texte_fr": "Anima Mundi vend des armures ? J'y vais tout le\ntemps sans le savoir. Pas cher, mais qualité nulle.[000F][1205]"
   },
   {
     "id": 156,
@@ -2352,7 +2352,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "If[SP]I'm[SP]gonna[SP]date[SP]someone[SP]new,[SP]I'd[SP]rather[SP]go\nwith[SP]a[SP]Cuss[SP]High[SP]guy.[1205][000F][SP]Everyone[SP]at[SP]Sevens[SP]is\nunder[SP]the[SP]principal's[SP]thumb.[SP]Snooooore!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Quitte à sortir avec un gars, je préfère Kakasu.[1205][000F]\nÀ Seven, ils sont tous sous la coupe de Hanya. Nul !"
+    "texte_fr": "Quitte à sortir avec un gars, je préfère Kakasu.[000F][1205]\nÀ Seven, ils sont tous sous la coupe de Hanya. Nul !"
   },
   {
     "id": 157,
@@ -2367,7 +2367,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]hear[SP]there[SP]are[SP]some[SP]uber-cute[SP]Cuss[SP]High\nguys[SP]in[SP]the[SP]secret[SP]lounge.[1205][000F]",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Des beaux gosses de Kakasu\nsont au salon secret, on dit.[1205][000F][NL]J'aimerais y aller.\nMais je n'ai pas de masque."
+    "texte_fr": "Des beaux gosses de Kakasu\nsont au salon secret, on dit.[000F][1205][NL]J'aimerais y aller.\nMais je n'ai pas de masque."
   },
   {
     "id": 158,
@@ -2397,7 +2397,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Yeee![SP]I[SP]did[SP]it,[SP]I[SP]did[SP]it![1205][000F][SP]I[SP]got[SP]tickets[SP]to\nthe[SP]masquerade![1205][000F][SP]It's[SP]the[SP]perfect[SP]chance[SP]to\nget[SP]a[SP]Cuss[SP]High[SP]boyfriend!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Yeee ! J'ai eu des billets pour le bal masqué ![1205][000F]\nParfait pour trouver un petit ami de Kakasu ![NL]Faut que je sois bien habillée.[1205][000F]\nEt je devrais inviter mes copines !"
+    "texte_fr": "Yeee ! J'ai eu des billets pour le bal masqué ![000F][1205]\nParfait pour trouver un petit ami de Kakasu ![NL]Faut que je sois bien habillée.[000F][1205]\nEt je devrais inviter mes copines !"
   },
   {
     "id": 160,
@@ -2412,7 +2412,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]gotta[SP]make[SP]sure[SP]to[SP]dress[SP]up.[1205][000F][SP]Oh[SP]yeah,[SP]and\nI[SP]should[SP]invite[SP]my[SP]friends[SP]too!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Qualité bonne, mais très cher.[1205][000F]"
+    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Qualité bonne, mais très cher.[000F][1205]"
   },
   {
     "id": 161,
@@ -2442,7 +2442,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "So[SP]they're[SP]all[SP]around[SP]my[SP]age.[1205][000F][SP]They're[SP]so[SP]lucky,\ngetting[SP]to[SP]make[SP]their[SP]idol[SP]debuts...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Super sélection, mauvais rachat.[1205][000F]"
+    "texte_fr": "T'es allé chez Rosa Candida à Aoba ? Ils vendent\ndes armures. Super sélection, mauvais rachat.[000F][1205]"
   },
   {
     "id": 163,
@@ -2457,7 +2457,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Looks[SP]like[SP]Giga[SP]Macho's[SP]already[SP]packed[SP]with\nMuses[SP]fans.[1205][000F][SP]*sigh*[SP]I[SP]bet[SP]I[SP]couldn't[SP]get[SP]in\nnow[SP]if[SP]I[SP]went.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Giga Macho est plein de fans de Muses.[1205][000F]\n*soupir* Je pourrais même pas y entrer."
+    "texte_fr": "Giga Macho est plein de fans de Muses.[000F][1205]\n*soupir* Je pourrais même pas y entrer."
   },
   {
     "id": 164,
@@ -2487,7 +2487,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]there[SP]was[SP]a[SP]Muses[SP]show[SP]at[SP]the[SP]outdoor\nconcert[SP]hall,[SP]right?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Il y a eu un concert de Muses à la\nsalle en plein air, non ?[NL]Et Muses était un trio, non ?\nHuh... Étrange...[NL]Il y en avait deux autres, mais je ne me\nsouviens que de Lisa... Bref, c'est pas grave."
+    "texte_fr": "Il y a eu un concert de Muses à la\nsalle en plein air, non ?[NL]Et Muses était un trio, non ?\nHuh... Étrange...[NL]Il y en avait deux autres, mais je ne me souviens que de Lisa... Bref, c'est pas grave."
   },
   {
     "id": 166,
@@ -2502,7 +2502,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "And[SP]Muses[SP]was[SP]a[SP]trio,[SP]right?[1205][000F][SP]Huh...\nThat's[SP]weird...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Prix et qualité moyens.[1205][000F]"
+    "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Prix et qualité moyens.[000F][1205]"
   },
   {
     "id": 167,
@@ -2517,7 +2517,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]know[SP]there[SP]were[SP]two[SP]others,[SP]but[SP]I[SP]only\nremember[SP]that[SP]Lisa[SP]girl...[1205][000F][SP]W-Well,[SP]I[SP]guess\nit[SP]doesn't[SP]really[SP]matter.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Mauvais choix, rachat top.[1205][000F]"
+    "texte_fr": "London Clothier vend des armures. Sûrement des\ncommandes spéciales. Mauvais choix, rachat top.[000F][1205]"
   },
   {
     "id": 168,
@@ -2532,7 +2532,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Everyone's[SP]panicking[SP]about[SP]terrorists[SP]and[SP]that\nstuff,[SP]but[SP]why[SP]worry[SP]so[SP]much?[1205][000F][SP]I[SP]bet[SP]it'll[SP]all\ntake[SP]care[SP]of[SP]itself.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Tout le monde panique à cause des terroristes.\nMais pourquoi ?[1205][000F] Ça va s'arranger tout seul."
+    "texte_fr": "Tout le monde panique à cause des terroristes.\nMais pourquoi ?[000F][1205] Ça va s'arranger tout seul."
   },
   {
     "id": 169,
@@ -2547,7 +2547,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I-I[SP]can't[SP]believe[SP]they[SP]were[SP]going[SP]after\nGOLD...[1205][000F][SP]There[SP]has[SP]to[SP]be[SP]some[SP]mistake.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "J-Je n'y crois pas pour GOLD...[1205][000F]\nIl doit y avoir une erreur.[NL]C'est sûrement le canular d'une émission,\nou un abruti qui fait une blague..."
+    "texte_fr": "J-Je n'y crois pas pour GOLD...[000F][1205]\nIl doit y avoir une erreur.[NL]C'est sûrement le canular d'une émission,\nou un abruti qui fait une blague..."
   },
   {
     "id": 170,
@@ -2577,7 +2577,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]can't[SP]believe[SP]they[SP]blew[SP]up[SP]GOLD...[1205][000F][SP]This\ncan't[SP]be[SP]real.[SP]I[SP]mean,[SP]nothing[SP]bad[SP]ever\nhappened[SP]here[SP]before[SP]now.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ils ont fait exploser GOLD...[1205][000F]\nC'est faux. Rien de mal n'arrive jamais ici.[NL]Qu'est-ce qui va nous arriver ? On va s'en sortir,\nnon ? Ils vont attraper les terroristes\net tout va redevenir comme avant, hein ?"
+    "texte_fr": "Ils ont fait exploser GOLD...[000F][1205]\nC'est faux. Rien de mal n'arrive jamais ici.[NL]Qu'est-ce qui va nous arriver ? On va s'en sortir,\nnon ? Ils vont attraper les terroristes et tout va redevenir comme avant, hein ?"
   },
   {
     "id": 172,
@@ -2592,7 +2592,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "What's[SP]going[SP]to[SP]happen[SP]to[SP]us?[SP]We'll[SP]be[SP]okay,\nwon't[SP]we?[1205][000A][SP]They're[SP]gonna[SP]catch[SP]the[SP]terrorists\nand[SP]make[SP]everything[SP]all[SP]right[SP]again,[SP]right?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, tu savais pour le casino dans Mu ?[1106][NL]J'avais entendu des rumeurs, mais c'est vrai.[1106][NL]Les machines à sous sont le meilleur pari.\nOn gagne le gros lot à la #1. Un ami me l'a dit.[1205][000A]"
+    "texte_fr": "Hé, tu savais pour le casino dans Mu ?[1106][NL]J'avais entendu des rumeurs, mais c'est vrai.[1106][NL]Les machines à sous sont le meilleur pari.\nOn gagne le gros lot à la #1. Un ami me l'a dit.[000A][1205]"
   },
   {
     "id": 173,
@@ -2607,7 +2607,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Y-You're[SP]right...[SP]I[SP]can't[SP]shut[SP]out[SP]reality\nlike[SP]this.[1205][000F][SP]It's[SP]just,[SP]I[SP]never[SP]imagined[SP]such\nhorrible[SP]things[SP]could[SP]happen[SP]this[SP]close.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "T-Tu as raison... Faut pas fuir la réalité.[1205][000F]\nJe n'aurais jamais imaginé ça si près.[NL]Mais ils ont déjà un suspect, alors ce sera\nbientôt fini. N'est-ce pas ?"
+    "texte_fr": "T-Tu as raison... Faut pas fuir la réalité.[000F][1205]\nJe n'aurais jamais imaginé ça si près.[NL]Mais ils ont déjà un suspect, alors ce sera\nbientôt fini. N'est-ce pas ?"
   },
   {
     "id": 174,
@@ -2637,7 +2637,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Huh?[SP]The[SP]In[SP]Lak'ech?[1205][000F][SP]Yeah...[SP]I[SP]saw[SP]that[SP]on[SP]the\nnews[SP]and[SP]rushed[SP]to[SP]the[SP]bookstore,[SP]but[SP]they\nwere[SP]all[SP]sold[SP]out.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hein ? L'In Lak'ech ?[1205][000F] J'ai vu aux infos\net j'ai couru à la librairie, mais rupture de stock.[NL]Ils ont été dévalisés quasi instantanément."
+    "texte_fr": "Hein ? L'In Lak'ech ?[000F][1205] J'ai vu aux infos\net j'ai couru à la librairie, mais rupture de stock.[NL]Ils ont été dévalisés quasi instantanément."
   },
   {
     "id": 176,
@@ -2667,7 +2667,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Th-Those[SP]soldiers[SP]were[SP]headed[SP]to\nMt.[SP]Katatsumuri...[1205][000F][SP]They'll[SP]probably[SP]leave\nus[SP]alone[SP]if[SP]we[SP]don't[SP]get[SP]in[SP]their[SP]way.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "C-Ces soldats allaient au Mt Katatsumuri...[1205][000F]\nIls nous laisseront si on ne les gêne pas."
+    "texte_fr": "C-Ces soldats allaient au Mt Katatsumuri...[000F][1205]\nIls nous laisseront si on ne les gêne pas."
   },
   {
     "id": 178,
@@ -2682,7 +2682,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "The[SP]end[SP]of[SP]the[SP]world's[SP]pretty[SP]harsh,[SP]but[SP]doesn't\nit[SP]feel[SP]nice,[SP]in[SP]a[SP]way?[1205][000F][SP]It's[SP]not[SP]like[SP]anything\ngood[SP]happened[SP]down[SP]there[SP]anyway.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "La fin du monde c'est dur, mais ça fait du bien,\nnon ?[1205][000F] Rien de bon ne se passe ici, de toute façon.[NL]Si ce monde merdique disparaît, on fera un\nnouveau départ... Ouais, c'est sûrement ça.[NL]*soupir* Que va-t-il se passer ici..."
+    "texte_fr": "La fin du monde c'est dur, mais ça fait du bien,\nnon ?[000F][1205] Rien de bon ne se passe ici, de toute façon.[NL]Si ce monde merdique disparaît, on fera un\nnouveau départ... Ouais, c'est sûrement ça.[NL]*soupir* Que va-t-il se passer ici..."
   },
   {
     "id": 179,
@@ -2712,7 +2712,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "*sigh*[1205][0008][SP]I[SP]wonder[SP]what'll[SP]happen[SP]down[SP]there...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Je suis dégoûtée... Le patron de Time\nCastle a donné son arme légendaire à une fille.[1106][NL]Ça veut dire quoi ? Elle est comment ?\nTout ce que je sais, c'est qu'elle a les cheveux courts.[1205][0008]"
+    "texte_fr": "Je suis dégoûtée... Le patron de Time\nCastle a donné son arme légendaire à une fille.[1106][NL]Ça veut dire quoi ? Elle est comment ?\nTout ce que je sais, c'est qu'elle a les cheveux courts.[0008][1205]"
   },
   {
     "id": 181,
@@ -2757,7 +2757,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]heard[SP]from[SP]someone[SP]else[SP]that[SP]once[SP]the[SP]Grand\nCross[SP]happens,[SP]gas[SP]from[SP]the[SP]other[SP]planets[SP]is\ngonna[SP]cover[SP]the[SP]Earth.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "J'ai entendu dire que quand la Croix\naura lieu, les gaz des autres planètes\nvont recouvrir la Terre.[NL]Certaines planètes sont faites de gaz, non ?\nIls sont toxiques, et tout le monde en bas mourra."
+    "texte_fr": "J'ai entendu dire que quand la Croix\naura lieu, les gaz des autres planètes\nvont recouvrir la Terre.[NL]Certaines planètes sont faites de gaz, non ? Ils sont toxiques, et tout le monde en bas mourra."
   },
   {
     "id": 184,
@@ -2832,7 +2832,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]you[SP]think[SP]it's[SP]true[SP]that[SP]Zodiac's[SP]second\nfloor[SP]is[SP]a[SP]dungeon[SP]now?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "C'est vrai que le 2e étage de Zodiac\nest devenu un donjon ?[NL]Mes amies adorent les objets là-bas...\nMais c'est nul ! Pourquoi un donjon !? Mon club\nest gâché !"
+    "texte_fr": "C'est vrai que le 2e étage de Zodiac\nest devenu un donjon ?[NL]Mes amies adorent les objets là-bas...\nMais c'est nul ! Pourquoi un donjon !? Mon club est gâché !"
   },
   {
     "id": 189,
@@ -2847,7 +2847,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "My[SP]friends[SP]rave[SP]about[SP]all[SP]the[SP]items[SP]there...[1205][000F]\nBut[SP]it[SP]sucks![SP]Why[SP]a[SP]dungeon!?[SP]My[SP]favorite\nclub's[SP]all[SP]messed[SP]up[SP]now!",
     "nom_fr": "Lycéen de Seven",
-    "texte_fr": "J-Je suis allé à la salle de concert\nil y a une seconde.[1205][U+000A] T-Tout le monde est excité,\nune énorme f-file d'attente à l'entrée.[1106][NL]T-Tu es incroyable, Lisa-san...[1205][U+000A] Mais [1113]-\nsenpai est plus qu'un ami pour toi...[1205][U+000A]\nJe suis si jaloux...[1205][U+000A] Tellement envieux...[000F]"
+    "texte_fr": "J-Je suis allé à la salle de concert\nil y a une seconde.[1205][U+000A] T-Tout le monde est excité,\nune énorme f-file d'attente à l'entrée.[1106][NL]T-Tu es incroyable, Lisa-san...[1205][U+000A] Mais [1113]- senpai est plus qu'un ami pour toi...[1205][U+000A] Je suis si jaloux...[1205][U+000A] Tellement envieux...[000F]"
   },
   {
     "id": 190,
@@ -2967,7 +2967,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "So[SP]there[SP]really[SP]was[SP]a[SP]Jumping[SP]Geezer[SP]at\nMt.[SP]Katatsumuri...[1205][000F][SP]These[SP]guys[SP]were[SP]talking\nabout[SP]it[SP]on[SP]the[SP]train,[SP]and[SP]it[SP]was[SP]bugging[SP]me.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Il y avait donc vraiment un Vieux Sauteur au\nMt Katatsumuri...[1205][000F] Ces types en parlaient\ndans le train, et ça me tracassait."
+    "texte_fr": "Il y avait donc vraiment un Vieux Sauteur au\nMt Katatsumuri...[000F][1205] Ces types en parlaient\ndans le train, et ça me tracassait."
   },
   {
     "id": 198,
@@ -3012,7 +3012,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]do[SP]you[SP]know[SP]about[SP]the[SP]Dresser[SP]Hag?[SP]They\nsay[SP]she's[SP]at[SP]the[SP]abandoned[SP]factory.[1205][000F][SP]What[SP]is\nthat,[SP]some[SP]kinda[SP]monster?[1205][000F][SP]Weird[SP]name[SP]for[SP]one.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Tu connais la Mégère à Commode ? Elle serait à\nl'usine abandonnée.[1205][000F] C'est un monstre ?[1205][000F]\nDrôle de nom."
+    "texte_fr": "Tu connais la Mégère à Commode ? Elle serait à\nl'usine abandonnée.[000F][1205] C'est un monstre ?[000F][1205]\nDrôle de nom."
   },
   {
     "id": 201,
@@ -3042,7 +3042,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle's[SP]so[SP]cool.[SP]He[SP]sells\nweapons[SP]in[SP]secret,[SP]like[SP]one[SP]of[SP]those[SP]smugglers\nin[SP]spy[SP]movies.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Le boss de Time Castle est trop cool.\nIl vend des armes en secret, comme un\ncontrebandier de film.[NL]Ce qu'il a coûte cher, mais c'est bien.\nExactement ce que je pensais !"
+    "texte_fr": "Le boss de Time Castle est trop cool.\nIl vend des armes en secret, comme un\ncontrebandier de film.[NL]Ce qu'il a coûte cher, mais c'est bien. Exactement ce que je pensais !"
   },
   {
     "id": 203,
@@ -3072,7 +3072,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle's[SP]so[SP]cool.[SP]He[SP]sells\nweapons[SP]in[SP]secret,[SP]like[SP]one[SP]of[SP]those[SP]smugglers\nin[SP]spy[SP]movies.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Le boss de Time Castle est trop cool.\nIl vend des armes en secret, comme un\ncontrebandier de film.[NL]Ses trucs sont pas chers et merdiques.\nJe ne m'y attendais pas..."
+    "texte_fr": "Le boss de Time Castle est trop cool.\nIl vend des armes en secret, comme un\ncontrebandier de film.[NL]Ses trucs sont pas chers et merdiques. Je ne m'y attendais pas..."
   },
   {
     "id": 205,
@@ -3102,7 +3102,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after\nall,[SP]huh?[1205][000F][SP]I[SP]knew[SP]it.[1205][000F][SP]I[SP]could[SP]tell[SP]in[SP]my\ngut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][000F]\nJe le savais.[1205][000F] Je sentais qu'il préparait un\nmauvais coup.[NL]Il a du choix, mais paie une misère.\nIl achète rien et se fait un paquet en\nrevendant. Sale type."
+    "texte_fr": "Ce Tony était un contrebandier d'armes ?[000F][1205]\nJe le savais.[000F][1205] Je sentais qu'il préparait un\nmauvais coup.[NL]Il a du choix, mais paie une misère. Il achète rien et se fait un paquet en revendant. Sale type."
   },
   {
     "id": 207,
@@ -3117,7 +3117,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]hear[SP]his[SP]selection's[SP]good,[SP]but[SP]the[SP]resale\nvalue[SP]sucks.[SP]Like,[SP]he'll[SP]pay[SP]you[SP]barely[SP]anything\nand[SP]make[SP]a[SP]bundle[SP]selling[SP]it.[1205][000F][SP]What[SP]a[SP]creep.",
     "nom_fr": "Yukino",
-    "texte_fr": "Waouh, cette Ulala c'était quelque chose.\nMais on a arrêté les bombes, donc tout\nest bien qui finit bien.[1106][NL]Il ne reste que le Roi Lion et le Musée de\nl'Aérospatiale. Il s'est moqué de nous, c'est\nl'heure de la revanche ![1205][000F]"
+    "texte_fr": "Waouh, cette Ulala c'était quelque chose.\nMais on a arrêté les bombes, donc tout\nest bien qui finit bien.[1106][NL]Il ne reste que le Roi Lion et le Musée de l'Aérospatiale. Il s'est moqué de nous, c'est l'heure de la revanche ![000F][1205]"
   },
   {
     "id": 208,
@@ -3132,7 +3132,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after\nall,[SP]huh?[1205][000F][SP]I[SP]knew[SP]it.[1205][000F][SP]I[SP]could[SP]tell[SP]in[SP]my\ngut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][000F]\nJe le savais.[1205][000F] Je sentais qu'il préparait un\nmauvais coup.[NL]Il vend des merdes pour presque rien.\nÇa lui ressemble bien."
+    "texte_fr": "Ce Tony était un contrebandier d'armes ?[000F][1205]\nJe le savais.[000F][1205] Je sentais qu'il préparait un\nmauvais coup.[NL]Il vend des merdes pour presque rien. Ça lui ressemble bien."
   },
   {
     "id": 209,
@@ -3147,7 +3147,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]hear[SP]he[SP]sells[SP]basically[SP]junk[SP]for[SP]almost[SP]no\nmoney.[1205][000F][SP]That[SP]totally[SP]sounds[SP]like[SP]him.",
     "nom_fr": "Ginko",
-    "texte_fr": "C'était aussi leur volonté... ?\nMais ils étaient si gentils...[1205][000F]"
+    "texte_fr": "C'était aussi leur volonté... ?\nMais ils étaient si gentils...[000F][1205]"
   },
   {
     "id": 210,
@@ -3162,7 +3162,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after\nall,[SP]huh?[1205][000F][SP]I[SP]knew[SP]it.[1205][000F][SP]I[SP]could[SP]tell[SP]in[SP]my\ngut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][000F]\nJe le savais.[1205][000F] Je sentais qu'il préparait un\nmauvais coup.[NL]Ses articles sont dans la moyenne. C'est bizarre\nqu'il vende des armes ordinaires.\nC'est tout lui ça."
+    "texte_fr": "Ce Tony était un contrebandier d'armes ?[000F][1205]\nJe le savais.[000F][1205] Je sentais qu'il préparait un\nmauvais coup.[NL]Ses articles sont dans la moyenne. C'est bizarre qu'il vende des armes ordinaires. C'est tout lui ça."
   },
   {
     "id": 211,
@@ -3177,7 +3177,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]hear[SP]his[SP]selection[SP]and[SP]stuff's[SP]all[SP]average.\nIt's[SP]so[SP]weird[SP]he[SP]sells[SP]weapons,[SP]but[SP]they're\nall[SP]ordinary.[1205][000F][SP]He[SP]would,[SP]though.",
     "nom_fr": "Maya",
-    "texte_fr": "PACHINKO SILVER ![1205][000F]"
+    "texte_fr": "PACHINKO SILVER ![000F][1205]"
   },
   {
     "id": 212,
@@ -3192,7 +3192,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "That[SP]Tony[SP]creep[SP]was[SP]a[SP]weapons[SP]smuggler[SP]after\nall,[SP]huh?[1205][000F][SP]I[SP]knew[SP]it.[1205][000F][SP]I[SP]could[SP]tell[SP]in[SP]my\ngut[SP]he[SP]was[SP]up[SP]to[SP]no[SP]good.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Ce Tony était un contrebandier d'armes ?[1205][000F]\nJe le savais.[1205][000F] Je sentais qu'il préparait un\nmauvais coup.[NL]Il a de bons trucs, mais c'est une arnaque.\nÇa lui ressemble tout à fait."
+    "texte_fr": "Ce Tony était un contrebandier d'armes ?[000F][1205]\nJe le savais.[000F][1205] Je sentais qu'il préparait un\nmauvais coup.[NL]Il a de bons trucs, mais c'est une arnaque. Ça lui ressemble tout à fait."
   },
   {
     "id": 213,
@@ -3222,7 +3222,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[NL]Je le savais... C'est le genre\nd'endroit où on trouverait des mafieux.[NL]Mais ils vendent peu. Les échanges sont\nleur truc. Ils envoient les armes à la Mafia. Brrrr..."
+    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[NL]Je le savais... C'est le genre\nd'endroit où on trouverait des mafieux.[NL]Mais ils vendent peu. Les échanges sont leur truc. Ils envoient les armes à la Mafia. Brrrr..."
   },
   {
     "id": 215,
@@ -3267,7 +3267,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[NL]Je le savais... C'est le genre\nd'endroit où on trouverait des mafieux.[NL]Pas cher, mais de mauvaise qualité. Les flics\nsévissent, ils vendent tout pour amasser de l'argent."
+    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[NL]Je le savais... C'est le genre\nd'endroit où on trouverait des mafieux.[NL]Pas cher, mais de mauvaise qualité. Les flics sévissent, ils vendent tout pour amasser de l'argent."
   },
   {
     "id": 218,
@@ -3282,7 +3282,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]knew[SP]it...[1205][0014][SP]Like,[SP]that[SP]store[SP]was[SP]exactly[SP]the\nkinda[SP]place[SP]you'd[SP]find[SP]Mafia[SP]goons[SP]or[SP]something.",
     "nom_fr": "Yukino",
-    "texte_fr": "Ok. C'est parti...[1205][0014]"
+    "texte_fr": "Ok. C'est parti...[0014][1205]"
   },
   {
     "id": 219,
@@ -3312,7 +3312,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[NL]Je le savais... C'est le genre\nd'endroit où on trouverait des mafieux.[NL]Qualité bonne, mais vraiment cher. Ils vendront\nn'importe quoi pour de l'argent. Brrrr..."
+    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[NL]Je le savais... C'est le genre\nd'endroit où on trouverait des mafieux.[NL]Qualité bonne, mais vraiment cher. Ils vendront n'importe quoi pour de l'argent. Brrrr..."
   },
   {
     "id": 221,
@@ -3357,7 +3357,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[NL]Je le savais... C'est le genre\nd'endroit où on trouverait des mafieux.[NL]Leur sélection est bonne, mais ils paient mal.\nC'est louche, à mon avis."
+    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[NL]Je le savais... C'est le genre\nd'endroit où on trouverait des mafieux.[NL]Leur sélection est bonne, mais ils paient mal. C'est louche, à mon avis."
   },
   {
     "id": 224,
@@ -3372,7 +3372,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]knew[SP]it...[1205][0014][SP]Like,[SP]that[SP]store[SP]was[SP]exactly[SP]the\nkinda[SP]place[SP]you'd[SP]find[SP]Mafia[SP]goons[SP]or[SP]something.",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei ! Sans ce lieu, on aurait\nempêché la chute de GOLD ![1205][0014]"
+    "texte_fr": "Kehhei ! Sans ce lieu, on aurait\nempêché la chute de GOLD ![0014][1205]"
   },
   {
     "id": 225,
@@ -3402,7 +3402,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]Clair[SP]de[SP]Lune[SP]in[SP]Aoba[SP]sells[SP]weapons,\nright?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[NL]Je le savais... C'est le genre\nd'endroit où on trouverait des mafieux.[NL]Qualité et prix moyens. Ce qui est effrayant,\nc'est que de tels détails soient dans la rumeur."
+    "texte_fr": "Hé, Clair de Lune à Aoba vend\ndes armes, non ?[NL]Je le savais... C'est le genre\nd'endroit où on trouverait des mafieux.[NL]Qualité et prix moyens. Ce qui est effrayant, c'est que de tels détails soient dans la rumeur."
   },
   {
     "id": 227,
@@ -3417,7 +3417,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]knew[SP]it...[1205][0014][SP]Like,[SP]that[SP]store[SP]was[SP]exactly[SP]the\nkinda[SP]place[SP]you'd[SP]find[SP]Mafia[SP]goons[SP]or[SP]something.",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est fermé. Ce n'est pas une\nsurprise, vu la situation...[1205][0014]"
+    "texte_fr": "C'est fermé. Ce n'est pas une\nsurprise, vu la situation...[0014][1205]"
   },
   {
     "id": 228,
@@ -3717,7 +3717,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Anima[SP]Mundi[SP]sells[SP]armor?[SP]I[SP]go[SP]there[SP]all[SP]the\ntime[SP]and[SP]I[SP]never[SP]knew[SP]that.[SP]That[SP]store's[SP]got\na[SP]really[SP]great[SP]selection.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Anima Mundi vend des armures ? J'y vais tout le\ntemps et je n'en savais rien. Ce magasin a\nune super sélection.[NL]Quoi ? Les prix de rachat ? J'en sais rien...\nJe ne me ferais pas trop d'illusions."
+    "texte_fr": "Anima Mundi vend des armures ? J'y vais tout le\ntemps et je n'en savais rien. Ce magasin a\nune super sélection.[NL]Quoi ? Les prix de rachat ? J'en sais rien... Je ne me ferais pas trop d'illusions."
   },
   {
     "id": 248,
@@ -4152,7 +4152,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Huh,[SP]so[SP]Shiraishi[SP]Ramen[SP]in[SP]Hirasaka[SP]has[SP]a\nlegendary[SP]weapon[SP]for[SP]sale.[1205][000F][SP]I[SP]wonder[SP]if[SP]she\npicked[SP]it[SP]up[SP]on[SP]one[SP]of[SP]her[SP]spying[SP]missions.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Shiraishi Ramen vend une arme légendaire.[1205][000F]\nObtenue lors d'une mission d'espionnage ?"
+    "texte_fr": "Shiraishi Ramen vend une arme légendaire.[000F][1205]\nObtenue lors d'une mission d'espionnage ?"
   },
   {
     "id": 277,
@@ -4167,7 +4167,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I[SP]wouldn't[SP]be[SP]surprised[SP]if[SP]Clair[SP]de[SP]Lune[SP]had\na[SP]legendary[SP]weapon[SP]lying[SP]around.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Clair de Lune pourrait avoir une arme\nlégendaire.[NL]Il y a des pierres de lune incrustées, et\nle magasin a une atmosphère mystérieuse.[NL]Vendre des armes ? Je vais me faire tirer\ndessus si je ne fais pas attention."
+    "texte_fr": "Clair de Lune pourrait avoir une arme\nlégendaire.[NL]Il y a des pierres de lune incrustées, et\nle magasin a une atmosphère mystérieuse.[NL]Vendre des armes ? Je vais me faire tirer dessus si je ne fais pas attention."
   },
   {
     "id": 278,
@@ -4242,7 +4242,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "There's[SP]a[SP]really[SP]nasty[SP]rumor[SP]going[SP]around![1205][000F][SP]They\nsay[SP]the[SP]Time[SP]Castle[SP]owner[SP]doesn't[SP]have[SP]his\nlegendary[SP]weapon[SP]'cause[SP]he's[SP]too[SP]chicken.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Vilaine rumeur ![1205][000F] Le patron de Time Castle\nn'a pas son arme car il a la trouille.[NL]Il n'ose pas aller à l'usine pour la récupérer.\nUn mec aussi cool n'est pas lâche ! C'est faux !"
+    "texte_fr": "Vilaine rumeur ![000F][1205] Le patron de Time Castle\nn'a pas son arme car il a la trouille.[NL]Il n'ose pas aller à l'usine pour la récupérer.\nUn mec aussi cool n'est pas lâche ! C'est faux !"
   },
   {
     "id": 283,
@@ -4272,7 +4272,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Did[SP]a[SP]demon[SP]steal[SP]the[SP]legendary[SP]weapon[SP]at\nTime[SP]Castle?[1205][000F][SP]That's[SP]the[SP]rumor[SP]I[SP]heard,[SP]but...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Un démon a volé l'arme de Time Castle ?[1205][000F]\nC'est la rumeur, mais..."
+    "texte_fr": "Un démon a volé l'arme de Time Castle ?[000F][1205]\nC'est la rumeur, mais..."
   },
   {
     "id": 285,
@@ -4347,7 +4347,7 @@
     "nom_orig": "Sevens[SP]High[SP]male[SP]student",
     "texte_orig": "Oh,[SP]L-Lisa-san![1205][000A][SP]I[SP]finally[SP]found[SP]you.[1205][000A]\nI-I[SP]saw[SP]the[SP]poster![1205][000A][SP]Th-That[SP]silhouette\nis[SP]you,[SP]right?",
     "nom_fr": "Lycéen de Seven",
-    "texte_fr": "Oh, L-Lisa-san ![1205][000A] Enfin trouvée.[1205][000A]\nJ-J'ai vu l'affiche ![1205][000A] C-Cette silhouette\nc'est toi ?[NL]J-J'ai tout de suite compris en la voyant.\nE-Enfin, puisque je t'ai toujours\nobservée et tout... J'ai raison, non ?"
+    "texte_fr": "Oh, L-Lisa-san ![000A][1205] Enfin trouvée.[000A][1205]\nJ-J'ai vu l'affiche ![000A][1205] C-Cette silhouette\nc'est toi ?[NL]J-J'ai tout de suite compris en la voyant. E-Enfin, puisque je t'ai toujours observée et tout... J'ai raison, non ?"
   },
   {
     "id": 290,
@@ -4377,7 +4377,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Poster?[1205][000F][SP]Silhouette?[1205][000F][SP]I,[SP]uh,[SP]have[SP]no[SP]idea[SP]what\nyou're[SP]talking[SP]about.[SP]Whatever[SP]it[SP]is,[SP]it's\nnot[SP]me.[SP]You've[SP]got[SP]the[SP]wrong[SP]girl,[SP]dude.",
     "nom_fr": "Ginko",
-    "texte_fr": "Affiche ?[1205][000F] Silhouette ?[1205][000F] Je vois pas de quoi\ntu parles. Ce n'est pas moi. Tu te trompes de fille."
+    "texte_fr": "Affiche ?[000F][1205] Silhouette ?[000F][1205] Je vois pas de quoi\ntu parles. Ce n'est pas moi. Tu te trompes de fille."
   },
   {
     "id": 292,
@@ -4392,7 +4392,7 @@
     "nom_orig": "Sevens[SP]High[SP]male[SP]student",
     "texte_orig": "C-Congratulations[SP]on[SP]your[SP]debut,[SP]L-Lisa-san.[1205][000A]\nI-I[SP]looked[SP]all[SP]over[SP]for[SP]you[SP]to[SP]tell[SP]you[SP]that...",
     "nom_fr": "Lycéen de Seven",
-    "texte_fr": "F-Félicitations pour tes débuts, L-Lisa-san.[1205][000A]\nJ-Je t'ai cherchée partout pour te dire ça...[NL]T-Tu ferais une super idole... J-Je veux dire,\ntu es mignonne... belle... et gentille..."
+    "texte_fr": "F-Félicitations pour tes débuts, L-Lisa-san.[000A][1205]\nJ-Je t'ai cherchée partout pour te dire ça...[NL]T-Tu ferais une super idole... J-Je veux dire,\ntu es mignonne... belle... et gentille..."
   },
   {
     "id": 293,
@@ -4422,7 +4422,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "T-Toche...[1205][000F][SP]But[SP]I[SP]think[SP]this[SP]is[SP]just[SP]a[SP]big\nmisunderstanding.[SP]I-I[SP]never[SP]said[SP]I[SP]was[SP]going\nto[SP]be[SP]debuting.",
     "nom_fr": "Ginko",
-    "texte_fr": "T-Toche...[1205][000F] Mais c'est un grand\nmalentendu. J-Je n'ai jamais dit que j'allais\ndébuter."
+    "texte_fr": "T-Toche...[000F][1205] Mais c'est un grand\nmalentendu. J-Je n'ai jamais dit que j'allais\ndébuter."
   },
   {
     "id": 295,
@@ -4437,7 +4437,7 @@
     "nom_orig": "Sevens[SP]High[SP]male[SP]student",
     "texte_orig": "Oh,[SP]L-Lisa-san,[SP]are[SP]you[SP]going[SP]to[SP]Mu?[1205][000A][SP]There's\ngoing[SP]to[SP]be[SP]a[SP]promo[SP]video[SP]shoot[SP]there,[SP]right?[1205][000A]\nG-Good[SP]luck.",
     "nom_fr": "Lycéen de Seven",
-    "texte_fr": "Oh, L-Lisa-san, tu vas à Mu ?[1205][000A] Il va y\navoir le tournage d'une vidéo promo, c'est ça ?[1205][000A]\nB-Bonne chance."
+    "texte_fr": "Oh, L-Lisa-san, tu vas à Mu ?[000A][1205] Il va y\navoir le tournage d'une vidéo promo, c'est ça ?[000A][1205]\nB-Bonne chance."
   },
   {
     "id": 296,
@@ -4452,7 +4452,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Wh-Whoa,[SP]if[SP]you[SP]think[SP]I'm[SP]debuting[SP]because[SP]you\nsaw[SP]some[SP]poster,[SP]you're[SP]way[SP]off[SP]base.[1205][000F][SP]I[SP]am[SP]NOT\nbecoming[SP]an[SP]idol.",
     "nom_fr": "Ginko",
-    "texte_fr": "Wh-Whoa, si tu penses ça à cause d'une\naffiche, tu te plantes.[1205][000F] Je ne\ndeviens PAS une idole.[NL]Je vais à Mu pour remettre les pendules à l'heure !"
+    "texte_fr": "Wh-Whoa, si tu penses ça à cause d'une\naffiche, tu te plantes.[000F][1205] Je ne\ndeviens PAS une idole.[NL]Je vais à Mu pour remettre les pendules à l'heure !"
   },
   {
     "id": 297,
@@ -4482,7 +4482,7 @@
     "nom_orig": "Sevens[SP]High[SP]male[SP]student",
     "texte_orig": "Y-You're[SP]the[SP]hero[SP]of[SP]S-Sevens,[SP]Lisa-san...[1205][000F]\nPlease[SP]bring[SP]back[SP]S-Sevens'[SP]popularity...[1205][000F]\nW-We're[SP]counting[SP]on[SP]you...",
     "nom_fr": "Lycéen de Seven",
-    "texte_fr": "T-Tu es l'héroïne de S-Seven, Lisa-san...[1205][000F]\nS'il te plaît, rends à S-Seven sa popularité...[1205][000F]\nO-On compte sur toi..."
+    "texte_fr": "T-Tu es l'héroïne de S-Seven, Lisa-san...[000F][1205]\nS'il te plaît, rends à S-Seven sa popularité...[000F][1205]\nO-On compte sur toi..."
   },
   {
     "id": 299,
@@ -4497,7 +4497,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![SP]Enough[SP]of[SP]this[SP]bullshit![1205][000F][SP]You[SP]don't[SP]know\nwhat[SP]I'm[SP]going[SP]through!",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei ! Assez de ces conneries ![1205][000F] Tu ne sais\npas ce que je traverse ![NL]Jamais idole, je\nm'en fiche de Seven !"
+    "texte_fr": "Kehhei ! Assez de ces conneries ![000F][1205] Tu ne sais\npas ce que je traverse ![NL]Jamais idole, je\nm'en fiche de Seven !"
   },
   {
     "id": 300,
@@ -4527,7 +4527,7 @@
     "nom_orig": "Sevens[SP]High[SP]male[SP]student",
     "texte_orig": "I-I[SP]went[SP]to[SP]th-the[SP]outdoor[SP]concert[SP]hall\na[SP]second[SP]ago.[1205][000A][SP]E-Everyone's[SP]so[SP]excited,\nthere[SP]was[SP]a[SP]huge[SP]l-line[SP]at[SP]the[SP]entrance.",
     "nom_fr": "Lycéen de Seven",
-    "texte_fr": "J-Je suis allé à la salle de concert\nil y a une seconde.[1205][000A] T-Tout le monde est excité,\nune énorme f-file d'attente à l'entrée.[NL]T-Tu es incroyable, Lisa-san... Mais -\nsenpai est plus qu'un ami pour toi...\nJe suis si jaloux... Tellement envieux..."
+    "texte_fr": "J-Je suis allé à la salle de concert\nil y a une seconde.[000A][1205] T-Tout le monde est excité,\nune énorme f-file d'attente à l'entrée.[NL]T-Tu es incroyable, Lisa-san... Mais - senpai est plus qu'un ami pour toi... Je suis si jaloux... Tellement envieux..."
   },
   {
     "id": 302,
@@ -4557,7 +4557,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Wh...[SP]Why[SP]won't[SP]the[SP]executives[SP]come[SP]back[SP]to\nhelp[SP]us!?[1205][000F][SP]There's[SP]no[SP]way[SP]we[SP]can[SP]protect[SP]the\npeople[SP]of[SP]Sumaru[SP]alone![1205][000F][SP]S-Someone[SP]help[SP]us!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Qu... Pourquoi les cadres ne reviennent pas\naider !?[1205][000F] On ne pourra jamais protéger les\nhabitants seuls ![1205][000F] Qu-Qu'on nous aide !"
+    "texte_fr": "Qu... Pourquoi les cadres ne reviennent pas\naider !?[000F][1205] On ne pourra jamais protéger les\nhabitants seuls ![000F][1205] Qu-Qu'on nous aide !"
   },
   {
     "id": 304,
@@ -4572,7 +4572,7 @@
     "nom_orig": "Last[SP]Battalion",
     "texte_orig": "We[SP]are[SP]the[SP]mightiest.[SP]We[SP]stand[SP]unrivalled.[1205][000F]\nThose[SP]who[SP]dare[SP]stand[SP]in[SP]the[SP]way[SP]of[SP]our[SP]march\nshall[SP]be[SP]crushed[SP]by[SP]the[SP]holy[SP]lance.",
     "nom_fr": "Bataillon",
-    "texte_fr": "Nous sommes les plus forts, sans égal.[1205][000F]\nCeux sur notre chemin seront écrasés par\nla lance sacrée."
+    "texte_fr": "Nous sommes les plus forts, sans égal.[000F][1205]\nCeux sur notre chemin seront écrasés par\nla lance sacrée."
   },
   {
     "id": 305,
@@ -4587,7 +4587,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Zodiac's[SP]a[SP]club,[SP]but[SP]you've[SP]never[SP]been[SP]inside,\nhave[SP]you,[SP]Chinyan?[SP]I[SP]haven't[SP]been[SP]around[SP]here\nlately[SP]either...",
     "nom_fr": "Lisa",
-    "texte_fr": "Zodiac est un club, tu n'y es jamais entré,\nChinyan ? Je ne suis pas venue dans le\ncoin non plus...[NL]Les gars de Seven ne viennent plus à cause de\nla maladie ? Les élèves de Kakasu les ont\nremplacés, on dirait."
+    "texte_fr": "Zodiac est un club, tu n'y es jamais entré,\nChinyan ? Je ne suis pas venue dans le\ncoin non plus...[NL]Les gars de Seven ne viennent plus à cause de la maladie ? Les élèves de Kakasu les ont remplacés, on dirait."
   },
   {
     "id": 306,
@@ -4617,7 +4617,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Zodiac's[SP]a[SP]club,[SP]but[SP]you've[SP]never[SP]been[SP]inside,\nhave[SP]you,[SP]Chinyan?[SP]I[SP]haven't[SP]been[SP]around[SP]here\nlately[SP]either...",
     "nom_fr": "Ginko",
-    "texte_fr": "Zodiac est un club, tu n'y es jamais entré,\nChinyan ? Je ne suis pas venue dans le\ncoin non plus...[NL]Les gars de Seven ne viennent plus à cause de\nla maladie ? Les élèves de Kakasu les ont\nremplacés, on dirait."
+    "texte_fr": "Zodiac est un club, tu n'y es jamais entré,\nChinyan ? Je ne suis pas venue dans le\ncoin non plus...[NL]Les gars de Seven ne viennent plus à cause de la maladie ? Les élèves de Kakasu les ont remplacés, on dirait."
   },
   {
     "id": 308,
@@ -4752,7 +4752,7 @@
     "nom_orig": "Maya",
     "texte_orig": "GOLD,[SP]huh...?[SP]Could[SP]this[SP]be[SP]the[SP]next[SP]target?\nOr...?[1205][000F]",
     "nom_fr": "Maya",
-    "texte_fr": "GOLD, hein... ? C'est la prochaine cible ?\nOu... ?[1205][000F]"
+    "texte_fr": "GOLD, hein... ? C'est la prochaine cible ?\nOu... ?[000F][1205]"
   },
   {
     "id": 317,
@@ -4767,7 +4767,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Where[SP]else[SP]could[SP]it[SP]be?[1205][000F][SP]Let's[SP]just[SP]hurry[SP]up\nand[SP]get[SP]inside.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Où d'autre ?[1205][000F] Dépêchons-nous\nd'entrer."
+    "texte_fr": "Où d'autre ?[000F][1205] Dépêchons-nous\nd'entrer."
   },
   {
     "id": 318,
@@ -4782,7 +4782,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]can't[SP]afford[SP]to[SP]make[SP]another[SP]mistake.[1205][000F]\nIs[SP]GOLD[SP]where[SP]we[SP]should[SP]go,[SP]or...?",
     "nom_fr": "Maya",
-    "texte_fr": "On n'a pas le droit à l'erreur.[1205][000F]\nC'est GOLD la cible, ou... ?"
+    "texte_fr": "On n'a pas le droit à l'erreur.[000F][1205]\nC'est GOLD la cible, ou... ?"
   },
   {
     "id": 319,
@@ -4797,7 +4797,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Dammit,[SP]which[SP]one[SP]is[SP]it?[1205][000F][SP]Choices[SP]like[SP]this[SP]make\nme[SP]queasy.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Bordel, c'est où ?[1205][000F] Choisir me\ndonne la nausée."
+    "texte_fr": "Bordel, c'est où ?[000F][1205] Choisir me\ndonne la nausée."
   },
   {
     "id": 320,
@@ -4812,7 +4812,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun?[1205][000F][SP]Should[SP]we[SP]search[SP]through[SP]here?",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun ?[1205][000F] On fouille ici ?On fouille ici ?\n[NULL][NULL]Ouais, allons voir.[NULL][NULL]\n[NULL][NULL]Non, c'est pas ici.[NULL][NULL][NL]Ok, on va se fier à l'instinct de .\nInutile d'hésiter plus longtemps.\nOn y va !"
+    "texte_fr": "[1113]-kun ?[000F][1205] On fouille ici ?On fouille ici ?\n[NULL][NULL]Ouais, allons voir.[NULL][NULL]\n[NULL][NULL]Non, c'est pas ici.[NULL][NULL][NL]Ok, on va se fier à l'instinct de . Inutile d'hésiter plus longtemps. On y va !"
   },
   {
     "id": 321,
@@ -4857,7 +4857,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Wow,[SP]that[SP]Ulala[SP]lady[SP]was[SP]something[SP]else.[SP]She\nscared[SP]even[SP]me[SP]a[SP]little...[SP]But[SP]we[SP]stopped[SP]the\nbombs,[SP]so[SP]I[SP]guess[SP]it[SP]worked[SP]out[SP]in[SP]the[SP]end.",
     "nom_fr": "Yukino",
-    "texte_fr": "Waouh, cette Ulala c'était quelque chose.\nMais on a arrêté les bombes, donc tout\nest bien qui finit bien.[NL]Il ne reste que le Roi Lion et le Musée de\nl'Aérospatiale. Il s'est moqué de nous, c'est\nl'heure de la revanche !"
+    "texte_fr": "Waouh, cette Ulala c'était quelque chose.\nMais on a arrêté les bombes, donc tout\nest bien qui finit bien.[NL]Il ne reste que le Roi Lion et le Musée de l'Aérospatiale. Il s'est moqué de nous, c'est l'heure de la revanche !"
   },
   {
     "id": 324,
@@ -4962,7 +4962,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Pachinko[SP]Silver,[SP]huh...?[1205][000F][SP]I'd[SP]hate[SP]to[SP]see[SP]this\nplace[SP]go,[SP]that's[SP]for[SP]sure.[SP]But[SP]it[SP]might[SP]not\nbe[SP]the[SP]target...",
     "nom_fr": "Maya",
-    "texte_fr": "Pachinko Silver... ?[1205][000F] Je détesterais voir ça\ndisparaître. Mais c'est peut-être pas la cible..."
+    "texte_fr": "Pachinko Silver... ?[000F][1205] Je détesterais voir ça\ndisparaître. Mais c'est peut-être pas la cible..."
   },
   {
     "id": 331,
@@ -4977,7 +4977,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "In[SP]any[SP]case,[SP]we[SP]gotta[SP]move.[1205][000F][SP]Let's[SP]stop[SP]second-\nguessing[SP]ourselves[SP]and[SP]get[SP]this[SP]done!",
     "nom_fr": "Eikichi",
-    "texte_fr": "En tout cas, faut bouger.[1205][000F] Arrêtons de\ndouter et finissons-en !"
+    "texte_fr": "En tout cas, faut bouger.[000F][1205] Arrêtons de\ndouter et finissons-en !"
   },
   {
     "id": 332,
@@ -4992,7 +4992,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]can't[SP]make[SP]the[SP]same[SP]mistake[SP]again.[SP]Is[SP]this\nthe[SP]target?[1205][000F][SP]It[SP]could[SP]always[SP]be[SP]GOLD...",
     "nom_fr": "Maya",
-    "texte_fr": "On ne peut pas répéter l'erreur. Est-ce\nla cible ?[1205][000F] Ça pourrait être GOLD..."
+    "texte_fr": "On ne peut pas répéter l'erreur. Est-ce\nla cible ?[000F][1205] Ça pourrait être GOLD..."
   },
   {
     "id": 333,
@@ -5007,7 +5007,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It[SP]could[SP]just[SP]as[SP]likely[SP]be[SP]this[SP]place,[SP]though.[1205][000F]\nSheesh,[SP]this[SP]is[SP]a[SP]lot[SP]of[SP]responsibility...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mais ça pourrait tout aussi bien être ici.[1205][000F]\nPfff, c'est une lourde responsabilité..."
+    "texte_fr": "Mais ça pourrait tout aussi bien être ici.[000F][1205]\nPfff, c'est une lourde responsabilité..."
   },
   {
     "id": 334,
@@ -5022,7 +5022,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun?[1205][000F][SP]Should[SP]we[SP]search[SP]through[SP]here?",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun ?[1205][000F] On fouille ici ?On fouille ici ?\n[NULL][NULL]Ouais, allons voir.[NULL][NULL]\n[NULL][NULL]Non, c'est pas ici.[NULL][NULL][NL]Pas ici, alors. En route pour GOLD !"
+    "texte_fr": "[1113]-kun ?[000F][1205] On fouille ici ?On fouille ici ?\n[NULL][NULL]Ouais, allons voir.[NULL][NULL]\n[NULL][NULL]Non, c'est pas ici.[NULL][NULL][NL]Pas ici, alors. En route pour GOLD !"
   },
   {
     "id": 335,
@@ -5082,7 +5082,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Ulala![1205][000F][SP]What're[SP]you[SP]doing[SP]here?[SP]Did[SP]something\nhappen?",
     "nom_fr": "Maya",
-    "texte_fr": "Ulala ![1205][000F] Que fais-tu ici ?\nUn problème ?"
+    "texte_fr": "Ulala ![000F][1205] Que fais-tu ici ?\nUn problème ?"
   },
   {
     "id": 339,
@@ -5097,7 +5097,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "Can't[SP]you[SP]tell?[1205][000F][SP]I[SP]had[SP]a[SP]feeling[SP]luck[SP]was[SP]on[SP]my\nside[SP]today![SP]And[SP]sure[SP]enough,[SP]I[SP]hit[SP]the[SP]jackpot!",
     "nom_fr": "Ulala",
-    "texte_fr": "Ça se voit pas ?[1205][000F] La chance me souriait !\nEt bingo, j'ai touché le gros lot ![NL]Je sentais que je pouvais continuer...\nMais c'est l'heure de mon entraînement.\nJ'ai décidé d'être sage et partir."
+    "texte_fr": "Ça se voit pas ?[000F][1205] La chance me souriait !\nEt bingo, j'ai touché le gros lot ![NL]Je sentais que je pouvais continuer...\nMais c'est l'heure de mon entraînement. J'ai décidé d'être sage et partir."
   },
   {
     "id": 340,
@@ -5127,7 +5127,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Wait[SP]a[SP]sec![1205][000F][SP]Your[SP]fitness[SP]club[SP]was[SP]GOLD!",
     "nom_fr": "Maya",
-    "texte_fr": "Attends ![1205][000F] Ton club c'était GOLD !"
+    "texte_fr": "Attends ![000F][1205] Ton club c'était GOLD !"
   },
   {
     "id": 342,
@@ -5247,7 +5247,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "Noooooo![1205][000F][SP]GOOOOOLD![1205][000F][SP]My[SP]gym!",
     "nom_fr": "Ulala",
-    "texte_fr": "Non ![1205][000F] GOLD ![1205][000F] Ma gym !"
+    "texte_fr": "Non ![000F][1205] GOLD ![000F][1205] Ma gym !"
   },
   {
     "id": 350,
@@ -5262,7 +5262,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh?[SP]Why?[1205][000F][SP]Pachinko[SP]Silver[SP]wasn't[SP]the[SP]target?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein ?[1205][000F] Silver pas visé ?"
+    "texte_fr": "Hein ?[000F][1205] Silver pas visé ?"
   },
   {
     "id": 351,
@@ -5277,7 +5277,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "Did[SP]the[SP]terrorists[SP]do[SP]this!?[1205][000F][SP]This[SP]isn't[SP]funny!\nI[SP]just[SP]joined[SP]this[SP]place![1205][000F][SP]And[SP]I[SP]fully[SP]paid[SP]my\nmembership[SP]in[SP]advance!",
     "nom_fr": "Ulala",
-    "texte_fr": "Les terroristes ont fait ça !?[1205][000F] Pas drôle !\nJe viens de m'inscrire ![1205][000F] J'ai payé d'avance !"
+    "texte_fr": "Les terroristes ont fait ça !?[000F][1205] Pas drôle !\nJe viens de m'inscrire ![000F][1205] J'ai payé d'avance !"
   },
   {
     "id": 352,
@@ -5292,7 +5292,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Uh--[1205][000A]Ulala!",
     "nom_fr": "Maya",
-    "texte_fr": "Eh-[1205][000A]Ulala!"
+    "texte_fr": "Eh-[000A][1205]Ulala!"
   },
   {
     "id": 353,
@@ -5307,7 +5307,7 @@
     "nom_orig": "Elly's[SP]voice",
     "texte_orig": "Hello?[SP]Elly[SP]here.[1205][000F][SP]I've[SP]figured[SP]out[SP]the[SP]last\ntarget.[1205][000F][SP]It's[SP]south-southeast[SP]of[SP]Sevens...",
     "nom_fr": "Voix d'Elly",
-    "texte_fr": "Allô ? C'est Elly.[1205][000F] J'ai découvert la dernière\ncible.[1205][000F] C'est au sud-sud-est de Seven...[NL]Un seul bâtiment dans cette direction :\nLe Musée de l'Aérospatiale. Faites vite !"
+    "texte_fr": "Allô ? C'est Elly.[000F][1205] J'ai découvert la dernière\ncible.[000F][1205] C'est au sud-sud-est de Seven...[NL]Un seul bâtiment dans cette direction :\nLe Musée de l'Aérospatiale. Faites vite !"
   },
   {
     "id": 354,
@@ -5337,7 +5337,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "You[SP]hear[SP]that,[SP]guys?[1205][000F][SP]We[SP]finally[SP]got[SP]a[SP]concrete\nclue.[SP]The[SP]last[SP]target's[SP]the[SP]Aerospace[SP]Museum!",
     "nom_fr": "Yukino",
-    "texte_fr": "Vous avez entendu ?[1205][000F] On a une piste. La\ndernière cible est le Musée de l'Aérospatiale !"
+    "texte_fr": "Vous avez entendu ?[000F][1205] On a une piste. La\ndernière cible est le Musée de l'Aérospatiale !"
   },
   {
     "id": 356,
@@ -5367,7 +5367,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]agree...[SP]If[SP]the[SP]Aerospace[SP]Museum[SP]is[SP]the[SP]last\ntarget,[SP]you[SP]can[SP]bet[SP]King[SP]Leo[SP]will[SP]be[SP]there.[1205][000F]\nLet's[SP]put[SP]an[SP]end[SP]to[SP]this!",
     "nom_fr": "Maya",
-    "texte_fr": "D'accord... Si le Musée est la dernière\ncible, le Roi Lion y sera.[1205][000F] Mettons\nun terme à tout ça !"
+    "texte_fr": "D'accord... Si le Musée est la dernière\ncible, le Roi Lion y sera.[000F][1205] Mettons\nun terme à tout ça !"
   },
   {
     "id": 358,

--- a/traduction/MMAP03.json
+++ b/traduction/MMAP03.json
@@ -42,7 +42,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "I...[SP]I[SP]can't[SP]believe[SP]the[SP]concert[SP]hall[SP]burned\ndown...[1205][000F][SP]Wh-What[SP]happened[SP]in[SP]there?[SP]Is[SP]the\naudience[SP]okay?",
     "nom_fr": "Employé",
-    "texte_fr": "Je... La salle a brûlé...[1205][000F]\nQue s'est-il passé ? Le public va bien ?"
+    "texte_fr": "Je... La salle a brûlé...[000F][1205]\nQue s'est-il passé ? Le public va bien ?"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "I[SP]heard[SP]from[SP]a[SP]friend[SP]that[SP]Smile[SP]Hirasaka[SP]and\nGOLD[SP]were[SP]targeted[SP]by[SP]terrorists[SP]too.[1205][000F][SP]Luckily,\nboth[SP]attacks[SP]were[SP]thwarted...",
     "nom_fr": "Employé",
-    "texte_fr": "Un ami m'a dit que Smile Hirasaka et GOLD ont aussi été visés.[1205][000F]\nHeureusement, les deux ont été évités...[NL]Mais ils étaient bondés.\nQui voudrait bombarder ça ? Le coupable est inhumain !"
+    "texte_fr": "Un ami m'a dit que Smile Hirasaka et GOLD ont aussi été visés.[000F][1205]\nHeureusement, les deux ont été évités...[NL]Mais ils étaient bondés.\nQui voudrait bombarder ça ? Le coupable est inhumain !"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "My[SP]friend[SP]told[SP]me[SP]that[SP]the[SP]terrorists[SP]even[SP]blew\nup[SP]Smile[SP]Hirasaka.[1205][000F][SP]I[SP]hear[SP]the[SP]death[SP]toll[SP]was\ntremendous.",
     "nom_fr": "Employé",
-    "texte_fr": "Mon ami dit que les terroristes ont fait sauter Smile Hirasaka.[1205][000F]\nDe nombreux morts.[NL]Beaucoup de monde aussi...\nPourquoi bombarder ça ? Inhumain !"
+    "texte_fr": "Mon ami dit que les terroristes ont fait sauter Smile Hirasaka.[000F][1205]\nDe nombreux morts.[NL]Beaucoup de monde aussi...\nPourquoi bombarder ça ? Inhumain !"
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "My[SP]friend[SP]told[SP]me[SP]that[SP]the[SP]terrorists[SP]even[SP]blew\nup[SP]GOLD[SP]in[SP]Yumezaki.[1205][000F][SP]I[SP]hear[SP]the[SP]death[SP]toll[SP]was\ntremendous.",
     "nom_fr": "Employé",
-    "texte_fr": "Mon ami dit qu'ils ont fait sauter GOLD à Yumezaki.[1205][000F]\nBeaucoup de morts.[NL]Beaucoup de monde aussi...\nPourquoi bombarder ça ? Inhumain !"
+    "texte_fr": "Mon ami dit qu'ils ont fait sauter GOLD à Yumezaki.[000F][1205]\nBeaucoup de morts.[NL]Beaucoup de monde aussi...\nPourquoi bombarder ça ? Inhumain !"
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "I[SP]heard[SP]from[SP]a[SP]friend[SP]that[SP]terrorists[SP]struck\nat[SP]both[SP]Smile[SP]Hirasaka[SP]and[SP]GOLD.[1205][000F][SP]So[SP]many\npeople[SP]died...",
     "nom_fr": "Employé",
-    "texte_fr": "Un ami m'a dit que les terroristes ont frappé\n Smile Hirasaka et GOLD.[1205][000F] Tant de morts...[NL]Bondés. Qui voudrait\nbombarder ça ? Inhumain !"
+    "texte_fr": "Un ami m'a dit que les terroristes ont frappé\n Smile Hirasaka et GOLD.[000F][1205] Tant de morts...[NL]Bondés. Qui voudrait\nbombarder ça ? Inhumain !"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "They[SP]were[SP]both[SP]packed[SP]with[SP]people.[SP]Who'd[SP]want[1205][000F]\nto[SP]bomb[SP]someplace[SP]like[SP]that?[SP]The[SP]culprit[SP]is\ninhuman...!",
     "nom_fr": "Femme active",
-    "texte_fr": "Aoba est célèbre pour sa salle de concert,\n mais ce n'est pas notre seule fierté.[1106][NL]Kismet Publishing (Coolest) et Sumaru TV\n sont dans ce quartier.[1106][NL]Ça n'a pas le peps de Yumezaki,\n mais ce quartier est le cœur\n qui alimente Sumaru en infos.[1205][000F]"
+    "texte_fr": "Aoba est célèbre pour sa salle de concert,\n mais ce n'est pas notre seule fierté.[1106][NL]Kismet Publishing (Coolest) et Sumaru TV\nsont dans ce quartier.[1106][NL]Ça n'a pas le peps de Yumezaki, mais ce quartier est le cœur qui alimente Sumaru en infos.[000F][1205]"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Even[SP]the[SP]Aerospace[SP]Museum[SP]was[SP]bombed...[1205][000F]\nThat's[SP]already[SP]six[SP]attacks[SP]in[SP]total.[1205][000F]",
     "nom_fr": "Employé",
-    "texte_fr": "Même le musée aérospatial a été bombardé...[1205][000F]\nSix attaques au total.[1205][000F][NL]Combien de morts pour cette bande de cinq !?"
+    "texte_fr": "Même le musée aérospatial a été bombardé...[000F][1205]\nSix attaques au total.[000F][1205][NL]Combien de morts pour cette bande de cinq !?"
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "The[SP]paper's[SP]reporting[SP]now[SP]that[SP]the[SP]Masked\nCircle[SP]and[SP]the[SP]Last[SP]Battalion[SP]are[SP]fighting\nover[SP]the[SP]secret[SP]treasure[SP]of[SP]Sumaru.",
     "nom_fr": "Employé",
-    "texte_fr": "Le journal dit que le Cercle Masqué\n et le Dernier Bataillon se battent\n pour le trésor secret de Sumaru.[NL]C'était la raison de la vague de terreur aussi.\nQu'ils le prennent et s'en aillent. On n'en a pas besoin !"
+    "texte_fr": "Le journal dit que le Cercle Masqué\n et le Dernier Bataillon se battent\npour le trésor secret de Sumaru.[NL]C'était la raison de la vague de terreur aussi. Qu'ils le prennent et s'en aillent. On n'en a pas besoin !"
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Th-That[SP]mark...![1205][000F][SP]Why[SP]are[SP]soldiers[SP]with[SP]that\ninsignia[SP]coming[SP]to[SP]Sumaru[SP]now!?[SP]It[SP]makes\nno[SP]sense!",
     "nom_fr": "Employé",
-    "texte_fr": "Ce symbole...![1205][000F]\nPourquoi ces soldats viennent à Sumaru ? Insensé !"
+    "texte_fr": "Ce symbole...![000F][1205]\nPourquoi ces soldats viennent à Sumaru ? Insensé !"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "D-Did[SP]the[SP]Masked[SP]Circle[SP]and[SP]the[SP]Last[SP]Battalion\ncause[SP]those[SP]temples[SP]to[SP]appear,[SP]too?",
     "nom_fr": "Employé",
-    "texte_fr": "Le Cercle Masqué et le Dernier Bataillon\n ont-ils aussi fait apparaître ces temples ?[NL]Une fois apparus,\n ils se sont tous précipités à l'intérieur.[NL]Ugh... C'en est trop...\nJe deviendrai fou avant d'évoluer..."
+    "texte_fr": "Le Cercle Masqué et le Dernier Bataillon\n ont-ils aussi fait apparaître ces temples ?[NL]Une fois apparus,\nils se sont tous précipités à l'intérieur.[NL]Ugh... C'en est trop... Je deviendrai fou avant d'évoluer..."
   },
   {
     "id": 17,
@@ -297,7 +297,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Aoba[SP]is[SP]famous[SP]for[SP]its[SP]outdoor[SP]concert[SP]hall,\nbut[SP]that's[SP]not[SP]the[SP]only[SP]thing[SP]we're[SP]known[SP]for.",
     "nom_fr": "Femme active",
-    "texte_fr": "Aoba est célèbre pour sa salle de concert,\n mais ce n'est pas notre seule fierté.[NL]Kismet Publishing (Coolest) et Sumaru TV\n sont dans ce quartier.[NL]Ça n'a pas le peps de Yumezaki,\n mais ce quartier est le cœur\n qui alimente Sumaru en infos."
+    "texte_fr": "Aoba est célèbre pour sa salle de concert,\n mais ce n'est pas notre seule fierté.[NL]Kismet Publishing (Coolest) et Sumaru TV\nsont dans ce quartier.[NL]Ça n'a pas le peps de Yumezaki, mais ce quartier est le cœur qui alimente Sumaru en infos."
   },
   {
     "id": 20,
@@ -327,7 +327,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "It[SP]may[SP]not[SP]have[SP]Yumezaki's[SP]pizazz,[SP]but[SP]I[SP]think\nthis[SP]ward[SP]is[SP]the[SP]beating[SP]heart[SP]that[SP]feeds\ninformation[SP]across[SP]Sumaru[SP]City.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Comment de telles absurdités arrivent ?[1205][U+000A]\nJe l'ai vu de mes yeux...[1205][U+000A]\nJe n'ai pas le choix, je dois y croire...[1106][NL]Alors cette histoire de Terre anéantie doit être vraie aussi...[1205][U+000F]\nQue va-t-il exactement se passer ?"
+    "texte_fr": "Comment de telles absurdités arrivent ?[1205][U+000A]\nJe l'ai vu de mes yeux...[1205][U+000A]\nJe n'ai pas le choix, je dois y croire...[1106][NL]Alors cette histoire de Terre anéantie doit être vraie aussi...[1205][U+000F] Que va-t-il exactement se passer ?"
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "I[SP]just[SP]saw[SP]a[SP]Masked[SP]Circle[SP]member[SP]in[SP]a[SP]store.[1205][000F]\nHe[SP]was[SP]saying[SP]some[SP]scary[SP]stuff...",
     "nom_fr": "Femme active",
-    "texte_fr": "Je viens de voir un membre du Cercle Masqué.[1205][000F]\nIl disait des trucs effrayants...[NL]Nul doute que c'est eux qui ont incendié la salle.\nUne menace, comme les rumeurs le disaient."
+    "texte_fr": "Je viens de voir un membre du Cercle Masqué.[000F][1205]\nIl disait des trucs effrayants...[NL]Nul doute que c'est eux qui ont incendié la salle.\nUne menace, comme les rumeurs le disaient."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "There's[SP]no[SP]doubt[SP]that[SP]it[SP]was[SP]them[SP]who[SP]set[SP]fire\nto[SP]the[SP]outdoor[SP]concert[SP]hall.[SP]They're[SP]a[SP]menace,\njust[SP]like[SP]the[SP]rumors[SP]said.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un collègue dit que la Grande Croix provoquera\n l'attraction des autres planètes,\n causant un tsunami géant.[1106][NL]Je ne connais pas bien la science...[1205][U+000F]\nEst-ce seulement possible ?"
+    "texte_fr": "Un collègue dit que la Grande Croix provoquera\n l'attraction des autres planètes,\ncausant un tsunami géant.[1106][NL]Je ne connais pas bien la science...[1205][U+000F] Est-ce seulement possible ?"
   },
   {
     "id": 24,
@@ -402,7 +402,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "I-I[SP]heard[SP]the[SP]Oracle[SP]in[SP]the[SP]In[SP]Lak'ech[SP]talks\nabout[SP]everything[SP]that's[SP]happened[SP]lately,\nbut[SP]that's[SP]just[SP]a[SP]marketing[SP]angle.",
     "nom_fr": "Femme active",
-    "texte_fr": "L'Oracle dans l'In Lak'ech parle de tout,\n mais ce n'est qu'un argument marketing.[NL]Ce n'est pas une grande prophétie.\nCe serait ridicule...[NL]Tu ne crois pas ?\nJ'ai raison, non ?"
+    "texte_fr": "L'Oracle dans l'In Lak'ech parle de tout,\n mais ce n'est qu'un argument marketing.[NL]Ce n'est pas une grande prophétie.\nCe serait ridicule...[NL]Tu ne crois pas ? J'ai raison, non ?"
   },
   {
     "id": 27,
@@ -447,7 +447,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Why[SP]are[SP]soldiers[SP]raining[SP]from[SP]the[SP]sky!?[SP]Is[SP]this\nthing[SP]saying[SP]there's[SP]some[SP]secret[SP]treasure[SP]here\nin[SP]Sumaru!?[1205][000F][SP]I-I[SP]refuse[SP]to[SP]believe[SP]that![SP]No!",
     "nom_fr": "Femme active",
-    "texte_fr": "Pourquoi les soldats pleuvent du ciel !?\nCe truc dit qu'il y a un trésor secret à Sumaru !?[1205][000F]\nJe refuse de le croire ! Non !"
+    "texte_fr": "Pourquoi les soldats pleuvent du ciel !?\nCe truc dit qu'il y a un trésor secret à Sumaru !?[000F][1205]\nJe refuse de le croire ! Non !"
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Huh!?[1205][000A][SP]Didn't[SP]you[SP]just[SP]go[SP]into[SP]that[SP]temple?[1205][000F]\nYeah,[SP]carrying[SP]this[SP]weird[SP]skull...[1205][000F][SP]A-Am[SP]I\nseeing[SP]things...?",
     "nom_fr": "Femme active",
-    "texte_fr": "Hein ?[1205][000A] Tu n'es pas entré dans ce temple ?[1205][000F]\nOui, avec ce drôle de crâne...[1205][000F]\nJ'ai des hallucinations ?"
+    "texte_fr": "Hein ?[000A][1205] Tu n'es pas entré dans ce temple ?[000F][1205]\nOui, avec ce drôle de crâne...[000F][1205]\nJ'ai des hallucinations ?"
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Ever[SP]hear[SP]the[SP]rumor[SP]that[SP]Rosa[SP]Candida[SP]sells\nreal[SP]armor?[1205][000F][SP]An[SP]office[SP]mate[SP]of[SP]mine[SP]told[SP]me\nabout[SP]it,[SP]and[SP]I've[SP]been[SP]curious[SP]ever[SP]since.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tu as entendu que Rosa Candida vend de vraies armures ?[1205][000F]\nUn collègue m'en a parlé, je suis curieux.[NL]Il a dû voir ça sur Internet.[NL]Au Double Slash, on peut utiliser leurs PC\n pour surfer sur Internet.[NL]Même un vieux comme moi pourrait chercher,\nmais je suis nul en informatique.\nUn de mes travers."
+    "texte_fr": "Tu as entendu que Rosa Candida vend de vraies armures ?[000F][1205]\nUn collègue m'en a parlé, je suis curieux.[NL]Il a dû voir ça sur Internet.[NL]Au Double Slash, on peut utiliser leurs PC\npour surfer sur Internet.[NL]Même un vieux comme moi pourrait chercher, mais je suis nul en informatique. Un de mes travers."
   },
   {
     "id": 32,
@@ -567,7 +567,7 @@
     "nom_orig": "Man",
     "texte_orig": "I[SP]can't[SP]believe[SP]such[SP]a[SP]terrible[SP]tragedy\nhappened...[1205][000F][SP]But[SP]if[SP]sketches[SP]of[SP]the[SP]culprits[SP]are\nout,[SP]it[SP]won't[SP]be[SP]long[SP]before[SP]they're[SP]arrested.",
     "nom_fr": "Homme",
-    "texte_fr": "Je n'arrive pas à croire qu'une telle tragédie soit arrivée.[1205][000F]\nMais avec les portraits-robots, ils seront bientôt arrêtés."
+    "texte_fr": "Je n'arrive pas à croire qu'une telle tragédie soit arrivée.[000F][1205]\nMais avec les portraits-robots, ils seront bientôt arrêtés."
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "My[SP]entire[SP]office[SP]is[SP]buzzing[SP]about[SP]whether[SP]or\nnot[SP]the[SP]In[SP]Lak'ech[SP]is[SP]true.[1205][000F][SP]All[SP]the[SP]younger\nemployees[SP]seem[SP]to[SP]believe[SP]in[SP]it.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tout le bureau parle de si l'In Lak'ech est vrai.[1205][000F]\nLes jeunes y croient."
+    "texte_fr": "Tout le bureau parle de si l'In Lak'ech est vrai.[000F][1205]\nLes jeunes y croient."
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Most[SP]of[SP]those[SP]soldiers[SP]were[SP]heading[SP]to\nMt.[SP]Katatsumuri.[1205][000F][SP]But[SP]why[SP]would[SP]they[SP]go[SP]there?\nI[SP]don't[SP]understand.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "La plupart des soldats allaient au mont Katatsumuri.[1205][000F]\nPourquoi ? Je ne comprends pas."
+    "texte_fr": "La plupart des soldats allaient au mont Katatsumuri.[000F][1205]\nPourquoi ? Je ne comprends pas."
   },
   {
     "id": 40,
@@ -612,7 +612,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "How[SP]can[SP]such[SP]nonsensical[SP]things[SP]be[SP]happening?[1205][000A]\nW-Well,[SP]I've[SP]seen[SP]it[SP]for[SP]myself...[1205][000A][SP]I[SP]don't\nhave[SP]a[SP]choice[SP]but[SP]to[SP]believe[SP]it...",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Comment de telles absurdités arrivent ?[1205][000A]\nJe l'ai vu de mes yeux...[1205][000A]\nJe n'ai pas le choix, je dois y croire...[NL]Alors cette histoire de Terre anéantie doit être vraie aussi...\nQue va-t-il exactement se passer ?"
+    "texte_fr": "Comment de telles absurdités arrivent ?[000A][1205]\nJe l'ai vu de mes yeux...[000A][1205]\nJe n'ai pas le choix, je dois y croire...[NL]Alors cette histoire de Terre anéantie doit être vraie aussi... Que va-t-il exactement se passer ?"
   },
   {
     "id": 41,
@@ -627,7 +627,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "But[SP]in[SP]that[SP]case,[SP]this[SP]talk[SP]about[SP]the[SP]Earth\nbeing[SP]annihilated[SP]must[SP]be[SP]true,[SP]too...[1205][000F][SP]What\nexactly[SP]is[SP]going[SP]to[SP]happen?",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tony : armes de qualité, prix élevés.[1205][000F]"
+    "texte_fr": "Tony : armes de qualité, prix élevés.[000F][1205]"
   },
   {
     "id": 42,
@@ -642,7 +642,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "My[SP]men[SP]say[SP]that[SP]the[SP]Grand[SP]Cross[SP]will[SP]cause[SP]the\nmantle's[SP]temperature[SP]to[SP]rise,[SP]making[SP]the[SP]Earth\na[SP]scorching[SP]hell...[1205][000F][SP]Is[SP]that[SP]how[SP]the[SP]world[SP]ends?",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Mes collègues disent que la Grande Croix fera monter\n la température, transformant la Terre en enfer...[1205][000F]\nC'est ainsi que le monde finit ?"
+    "texte_fr": "Mes collègues disent que la Grande Croix fera monter\n la température, transformant la Terre en enfer...[000F][1205]\nC'est ainsi que le monde finit ?"
   },
   {
     "id": 43,
@@ -657,7 +657,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "A[SP]colleague[SP]of[SP]mine[SP]says[SP]the[SP]Grand[SP]Cross[SP]will\nresult[SP]in[SP]the[SP]gravitational[SP]pull[SP]of[SP]the[SP]other\nplanets[SP]causing[SP]a[SP]gigantic[SP]tsunami.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un collègue dit que la Grande Croix provoquera\n l'attraction des autres planètes,\n causant un tsunami géant.[NL]Je ne connais pas bien la science...\nEst-ce seulement possible ?"
+    "texte_fr": "Un collègue dit que la Grande Croix provoquera\n l'attraction des autres planètes,\ncausant un tsunami géant.[NL]Je ne connais pas bien la science... Est-ce seulement possible ?"
   },
   {
     "id": 44,
@@ -672,7 +672,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "I[SP]don't[SP]know[SP]much[SP]about[SP]science...[1205][000F][SP]Is[SP]that\neven[SP]possible?",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Clair de Lune... J'y suis allé avec un associé.\nIls vendent des armes ?[1106][NL]Qualité premium, mais cher.[1205][000F]"
+    "texte_fr": "Clair de Lune... J'y suis allé avec un associé.\nIls vendent des armes ?[1106][NL]Qualité premium, mais cher.[000F][1205]"
   },
   {
     "id": 45,
@@ -687,7 +687,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "That[SP]was[SP]strange.[1205][000A][SP]My[SP]men[SP]had[SP]all[SP]been[SP]arguing\nover[SP]how[SP]the[SP]world[SP]down[SP]there[SP]would[SP]end,[SP]when\nsuddenly[SP]they[SP]settled[SP]on[SP]one[SP]idea.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "C'était étrange.[1205][000A]\nIls discutaient de la fin du monde en bas,\n quand soudain ils se sont mis d'accord sur une idée.[NL]Ils pensent que la Grande Croix\n arrêtera la rotation de la Terre.[NL]Je n'ai pas suivi,\n mais tout sur Terre sera emporté à grande vitesse ?"
+    "texte_fr": "C'était étrange.[000A][1205]\nIls discutaient de la fin du monde en bas,\nquand soudain ils se sont mis d'accord sur une idée.[NL]Ils pensent que la Grande Croix arrêtera la rotation de la Terre.[NL]Je n'ai pas suivi, mais tout sur Terre sera emporté à grande vitesse ?"
   },
   {
     "id": 46,
@@ -732,7 +732,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "So[SP]there[SP]are[SP]talking[SP]flowers[SP]in[SP]Aoba[SP]Park...\nWhen[SP]I[SP]first[SP]heard,[SP]I[SP]thought[SP]it[SP]was[SP]a[SP]joke.[1205][000F]\nI'm[SP]curious[SP]to[SP]know[SP]what[SP]plants[SP]think[SP]about.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Des fleurs qui parlent dans le parc d'Aoba...\nJ'ai d'abord cru à une blague.[1205][000F]\nCurieux de savoir à quoi pensent les plantes."
+    "texte_fr": "Des fleurs qui parlent dans le parc d'Aoba...\nJ'ai d'abord cru à une blague.[000F][1205]\nCurieux de savoir à quoi pensent les plantes."
   },
   {
     "id": 49,
@@ -747,7 +747,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "It[SP]seems[SP]Zodiac's[SP]second[SP]floor[SP]has[SP]become[SP]a\ngiant[SP]dungeon.[1205][000F][SP]The[SP]rumor[SP]is[SP]that[SP]there's[SP]tons\nof[SP]great[SP]items[SP]there...",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Il paraît que le deuxième étage de Zodiac est devenu\n un immense donjon.[1205][000F] Beaucoup de bons objets...[NL]Un nouveau coup de pub ? Qu'en pensez-vous ?"
+    "texte_fr": "Il paraît que le deuxième étage de Zodiac est devenu\n un immense donjon.[000F][1205] Beaucoup de bons objets...[NL]Un nouveau coup de pub ? Qu'en pensez-vous ?"
   },
   {
     "id": 50,
@@ -792,7 +792,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "If[SP]enough[SP]people[SP]say[SP]so,[SP]it[SP]must[SP]be[SP]true...[1205][000F]\nBrrr![SP]I[SP]just[SP]felt[SP]a[SP]chill[SP]down[SP]my[SP]spine.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "La boutique de Rengedai vend armures et vêtements ?\nQualité et prix moyens.[1106][NL]*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur...[1205][000F]"
+    "texte_fr": "La boutique de Rengedai vend armures et vêtements ?\nQualité et prix moyens.[1106][NL]*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur...[000F][1205]"
   },
   {
     "id": 53,
@@ -807,7 +807,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Is[SP]there[SP]something[SP]called[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the\nabandoned[SP]factory?[1205][000F][SP]Yikes,[SP]now[SP]I[SP]can't[SP]even[SP]take\na[SP]taxi[SP]ride[SP]without[SP]worrying[SP]anymore.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un Taxi Maudit à l'usine abandonnée ?[1205][000F]\nOuf, je ne peux même plus prendre un taxi sans m'inquiéter."
+    "texte_fr": "Un Taxi Maudit à l'usine abandonnée ?[000F][1205]\nOuf, je ne peux même plus prendre un taxi sans m'inquiéter."
   },
   {
     "id": 54,
@@ -837,7 +837,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "A[SP]taxi[SP]driver[SP]told[SP]me[SP]about[SP]it.[1205][000F][SP]He[SP]said[SP]he's\nhaving[SP]trouble[SP]getting[SP]customers[SP]because\nof[SP]that[SP]thing.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Anima Mundi vend des armures. Nouvelle mode ?\nQualité et prix moyens.[1205][000F]"
+    "texte_fr": "Anima Mundi vend des armures. Nouvelle mode ?\nQualité et prix moyens.[000F][1205]"
   },
   {
     "id": 56,
@@ -867,7 +867,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "There's[SP]a[SP]Jumping[SP]Geezer[SP]at[SP]Mt.[SP]Katatsumuri?\nIsn't[SP]that[SP]just[SP]one[SP]of[SP]those[SP]Last[SP]Battalion\nguys?[1205][000F][SP]Yeah,[SP]I[SP]bet[SP]that's[SP]all[SP]it[SP]is.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un Sauteur Vieux au mont Katatsumuri ?\nC'est juste un gars du Dernier Bataillon, non ?[1205][000F]\nOuais, ça doit être ça."
+    "texte_fr": "Un Sauteur Vieux au mont Katatsumuri ?\nC'est juste un gars du Dernier Bataillon, non ?[000F][1205]\nOuais, ça doit être ça."
   },
   {
     "id": 58,
@@ -882,7 +882,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "I[SP]can't[SP]believe[SP]they[SP]still[SP]tell[SP]that[SP]story...\nKudan,[SP]huh...?[1205][000F][SP]Even[SP]at[SP]my[SP]age,[SP]I'm[SP]afraid[SP]of\nthat[SP]thing...[1205][000F][SP]Brrr![SP]Still[SP]gives[SP]me[SP]the[SP]creeps.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Je n'arrive pas à croire qu'on raconte encore ça...\nKudan...[1205][000F] Même à mon âge, j'en ai peur.[1205][000F]\nBrrr ! Ça me donne toujours des frissons."
+    "texte_fr": "Je n'arrive pas à croire qu'on raconte encore ça...\nKudan...[000F][1205] Même à mon âge, j'en ai peur.[000F][1205]\nBrrr ! Ça me donne toujours des frissons."
   },
   {
     "id": 59,
@@ -897,7 +897,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "There's[SP]a[SP]secret[SP]CD[SP]at[SP]Giga[SP]Macho?[SP]Stores[SP]have\nbeen[SP]coming[SP]up[SP]with[SP]odd[SP]promotional[SP]stunts\nlately.[1205][000F][SP]Though[SP]it[SP]does[SP]pique[SP]my[SP]interest...",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Un CD secret chez Giga Macho ?\nLes magasins ont des promotions bizarres.[1205][000F]\nCela pique ma curiosité..."
+    "texte_fr": "Un CD secret chez Giga Macho ?\nLes magasins ont des promotions bizarres.[000F][1205]\nCela pique ma curiosité..."
   },
   {
     "id": 60,
@@ -912,7 +912,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Do[SP]you[SP]know[SP]the[SP]Dresser[SP]Hag?[1205][000F][SP]There's[SP]a[SP]creature\ncalled[SP]that[SP]at[SP]the[SP]abandoned[SP]factory.[1205][000F][SP]Does[SP]that\nmean[SP]it[SP]lives[SP]inside[SP]a[SP]dresser?",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Tu connais la Sorcière du Buffet ?[1205][000F]\nElle serait à l'usine abandonnée.[1205][000F]\nElle vit dans un buffet ?"
+    "texte_fr": "Tu connais la Sorcière du Buffet ?[000F][1205]\nElle serait à l'usine abandonnée.[000F][1205]\nElle vit dans un buffet ?"
   },
   {
     "id": 61,
@@ -1107,7 +1107,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Rumor[SP]has[SP]it[SP]their[SP]stuff[SP]is[SP]top-tier,\nbut[SP]it's[SP]not[SP]exactly[SP]affordable.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][U+000F]\nL'idée de jouer m'excite...[1106][NL]Un ami y est allé.[1205][U+000F] On peut gagner gros\nà la machine à sous du fond.\n#1 ou #8 ?"
+    "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][U+000F]\nL'idée de jouer m'excite...[1106][NL]Un ami y est allé.[1205][U+000F] On peut gagner gros à la machine à sous du fond. #1 ou #8 ?"
   },
   {
     "id": 74,
@@ -1182,7 +1182,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Average[SP]quality[SP]and[SP]prices,[SP]huh...?[1205][000F][SP]I'd[SP]never\nhave[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real[SP]weapons.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Qualité et prix moyens ?[1205][000F]\nJamais imaginé que Jolly Roger vendait des armes.[NL]Qu'est-il arrivé à cette ville ?"
+    "texte_fr": "Qualité et prix moyens ?[000F][1205]\nJamais imaginé que Jolly Roger vendait des armes.[NL]Qu'est-il arrivé à cette ville ?"
   },
   {
     "id": 79,
@@ -1212,7 +1212,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Low[SP]prices,[SP]but[SP]low[SP]quality,[SP]huh...?[1205][000F][SP]I'd[SP]never\nhave[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real[SP]weapons.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Prix bas, qualité basse ?[1205][000F]\nJamais imaginé que Jolly Roger vendait des armes.[NL]Qu'est-il arrivé à cette ville ?"
+    "texte_fr": "Prix bas, qualité basse ?[000F][1205]\nJamais imaginé que Jolly Roger vendait des armes.[NL]Qu'est-il arrivé à cette ville ?"
   },
   {
     "id": 81,
@@ -1227,7 +1227,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Honestly,[SP]what's[SP]happened[SP]to[SP]this[SP]city?",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Quelle malchance. Le propriétaire a donné\nl'arme légendaire.[1106][NL]À une fille aux cheveux courts, dit-on.\nIndice trop vague. *soupir*\nSi seulement je l'avais achetée !"
+    "texte_fr": "Quelle malchance. Le propriétaire a donné\nl'arme légendaire.[1106][NL]À une fille aux cheveux courts, dit-on.\nIndice trop vague. *soupir* Si seulement je l'avais achetée !"
   },
   {
     "id": 82,
@@ -1242,7 +1242,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Great[SP]selection,[SP]but[SP]low[SP]resale[SP]prices,[SP]huh...?[1205][000F]\nI'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real\nweapons.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Bon choix, reprises basses ?[1205][000F]\nJamais imaginé que Jolly Roger vendait des armes.[NL]Qu'est-il arrivé à cette ville ?"
+    "texte_fr": "Bon choix, reprises basses ?[000F][1205]\nJamais imaginé que Jolly Roger vendait des armes.[NL]Qu'est-il arrivé à cette ville ?"
   },
   {
     "id": 83,
@@ -1272,7 +1272,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Poor[SP]selection,[SP]but[SP]great[SP]resale[SP]prices,[SP]eh...?[1205][000F]\nI'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold[SP]real\nweapons.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Peu de choix, bonnes reprises ?[1205][000F]\nJamais imaginé que Jolly Roger vendait des armes.[NL]Qu'est-il arrivé à cette ville ?"
+    "texte_fr": "Peu de choix, bonnes reprises ?[000F][1205]\nJamais imaginé que Jolly Roger vendait des armes.[NL]Qu'est-il arrivé à cette ville ?"
   },
   {
     "id": 85,
@@ -1302,7 +1302,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Great[SP]quality,[SP]but[SP]high[SP]prices,[SP]huh...?[1205][000F]\nI'd[SP]never[SP]have[SP]guessed[SP]Jolly[SP]Roger[SP]sold\nreal[SP]weapons.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Bonne qualité, prix élevés ?[1205][000F]\nJamais imaginé que Jolly Roger vendait des armes.[NL]Qu'est-il arrivé à cette ville ?"
+    "texte_fr": "Bonne qualité, prix élevés ?[000F][1205]\nJamais imaginé que Jolly Roger vendait des armes.[NL]Qu'est-il arrivé à cette ville ?"
   },
   {
     "id": 87,
@@ -1332,7 +1332,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor\nas[SP]well[SP]as[SP]clothes?[1205][000F][SP]I[SP]heard[SP]their[SP]quality[SP]and\nprices[SP]are[SP]average.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "La boutique de Rengedai vend armures et vêtements ?\nQualité et prix moyens.[1205][000F][NL]*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur..."
+    "texte_fr": "La boutique de Rengedai vend armures et vêtements ?\nQualité et prix moyens.[000F][1205][NL]*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur..."
   },
   {
     "id": 89,
@@ -1362,7 +1362,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor\nas[SP]well[SP]as[SP]clothes?[1205][000F][SP]I[SP]heard[SP]their[SP]prices[SP]are\nlow,[SP]but[SP]so[SP]is[SP]the[SP]quality.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Boutique de Rengedai : armures.\nPrix bas, qualité basse.[1205][000F][NL]*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur..."
+    "texte_fr": "Boutique de Rengedai : armures.\nPrix bas, qualité basse.[000F][1205][NL]*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur..."
   },
   {
     "id": 91,
@@ -1392,7 +1392,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Is[SP]it[SP]true[SP]the[SP]boutique[SP]in[SP]Rengedai[SP]sells[SP]armor\nas[SP]well[SP]as[SP]clothes?[1205][000F][SP]I[SP]heard[SP]their[SP]quality[SP]is\nhigh,[SP]but[SP]so[SP]are[SP]their[SP]prices.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Boutique de Rengedai : armures.\nHaute qualité, prix élevés.[1205][000F][NL]*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur..."
+    "texte_fr": "Boutique de Rengedai : armures.\nHaute qualité, prix élevés.[000F][1205][NL]*soupir* Vendre seulement des vêtements ne suffit plus ?\nÇa fait peur..."
   },
   {
     "id": 93,
@@ -1482,7 +1482,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nThey[SP]don't[SP]have[SP]a[SP]great[SP]selection,[SP]but[SP]their\nresale[SP]prices[SP]are[SP]worth[SP]it.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba vend des armures.\nPeu de choix, reprises intéressantes.[NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+    "texte_fr": "Rosa Candida à Aoba vend des armures.\nPeu de choix, reprises intéressantes.[NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ? Cette ville devient folle."
   },
   {
     "id": 99,
@@ -1512,7 +1512,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nTheir[SP]quality[SP]and[SP]prices[SP]seem[SP]average.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba : armures,\nqualité et prix moyens.[NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+    "texte_fr": "Rosa Candida à Aoba : armures,\nqualité et prix moyens.[NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ? Cette ville devient folle."
   },
   {
     "id": 101,
@@ -1542,7 +1542,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nTheir[SP]quality[SP]is[SP]great,[SP]but[SP]I[SP]hear[SP]they're\nexpensive.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba :\nbonne qualité, cher.[NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+    "texte_fr": "Rosa Candida à Aoba :\nbonne qualité, cher.[NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ? Cette ville devient folle."
   },
   {
     "id": 103,
@@ -1572,7 +1572,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nTheir[SP]prices[SP]are[SP]certainly[SP]right,[SP]but[SP]there's\na[SP]certain[SP]lack[SP]of[SP]quality[SP]there.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba : prix corrects,\nmais qualité insuffisante.[NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+    "texte_fr": "Rosa Candida à Aoba : prix corrects,\nmais qualité insuffisante.[NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ? Cette ville devient folle."
   },
   {
     "id": 105,
@@ -1602,7 +1602,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Seems[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]sells[SP]real[SP]armor.\nThey[SP]have[SP]a[SP]great[SP]selection,[SP]but[SP]their[SP]resale\nprices[SP]seem[SP]low.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Rosa Candida à Aoba :\ngrand choix, reprises basses.[NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ?\nCette ville devient folle."
+    "texte_fr": "Rosa Candida à Aoba :\ngrand choix, reprises basses.[NL]Des boutiques qui vendent des armures ?\nDes restaurants qui vendent des armes ? Cette ville devient folle."
   },
   {
     "id": 107,
@@ -1707,7 +1707,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][000F][SP]But[SP]I\nhear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll\nget[SP]real[SP]weapons[SP]and[SP]items.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Je n'ai jamais gagné de concours.[1205][000F]\nMais gagner donne de vraies armes et objets.[NL]Difficile à gagner, mais lots sympas.\nJe devrais peut-être réessayer."
+    "texte_fr": "Je n'ai jamais gagné de concours.[000F][1205]\nMais gagner donne de vraies armes et objets.[NL]Difficile à gagner, mais lots sympas.\nJe devrais peut-être réessayer."
   },
   {
     "id": 114,
@@ -1737,7 +1737,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][000F][SP]But[SP]I\nhear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll\nget[SP]real[SP]weapons[SP]and[SP]items.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais gagné de concours.[1205][000F]\nMais gagner donne de vraies armes et objets.[NL]Très rare de gagner, lots incroyables.\nJe devrais réessayer."
+    "texte_fr": "Jamais gagné de concours.[000F][1205]\nMais gagner donne de vraies armes et objets.[NL]Très rare de gagner, lots incroyables.\nJe devrais réessayer."
   },
   {
     "id": 116,
@@ -1767,7 +1767,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "I've[SP]never[SP]won[SP]any[SP]sweepstakes[SP]myself...[1205][000F][SP]But[SP]I\nhear[SP]if[SP]you[SP]win[SP]this[SP]magazine's[SP]contest,[SP]you'll\nget[SP]real[SP]weapons[SP]and[SP]items.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais gagné de concours.[1205][000F]\nMais gagner donne de vraies armes et objets.[NL]Facile à gagner, prix pourris.\nJe n'ai jamais gagné. J'ai la pire chance."
+    "texte_fr": "Jamais gagné de concours.[000F][1205]\nMais gagner donne de vraies armes et objets.[NL]Facile à gagner, prix pourris.\nJe n'ai jamais gagné. J'ai la pire chance."
   },
   {
     "id": 118,
@@ -1797,7 +1797,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it\nseems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][000F][SP]I[SP]get[SP]a[SP]tingle[SP]of\nexcitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][000F]\nL'idée de jouer m'excite...[NL]Un ami y est allé. On peut gagner gros\nà la machine de poker n°5.\nJe ne sais pas jouer au poker."
+    "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[000F][1205]\nL'idée de jouer m'excite...[NL]Un ami y est allé. On peut gagner gros à la machine de poker n°5. Je ne sais pas jouer au poker."
   },
   {
     "id": 120,
@@ -1812,7 +1812,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "A[SP]friend[SP]of[SP]mine[SP]went...[1205][000F][SP]He[SP]said[SP]you[SP]can[SP]win\nbig[SP]at[SP]the[SP]#5[SP]poker[SP]machine.[SP]Unfortunately,\nI[SP]don't[SP]know[SP]how[SP]to[SP]play[SP]poker.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Rosa Candida vend des armures.\nQualité basse, prix bas.[1106][NL]Je ne sais si c'est vrai,\nmais je vais vérifier. Intéressant.[1205][000F]"
+    "texte_fr": "Rosa Candida vend des armures.\nQualité basse, prix bas.[1106][NL]Je ne sais si c'est vrai,\nmais je vais vérifier. Intéressant.[000F][1205]"
   },
   {
     "id": 121,
@@ -1827,7 +1827,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it\nseems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][000F][SP]I[SP]get[SP]a[SP]tingle[SP]of\nexcitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][000F]\nL'idée de jouer m'excite...[NL]Un ami y est allé. On peut gagner gros\nà la machine à sous du fond.\n#1 ou #8 ?"
+    "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[000F][1205]\nL'idée de jouer m'excite...[NL]Un ami y est allé. On peut gagner gros à la machine à sous du fond. #1 ou #8 ?"
   },
   {
     "id": 122,
@@ -1842,7 +1842,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "A[SP]friend[SP]of[SP]mine[SP]went...[1205][000F][SP]He[SP]said[SP]you[SP]can[SP]win\nbig[SP]at[SP]the[SP]slot[SP]machine[SP]at[SP]the[SP]end.[SP]I[SP]wonder,\ndid[SP]he[SP]mean[SP]the[SP]#1[SP]or[SP]#8[SP]machine?",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Ma fille va souvent chez Anima Mundi.\nIls vendent des armures ? Qualité et prix moyens.[1106][NL]J'espère qu'elle n'achète rien de bizarre...[1205][000F]"
+    "texte_fr": "Ma fille va souvent chez Anima Mundi.\nIls vendent des armures ? Qualité et prix moyens.[1106][NL]J'espère qu'elle n'achète rien de bizarre...[000F][1205]"
   },
   {
     "id": 123,
@@ -1857,7 +1857,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "I've[SP]never[SP]been[SP]interested[SP]in[SP]arcades,[SP]but[SP]it\nseems[SP]Mu[SP]has[SP]a[SP]casino[SP]now.[1205][000F][SP]I[SP]get[SP]a[SP]tingle[SP]of\nexcitement[SP]at[SP]the[SP]thought[SP]of[SP]gambling...",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[1205][000F]\nL'idée de jouer m'excite...[NL]Un ami y est allé. On peut gagner gros\nau blackjack.\nMais ce serait mal si ma femme le savait..."
+    "texte_fr": "Jamais intéressé par les arcades,\nmais Mu a un casino maintenant.[000F][1205]\nL'idée de jouer m'excite...[NL]Un ami y est allé. On peut gagner gros au blackjack. Mais ce serait mal si ma femme le savait..."
   },
   {
     "id": 124,
@@ -1872,7 +1872,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "A[SP]friend[SP]of[SP]mine[SP]went...[SP]He[SP]said[SP]you[SP]can[SP]win\nbig[SP]at[SP]blackjack.[1205][000F][SP]Then[SP]again,[SP]it[SP]would[SP]be[SP]bad\nif[SP]my[SP]wife[SP]found[SP]out...",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Ma fille va chez Anima Mundi.\nArmures : reprises basses, mais grand choix.[1106][NL]J'espère qu'elle n'achète rien de bizarre...[1205][000F]"
+    "texte_fr": "Ma fille va chez Anima Mundi.\nArmures : reprises basses, mais grand choix.[1106][NL]J'espère qu'elle n'achète rien de bizarre...[000F][1205]"
   },
   {
     "id": 125,
@@ -1887,7 +1887,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "I[SP]may[SP]not[SP]look[SP]it,[SP]but[SP]I[SP]love[SP]antiques.[SP]I[SP]used\nto[SP]frequent[SP]places[SP]like[SP]Time[SP]Castle.[1205][000F][SP]By[SP]the\nway,[SP]do[SP]you[SP]know[SP]what[SP]a[SP]legendary[SP]weapon[SP]is?",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "J'adore les antiquités. Je fréquentais Time Castle.[1205][000F]\nAu fait, savez-vous ce qu'est une arme légendaire ?[NL]Shiraishi Ramen en aurait une.\nJ'aimerais au moins la voir."
+    "texte_fr": "J'adore les antiquités. Je fréquentais Time Castle.[000F][1205]\nAu fait, savez-vous ce qu'est une arme légendaire ?[NL]Shiraishi Ramen en aurait une.\nJ'aimerais au moins la voir."
   },
   {
     "id": 126,
@@ -1962,7 +1962,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "No[SP]wonder[SP]there's[SP]nothing[SP]like[SP]a[SP]legendary\nweapon[SP]at[SP]Time[SP]Castle.[SP]Apparently,[SP]it[SP]hasn't\nbeen[SP]delivered[SP]yet.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Pas étonnant qu'il n'y ait pas d'arme légendaire.\nElle n'a pas encore été livrée.[NL]Le vendeur attend à l'usine abandonnée,\nmais le propriétaire a peur des monstres.\nQuel lâche !"
+    "texte_fr": "Pas étonnant qu'il n'y ait pas d'arme légendaire.\nElle n'a pas encore été livrée.[NL]Le vendeur attend à l'usine abandonnée,\nmais le propriétaire a peur des monstres. Quel lâche !"
   },
   {
     "id": 131,
@@ -2007,7 +2007,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Augh,[SP]I[SP]was[SP]too[SP]late...[SP]Apparently[SP]a[SP]terribly\nunlucky[SP]woman[SP]bought[SP]Time[SP]Castle's[SP]legendary\nweapon[SP]before[SP]I[SP]could[SP]see[SP]it.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Trop tard. Une femme malchanceuse a acheté\nl'arme légendaire avant que je puisse la voir.[NL]Un autre amateur d'antiquités.\nSi j'avais décidé plus tôt, j'aurais été premier.\nQuel dommage."
+    "texte_fr": "Trop tard. Une femme malchanceuse a acheté\nl'arme légendaire avant que je puisse la voir.[NL]Un autre amateur d'antiquités.\nSi j'avais décidé plus tôt, j'aurais été premier. Quel dommage."
   },
   {
     "id": 134,
@@ -2037,7 +2037,7 @@
     "nom_orig": "Middle-aged[SP]office[SP]worker",
     "texte_orig": "Honestly,[SP]of[SP]all[SP]the[SP]luck.[SP]It[SP]seems[SP]the[SP]owner\nof[SP]Time[SP]Castle[SP]gave[SP]away[SP]that[SP]legendary[SP]weapon.",
     "nom_fr": "Employé d'âge moyen",
-    "texte_fr": "Quelle malchance. Le propriétaire a donné\nl'arme légendaire.[NL]À une fille aux cheveux courts, dit-on.\nIndice trop vague. *soupir*\nSi seulement je l'avais achetée !"
+    "texte_fr": "Quelle malchance. Le propriétaire a donné\nl'arme légendaire.[NL]À une fille aux cheveux courts, dit-on.\nIndice trop vague. *soupir* Si seulement je l'avais achetée !"
   },
   {
     "id": 136,
@@ -2067,7 +2067,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Have[SP]you[SP]heard[SP]the[SP]rumor[SP]that[SP]a[SP]woman's[SP]ghost\nis[SP]appearing[SP]in[SP]Aoba[SP]Park?[1205][000F]",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Tu as entendu ? Le fantôme d'une femme\n apparaît dans le parc d'Aoba.[1205][000F][NL]Tu crois que c'est vrai ?\nJe devrais changer mon itinéraire."
+    "texte_fr": "Tu as entendu ? Le fantôme d'une femme\n apparaît dans le parc d'Aoba.[000F][1205][NL]Tu crois que c'est vrai ?\nJe devrais changer mon itinéraire."
   },
   {
     "id": 138,
@@ -2112,7 +2112,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "There's[SP]no[SP]one[SP]left[SP]to[SP]put[SP]out[SP]the[SP]flames[SP]in\ncase[SP]of[SP]another[SP]attack!",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Un casino dans la salle d'arcade ?[1205][U+000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible ![1106][NL][1432][NULL][NULL][0014]Gros lots aux machines n°1 ![1432][NULL][NULL][0014]\nPas pour des lycéens !\nÀ signaler à l'association de parents d'élèves !"
+    "texte_fr": "Un casino dans la salle d'arcade ?[1205][U+000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible ![1106][NL][1432][NULL][NULL][0014]Gros lots aux machines n°1 ![1432][NULL][NULL][0014] Pas pour des lycéens ! À signaler à l'association de parents d'élèves !"
   },
   {
     "id": 141,
@@ -2127,7 +2127,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Do[SP]you[SP]know[SP]what[SP]this[SP]Last[SP]Battalion[SP]thing[SP]is?[1205][000F]\nI[SP]hear[SP]they're[SP]the[SP]terrorists[SP]responsible[SP]for\nthe[SP]attacks,[SP]but[SP]I've[SP]never[SP]heard[SP]of[SP]them.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Tu sais ce qu'est le Dernier Bataillon ?[1205][000F]\nOn dit qu'ils sont les terroristes responsables,\nmais je n'en ai jamais entendu parler.[NL]Le Cercle Masqué n'est pas le seul groupe ?\nPourquoi attaquent-ils la ville !?\nJe ne sais pas quoi faire !"
+    "texte_fr": "Tu sais ce qu'est le Dernier Bataillon ?[000F][1205]\nOn dit qu'ils sont les terroristes responsables,\nmais je n'en ai jamais entendu parler.[NL]Le Cercle Masqué n'est pas le seul groupe ? Pourquoi attaquent-ils la ville !? Je ne sais pas quoi faire !"
   },
   {
     "id": 142,
@@ -2142,7 +2142,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Are[SP]the[SP]Masked[SP]Circle[SP]not[SP]the[SP]only[SP]guys[SP]like\nthat[SP]walking[SP]around?[1205][000F][SP]If[SP]so,[SP]why[SP]are[SP]they\nattacking[SP]the[SP]city!?[SP]I[SP]don't[SP]know[SP]what[SP]to[SP]do!",
     "nom_fr": "Promeneuse",
-    "texte_fr": "L'arme légendaire du Shiraishi Ramen ?\nDangereuse, mais je suis curieuse.[1205][000F]"
+    "texte_fr": "L'arme légendaire du Shiraishi Ramen ?\nDangereuse, mais je suis curieuse.[000F][1205]"
   },
   {
     "id": 143,
@@ -2157,7 +2157,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "I[SP]heard[SP]they[SP]posted[SP]composite[SP]sketches[SP]of[SP]the\nsuspects.[SP]So[SP]are[SP]they[SP]Masked[SP]Circle?[1205][000F][SP]Or[SP]Last\nBattalion?[1205][000F][SP]I'm[SP]just[SP]so[SP]confused.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Ils ont affiché des portraits-robots.\nIls sont du Cercle Masqué ?[1205][000F] Ou du Dernier Bataillon ?[1205][000F]\nJe suis perdue."
+    "texte_fr": "Ils ont affiché des portraits-robots.\nIls sont du Cercle Masqué ?[000F][1205] Ou du Dernier Bataillon ?[000F][1205]\nJe suis perdue."
   },
   {
     "id": 144,
@@ -2202,7 +2202,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "I[SP]wonder[SP]if[SP]it's[SP]safe[SP]to[SP]be[SP]out[SP]like[SP]this.[1205][000F]\nB-But[SP]where[SP]would[SP]I[SP]hide?[SP]We[SP]can't[SP]rely[SP]on\nthe[SP]police[SP]anymore,[SP]after[SP]all...",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Est-ce sûr d'être dehors ?[1205][000F]\nMais où me cacher ? On ne peut plus compter\n sur la police..."
+    "texte_fr": "Est-ce sûr d'être dehors ?[000F][1205]\nMais où me cacher ? On ne peut plus compter\n sur la police..."
   },
   {
     "id": 147,
@@ -2217,7 +2217,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Whew...[1205][000A][SP]Now[SP]that[SP]we're[SP]in[SP]the[SP]sky,[SP]my[SP]options\nfor[SP]walking[SP]are[SP]limited.[1205][000F][SP]Huh?[SP]Now's[SP]not[SP]the\ntime[SP]for[SP]that?",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Ouf...[1205][000A] Dans le ciel, mes options de marche sont limitées.[1205][000F]\nHein ? Ce n'est pas le moment ?[NL]Inutile de paniquer. Ça a déjà trop empiré.\nJe m'en fiche qu'on évolue ou qu'on meure."
+    "texte_fr": "Ouf...[000A][1205] Dans le ciel, mes options de marche sont limitées.[000F][1205]\nHein ? Ce n'est pas le moment ?[NL]Inutile de paniquer. Ça a déjà trop empiré.\nJe m'en fiche qu'on évolue ou qu'on meure."
   },
   {
     "id": 148,
@@ -2232,7 +2232,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "But[SP]there's[SP]no[SP]use[SP]panicking[SP]if[SP]things[SP]have\ngotten[SP]this[SP]bad.[1205][000F][SP]I[SP]don't[SP]care[SP]anymore[SP]if[SP]we\nevolve[SP]or[SP]all[SP]die[SP]off.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio a donné l'arme à une fille aux cheveux courts.[1106][NL]C'est un joli geste, malgré tout.\nJ'aimerais recevoir des cadeaux parfois.\nMon mari sait à peine que j'existe.[1205][000F]"
+    "texte_fr": "Le proprio a donné l'arme à une fille aux cheveux courts.[1106][NL]C'est un joli geste, malgré tout.\nJ'aimerais recevoir des cadeaux parfois.\nMon mari sait à peine que j'existe.[000F][1205]"
   },
   {
     "id": 149,
@@ -2247,7 +2247,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Have[SP]you[SP]heard?[1205][000F][SP]There[SP]are[SP]countless[SP]rumors\nflying[SP]around[SP]about[SP]what[SP]kind[SP]of[SP]end[SP]the\npeople[SP]below[SP]will[SP]face.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Tu as entendu ?[1205][000F]\nDes rumeurs sur la fin des gens d'en bas.[NL]La dernière : la Grande Croix provoquera\n une tempête magnétique brûlant la Terre."
+    "texte_fr": "Tu as entendu ?[000F][1205]\nDes rumeurs sur la fin des gens d'en bas.[NL]La dernière : la Grande Croix provoquera\n une tempête magnétique brûlant la Terre."
   },
   {
     "id": 150,
@@ -2262,7 +2262,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "The[SP]latest[SP]is[SP]that[SP]when[SP]the[SP]Grand[SP]Cross[SP]is\ncomplete,[SP]an[SP]intense[SP]magnetic[SP]storm[SP]will[SP]arise\nand[SP]scorch[SP]the[SP]Earth's[SP]surface.",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Joker s'est enfui à Caracol avec les cadres ![1205][U+000F]\nIl nous a laissés dans la merde ![1106][NL]Nos idéaux exaucés ? N'importe quoi !\nIl a juste aspiré notre Énergie Idéale\n pour ses propres rêves !"
+    "texte_fr": "Joker s'est enfui à Caracol avec les cadres ![1205][U+000F]\nIl nous a laissés dans la merde ![1106][NL]Nos idéaux exaucés ? N'importe quoi !\nIl a juste aspiré notre Énergie Idéale pour ses propres rêves !"
   },
   {
     "id": 151,
@@ -2277,7 +2277,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Hey,[SP]did[SP]you[SP]hear?[1205][000A][SP]When[SP]the[SP]Grand[SP]Cross[SP]is\ncomplete,[SP]a[SP]plasma[SP]vortex[SP]will[SP]form[SP]and[SP]the\nwhole[SP]Earth[SP]will[SP]look[SP]like[SP]those[SP]crop[SP]circles.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Hé, tu as entendu ?[1205][000A]\nLa Grande Croix créera un vortex de plasma,\n la Terre ressemblera à des crop circles."
+    "texte_fr": "Hé, tu as entendu ?[000A][1205]\nLa Grande Croix créera un vortex de plasma,\n la Terre ressemblera à des crop circles."
   },
   {
     "id": 152,
@@ -2292,7 +2292,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "It[SP]seems[SP]like[SP]when[SP]the[SP]Grand[SP]Cross[SP]is[SP]over,[SP]the\nbalance[SP]of[SP]gravity[SP]will[SP]crumble[SP]and[SP]the[SP]Earth's\nrotation[SP]will[SP]stop.[1205][000F][SP]Then[SP]the[SP]world[SP]will[SP]end.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Après la Grande Croix, la gravité s'effondrera,\n la Terre s'arrêtera.[1205][000F]\nAlors le monde finira."
+    "texte_fr": "Après la Grande Croix, la gravité s'effondrera,\n la Terre s'arrêtera.[000F][1205]\nAlors le monde finira."
   },
   {
     "id": 153,
@@ -2307,7 +2307,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Hey,[SP]have[SP]you[SP]heard[SP]about[SP]Zodiac?[SP]Their[SP]second\nfloor[SP]is[SP]a[SP]huge[SP]dungeon[SP]now,[SP]filled[SP]with[SP]items.[1205][000F]\nWhat[SP]a[SP]weird[SP]club.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Tu as entendu parler de Zodiac ?\nLeur deuxième étage est devenu un donjon rempli d'objets.[1205][000F]\nBizarre."
+    "texte_fr": "Tu as entendu parler de Zodiac ?\nLeur deuxième étage est devenu un donjon rempli d'objets.[000F][1205]\nBizarre."
   },
   {
     "id": 154,
@@ -2337,7 +2337,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "H-Hey,[SP]the[SP]rumor[SP]about[SP]that[SP]idol's[SP]ghost[SP]in\nAoba[SP]Park[SP]was[SP]real,[SP]wasn't[SP]it?[1205][000F][SP]I[SP]heard[SP]people\nin[SP]the[SP]city[SP]talking[SP]about[SP]it[SP]too!",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Hé, le fantôme de l'idole à Aoba était réel ?[1205][000F]\nJ'ai entendu des gens en parler ![NL]Qu'est-ce que je fais ?\nCela a toujours fait partie de mon itinéraire.[NL]Je ne veux pas me faire posséder.\nJe vais éviter de passer par ici désormais."
+    "texte_fr": "Hé, le fantôme de l'idole à Aoba était réel ?[000F][1205]\nJ'ai entendu des gens en parler ![NL]Qu'est-ce que je fais ?\nCela a toujours fait partie de mon itinéraire.[NL]Je ne veux pas me faire posséder. Je vais éviter de passer par ici désormais."
   },
   {
     "id": 156,
@@ -2352,7 +2352,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Ugh,[SP]what[SP]should[SP]I[SP]do...?[1205][000F][SP]This[SP]has[SP]always[SP]been\npart[SP]of[SP]the[SP]route[SP]I[SP]take[SP]on[SP]my[SP]walks.",
     "nom_fr": "Yukiko",
-    "texte_fr": "Il a fait ça pour qu'on ne l'arrête pas.\nIl ne reste plus que nous.[1205][000F]"
+    "texte_fr": "Il a fait ça pour qu'on ne l'arrête pas.\nIl ne reste plus que nous.[000F][1205]"
   },
   {
     "id": 157,
@@ -2367,7 +2367,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "I[SP]don't[SP]want[SP]to[SP]get[SP]possessed[SP]by[SP]some[SP]evil\nspirit...[1205][000F][SP]I-I'm[SP]gonna[SP]stop[SP]passing[SP]by[SP]here\nfrom[SP]now[SP]on.",
     "nom_fr": "Michel",
-    "texte_fr": "Oui, c'était le plan depuis le début !\nOn va abattre ce salaud nous-mêmes ![1205][000F]"
+    "texte_fr": "Oui, c'était le plan depuis le début !\nOn va abattre ce salaud nous-mêmes ![000F][1205]"
   },
   {
     "id": 158,
@@ -2397,7 +2397,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Huh?[1205][000F][SP]It[SP]wasn't[SP]a[SP]Cursed[SP]Taxi[SP]at[SP]the[SP]abandoned\nfactory,[SP]it[SP]was[SP]a[SP]Cursed[SP]Escort?[1205][000F][SP]But[SP]don't[SP]they\nwork[SP]pretty[SP]much[SP]the[SP]same[SP]way?",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Hein ?[1205][000F] C'est une Escorte Maudite, pas un Taxi ?[1205][000F]\nMais ça revient au même, non ?"
+    "texte_fr": "Hein ?[000F][1205] C'est une Escorte Maudite, pas un Taxi ?[000F][1205]\nMais ça revient au même, non ?"
   },
   {
     "id": 160,
@@ -2412,7 +2412,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Hey,[SP]does[SP]Kuchisake-onna[SP]really[SP]exist?[SP]I[SP]heard\nshe's[SP]shown[SP]up[SP]at[SP]Mt.[SP]Iwato![1205][000F][SP]Now[SP]I[SP]can't[SP]go\nwalking[SP]there[SP]anymore[SP]either...",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Kuchisake-onna existe ?\nElle serait au mont Iwato ![1205][000F]\nJe ne peux plus y aller non plus..."
+    "texte_fr": "Kuchisake-onna existe ?\nElle serait au mont Iwato ![000F][1205]\nJe ne peux plus y aller non plus..."
   },
   {
     "id": 161,
@@ -2427,7 +2427,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Hey,[SP]what's[SP]a[SP]Jumping[SP]Geezer?[1205][000F][SP]Because[SP]I[SP]heard\na[SP]rumor[SP]there's[SP]a[SP]creature[SP]called[SP]that[SP]at\nMt.[SP]Katatsumuri.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "C'est quoi un Sauteur Vieux ?[1205][000F]\nIl y en aurait un au mont Katatsumuri.[NL]Avec les soldats, je ne m'approchais déjà pas.\nC'est une chose après l'autre..."
+    "texte_fr": "C'est quoi un Sauteur Vieux ?[000F][1205]\nIl y en aurait un au mont Katatsumuri.[NL]Avec les soldats, je ne m'approchais déjà pas.\nC'est une chose après l'autre..."
   },
   {
     "id": 162,
@@ -2442,7 +2442,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Well,[SP]with[SP]the[SP]soldiers[SP]patrolling[SP]there,\nI[SP]wasn't[SP]going[SP]near[SP]that[SP]mountain[SP]to[SP]begin\nwith.[1205][000F][SP]It's[SP]just[SP]one[SP]thing[SP]after[SP]another...",
     "nom_fr": "Maya",
-    "texte_fr": "Nous avons déjà le crâne de cristal.\nTrouvons les autres.[1205][000F]"
+    "texte_fr": "Nous avons déjà le crâne de cristal.\nTrouvons les autres.[000F][1205]"
   },
   {
     "id": 163,
@@ -2457,7 +2457,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "What[SP]am[SP]I[SP]going[SP]to[SP]do!?[1205][000F][SP]I[SP]can't[SP]sleep[SP]alone\nafter[SP]hearing[SP]a[SP]story[SP]like[SP]that![SP]I[SP]need[SP]to\ntry[SP]and[SP]put[SP]Kudan[SP]out[SP]of[SP]my[SP]mind...",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Je vais faire quoi !?[1205][000F]\nJe ne peux plus dormir seule après ça !\nIl faut que je chasse Kudan de mon esprit..."
+    "texte_fr": "Je vais faire quoi !?[000F][1205]\nJe ne peux plus dormir seule après ça !\nIl faut que je chasse Kudan de mon esprit..."
   },
   {
     "id": 164,
@@ -2517,7 +2517,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Why[SP]would[SP]something[SP]like[SP]that[SP]be[SP]at[SP]the\nabandoned[SP]factory...?[1205][000F][SP]Well,[SP]guess[SP]I'm[SP]not\ngoing[SP]near[SP]there[SP]anymore.",
     "nom_fr": "Ginko",
-    "texte_fr": "Attends, Chinyan ! On n'a pas encore le crâne\ndu temple du Taureau. Allons-y d'abord.[1205][000F]"
+    "texte_fr": "Attends, Chinyan ! On n'a pas encore le crâne\ndu temple du Taureau. Allons-y d'abord.[000F][1205]"
   },
   {
     "id": 168,
@@ -2532,7 +2532,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][000F][SP]I[SP]mean,\nan[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Rengedai doit être effrayant.[1205][000F]\nUne boutique d'antiquités qui vend des armes ?[NL]Qualité et prix moyens."
+    "texte_fr": "Rengedai doit être effrayant.[000F][1205]\nUne boutique d'antiquités qui vend des armes ?[NL]Qualité et prix moyens."
   },
   {
     "id": 169,
@@ -2562,7 +2562,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][000F][SP]I[SP]mean,\nan[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Rengedai doit être effrayant.[1205][000F]\nUne boutique d'antiquités qui vend des armes ?[NL]Qualité excellente, cher."
+    "texte_fr": "Rengedai doit être effrayant.[000F][1205]\nUne boutique d'antiquités qui vend des armes ?[NL]Qualité excellente, cher."
   },
   {
     "id": 171,
@@ -2592,7 +2592,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Rengedai[SP]must[SP]be[SP]a[SP]scary[SP]place...[1205][000F][SP]I[SP]mean,\nan[SP]antique[SP]shop[SP]that[SP]sells[SP]real[SP]weapons?",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Rengedai doit être effrayant.[1205][000F]\nUne boutique d'antiquités qui vend des armes ?[NL]Qualité moyenne, mais bon marché."
+    "texte_fr": "Rengedai doit être effrayant.[000F][1205]\nUne boutique d'antiquités qui vend des armes ?[NL]Qualité moyenne, mais bon marché."
   },
   {
     "id": 173,
@@ -2967,7 +2967,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][000F][SP]I[SP]hear[SP]the[SP]quality\nand[SP]prices[SP]are[SP]average,[SP]though.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\n[1205][000F]Qualité et prix moyens."
+    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\n[000F][1205]Qualité et prix moyens."
   },
   {
     "id": 198,
@@ -2982,7 +2982,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][000F][SP]I[SP]hear[SP]they're\ncheap,[SP]but[SP]low[SP]quality.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\n[1205][000F]Bon marché, basse qualité."
+    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\n[000F][1205]Bon marché, basse qualité."
   },
   {
     "id": 199,
@@ -2997,7 +2997,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][000F][SP]His[SP]selection[SP]is\ngreat,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]low.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\n[1205][000F]Grand choix, reprises basses."
+    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\n[000F][1205]Grand choix, reprises basses."
   },
   {
     "id": 200,
@@ -3012,7 +3012,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][000F][SP]His[SP]selection[SP]is\nskimpy,[SP]but[SP]the[SP]resale[SP]prices[SP]are[SP]great.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\n[1205][000F]Peu de choix, reprises excellentes."
+    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\n[000F][1205]Peu de choix, reprises excellentes."
   },
   {
     "id": 201,
@@ -3027,7 +3027,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "The[SP]owner[SP]of[SP]Jolly[SP]Roger[SP]sells[SP]weapons[SP]because\nhe[SP]used[SP]to[SP]be[SP]a[SP]pirate,[SP]huh?[1205][000F][SP]I[SP]hear[SP]the[SP]quality\nis[SP]great,[SP]but[SP]his[SP]stuff[SP]is[SP]expensive.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\n[1205][000F]Qualité excellente, cher."
+    "texte_fr": "Le proprio du Jolly Roger vend des armes car il était pirate.\n[000F][1205]Qualité excellente, cher."
   },
   {
     "id": 202,
@@ -3402,7 +3402,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][000F]\nMais ils vendent aussi des armures ?[NL]Et si c'est ce qu'il me fabrique ?\nPourquoi vendre aussi des armures ?"
+    "texte_fr": "Je fais faire un costume chez London Clothier.[000F][1205]\nMais ils vendent aussi des armures ?[NL]Et si c'est ce qu'il me fabrique ?\nPourquoi vendre aussi des armures ?"
   },
   {
     "id": 227,
@@ -3432,7 +3432,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][000F]\nMais ils vendent aussi des armures ?[NL]Et si c'est ce qu'il me fabrique ?\nBon marché, mais je ne peux pas travailler en armure !"
+    "texte_fr": "Je fais faire un costume chez London Clothier.[000F][1205]\nMais ils vendent aussi des armures ?[NL]Et si c'est ce qu'il me fabrique ?\nBon marché, mais je ne peux pas travailler en armure !"
   },
   {
     "id": 229,
@@ -3462,7 +3462,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][000F]\nMais ils vendent aussi des armures ?[NL]Et si c'est ce qu'il me fabrique ?\nQualité excellente, mais si ça me ruine, à quoi bon !"
+    "texte_fr": "Je fais faire un costume chez London Clothier.[000F][1205]\nMais ils vendent aussi des armures ?[NL]Et si c'est ce qu'il me fabrique ?\nQualité excellente, mais si ça me ruine, à quoi bon !"
   },
   {
     "id": 231,
@@ -3492,7 +3492,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][000F]\nMais ils vendent aussi des armures ?[NL]Et si c'est ce qu'il me fabrique ?\nQualité et prix raisonnables, mais ce n'est pas le problème."
+    "texte_fr": "Je fais faire un costume chez London Clothier.[000F][1205]\nMais ils vendent aussi des armures ?[NL]Et si c'est ce qu'il me fabrique ?\nQualité et prix raisonnables, mais ce n'est pas le problème."
   },
   {
     "id": 233,
@@ -3522,7 +3522,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "What[SP]should[SP]I[SP]do...?[SP]I'm[SP]having[SP]London[SP]Clothier\ntailor[SP]a[SP]new[SP]suit[SP]for[SP]me.[1205][000F][SP]But[SP]don't[SP]they[SP]also\nsell[SP]armor[SP]there?",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Je fais faire un costume chez London Clothier.[1205][000F]\nMais ils vendent aussi des armures ?[NL]Et si c'est ce qu'il me fabrique ?\nBonnes reprises, mais pas de remboursement intégral, si ?"
+    "texte_fr": "Je fais faire un costume chez London Clothier.[000F][1205]\nMais ils vendent aussi des armures ?[NL]Et si c'est ce qu'il me fabrique ?\nBonnes reprises, mais pas de remboursement intégral, si ?"
   },
   {
     "id": 235,
@@ -3552,7 +3552,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][000F]\nI[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Tu connais les concours de magazines ?[1205][000F]\nOn peut gagner de vraies armes.[NL]Intéressant et excitant.[NL]On gagne rarement, mais beaux lots.\nPourquoi ne pas essayer ?"
+    "texte_fr": "Tu connais les concours de magazines ?[000F][1205]\nOn peut gagner de vraies armes.[NL]Intéressant et excitant.[NL]On gagne rarement, mais beaux lots.\nPourquoi ne pas essayer ?"
   },
   {
     "id": 237,
@@ -3597,7 +3597,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][000F]\nI[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Tu connais les concours de magazines ?[1205][000F]\nOn peut gagner de vraies armes.[NL]Intéressant et excitant.[NL]Très rare de gagner, lots incroyables.\nPourquoi ne pas essayer ?"
+    "texte_fr": "Tu connais les concours de magazines ?[000F][1205]\nOn peut gagner de vraies armes.[NL]Intéressant et excitant.[NL]Très rare de gagner, lots incroyables.\nPourquoi ne pas essayer ?"
   },
   {
     "id": 240,
@@ -3642,7 +3642,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]magazine[SP]sweepstakes?[1205][000F]\nI[SP]hear[SP]you[SP]can[SP]win[SP]real[SP]weapons[SP]and[SP]items.",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Tu connais les concours de magazines ?[1205][000F]\nOn peut gagner de vraies armes.[NL]Intéressant et excitant.[NL]Facile à gagner, lots moyens.\nPourquoi ne pas essayer quand même ?"
+    "texte_fr": "Tu connais les concours de magazines ?[000F][1205]\nOn peut gagner de vraies armes.[NL]Intéressant et excitant.[NL]Facile à gagner, lots moyens.\nPourquoi ne pas essayer quand même ?"
   },
   {
     "id": 243,
@@ -3687,7 +3687,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the\narcade?[1205][000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was\nhorrified[SP]to[SP]hear[SP]about[SP]it!",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Un casino dans la salle d'arcade ?[1205][000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible ![NL][NULL][NULL]On peut gagner gros au poker ![NULL][NULL]\nPas une conversation pour des lycéens !\nJe devrais le signaler à l'association de parents d'élèves !"
+    "texte_fr": "Un casino dans la salle d'arcade ?[000F][1205]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible ![NL][NULL][NULL]On peut gagner gros au poker ![NULL][NULL] Pas une conversation pour des lycéens ! Je devrais le signaler à l'association de parents d'élèves !"
   },
   {
     "id": 246,
@@ -3717,7 +3717,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the\narcade?[1205][000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was\nhorrified[SP]to[SP]hear[SP]about[SP]it!",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Un casino dans la salle d'arcade ?[1205][000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible ![NL][NULL][NULL]Gros lots aux machines n°1 ![NULL][NULL]\nPas pour des lycéens !\nÀ signaler à l'association de parents d'élèves !"
+    "texte_fr": "Un casino dans la salle d'arcade ?[000F][1205]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible ![NL][NULL][NULL]Gros lots aux machines n°1 ![NULL][NULL] Pas pour des lycéens ! À signaler à l'association de parents d'élèves !"
   },
   {
     "id": 248,
@@ -3747,7 +3747,7 @@
     "nom_orig": "Walking[SP]woman",
     "texte_orig": "Is[SP]it[SP]true[SP]they[SP]put[SP]up[SP]a[SP]casino[SP]inside[SP]the\narcade?[1205][000F][SP]That's[SP]how[SP]good[SP]kids[SP]go[SP]bad![SP]I[SP]was\nhorrified[SP]to[SP]hear[SP]about[SP]it!",
     "nom_fr": "Promeneuse",
-    "texte_fr": "Un casino dans la salle d'arcade ?[1205][000F]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible ![NL]Où ai-je entendu ça ? Un jeune homme se vantait\nd'avoir gagné gros au blackjack."
+    "texte_fr": "Un casino dans la salle d'arcade ?[000F][1205]\nC'est comme ça que les bons enfants deviennent mauvais !\nHorrible ![NL]Où ai-je entendu ça ? Un jeune homme se vantait d'avoir gagné gros au blackjack."
   },
   {
     "id": 250,
@@ -3957,7 +3957,7 @@
     "nom_orig": "Man",
     "texte_orig": "Would[SP]you[SP]believe[SP]me[SP]if[SP]I[SP]said[SP][E4][NULL][NULL][0006]flowers[SP]can\ntalk[E4][NULL][NULL][0002]?[1205][000F][SP]Most[SP]people[SP]wouldn't.[SP]But[SP]there[SP]is\nsomeone[SP]in[SP]this[SP]park[SP]who[SP]speaks[SP]to[SP]flowers.",
     "nom_fr": "Homme",
-    "texte_fr": "Croirais-tu que [E4][NULL][NULL][0006]les fleurs peuvent parler[E4][NULL][NULL][0002] ?[1205][000F]\nLa plupart non. Mais quelqu'un ici parle aux fleurs.[NL]Il s'occupe des fleurs et leur parle.\nOn dit qu'elles lui répondent.[NL]Au final, c'est toi qui décides du réel.\nSi tu es fatigué de cette triste réalité,\nparle aux fleurs."
+    "texte_fr": "Croirais-tu que [E4][NULL][NULL][0006]les fleurs peuvent parler[E4][NULL][NULL][0002] ?[000F][1205]\nLa plupart non. Mais quelqu'un ici parle aux fleurs.[NL]Il s'occupe des fleurs et leur parle.\nOn dit qu'elles lui répondent.[NL]Au final, c'est toi qui décides du réel. Si tu es fatigué de cette triste réalité, parle aux fleurs."
   },
   {
     "id": 264,
@@ -4002,7 +4002,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Dammit,[SP]that[SP]Joker[SP]ran[SP]off[SP]to[SP]Caracol[SP]along\nwith[SP]the[SP]executives![1205][000F][SP]He's[SP]left[SP]us[SP]holding[SP]the\nbag[SP]here!",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Joker s'est enfui à Caracol avec les cadres ![1205][000F]\nIl nous a laissés dans la merde ![NL]Nos idéaux exaucés ? N'importe quoi !\nIl a juste aspiré notre Énergie Idéale\n pour ses propres rêves !"
+    "texte_fr": "Joker s'est enfui à Caracol avec les cadres ![000F][1205]\nIl nous a laissés dans la merde ![NL]Nos idéaux exaucés ? N'importe quoi !\nIl a juste aspiré notre Énergie Idéale pour ses propres rêves !"
   },
   {
     "id": 267,
@@ -4287,7 +4287,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "H-Hold[SP]the[SP]phone,[SP]man.[1205][000F][SP]We're[SP]still[SP]not[SP]done\nwith[SP]Scorpio[SP]Temple.[1205][000F][SP]Let's[SP]go[SP]grab[SP]the[SP]skull\nfrom[SP]there[SP]first.",
     "nom_fr": "Michel",
-    "texte_fr": "A-Attends, mec.[1205][000F] On n'a pas fini avec\ntemple du Scorpion.[1205][000F] Prenons ce crâne d'abord.[NL]Attends. On n'a pas fini avec\nle temple du Verseau."
+    "texte_fr": "A-Attends, mec.[000F][1205] On n'a pas fini avec\ntemple du Scorpion.[000F][1205] Prenons ce crâne d'abord.[NL]Attends. On n'a pas fini avec\nle temple du Verseau."
   },
   {
     "id": 286,

--- a/traduction/MMAP04.json
+++ b/traduction/MMAP04.json
@@ -12,7 +12,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "Heh...[SP]There's[SP]a[SP]nice[SP]breeze[SP]today,[SP]too...[1205][000F]\nAll[SP]men[SP]are[SP]on[SP]a[SP]journey,[SP]somewhere[SP]in[SP]their\nhearts.",
     "nom_fr": "Gars cool",
-    "texte_fr": "Aujourd'hui aussi, la brise est douce...[1205][000F]\nChacun vit son voyage, quelque part dans\nson coeur.[NL]Au moment où ils atteignent la côte et\nenvisagent de s'installer, ils repartent voguer\nen mer.[NL]L'océan est un refuge éternel pour ces gens...\nUn endroit où ils ne cessent de retourner.[NL]Kounan est un endroit comme ça, gamin.\nC'est une ville de durs à cuire."
+    "texte_fr": "Aujourd'hui aussi, la brise est douce...[000F][1205]\nChacun vit son voyage, quelque part dans\nson coeur.[NL]Au moment où ils atteignent la côte et envisagent de s'installer, ils repartent voguer en mer.[NL]L'océan est un refuge éternel pour ces gens... Un endroit où ils ne cessent de retourner.[NL]Kounan est un endroit comme ça, gamin. C'est une ville de durs à cuire."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "Just[SP]when[SP]they[SP]finally[SP]make[SP]it[SP]to[SP]shore[SP]and\nought[SP]to[SP]think[SP]about[SP]settling[SP]down,[SP]they[SP]row\nout[SP]again[SP]into[SP]the[SP]sea.",
     "nom_fr": "Gars cool",
-    "texte_fr": "T'as dû piger que c'était une ville taillée\npour les durs à cuire, les adultes.[1205][U+000F] Mais regarde\nce bâtiment avec le dirigeable au sommet...[1106][NL]Ce fichu Musée Aéronautique.[1205][U+000F] Depuis sa construction,\ny'a foule de gosses qui viennent en voyage\nscolaire ou autre.[1106][NL]Je hais les mômes. Cette ville me correspond\nplus du tout.[1205][U+000F] Il doit être temps pour moi\nde retourner en mer."
+    "texte_fr": "T'as dû piger que c'était une ville taillée\npour les durs à cuire, les adultes.[1205][U+000F] Mais regarde\nce bâtiment avec le dirigeable au sommet...[1106][NL]Ce fichu Musée Aéronautique.[1205][U+000F] Depuis sa construction, y'a foule de gosses qui viennent en voyage scolaire ou autre.[1106][NL]Je hais les mômes. Cette ville me correspond plus du tout.[1205][U+000F] Il doit être temps pour moi de retourner en mer."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "Kid,[SP]this[SP]here[SP]Kounan[SP]is[SP]another[SP]such[SP]place.[1205][000F]\nIt's[SP]a[SP]city[SP]made[SP]for[SP]the[SP]hardboiled.",
     "nom_fr": "Gars cool",
-    "texte_fr": "Des gamins sont venus me dire que les cinq\nqu'on voit aux infos étaient des héros combattant\nle Cercle Masqué. Puis ils sont partis.[1106][NL]C'était les enfants du musée, pas vrai?\nTss. On dirait qu'ils sont saufs.[1106][NL]Ces cinq-là ont sauvés des gamins, hein?[1205][U+000F]\n...Ils ont pas l'air de mauvais bougres.[000F]"
+    "texte_fr": "Des gamins sont venus me dire que les cinq\nqu'on voit aux infos étaient des héros combattant\nle Cercle Masqué. Puis ils sont partis.[1106][NL]C'était les enfants du musée, pas vrai? Tss. On dirait qu'ils sont saufs.[1106][NL]Ces cinq-là ont sauvés des gamins, hein?[1205][U+000F] ...Ils ont pas l'air de mauvais bougres.[000F]"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "I[SP]think[SP]you[SP]get[SP]the[SP]picture[SP]already[SP]that[SP]this\nis[SP]a[SP]city[SP]for[SP]the[SP]hardboiled.[SP]For[SP]adults.[1205][000F][SP]But\nlook[SP]at[SP]that[SP]building[SP]with[SP]the[SP]blimp[SP]on[SP]top...",
     "nom_fr": "Gars cool",
-    "texte_fr": "T'as dû piger que c'était une ville taillée\npour les durs à cuire, les adultes.[1205][000F] Mais regarde\nce bâtiment avec le dirigeable au sommet...[NL]Ce fichu Musée Aéronautique. Depuis sa construction,\ny'a foule de gosses qui viennent en voyage\nscolaire ou autre.[NL]Je hais les mômes. Cette ville me correspond\nplus du tout. Il doit être temps pour moi\nde retourner en mer."
+    "texte_fr": "T'as dû piger que c'était une ville taillée\npour les durs à cuire, les adultes.[000F][1205] Mais regarde\nce bâtiment avec le dirigeable au sommet...[NL]Ce fichu Musée Aéronautique. Depuis sa construction, y'a foule de gosses qui viennent en voyage scolaire ou autre.[NL]Je hais les mômes. Cette ville me correspond plus du tout. Il doit être temps pour moi de retourner en mer."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "I[SP]hate[SP]rugrats.[SP]This[SP]city[SP]ain't[SP]so[SP]much[SP]for[SP]me\nanymore.[1205][000F][SP]Guess[SP]the[SP]day[SP]is[SP]coming[SP]when[SP]I'll[SP]be\ngoing[SP]back[SP]to[SP]the[SP]sea.",
     "nom_fr": "Gars cool",
-    "texte_fr": "Tu vois ces météores?[1205][U+000F] D'après ceux du Cercle\nMasqué c'est le [1432][NULL][NULL][0014]rugissement du lion[1432][NULL][NULL][0014] de\nleur oracle.[1106][NL]Hah, j'aurais du en profiter pour faire un voeu.\nVu leur nombre, je parie que beaucoup de mes\nvoeux se réaliseraient.[000F]"
+    "texte_fr": "Tu vois ces météores?[1205][U+000F] D'après ceux du Cercle\nMasqué c'est le [1432][NULL][NULL][0014]rugissement du lion[1432][NULL][NULL][0014] de\nleur oracle.[1106][NL]Hah, j'aurais du en profiter pour faire un voeu. Vu leur nombre, je parie que beaucoup de mes voeux se réaliseraient.[000F]"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "Looks[SP]like[SP]a[SP]pack[SP]of[SP]kids[SP]is[SP]here[SP]at[SP]the\nAerospace[SP]Museum[SP]on[SP]some[SP]kinda[SP]field[SP]trip.[1205][000F]\nTheir[SP]voices[SP]carry[SP]on[SP]the[SP]sea[SP]breeze...",
     "nom_fr": "Gars cool",
-    "texte_fr": "On dirait que des gamins sont en voyage\nscolaire au Musée de l'Aéronautique.[1205][000F]\nLeurs voix se mêlent à la brise marine...[NL]Tss. Je hais les mioches!"
+    "texte_fr": "On dirait que des gamins sont en voyage\nscolaire au Musée de l'Aéronautique.[000F][1205]\nLeurs voix se mêlent à la brise marine...[NL]Tss. Je hais les mioches!"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "Tch.[SP]This[SP]is[SP]why[SP]I[SP]hate[SP]rugrats!",
     "nom_fr": "Femme triste",
-    "texte_fr": "C'est la plage d'Ebisu.[1205][U+000A] Son nom vient des\ngens qui nommaient les corps ramenés par la\nhoule [1432][NULL][NULL][0014]Ebisu[1432][NULL][NULL][0014]...[1106][NL]Une plage accablée des noms de ceux ayant mis\nfin à leurs vies fugaces...[1205][U+000F] Ce lieu me va\nbien, moi qui ne peux oublier mon amour..."
+    "texte_fr": "C'est la plage d'Ebisu.[1205][U+000A] Son nom vient des\ngens qui nommaient les corps ramenés par la\nhoule [1432][NULL][NULL][0014]Ebisu[1432][NULL][NULL][0014]...[1106][NL]Une plage accablée des noms de ceux ayant mis fin à leurs vies fugaces...[1205][U+000F] Ce lieu me va bien, moi qui ne peux oublier mon amour..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "Some[SP]kids[SP]were[SP]just[SP]here[SP]and[SP]told[SP]me[SP]the[SP]group\nof[SP]five[SP]in[SP]the[SP]news[SP]are[SP]actually[SP]heroes[SP]fighting\nthe[SP]Masked[SP]Circle.[SP]Then[SP]they[SP]took[SP]off.",
     "nom_fr": "Gars cool",
-    "texte_fr": "Des gamins sont venus me dire que les cinq\nqu'on voit aux infos étaient des héros combattant\nle Cercle Masqué. Puis ils sont partis.[NL]C'était les enfants du musée, pas vrai?\nTss. On dirait qu'ils sont saufs.[NL]Ces cinq-là ont sauvés des gamins, hein?\n...Ils ont pas l'air de mauvais bougres."
+    "texte_fr": "Des gamins sont venus me dire que les cinq\nqu'on voit aux infos étaient des héros combattant\nle Cercle Masqué. Puis ils sont partis.[NL]C'était les enfants du musée, pas vrai? Tss. On dirait qu'ils sont saufs.[NL]Ces cinq-là ont sauvés des gamins, hein? ...Ils ont pas l'air de mauvais bougres."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "Those[SP]were[SP]the[SP]kids[SP]from[SP]the[SP]museum,[SP]right?\nTch.[SP]Looks[SP]like[SP]they[SP]were[SP]okay.",
     "nom_fr": "Femme éprise",
-    "texte_fr": "Je me demande comment s'appelle ce policier...[1205][U+000F]\nC-ces lunettes lui vont vraiment bien...[1205][U+000F]\nQuelle classe...[1106][NL]*soupir* Oh, dans quoi je me suis fourrée?[1205][U+000F]\nÇa pourrait être sérieux...[1205][U+000F] Excusez-moi,\nauriez-vous le nom de cet homme?"
+    "texte_fr": "Je me demande comment s'appelle ce policier...[1205][U+000F]\nC-ces lunettes lui vont vraiment bien...[1205][U+000F]\nQuelle classe...[1106][NL]*soupir* Oh, dans quoi je me suis fourrée?[1205][U+000F] Ça pourrait être sérieux...[1205][U+000F] Excusez-moi, auriez-vous le nom de cet homme?"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "So[SP]those[SP]five[SP]saved[SP]some[SP]kids,[SP]did[SP]they?[1205][000F]\n...Don't[SP]seem[SP]like[SP]such[SP]a[SP]bad[SP]bunch[SP]to[SP]me.",
     "nom_fr": "Femme éprise",
-    "texte_fr": "Qu'est ce qui ne va pas...[1205][U+000F] Les\nportraits-robot des suspects sont sortis, mais ça\nsemble attrister ce détective de police...[1106][NL]Si j'étais son amante, ce serait à moi de lui\nparler... Mais ce n'est pas ma place.\nJe peux seulement l'observer de loin.[1106][NL]Oh, j'oubliais. J'ai acheté des lunettes au style\nsimilaire aux siennes. Qu'en penses-tu? Elles\nme vont bien?[000F]"
+    "texte_fr": "Qu'est ce qui ne va pas...[1205][U+000F] Les\nportraits-robot des suspects sont sortis, mais ça\nsemble attrister ce détective de police...[1106][NL]Si j'étais son amante, ce serait à moi de lui parler... Mais ce n'est pas ma place. Je peux seulement l'observer de loin.[1106][NL]Oh, j'oubliais. J'ai acheté des lunettes au style similaire aux siennes. Qu'en penses-tu? Elles me vont bien?[000F]"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "The[SP]In[SP]Lak'ech,[SP]huh...?[SP]If[SP]the[SP]stuff[SP]written[SP]in\nthat[SP]is[SP]true,[SP]the[SP]world's[SP]gonna[SP]end[SP]once[SP]the\nGrand[SP]Cross[SP]is[SP]finished.",
     "nom_fr": "Gars cool",
-    "texte_fr": "L'In Lak'ech, hein...? Si ce qui y est écrit\nest vrai, la Croix Cosmique causera la fin du\nmonde une fois réalisée.[NL]Cette ville et cette mer pourraient disparaître.\nMon voyage pourrait cesser avec elles.\nUne triste fin à ma rude vie..."
+    "texte_fr": "L'In Lak'ech, hein...? Si ce qui y est écrit\nest vrai, la Croix Cosmique causera la fin du\nmonde une fois réalisée.[NL]Cette ville et cette mer pourraient disparaître. Mon voyage pourrait cesser avec elles. Une triste fin à ma rude vie..."
   },
   {
     "id": 13,
@@ -222,7 +222,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "Tch.[SP]If[SP]those[SP]guys[SP]are[SP]here,[SP]the[SP]In[SP]Lak'ech[SP]is\nlooking[SP]more[SP]and[SP]more[SP]right[SP]all[SP]the[SP]time.[1205][000F][SP]Are\nthose[SP]soldiers[SP]gonna[SP]destroy[SP]the[SP]world?",
     "nom_fr": "Gars cool",
-    "texte_fr": "Tss. Si ces mecs sont là, l'In Lak'ech\nparaît de plus en plus crédible.[1205][000F] Ces\nsoldats vont vraiment détruire le monde?"
+    "texte_fr": "Tss. Si ces mecs sont là, l'In Lak'ech\nparaît de plus en plus crédible.[000F][1205] Ces\nsoldats vont vraiment détruire le monde?"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "You[SP]see[SP]those[SP]meteors,[SP]kid?[1205][000F][SP]The[SP]Masked[SP]Circle\nguys[SP]say[SP]that's[SP]the[SP][1432][NULL][NULL][0014]lion's[SP]roar[1432][NULL][NULL][0014][SP]part[SP]of\ntheir[SP]Oracle.",
     "nom_fr": "Gars cool",
-    "texte_fr": "Tu vois ces météores?[1205][000F] D'après ceux du Cercle\nMasqué c'est le [1432][NULL][NULL][0014]rugissement du lion[1432][NULL][NULL][0014] de\nleur oracle.[NL]Hah, j'aurais du en profiter pour faire un voeu.\nVu leur nombre, je parie que beaucoup de mes\nvoeux se réaliseraient."
+    "texte_fr": "Tu vois ces météores?[000F][1205] D'après ceux du Cercle\nMasqué c'est le [1432][NULL][NULL][0014]rugissement du lion[1432][NULL][NULL][0014] de\nleur oracle.[NL]Hah, j'aurais du en profiter pour faire un voeu. Vu leur nombre, je parie que beaucoup de mes voeux se réaliseraient."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "Heh,[SP]I[SP]should've[SP]at[SP]least[SP]made[SP]a[SP]wish[SP]on[SP]'em.\nWith[SP]that[SP]many[SP]of[SP]'em[SP]shooting[SP]down,[SP]I[SP]bet\nI[SP]could've[SP]had[SP]lots[SP]of[SP]wishes[SP]come[SP]true.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "De ce que je sais...[1205][U+000F] Le voile mystèrieux\nenveloppant le troisième membre sera levé durant la\ndiffusion en direct au Giga Macho...[1106][NL]Oh, j'ai tant attendu ce jour![1205][U+000F] Maintenant,\nénigmatique dame...[1205][U+000F] révèle ton visage!"
+    "texte_fr": "De ce que je sais...[1205][U+000F] Le voile mystèrieux\nenveloppant le troisième membre sera levé durant la\ndiffusion en direct au Giga Macho...[1106][NL]Oh, j'ai tant attendu ce jour![1205][U+000F] Maintenant, énigmatique dame...[1205][U+000F] révèle ton visage!"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "What[SP]the[SP]hell[SP]is[SP]that?[1205][000A][SP]It's[SP]blown[SP]the[SP]hard-\nboiled[SP]atmosphere[SP]to[SP]hell[SP]and[SP]gone![1205][000F][SP]Just[SP]when\nthe[SP]Aerospace[SP]Museum[SP]was[SP]kaput,[SP]too...",
     "nom_fr": "Gars cool",
-    "texte_fr": "C'était quoi ça, bordel?[1205][000A] Ça a totalement pulvérisé\nl'atmosphère![1205] Comme quand le Musée\nAéronautique était kaput...[NL]J'en peux plus! Je repars en voyage!\n[000F]Je vais prendre un bateau, larguer les amarres\net... Ben... sûrement tomber du rebord, hum..."
+    "texte_fr": "C'était quoi ça, bordel?[000A][1205] Ça a totalement pulvérisé\nl'atmosphère![1205] Comme quand le Musée\nAéronautique était kaput...[NL]J'en peux plus! Je repars en voyage! [000F]Je vais prendre un bateau, larguer les amarres et... Ben... sûrement tomber du rebord, hum..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "I[SP]can't[SP]take[SP]it[SP]anymore![1205][000A][SP]I'm[SP]going[SP]on[SP]another\njourney![1205][000A][SP]I'll[SP]take[SP]a[SP]ship,[SP]set[SP]sail,[SP]and...[1205][000F]\nWell,[SP]I'll[SP]probably[SP]fall[SP]off[SP]the[SP]edge,[SP]huh...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ha. La salle de concert a brûlée...[1205][U+000F]\nLe bâtiment lui-même n'a pu contenir l'excitation\nissue des chansons de Muses.[1106][NL]Il est bon d'être resté dehors. Mais une\nchose ne colle pas.[1205][U+000F] Muses est censé être un\ntrio, mais...[1205][U+000F] Qui était aux côtés de Lisa?[000A][000A][000F]"
+    "texte_fr": "Ha. La salle de concert a brûlée...[1205][U+000F]\nLe bâtiment lui-même n'a pu contenir l'excitation\nissue des chansons de Muses.[1106][NL]Il est bon d'être resté dehors. Mais une chose ne colle pas.[1205][U+000F] Muses est censé être un trio, mais...[1205][U+000F] Qui était aux côtés de Lisa?[000A][000A][000F]"
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Sad[SP]woman",
     "texte_orig": "That's[SP]Ebisu[SP]Beach.[1205][000F][SP]It[SP]got[SP]its[SP]name[SP]because\npeople[SP]called[SP]the[SP]corpses[SP]that[SP]used[SP]to[SP]drift\nashore[SP][1432][NULL][NULL][0014]Ebisu-sama[1432][NULL][NULL][0014]...",
     "nom_fr": "Femme triste",
-    "texte_fr": "C'est la plage d'Ebisu.[1205] Son nom vient des\ngens qui nommaient les corps ramenés par la\nhoule [1432][NULL][NULL][0014]Ebisu[1432][NULL][NULL][0014]...[NL]Une plage accablée des noms de ceux ayant mis\nfin à leurs vies fugaces...[000F] Ce lieu me va\nbien, moi qui ne peux oublier mon amour..."
+    "texte_fr": "C'est la plage d'Ebisu.[1205] Son nom vient des\ngens qui nommaient les corps ramenés par la\nhoule [1432][NULL][NULL][0014]Ebisu[1432][NULL][NULL][0014]...[NL]Une plage accablée des noms de ceux ayant mis fin à leurs vies fugaces...[000F] Ce lieu me va bien, moi qui ne peux oublier mon amour..."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Sad[SP]woman",
     "texte_orig": "A[SP]beach[SP]bequeathed[SP]with[SP]the[SP]names[SP]of[SP]those[SP]who\nended[SP]their[SP]transient[SP]lives...[1205][000F][SP]A[SP]fitting[SP]place\nfor[SP]one[SP]like[SP]me[SP]who[SP]can't[SP]forget[SP]her[SP]man...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ceux de Sumaru TV rassemblent hâtivement du\nmatériel.[1205][U+000F] Ils préparent une émission spéciale sur\nles drames, je présume.[1106][NL]Ha! Si seulement ils m'avaient parlé, j'aurais\nreconté chaque petit détail de l'envol du\ndirigeable.[000F]"
+    "texte_fr": "Ceux de Sumaru TV rassemblent hâtivement du\nmatériel.[1205][U+000F] Ils préparent une émission spéciale sur\nles drames, je présume.[1106][NL]Ha! Si seulement ils m'avaient parlé, j'aurais reconté chaque petit détail de l'envol du dirigeable.[000F]"
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Sad[SP]woman",
     "texte_orig": "That[SP]gentleman...[1205][000F][SP]He[SP]seemed[SP]to[SP]be[SP]a[SP]police\ndetective,[SP]but[SP]he[SP]looked[SP]like[SP]my[SP]dead[SP]lover...",
     "nom_fr": "Femme triste",
-    "texte_fr": "Ce gentilhomme...[1205][000F] Il semble être policier,\nmais il ressemble à mon défunt mari...[NL]... O-oh mais, qu'est ce qui me prend...?\nJe rougis. Ça ne me ressemble pas..."
+    "texte_fr": "Ce gentilhomme...[000F][1205] Il semble être policier,\nmais il ressemble à mon défunt mari...[NL]... O-oh mais, qu'est ce qui me prend...?\nJe rougis. Ça ne me ressemble pas..."
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Sad[SP]woman",
     "texte_orig": "...[1205][000F]O-Oh[SP]my,[SP]what's[SP]come[SP]over[SP]me...?[1205][000F][SP]I[SP]feel\nsuddenly[SP]flushed.[SP]This[SP]is[SP]so[SP]unlike[SP]me...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Hmph... Le Bataillon est allé vers le Mont\nKatatsumuri.[1205][U+000F] Effrayé par moi, je parie.[1205][000F][000F]"
+    "texte_fr": "Hmph... Le Bataillon est allé vers le Mont\nKatatsumuri.[1205][U+000F] Effrayé par moi, je parie.[000F][1205][000F]"
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "I[SP]wonder[SP]what[SP]that[SP]police[SP]detective's[SP]name[SP]is...[1205][000F]\nTh-Those[SP]glasses[SP]really[SP]suit[SP]him...[1205][000F][SP]Such[SP]a\nsharp[SP]look...",
     "nom_fr": "Femme éprise",
-    "texte_fr": "Je me demande comment s'appelle ce policier...[1205][000F]\nC-ces lunettes lui vont vraiment bien...[1205][000F]\nQuelle classe...[NL]*soupir* Oh, dans quoi je me suis fourrée?\nÇa pourrait être sérieux... Excusez-moi,\nauriez-vous le nom de cet homme?"
+    "texte_fr": "Je me demande comment s'appelle ce policier...[000F][1205]\nC-ces lunettes lui vont vraiment bien...[000F][1205]\nQuelle classe...[NL]*soupir* Oh, dans quoi je me suis fourrée? Ça pourrait être sérieux... Excusez-moi, auriez-vous le nom de cet homme?"
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "*sigh*[SP]Oh,[SP]what[SP]have[SP]I[SP]gotten[SP]myself[SP]into?[1205][000F]\nThis[SP]could[SP]be[SP]serious...[1205][000F][SP]Excuse[SP]me,[SP]do[SP]you\nhappen[SP]to[SP]know[SP]that[SP]man's[SP]name?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "La fin du monde, hein...[1205][U+000F] Penses-tu qu'un\nmétéore ou équivalent va frapper la Terre?[1205][000F][000F]"
+    "texte_fr": "La fin du monde, hein...[1205][U+000F] Penses-tu qu'un\nmétéore ou équivalent va frapper la Terre?[000F][1205][000F]"
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "I[SP]wonder[SP]what's[SP]wrong...[1205][000F][SP]They[SP]posted[SP]composite\nsketches[SP]of[SP]the[SP]suspects,[SP]but[SP]that[SP]police\ndetective[SP]looks[SP]so[SP]sad[SP]about[SP]it...",
     "nom_fr": "Femme éprise",
-    "texte_fr": "Qu'est ce qui ne va pas...[1205][000F] Les\nportraits-robot des suspects sont sortis, mais ça\nsemble attrister ce détective de police...[NL]Si j'étais son amante, ce serait à moi de lui\nparler... Mais ce n'est pas ma place.\nJe peux seulement l'observer de loin.[NL]Oh, j'oubliais. J'ai acheté des lunettes au style\nsimilaire aux siennes. Qu'en penses-tu? Elles\nme vont bien?"
+    "texte_fr": "Qu'est ce qui ne va pas...[000F][1205] Les\nportraits-robot des suspects sont sortis, mais ça\nsemble attrister ce détective de police...[NL]Si j'étais son amante, ce serait à moi de lui parler... Mais ce n'est pas ma place. Je peux seulement l'observer de loin.[NL]Oh, j'oubliais. J'ai acheté des lunettes au style similaire aux siennes. Qu'en penses-tu? Elles me vont bien?"
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "If[SP]I[SP]was[SP]his[SP]lover,[SP]it[SP]would[SP]be[SP]up[SP]to[SP]me[SP]to\ntalk[SP]to[SP]him[SP]about[SP]it...[SP]But[SP]it's[SP]not[SP]my[SP]place.\nI[SP]can[SP]only[SP]watch[SP]him[SP]from[SP]afar[SP]like[SP]this.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Les choses deviennent intéressantes.[1205][U+000F] J'entend\ndire que la Croix Cosmique va stopper la\nrotation terrestre.[1106][NL]Ça, ça me plaît.[1205][U+000F] Même sa façon d'être\ndétruite est décadente![1205][U+000F] Ohohohoho!"
+    "texte_fr": "Les choses deviennent intéressantes.[1205][U+000F] J'entend\ndire que la Croix Cosmique va stopper la\nrotation terrestre.[1106][NL]Ça, ça me plaît.[1205][U+000F] Même sa façon d'être détruite est décadente![1205][U+000F] Ohohohoho!"
   },
   {
     "id": 27,
@@ -432,7 +432,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "That[SP]police[SP]detective[SP]seems[SP]happy[SP]for[SP]some\nreason[SP]after[SP]hearing[SP]the[SP]news.[1205][000F][SP]It's[SP]the[SP]first\ntime[SP]I've[SP]seen[SP]him[SP]smile.",
     "nom_fr": "Femme éprise",
-    "texte_fr": "Ce détective de police semblait heureux en\nentendant les informations.[1205][000F] C'est la première fois\nque je l'ai vu sourire."
+    "texte_fr": "Ce détective de police semblait heureux en\nentendant les informations.[000F][1205] C'est la première fois\nque je l'ai vu sourire."
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "I-I[SP]was[SP]almost[SP]attacked[SP]by[SP]those[SP]soldiers...[1205][000F]\nBut[SP]that[SP]police[SP]detective[SP]saved[SP]me![1205][000F][SP]Ahhh,[SP]I\ncould[SP]die[SP]happy[SP]now!",
     "nom_fr": "Femme éprise",
-    "texte_fr": "C-ces soldats m'ont presque agressée...[1205][000F]\nMais ce policier m'a sauvée![1205][000F] Ahhh,\nje peux mourir heureuse désormais!"
+    "texte_fr": "C-ces soldats m'ont presque agressée...[000F][1205]\nMais ce policier m'a sauvée![000F][1205] Ahhh,\nje peux mourir heureuse désormais!"
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Lovestruck[SP]woman",
     "texte_orig": "Hm?[1205][000A][SP]That[SP]blonde[SP]girl[SP]with[SP]you...[1205][000A][SP]Didn't[SP]she[SP]go\ninto[SP]that[SP]temple[SP]a[SP]second[SP]ago?[1205][000F][SP]Was[SP]I[SP]just\nseeing[SP]things...?",
     "nom_fr": "Femme éprise",
-    "texte_fr": "Hm?[000A][000A][1205][000F] Cette fille blonde avec toi...[1205] Elle\nn'est pas entrée dans ce temple à l'instant?[1205]\nOu j'ai halluciné...?"
+    "texte_fr": "Hm?[000A][000A][000F][1205] Cette fille blonde avec toi...[1205] Elle\nn'est pas entrée dans ce temple à l'instant?[1205]\nOu j'ai halluciné...?"
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "That[SP]producer,[SP]Ginji[SP]Sasaki...[1205][000F][SP]Looks[SP]like[SP]he's\ngot[SP]a[SP]new[SP]idol[SP]group[SP]lined[SP]up.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ce producteur, Ginji Sasaki...[1205][000F] Il aurait formé\nun nouveau groupe d'idols.[NL]La musique étanche la soif de mon coeur...\nQuel message Muses gravera dans mon coeur?\nCe suspense est délicieux..."
+    "texte_fr": "Ce producteur, Ginji Sasaki...[000F][1205] Il aurait formé\nun nouveau groupe d'idols.[NL]La musique étanche la soif de mon coeur...\nQuel message Muses gravera dans mon coeur? Ce suspense est délicieux..."
   },
   {
     "id": 32,
@@ -492,7 +492,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Songs[SP]slake[SP]my[SP]heart's[SP]thirst...[1205][000F][SP]What[SP]sort[SP]of\nmessage[SP]will[SP]Muses[SP]inscribe[SP]into[SP]my[SP]heart?[1205][000F]\nThe[SP]suspense[SP]is[SP]delectable...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Kuchisake-onna, hein...? Enfant, cette histoire\nme terrorisait.[1106][NL]Que de souvenirs...[1205][U+000F] Je doute qu'à votre âge\nvous la connaissiez.[1106][NL]Tenez, voici un devoir de sciences sociales:\nallez à ce Mont Iwato, là.[1205][U+000F] Vous pourriez\nla voir vous-même là-bas.[000F][000F]"
+    "texte_fr": "Kuchisake-onna, hein...? Enfant, cette histoire\nme terrorisait.[1106][NL]Que de souvenirs...[1205][U+000F] Je doute qu'à votre âge\nvous la connaissiez.[1106][NL]Tenez, voici un devoir de sciences sociales: allez à ce Mont Iwato, là.[1205][U+000F] Vous pourriez la voir vous-même là-bas.[000F][000F]"
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "From[SP]what[SP]I've[SP]heard...[1205][000F][SP]The[SP]veil[SP]of[SP]mystery\nsurrounding[SP]the[SP]third[SP]member[SP]will[SP]be[SP]torn[SP]off\nduring[SP]the[SP]live[SP]recording[SP]at[SP]Giga[SP]Macho...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "De ce que je sais...[1205][000F] Le voile mystèrieux\nenveloppant le troisième membre sera levé durant la\ndiffusion en direct au Giga Macho...[NL]Oh, j'ai tant attendu ce jour! Maintenant,\nénigmatique dame... révèle ton visage!"
+    "texte_fr": "De ce que je sais...[000F][1205] Le voile mystèrieux\nenveloppant le troisième membre sera levé durant la\ndiffusion en direct au Giga Macho...[NL]Oh, j'ai tant attendu ce jour! Maintenant, énigmatique dame... révèle ton visage!"
   },
   {
     "id": 34,
@@ -537,7 +537,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "A[SP]concert,[SP]hmm?[1205][000F][SP]To[SP]think[SP]I'd[SP]be[SP]graced[SP]with\ntheir[SP]singing[SP]voices[SP]so[SP]soon...[1205][000F][SP]I[SP]should[SP]make\nfor[SP]the[SP]outdoor[SP]concert[SP]hall[SP]post-haste.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Un concert, hmm?[1205][000F] Dire que je vais déjà\npouvoir être béni de leurs chants...[1205][000F] Je dois\nme préparer pour le concert séance tenante.[NL]Un ticket? Ha! Pas besoin de ticket. J'écouterais\npar-delà le mur. S'agiter bêtement n'est pas\nla seule façon de témoigner son soutien."
+    "texte_fr": "Un concert, hmm?[000F][1205] Dire que je vais déjà\npouvoir être béni de leurs chants...[000F][1205] Je dois\nme préparer pour le concert séance tenante.[NL]Un ticket? Ha! Pas besoin de ticket. J'écouterais par-delà le mur. S'agiter bêtement n'est pas la seule façon de témoigner son soutien."
   },
   {
     "id": 36,
@@ -552,7 +552,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "A[SP]ticket?[1205][000F][SP]Ha![SP]I[SP]need[SP]no[SP]ticket.[SP]I[SP]shall[SP]listen\nto[SP]them[SP]from[SP]beyond[SP]the[SP]wall.[SP]There[SP]are[SP]more\nways[SP]to[SP]show[SP]one's[SP]support[SP]than[SP]making[SP]a[SP]fuss.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Une dénommée Sorcière de\nla Commode est à l'usine abandonnée.[1106][NL]Elle encastrerait les passants dans sa\ncommode.[1205][000F]"
+    "texte_fr": "Es-tu au courant? Une dénommée Sorcière de\nla Commode est à l'usine abandonnée.[1106][NL]Elle encastrerait les passants dans sa\ncommode.[000F][1205]"
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Ha.[SP]So[SP]the[SP]concert[SP]hall[SP]has[SP]burned[SP]to[SP]ash...[1205][000F]\nThe[SP]building[SP]itself[SP]couldn't[SP]contain[SP]its\nexcitement[SP]for[SP]the[SP]Muses'[SP]song.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ha. La salle de concert a brûlée...[1205][000F]\nLe bâtiment lui-même n'a pu contenir l'excitation\nissue des chansons de Muses.[NL]Il est bon d'être resté dehors. Mais une\nchose ne colle pas. Muses est censé être un\ntrio, mais... Qui était aux côtés de Lisa?"
+    "texte_fr": "Ha. La salle de concert a brûlée...[000F][1205]\nLe bâtiment lui-même n'a pu contenir l'excitation\nissue des chansons de Muses.[NL]Il est bon d'être resté dehors. Mais une chose ne colle pas. Muses est censé être un trio, mais... Qui était aux côtés de Lisa?"
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Fortunate,[SP]then,[SP]that[SP]I[SP]was[SP]outside.[SP]But[SP]one\nthing[SP]seems[SP]amiss.[1205][000F][SP]Muses[SP]was[SP]meant[SP]to[SP]be[SP]a\ntrio,[SP]but...[1205][000F][SP]Who[SP]was[SP]there[SP]besides[SP]Lisa-chan?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ah, j'ai un bon plan pour toi.[1205][U+000F] Je te le\ndirais, si tu promets de ne pas en parler...[1106][NL]Tu vois...[1205][U+000F] Time Castle à Rengedai vendrait\nde vraies armes.[1205][U+000F] La sélection y est\nbonne, mais coûteuse. Dingue, non?[000F][000F]"
+    "texte_fr": "Ah, j'ai un bon plan pour toi.[1205][U+000F] Je te le\ndirais, si tu promets de ne pas en parler...[1106][NL]Tu vois...[1205][U+000F] Time Castle à Rengedai vendrait\nde vraies armes.[1205][U+000F] La sélection y est bonne, mais coûteuse. Dingue, non?[000F][000F]"
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Apparently[SP]the[SP]terrorists[SP]behind[SP]these[SP]attacks\nare[SP]a[SP]mysterious[SP]organization[SP]called[SP]the[SP]Last\nBattalion.[1205][000F][SP]I've[SP]heard[SP]people[SP]talk[SP]about[SP]them.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Apparemment les terroristes derrière ces attaques\nsont une organisation mystérieuse nommée Bataillon.[1205][000F]\nJ'ai entendu des gens en parler.[NL]Si ils doivent affronter ça, même si la\npolice n'était pas incapacitée, ils n'auraient\npresque aucune chance.[NL]Au moins maintenant ils ont une bonne raison\nd'échouer à protéger la ville--ils sont\nvictimes eux aussi."
+    "texte_fr": "Apparemment les terroristes derrière ces attaques\nsont une organisation mystérieuse nommée Bataillon.[000F][1205]\nJ'ai entendu des gens en parler.[NL]Si ils doivent affronter ça, même si la police n'était pas incapacitée, ils n'auraient presque aucune chance.[NL]Au moins maintenant ils ont une bonne raison d'échouer à protéger la ville--ils sont victimes eux aussi."
   },
   {
     "id": 40,
@@ -642,7 +642,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "The[SP]men[SP]at[SP]Sumaru[SP]TV[SP]are[SP]frantically[SP]gathering\nmaterial.[1205][000F][SP]I[SP]presume[SP]they're[SP]putting[SP]together[SP]a\nspecial[SP]on[SP]the[SP]terror[SP]wave.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ceux de Sumaru TV rassemblent hâtivement du\nmatériel.[1205][000F] Ils préparent une émission spéciale sur\nles drames, je présume.[NL]Ha! Si seulement ils m'avaient parlé, j'aurais\nreconté chaque petit détail de l'envol du\ndirigeable."
+    "texte_fr": "Ceux de Sumaru TV rassemblent hâtivement du\nmatériel.[000F][1205] Ils préparent une émission spéciale sur\nles drames, je présume.[NL]Ha! Si seulement ils m'avaient parlé, j'aurais reconté chaque petit détail de l'envol du dirigeable."
   },
   {
     "id": 43,
@@ -672,7 +672,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Hmph...[SP]The[SP]In[SP]Lak'ech[SP]says[SP]we'll[SP]evolve[SP]into\na[SP]higher[SP]form,[SP]called[SP]Idealians,[SP]upon[SP]the\ncompletion[SP]of[SP]the[SP]Grand[SP]Cross.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Hm... Selon l'In Lak'ech nous évoluerons en\nIdéaliens, une forme supérieure, quand la Croix\nCosmique sera complète.[NL]Une histoire intéressante, non? J'ai décidé d'y\ncroire. Ma vie ne saurait s'achever ainsi.\nUn futur plus stimulant doit m'attendre.[NL]Hohoho, je ne puis attendre l'instant de notre\ntransfiguration."
+    "texte_fr": "Hm... Selon l'In Lak'ech nous évoluerons en\nIdéaliens, une forme supérieure, quand la Croix\nCosmique sera complète.[NL]Une histoire intéressante, non? J'ai décidé d'y croire. Ma vie ne saurait s'achever ainsi. Un futur plus stimulant doit m'attendre.[NL]Hohoho, je ne puis attendre l'instant de notre transfiguration."
   },
   {
     "id": 45,
@@ -687,7 +687,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "A[SP]juicy[SP]story,[SP]no?[1205][000F][SP]I[SP]choose[SP]to[SP]believe[SP]it.[1205][000F]\nMy[SP]life[SP]would[SP]never[SP]end[SP]this[SP]way.[SP]There[SP]has[SP]to\nbe[SP]a[SP]more[SP]stimulating[SP]future[SP]in[SP]store[SP]for[SP]me.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. Elles sont bon marché,\nmais médiocres.[1205][1205][000F][000F]"
+    "texte_fr": "Clair de Lune semble avoir inclu des armes\nà son répertoire. Elles sont bon marché,\nmais médiocres.[1205][000F][1205][000F]"
   },
   {
     "id": 46,
@@ -717,7 +717,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Hmph...[SP]Most[SP]of[SP]the[SP]Last[SP]Battalion[SP]has[SP]fled\nfor[SP]Mt.[SP]Katatsumuri.[1205][000F][SP]Scared[SP]of[SP]me,[SP]I'll[SP]wager.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Hmph... Le Bataillon est allé vers le Mont\nKatatsumuri.[1205][000F] Effrayé par moi, je parie."
+    "texte_fr": "Hmph... Le Bataillon est allé vers le Mont\nKatatsumuri.[000F][1205] Effrayé par moi, je parie."
   },
   {
     "id": 48,
@@ -732,7 +732,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "I[SP]pity[SP]the[SP]poor[SP]souls[SP]below[SP]us...[SP]But[SP]at[SP]least\nour[SP]evolution[SP]will[SP]go[SP]unimpeded.[1205][000F][SP]Still,[SP]just\nhow[SP]will[SP]the[SP]world[SP]end?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ah, ces pauvres âmes là-dessous... Au moins\nrien ne gênera notre évolution.[1205][000F] Mais comment le\nmonde sera anéanti?"
+    "texte_fr": "Ah, ces pauvres âmes là-dessous... Au moins\nrien ne gênera notre évolution.[000F][1205] Mais comment le\nmonde sera anéanti?"
   },
   {
     "id": 49,
@@ -747,7 +747,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "The[SP]Earth's[SP]destruction,[SP]eh...[1205][000F][SP]Do[SP]you[SP]suppose\na[SP]meteor[SP]or[SP]somesuch[SP]will[SP]hit[SP]the[SP]Earth?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "La fin du monde, hein...[1205][000F] Penses-tu qu'un\nmétéore ou équivalent va frapper la Terre?"
+    "texte_fr": "La fin du monde, hein...[000F][1205] Penses-tu qu'un\nmétéore ou équivalent va frapper la Terre?"
   },
   {
     "id": 50,
@@ -762,7 +762,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "An[SP]acquaintance[SP]of[SP]mine[SP]told[SP]me[SP]that[SP]when[SP]the\nGrand[SP]Cross[SP]is[SP]complete,[SP]electrified[SP]rain[SP]will\npour[SP]down[SP]upon[SP]the[SP]Earth.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "D'après une connaissance, lorsque la Croix\nCosmique sera complète, une pluie électrifiée\ns'abattra sur Terre.[NL]Bah, sûrement une divagation issue de sa terreur.\nDans ce paradis nous ne sommes pas inquiétés."
+    "texte_fr": "D'après une connaissance, lorsque la Croix\nCosmique sera complète, une pluie électrifiée\ns'abattra sur Terre.[NL]Bah, sûrement une divagation issue de sa terreur. Dans ce paradis nous ne sommes pas inquiétés."
   },
   {
     "id": 51,
@@ -777,7 +777,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "That[SP]is[SP]supposedly[SP]the[SP]manner[SP]of[SP]its[SP]demise.[1205][000F]\nNothing[SP]for[SP]us[SP]to[SP]worry[SP]about,[SP]up[SP]here[SP]in[SP]the\nheavens.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Leur offre serait\nvariée, mais la valeur de revente basse.[1205][000F]"
+    "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Leur offre serait\nvariée, mais la valeur de revente basse.[000F][1205]"
   },
   {
     "id": 52,
@@ -792,7 +792,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Things[SP]are[SP]becoming[SP]interesting[SP]indeed.[1205][000A][SP]I[SP]hear\nnow[SP]that[SP]the[SP]Grand[SP]Cross[SP]will[SP]halt[SP]the[SP]Earth's\nrotation[SP]entirely.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Les choses deviennent intéressantes.[1205] J'entend\n[000A]dire que la Croix Cosmique va stopper la\nrotation terrestre.[NL]Ça, ça me plaît. Même sa façon d'être\ndétruite est décadente! Ohohohoho!"
+    "texte_fr": "Les choses deviennent intéressantes.[1205] J'entend\n[000A]dire que la Croix Cosmique va stopper la\nrotation terrestre.[NL]Ça, ça me plaît. Même sa façon d'être détruite est décadente! Ohohohoho!"
   },
   {
     "id": 53,
@@ -807,7 +807,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Now[SP]that's[SP]more[SP]like[SP]it.[1205][000A][SP]Even[SP]the[SP]method[SP]of\nits[SP]destruction[SP]is[SP]decadent![1205][000A][SP]Ohohoho!",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Les produits y seraient\nde qualité, mais assez chers.[1205][000A][1205][000A]"
+    "texte_fr": "Je n'avais jamais remarqué que le café du\ncoin vendait des armes. Les produits y seraient\nde qualité, mais assez chers.[000A][1205][000A][1205]"
   },
   {
     "id": 54,
@@ -837,7 +837,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "I[SP]hear[SP]that[SP]Zodiac's[SP]second[SP]floor[SP]is[SP]stuffed\nwith[SP]t[SP]reasure[SP]now.[SP]I'd[SP]like[SP]to[SP]see[SP]it[SP]for\nmyself...[1205][000F][SP]if[SP]it[SP]weren't[SP]for[SP]the[SP]monsters.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Le second étage du Zodiac serait actuellement\nrempli de trésors. Je serais bien allé\nvoir...[1205][000F] s'il n'y avait pas ces monstres.[NL]*soupir* Un moyen sûr de s'enrichir rapidement\ndoit bien exister."
+    "texte_fr": "Le second étage du Zodiac serait actuellement\nrempli de trésors. Je serais bien allé\nvoir...[000F][1205] s'il n'y avait pas ces monstres.[NL]*soupir* Un moyen sûr de s'enrichir rapidement doit bien exister."
   },
   {
     "id": 56,
@@ -867,7 +867,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "The[SP]ghost[SP]of[SP]an[SP]idol[SP]singer[SP]who[SP]died[SP]young\nhas[SP]been[SP]appearing[SP]at[SP]Aoba[SP]Park.[1205][000F][SP]Can[SP]she\nstill[SP]not[SP]forget[SP]me,[SP]even[SP]in[SP]death?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Le fantôme d'une idol, morte jeune, apparaîtrait\nau Parc d'Aoba.[1205][000F] Faillirait-elle à\nm'oublier, même dans la mort?"
+    "texte_fr": "Le fantôme d'une idol, morte jeune, apparaîtrait\nau Parc d'Aoba.[000F][1205] Faillirait-elle à\nm'oublier, même dans la mort?"
   },
   {
     "id": 58,
@@ -882,7 +882,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "There's[SP]something[SP]called[SP]a[SP]Cursed[SP]Taxi[SP]parked\nat[SP]the[SP]abandoned[SP]factory.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Un dénommé Taxi Maudit serait garé à\nl'usine abandonnée.[NL]Des histoires racontent qu'il fauche ses\nvictimes la nuit et se repose le jour.[NL]Cela ne peux que faire baisser sa clientèle.\nHasardeux, comme stratégie marketing!"
+    "texte_fr": "Un dénommé Taxi Maudit serait garé à\nl'usine abandonnée.[NL]Des histoires racontent qu'il fauche ses\nvictimes la nuit et se repose le jour.[NL]Cela ne peux que faire baisser sa clientèle. Hasardeux, comme stratégie marketing!"
   },
   {
     "id": 59,
@@ -942,7 +942,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Kuchisake-onna,[SP]hmm...?[SP]That[SP]story[SP]gave[SP]me\nquite[SP]a[SP]fright[SP]as[SP]a[SP]child.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Kuchisake-onna, hein...? Enfant, cette histoire\nme terrorisait.[NL]Que de souvenirs... Je doute qu'à votre âge\nvous la connaissiez.[NL]Tenez, voici un devoir de sciences sociales:\nallez à ce Mont Iwato, là. Vous pourriez\nla voir vous-même là-bas."
+    "texte_fr": "Kuchisake-onna, hein...? Enfant, cette histoire\nme terrorisait.[NL]Que de souvenirs... Je doute qu'à votre âge\nvous la connaissiez.[NL]Tenez, voici un devoir de sciences sociales: allez à ce Mont Iwato, là. Vous pourriez la voir vous-même là-bas."
   },
   {
     "id": 63,
@@ -957,7 +957,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Ah,[SP]the[SP]memories...[1205][000F][SP]I[SP]doubt[SP]children[SP]your[SP]age\nwould[SP]know[SP]who[SP]she[SP]is.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. La qualité y serait\nexcellente, mais les produits onéreux.[1205][000F]"
+    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. La qualité y serait\nexcellente, mais les produits onéreux.[000F][1205]"
   },
   {
     "id": 64,
@@ -972,7 +972,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Then[SP]here's[SP]a[SP]social[SP]studies[SP]assignment[SP]for\nyou:[SP]Go[SP]to[SP]this[SP]Mt.[SP]Iwato[SP]place.[1205][000F][SP]Apparently\nyou[SP]can[SP]see[SP]her[SP]for[SP]yourself[SP]there.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. On dit que c'est pas\ncher, mais de basse qualité.[1205][000F]"
+    "texte_fr": "Es-tu au courant? Rosa Candida à Aoba vend\nde vraies armures. On dit que c'est pas\ncher, mais de basse qualité.[000F][1205]"
   },
   {
     "id": 65,
@@ -987,7 +987,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Jumping[SP]Geezer,[SP]hmm...?[SP]I[SP]used[SP]to[SP]compete[SP]with\nhim[SP]quite[SP]often[SP]on[SP]mountain[SP]passes.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Le Vieux à Ressort, hein...? Je le défiais\nsouvent sur les sentiers à l'époque.[NL]Mais il était plus rapide. Il sautais\nau dessus de ma GT8.[NL]Si vous voulez l'affronter, allez au Mont\nKatatsumuri. Les six virages en épingle maudits...\nIl vous y attendra."
+    "texte_fr": "Le Vieux à Ressort, hein...? Je le défiais\nsouvent sur les sentiers à l'époque.[NL]Mais il était plus rapide. Il sautais\nau dessus de ma GT8.[NL]Si vous voulez l'affronter, allez au Mont Katatsumuri. Les six virages en épingle maudits... Il vous y attendra."
   },
   {
     "id": 66,
@@ -1002,7 +1002,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "He[SP]was[SP]much[SP]faster[SP]than[SP]me,[SP]though.[1205][000F][SP]He[SP]jumped\nright[SP]over[SP]my[SP]GT8.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients.[1106][NL]Leur sélection semble géniale, mais la valeur\nde revente y est basse.[1205][000F]"
+    "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients.[1106][NL]Leur sélection semble géniale, mais la valeur\nde revente y est basse.[000F][1205]"
   },
   {
     "id": 67,
@@ -1017,7 +1017,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "If[SP]you[SP]care[SP]to[SP]challenge[SP]him,[SP]go[SP]to[SP]Mt.\nKatatsumuri.[SP]The[SP]cursed[SP]six[SP]hairpin[SP]curves...[1205][000F]\nHe'll[SP]be[SP]waiting[SP]there[SP]for[SP]you.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients.[1106][NL]Ça semble être bon marché, mais de médiocre\nqualité.[1205][000F]"
+    "texte_fr": "Ça m'impressionne que London Clothier ose\nvendre de vraies armures aux clients.[1106][NL]Ça semble être bon marché, mais de médiocre\nqualité.[000F][1205]"
   },
   {
     "id": 68,
@@ -1032,7 +1032,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Harumph...[1205][000F][SP]I[SP]can't[SP]believe[SP]I'm[SP]letting[SP]this\nridiculous[SP]story[SP]affect[SP]me...[1205][000F][SP]Kudan,[SP]hmm?[1205][000F]\nAt[SP]that[SP]abandoned[SP]factory...[1205][000F][SP]No![SP]No[SP]more!",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Grumpf...[1205][000F] Il est impensable que cette ridicule\nhistoire puisse m'affecter...[1205][000F]Kudan, hmm?[1205][000F]\nÀ l'usine abandonnée...[1205][000F] Non! Assez!"
+    "texte_fr": "Grumpf...[000F][1205] Il est impensable que cette ridicule\nhistoire puisse m'affecter...[000F][1205]Kudan, hmm?[000F][1205]\nÀ l'usine abandonnée...[000F][1205] Non! Assez!"
   },
   {
     "id": 69,
@@ -1047,7 +1047,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Hmm...[SP]It[SP]appears[SP]the[SP]rumor[SP]was[SP]true[SP]about[SP]the\nsecret[SP]CD[SP]at[SP]Giga[SP]Macho.[1205][000F][SP]Time[SP]for[SP]me[SP]to[SP]go[SP]pick\nit[SP]up...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Hmm... Il semble que la rumeur du CD secret\ndu Giga Macho était fondée.[1205][000F] Je dois aller\nle chercher..."
+    "texte_fr": "Hmm... Il semble que la rumeur du CD secret\ndu Giga Macho était fondée.[000F][1205] Je dois aller\nle chercher..."
   },
   {
     "id": 70,
@@ -1062,7 +1062,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Have[SP]you[SP]heard?[1205][000F][SP]There's[SP]a[SP]creature[SP]called\na[SP]Dresser[SP]Hag[SP]at[SP]the[SP]abandoned[SP]factory.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Es-tu au courant? [1205][000F]Une dénommée Sorcière de\nla Commode est à l'usine abandonnée.[NL]Elle encastrerait les passants dans sa\ncommode."
+    "texte_fr": "Es-tu au courant? [000F][1205]Une dénommée Sorcière de\nla Commode est à l'usine abandonnée.[NL]Elle encastrerait les passants dans sa\ncommode."
   },
   {
     "id": 71,
@@ -1077,7 +1077,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "By[SP]all[SP]accounts,[SP]it[SP]shoves[SP]passersby[SP]into[SP]its\ndresser.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Tss, j'ai pas gagné...[1205][U+000F] Hm?[1205][U+000F] Oh, je pestais\njuste sur les loteries de magazines.[1106][NL]Les gagnants pourraient y obtenir armes\net objets.[1106][NL]Il est difficile de gagner, mais les\nprix sont assez bons.[1205][U+000F] Je vais réessayer,\nj'imagine..."
+    "texte_fr": "Tss, j'ai pas gagné...[1205][U+000F] Hm?[1205][U+000F] Oh, je pestais\njuste sur les loteries de magazines.[1106][NL]Les gagnants pourraient y obtenir armes\net objets.[1106][NL]Il est difficile de gagner, mais les prix sont assez bons.[1205][U+000F] Je vais réessayer, j'imagine..."
   },
   {
     "id": 72,
@@ -1092,7 +1092,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Ah,[SP]I[SP]have[SP]a[SP]hot[SP]tip[SP]for[SP]you.[1205][000F][SP]I'll[SP]let[SP]you[SP]in\non[SP]it,[SP]provided[SP]you[SP]don't[SP]tell[SP]anyone[SP]else...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ah, j'ai un bon plan pour toi.[1205][000F] Je te le\ndirais, si tu promets de ne pas en parler...[NL]Tu vois... Time Castle à Rengedai vendrait\nde vraies armes. Le prix et la qualité y\nsont standards. Dingue, non?"
+    "texte_fr": "Ah, j'ai un bon plan pour toi.[000F][1205] Je te le\ndirais, si tu promets de ne pas en parler...[NL]Tu vois... Time Castle à Rengedai vendrait\nde vraies armes. Le prix et la qualité y sont standards. Dingue, non?"
   },
   {
     "id": 73,
@@ -1107,7 +1107,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "You[SP]see...[1205][000F][SP]A[SP]store[SP]called[SP]Time[SP]Castle[SP]in\nRengedai[SP]sells[SP]real[SP]weapons.[1205][000F][SP]Their[SP]quality\nand[SP]price[SP]are[SP]average.[SP]Shocking,[SP]no?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Tss, j'ai pas gagné...[1205][U+000F] Hm?[1205][U+000F] Oh, je pestais\njuste sur les loteries de magazines.[1106][NL]Les gagnants pourraient y obtenir armes\net objets.[1106][NL]Gagner serait facile, mais les prix ne\nsont pas mirobolants.[1205][U+000F] Il est peut-être\ntemps d'arrêter...[000F][000F]"
+    "texte_fr": "Tss, j'ai pas gagné...[1205][U+000F] Hm?[1205][U+000F] Oh, je pestais\njuste sur les loteries de magazines.[1106][NL]Les gagnants pourraient y obtenir armes\net objets.[1106][NL]Gagner serait facile, mais les prix ne sont pas mirobolants.[1205][U+000F] Il est peut-être temps d'arrêter...[000F][000F]"
   },
   {
     "id": 74,
@@ -1122,7 +1122,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Ah,[SP]I[SP]have[SP]a[SP]hot[SP]tip[SP]for[SP]you.[1205][000F][SP]I'll[SP]let[SP]you[SP]in\non[SP]it,[SP]provided[SP]you[SP]don't[SP]tell[SP]anyone[SP]else...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ah, j'ai un bon plan pour toi.[1205][000F] Je te le\ndirais, si tu promets de ne pas en parler...[NL]Tu vois... Time Castle à Rengedai vendrait\nde vraies armes. La sélection y est\nbonne, mais coûteuse. Dingue, non?"
+    "texte_fr": "Ah, j'ai un bon plan pour toi.[000F][1205] Je te le\ndirais, si tu promets de ne pas en parler...[NL]Tu vois... Time Castle à Rengedai vendrait\nde vraies armes. La sélection y est bonne, mais coûteuse. Dingue, non?"
   },
   {
     "id": 75,
@@ -1137,7 +1137,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "You[SP]see...[1205][000F][SP]A[SP]store[SP]called[SP]Time[SP]Castle[SP]in\nRengedai[SP]sells[SP]real[SP]weapons.[1205][000F][SP]Their[SP]quality\nis[SP]good,[SP]but[SP]they're[SP]expensive.[SP]Shocking,[SP]no?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille![1106][NL]Mu étais donc aussi ce genre de lieu.\nLa chance qui ébranla Las Vegas va sévir...\nCar les machines à sous sont ma spécialité![1205][1205][000F][000F]"
+    "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille![1106][NL]Mu étais donc aussi ce genre de lieu. La chance qui ébranla Las Vegas va sévir... Car les machines à sous sont ma spécialité![1205][000F][1205][000F]"
   },
   {
     "id": 76,
@@ -1152,7 +1152,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Ah,[SP]I[SP]have[SP]a[SP]hot[SP]tip[SP]for[SP]you.[1205][000F][SP]I'll[SP]let[SP]you[SP]in\non[SP]it,[SP]provided[SP]you[SP]don't[SP]tell[SP]anyone[SP]else...",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Ah, j'ai un bon plan pour toi.[1205][000F] Je te le\ndirais, si tu promets de ne pas en parler...[NL]Tu vois... Time Castle à Rengedai vendrait\nde vraies armes. C'est pas cher, mais de\nbasse qualité. Dingue, non?"
+    "texte_fr": "Ah, j'ai un bon plan pour toi.[000F][1205] Je te le\ndirais, si tu promets de ne pas en parler...[NL]Tu vois... Time Castle à Rengedai vendrait\nde vraies armes. C'est pas cher, mais de basse qualité. Dingue, non?"
   },
   {
     "id": 77,
@@ -1167,7 +1167,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "You[SP]see...[1205][000F][SP]A[SP]store[SP]called[SP]Time[SP]Castle[SP]in\nRengedai[SP]sells[SP]real[SP]weapons.[1205][000F][SP]They're[SP]cheap,\nbut[SP]low[SP]quality.[SP]Shocking,[SP]no?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Hmm, ce restaurant de ramen vend une sorte\nd'arme légendaire... Heureusement qu'on m'a mis\nau jus.[1205][1205][000F][000F]"
+    "texte_fr": "Hmm, ce restaurant de ramen vend une sorte\nd'arme légendaire... Heureusement qu'on m'a mis\nau jus.[1205][000F][1205][000F]"
   },
   {
     "id": 78,
@@ -1182,7 +1182,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Great[SP]selection,[SP]but[SP]low[SP]resale[SP]value?[SP]Hmph,\neven[SP]that[SP]Tony[SP]has[SP]a[SP]hand[SP]in[SP]illicit[SP]weapon\nsales...[1205][000F][SP]The[SP]bastard's[SP]good.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Bonne sélection, mais bas prix de revente?\nHmph, même ce Tony traîne dans le trafic\nd'armes...[1205][000F] Doué, cet enfoiré."
+    "texte_fr": "Bonne sélection, mais bas prix de revente?\nHmph, même ce Tony traîne dans le trafic\nd'armes...[000F][1205] Doué, cet enfoiré."
   },
   {
     "id": 79,
@@ -1197,7 +1197,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Poor[SP]quality,[SP]but[SP]decent[SP]prices?[SP]Hmph,\neven[SP]that[SP]Tony[SP]has[SP]a[SP]hand[SP]in[SP]illicit[SP]weapon\nsales...[1205][000F][SP]The[SP]bastard's[SP]good.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Basse qualité, mais prix décents? Hmph,\nmême ce Tony traîne dans le trafic\nd'armes...[1205][000F] Doué, cet enfoiré."
+    "texte_fr": "Basse qualité, mais prix décents? Hmph,\nmême ce Tony traîne dans le trafic\nd'armes...[000F][1205] Doué, cet enfoiré."
   },
   {
     "id": 80,
@@ -1212,7 +1212,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Satisfaction[SP]guaranteed[SP]through[SP]average[SP]prices\nand[SP]quality?[SP]Hmph,[SP]even[SP]that[SP]Tony[SP]has[SP]a[SP]hand\nin[SP]illicit[SP]weapon[SP]sales...[1205][000F][SP]The[SP]bastard's[SP]good.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Prix et qualité standardisés pour une\nsatisfaction assurée? Hmph, même ce Tony traîne\ndans le trafic d'armes...[1205][000F] Doué, cet enfoiré."
+    "texte_fr": "Prix et qualité standardisés pour une\nsatisfaction assurée? Hmph, même ce Tony traîne\ndans le trafic d'armes...[000F][1205] Doué, cet enfoiré."
   },
   {
     "id": 81,
@@ -1227,7 +1227,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Expensive[SP]stock,[SP]but[SP]the[SP]highest[SP]quality...\nHmph,[SP]even[SP]that[SP]Tony[SP]has[SP]a[SP]hand[SP]in[SP]illicit\nweapon[SP]sales...[1205][000F][SP]The[SP]bastard's[SP]good.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Des produits coûteux, mais de haute qualité...\nHmph, même ce Tony traîne dans le trafic\nd'armes...[1205][000F] Doué, cet enfoiré."
+    "texte_fr": "Des produits coûteux, mais de haute qualité...\nHmph, même ce Tony traîne dans le trafic\nd'armes...[000F][1205] Doué, cet enfoiré."
   },
   {
     "id": 82,
@@ -1662,7 +1662,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Seems[SP]their[SP]stock[SP]is[SP]cheap,[SP]but[SP]not[SP]the\nhighest[SP]quality.",
     "nom_fr": "Eikichi",
-    "texte_fr": "M-minute papillon![1205][U+000F] On en a pas encore\nfini avec le Temple de Scorpio.[1205][U+000F] Récupérons\nle crâne là-bas d'abord.[1106][NL]Un instant. Nous n'avons pas terminé le\nTemple d'Aquarius."
+    "texte_fr": "M-minute papillon![1205][U+000F] On en a pas encore\nfini avec le Temple de Scorpio.[1205][U+000F] Récupérons\nle crâne là-bas d'abord.[1106][NL]Un instant. Nous n'avons pas terminé le Temple d'Aquarius."
   },
   {
     "id": 111,
@@ -1767,7 +1767,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Blast[SP]it,[SP]I[SP]didn't[SP]win...[1205][000F][SP]Hm?[1205][000F][SP]Oh,[SP]I[SP]was[SP]just\nfuming[SP]about[SP]the[SP]magazine[SP]sweepstakes.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Tss, j'ai pas gagné...[1205][000F] Hm?[1205][000F] Oh, je pestais\njuste sur les loteries de magazines.[NL]Les gagnants pourraient y obtenir armes\net objets.[NL]Il est difficile de gagner, mais les\nprix sont assez bons. Je vais réessayer,\nj'imagine..."
+    "texte_fr": "Tss, j'ai pas gagné...[000F][1205] Hm?[000F][1205] Oh, je pestais\njuste sur les loteries de magazines.[NL]Les gagnants pourraient y obtenir armes\net objets.[NL]Il est difficile de gagner, mais les prix sont assez bons. Je vais réessayer, j'imagine..."
   },
   {
     "id": 118,
@@ -1812,7 +1812,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Blast[SP]it,[SP]I[SP]didn't[SP]win...[1205][000F][SP]Hm?[1205][000F][SP]Oh,[SP]I[SP]was[SP]just\nfuming[SP]about[SP]the[SP]magazine[SP]sweepstakes.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Tss, j'ai pas gagné...[1205][000F] Hm?[1205][000F] Oh, je pestais\njuste sur les loteries de magazines.[NL]Les gagnants pourraient y obtenir armes\net objets.[NL]Gagner serait difficile, mais les prix\nsont vraiment rares. Je vais réessayer,\nj'imagine..."
+    "texte_fr": "Tss, j'ai pas gagné...[000F][1205] Hm?[000F][1205] Oh, je pestais\njuste sur les loteries de magazines.[NL]Les gagnants pourraient y obtenir armes\net objets.[NL]Gagner serait difficile, mais les prix sont vraiment rares. Je vais réessayer, j'imagine..."
   },
   {
     "id": 121,
@@ -1857,7 +1857,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Blast[SP]it,[SP]I[SP]didn't[SP]win...[1205][000F][SP]Hm?[1205][000F][SP]Oh,[SP]I[SP]was[SP]just\nfuming[SP]about[SP]the[SP]magazine[SP]sweepstakes.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Tss, j'ai pas gagné...[1205][000F] Hm?[1205][000F] Oh, je pestais\njuste sur les loteries de magazines.[NL]Les gagnants pourraient y obtenir armes\net objets.[NL]Gagner serait facile, mais les prix ne\nsont pas mirobolants. Il est peut-être\ntemps d'arrêter..."
+    "texte_fr": "Tss, j'ai pas gagné...[000F][1205] Hm?[000F][1205] Oh, je pestais\njuste sur les loteries de magazines.[NL]Les gagnants pourraient y obtenir armes\net objets.[NL]Gagner serait facile, mais les prix ne sont pas mirobolants. Il est peut-être temps d'arrêter..."
   },
   {
     "id": 124,
@@ -1902,7 +1902,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Harumph.[SP]Gambling[SP]is[SP]a[SP]man's[SP]sport...[SP]To[SP]risk\nmoney,[SP]fame,[SP]and[SP]potentially[SP]even[SP]your[SP]life[SP]for\na[SP]fighting[SP]chance.[SP]A[SP]casino[SP]is[SP]a[SP]battlefield!",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille![NL]Je n'imaginais pas Mu être ce genre de\nlieu. Le sorcier des cartes va sévir...\nCar le poker est ma spécialité!"
+    "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille![NL]Je n'imaginais pas Mu être ce genre de lieu. Le sorcier des cartes va sévir... Car le poker est ma spécialité!"
   },
   {
     "id": 127,
@@ -1932,7 +1932,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Harumph.[SP]Gambling[SP]is[SP]a[SP]man's[SP]sport...[SP]To[SP]risk\nmoney,[SP]fame,[SP]and[SP]potentially[SP]even[SP]your[SP]life[SP]for\na[SP]fighting[SP]chance.[SP]A[SP]casino[SP]is[SP]a[SP]battlefield!",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille![NL]Mu étais donc aussi ce genre de lieu.\nLa chance qui ébranla Las Vegas va sévir...\nCar les machines à sous sont ma spécialité!"
+    "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille![NL]Mu étais donc aussi ce genre de lieu. La chance qui ébranla Las Vegas va sévir... Car les machines à sous sont ma spécialité!"
   },
   {
     "id": 129,
@@ -1962,7 +1962,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Harumph.[SP]Gambling[SP]is[SP]a[SP]man's[SP]sport...[SP]To[SP]risk\nmoney,[SP]fame,[SP]and[SP]potentially[SP]even[SP]your[SP]life[SP]for\na[SP]fighting[SP]chance.[SP]A[SP]casino[SP]is[SP]a[SP]battlefield!",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille![NL]Je n'imaginais pas Mu être ce genre de\nlieu. Mes tactiques imparables vont sévir...\nCar le blackjack est ma spécialité!"
+    "texte_fr": "Grumpf. Les paris sont un truc d'homme... On\nrisque argent, gloire, et parfois vie pour se\nbattre. Le casino est un champ de bataille![NL]Je n'imaginais pas Mu être ce genre de lieu. Mes tactiques imparables vont sévir... Car le blackjack est ma spécialité!"
   },
   {
     "id": 131,
@@ -2007,7 +2007,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "That[SP]Clair[SP]de[SP]Lune[SP]place[SP]is[SP]selling[SP]some[SP]sort\nof[SP]legendary[SP]weapon.[1205][000F][SP]Are[SP]you[SP]interested[SP]as[SP]well?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Cet endroit, Clair de Lune, vend une sorte\nd'arme légendaire.[1205][000F] Es-tu intéressé, toi aussi?"
+    "texte_fr": "Cet endroit, Clair de Lune, vend une sorte\nd'arme légendaire.[000F][1205] Es-tu intéressé, toi aussi?"
   },
   {
     "id": 134,
@@ -2022,7 +2022,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "The[SP]owner[SP]of[SP]Time[SP]Castle[SP]is[SP]claiming[SP]he[SP]has[SP]no\nlegendary[SP]weapon,[SP]just[SP]to[SP]drive[SP]up[SP]its[SP]price.[1205][000F]\nHah![SP]I'm[SP]not[SP]fooled,[SP]believe[SP]you[SP]me!",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Le gérant du Time Castle nie posséder une\narme légendaire, juste pour faire monter ses prix.[1205][000F]\nHah! Je suis pas dupe, crois-moi!"
+    "texte_fr": "Le gérant du Time Castle nie posséder une\narme légendaire, juste pour faire monter ses prix.[000F][1205]\nHah! Je suis pas dupe, crois-moi!"
   },
   {
     "id": 135,
@@ -2037,7 +2037,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Apparently,[SP]Time[SP]Castle's[SP]legendary[SP]weapon[SP]is\nheld[SP]up[SP]in[SP]transit.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "L'arme légendaire du Time Castle ne serait\npas encore arrivée.[NL]Le vendeur est encore à l'usine abandonnée.\nJ'imagine que quelqu'un devrait directement y\naller pour la lui acheter..."
+    "texte_fr": "L'arme légendaire du Time Castle ne serait\npas encore arrivée.[NL]Le vendeur est encore à l'usine abandonnée.\nJ'imagine que quelqu'un devrait directement y aller pour la lui acheter..."
   },
   {
     "id": 136,
@@ -2067,7 +2067,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "Demon,[SP]eh...?[1205][000F][SP]Well,[SP]the[SP]fantastical[SP]Last\nBattalion[SP]actually[SP]existed.[SP]Who's[SP]to[SP]say\ndemons[SP]don't[SP]as[SP]well?",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Un démon, hein...?[1205][000F] Eh bien, le Bataillon\nexistait vraiment. Donc pourquoi pas les\ndémons aussi?[NL]La rumeur des démons ayant volée l'arme\nlégendaire du Time Castle peut aussi être\nvraie. Mais qu'importe. L'ère des Idéaliens arrive!"
+    "texte_fr": "Un démon, hein...?[000F][1205] Eh bien, le Bataillon\nexistait vraiment. Donc pourquoi pas les\ndémons aussi?[NL]La rumeur des démons ayant volée l'arme légendaire du Time Castle peut aussi être vraie. Mais qu'importe. L'ère des Idéaliens arrive!"
   },
   {
     "id": 138,
@@ -2127,7 +2127,7 @@
     "nom_orig": "Pompous[SP]man",
     "texte_orig": "It[SP]seems[SP]the[SP]owner[SP]of[SP]Time[SP]Castle[SP]made[SP]a\npresent[SP]of[SP]his[SP]legendary[SP]weapon[SP]to[SP]a[SP]girl\nwith[SP]short[SP]hair.",
     "nom_fr": "Homme pompeux",
-    "texte_fr": "Le propriétaire du Time Castle aurait\noffert son arme légendaire à une fille\naux cheveux courts.[NL]Quel sacré manipulateur... Pas aussi doué\nque moi, ceci dit."
+    "texte_fr": "Le propriétaire du Time Castle aurait\noffert son arme légendaire à une fille\naux cheveux courts.[NL]Quel sacré manipulateur... Pas aussi doué que moi, ceci dit."
   },
   {
     "id": 142,
@@ -2412,7 +2412,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I'm[SP]surprised[SP]we[SP]made[SP]it[SP]out[SP]alive...[1205][000F][SP]I[SP]mean\nout[SP]of[SP]the[SP]blimp,[SP]not[SP]the[SP]museum...",
     "nom_fr": "Ginko",
-    "texte_fr": "Je pensais pas qu'on sortirais vivants...[1205][000F] Du\ndirigeable, hein, pas du musée..."
+    "texte_fr": "Je pensais pas qu'on sortirais vivants...[000F][1205] Du\ndirigeable, hein, pas du musée..."
   },
   {
     "id": 161,
@@ -2502,7 +2502,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "There's[SP]still[SP]people[SP]fighting[SP]in[SP]there!?[1205][000F]\nBut[SP]there's[SP]no[SP]crystal[SP]skull[SP]anymore!\nThere's[SP]nothing[SP]for[SP]them[SP]to[SP]fight[SP]over!",
     "nom_fr": "Ginko",
-    "texte_fr": "Il y a encore des gens qui se battent\nlà-dedans!?[1205][000F] Mais il n'y a plus de crâne\nde crytal pour lequel se battre!"
+    "texte_fr": "Il y a encore des gens qui se battent\nlà-dedans!?[000F][1205] Mais il n'y a plus de crâne\nde crytal pour lequel se battre!"
   },
   {
     "id": 167,
@@ -2562,7 +2562,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It[SP]was[SP]probably[SP]to[SP]prevent[SP]the[SP]police[SP]from\ninterfering...[1205][000F][SP]We're[SP]the[SP]only[SP]ones[SP]left[SP]who\ncan[SP]stop[SP]him[SP]now.",
     "nom_fr": "Maya",
-    "texte_fr": "C'était sûrement pour empêcher la police\nd'interférer...[1205][000F] Il ne reste que nous pour\nl'arrêter désormais."
+    "texte_fr": "C'était sûrement pour empêcher la police\nd'interférer...[000F][1205] Il ne reste que nous pour\nl'arrêter désormais."
   },
   {
     "id": 171,
@@ -2577,7 +2577,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We[SP]can't[SP]go[SP]in[SP]at[SP]this[SP]rate...[1205][000F][SP]The[SP]nerve[SP]of\nthat[SP]asshole!",
     "nom_fr": "Eikichi",
-    "texte_fr": "On peut pas continuer comme ça...[1205][000F] Ce\nconnard est gonflé!"
+    "texte_fr": "On peut pas continuer comme ça...[000F][1205] Ce\nconnard est gonflé!"
   },
   {
     "id": 172,
@@ -2682,7 +2682,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "H-Hold[SP]the[SP]phone,[SP]man.[1205][000F][SP]We're[SP]still[SP]not[SP]done\nwith[SP]Scorpio[SP]Temple.[1205][000F][SP]Let's[SP]go[SP]grab[SP]the[SP]skull\nfrom[SP]there[SP]first.",
     "nom_fr": "Eikichi",
-    "texte_fr": "M-minute papillon![1205][000F] On en a pas encore\nfini avec le Temple de Scorpio.[1205][000F] Récupérons\nle crâne là-bas d'abord.[NL]Un instant. Nous n'avons pas terminé le\nTemple d'Aquarius."
+    "texte_fr": "M-minute papillon![000F][1205] On en a pas encore\nfini avec le Temple de Scorpio.[000F][1205] Récupérons\nle crâne là-bas d'abord.[NL]Un instant. Nous n'avons pas terminé le Temple d'Aquarius."
   },
   {
     "id": 179,

--- a/traduction/MMAP05.json
+++ b/traduction/MMAP05.json
@@ -12,7 +12,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Is[SP]the[SP]Exalted[SP]One[SP]up[SP]there?[1205][000F][SP]I[SP]hear[SP]gunshots\nand[SP]yells[SP]from[SP]the[SP]summit...[1205][0014][SP]The[SP]battle[SP]must\nbe[SP]raging[SP]on.",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "L'Exalté est là-haut ?[1205][000F] J'entends\ndes coups de feu du sommet...[1205][0014]\nLa bataille fait rage.[NL]Ces soldats gardent le chemin de montagne\net personne ne peut passer. Ils ont même\npris le téléphérique ! Qu'est-ce qu'on fait !?"
+    "texte_fr": "L'Exalté est là-haut ?[000F][1205] J'entends\ndes coups de feu du sommet...[0014][1205]\nLa bataille fait rage.[NL]Ces soldats gardent le chemin de montagne et personne ne peut passer. Ils ont même pris le téléphérique ! Qu'est-ce qu'on fait !?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "But[SP]those[SP]soldiers[SP]are[SP]guarding[SP]the[SP]mountain\npath[SP]and[SP]no[SP]one[SP]can[SP]get[SP]through.[1205][000F][SP]They've[SP]even\ntaken[SP]over[SP]the[SP]cable[SP]car![1205][000A][SP]What[SP]should[SP]we[SP]do!?",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Hé ! Ces météores ?[1205][U+000F] C'était\nles Léonides...[1205][U+000A] Rugissement du lion !\n[1205][U+000A]Hahaha, encore une étape de l'Oracle ![1106][NL]L'Exalté vit encore ![1205][U+000A] Nous évoluerons\nen Idéaliens, comme l'In Lak'ech\nl'a prédit ![000F][000A]"
+    "texte_fr": "Hé ! Ces météores ?[1205][U+000F] C'était\nles Léonides...[1205][U+000A] Rugissement du lion !\n[1205][U+000A]Hahaha, encore une étape de l'Oracle ![1106][NL]L'Exalté vit encore ![1205][U+000A] Nous évoluerons en Idéaliens, comme l'In Lak'ech l'a prédit ![000F][000A]"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Hey![SP]Did[SP]you[SP]see[SP]those[SP]meteors?[1205][000F][SP]Those[SP]were[SP]the\nLeonids...[1205][000A][SP]The[SP]lion's[SP]roar![1205][000A][SP]Hahaha,[SP]another\nstep[SP]in[SP]the[SP]Oracle[SP]fulfilled!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Hé ! Ces météores ?[1205][000F] C'était\nles Léonides...[1205][000A] Rugissement du lion !\n[1205][000A]Hahaha, encore une étape de l'Oracle ![NL]L'Exalté vit encore ! Nous évoluerons\nen Idéaliens, comme l'In Lak'ech\nl'a prédit !"
+    "texte_fr": "Hé ! Ces météores ?[000F][1205] C'était\nles Léonides...[000A][1205] Rugissement du lion !\n[000A][1205]Hahaha, encore une étape de l'Oracle ![NL]L'Exalté vit encore ! Nous évoluerons en Idéaliens, comme l'In Lak'ech l'a prédit !"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "The[SP]Exalted[SP]One[SP]still[SP]lives![1205][000A][SP]We[SP]will[SP]evolve\ninto[SP]Idealians,[SP]just[SP]as[SP]the[SP]In[SP]Lak'ech[SP]has\nforetold!",
     "nom_fr": "Randonneur",
-    "texte_fr": "Oh ![1205][U+0008] J'avais presque oublié l'essentiel.[1205][U+000A]\nMon vrai but sur le Mont Katatsumuri ![1106][NL]Hein ?[1205][U+000A] Vraiment ?[1106][NL]Le [E4][NULL][NULL][U+0006]Vieux Sauteur[E4][NULL][NULL][0002], c'est lui ![1205][U+000A]\nLe Vieux Sauteur ![1205][U+000A] J'ai vu un vieux sauter\nde branche en branche l'autre fois. Sérieux ![1205][U+000A][1106][NL]Un gars aussi vieux qui fait ça, seul\nle vrai Vieux Sauteur le peut ![1205][U+000F]\nJ'arrive pas à croire ma chance ![1106][NL]Voilà pourquoi je voulais une preuve\nphotographique, et peut-être une photo\npour moi.[1106][NL]Mais avec ces militaires,\nma chance est envolée...[1106][NL]Hé, vous pourriez me rapporter une preuve[1205][U+000F]\nque le Vieux Sauteur existe ?[1205][U+000F]\nJe vous donne une récompense ! S'il vous plaîîît ![000A]"
+    "texte_fr": "Oh ![1205][U+0008] J'avais presque oublié l'essentiel.[1205][U+000A]\nMon vrai but sur le Mont Katatsumuri ![1106][NL]Hein ?[1205][U+000A] Vraiment ?[1106][NL]Le [E4][NULL][NULL][U+0006]Vieux Sauteur[E4][NULL][NULL][0002], c'est lui ![1205][U+000A]\nLe Vieux Sauteur ![1205][U+000A] J'ai vu un vieux sauter de branche en branche l'autre fois. Sérieux ![1205][U+000A][1106][NL]Un gars aussi vieux qui fait ça, seul le vrai Vieux Sauteur le peut ![1205][U+000F] J'arrive pas à croire ma chance ![1106][NL]Voilà pourquoi je voulais une preuve photographique, et peut-être une photo pour moi.[1106][NL]Mais avec ces militaires, ma chance est envolée...[1106][NL]Hé, vous pourriez me rapporter une preuve[1205][U+000F] que le Vieux Sauteur existe ?[1205][U+000F] Je vous donne une récompense ! S'il vous plaîîît ![000A]"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Walking[SP]along,[SP]checking[SP]out[SP]the[SP]scenery...[1205][000F]\nMountain[SP]climbing[SP]like[SP]usual,[SP]heigh-ho...\nHm?[SP]Aaaaaaaaaaaah!",
     "nom_fr": "Randonneur",
-    "texte_fr": "Je me promenais admirant le paysage...[1205][000F]\nJe grimpais comme d'hab, tra-la-la...\nHm ? Aaaaaaaaaaaah ![NL]...Et d'un coup. Des soldats armés jusqu'aux\ndents ont grimpé la montagne et je me\nsuis à peine sorti vivant.[NL]Pfff, j'avais une belle rando avant ça !\nC'est quoi leur problème !?"
+    "texte_fr": "Je me promenais admirant le paysage...[000F][1205]\nJe grimpais comme d'hab, tra-la-la...\nHm ? Aaaaaaaaaaaah ![NL]...Et d'un coup. Des soldats armés jusqu'aux dents ont grimpé la montagne et je me suis à peine sorti vivant.[NL]Pfff, j'avais une belle rando avant ça ! C'est quoi leur problème !?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "...Bam,[SP]just[SP]like[SP]that.[SP]Suddenly[SP]these[SP]soldiers\nwith[SP]scary[SP]weapons[SP]came[SP]up[SP]the[SP]mountain[SP]and[SP]I\nbarely[SP]got[SP]back[SP]down[SP]here[SP]with[SP]my[SP]life.",
     "nom_fr": "Randonneur",
-    "texte_fr": "Attendez...[1205][U+000F] Ce sont les [E4][NULL][NULL][U+0006]Geta Sauteurs[E4][NULL][NULL][0002]\ndu Vieux Sauteur ?[1106][NL]Ooooooh ![1205][U+000F] Vous les avez eus !?[1205][U+000F]\nAhhhh, c'est encore mieux qu'une photo ![1205][U+000F]\nMerci ! Oh, c'est trop bien ![1106][NL]Tenez, voici quelque chose pour vous.\nC'est une [E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Carte Lumière[E4][NULL][NULL][0002]. Je vous l'offre !"
+    "texte_fr": "Attendez...[1205][U+000F] Ce sont les [E4][NULL][NULL][U+0006]Geta Sauteurs[E4][NULL][NULL][0002]\ndu Vieux Sauteur ?[1106][NL]Ooooooh ![1205][U+000F] Vous les avez eus !?[1205][U+000F]\nAhhhh, c'est encore mieux qu'une photo ![1205][U+000F] Merci ! Oh, c'est trop bien ![1106][NL]Tenez, voici quelque chose pour vous. C'est une [E4][NULL][NULL][U+0004][U+1433][NULL][NULL][U+0004]Carte Lumière[E4][NULL][NULL][0002]. Je vous l'offre !"
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Oh![1205][0008][SP]I[SP]almost[SP]forgot[SP]the[SP]important[SP]part.[1205][000A][SP]The\nwhole[SP]reason[SP]I[SP]was[SP]hiking[SP]on[SP]Mt.[SP]Katatsumuri!",
     "nom_fr": "Randonneur",
-    "texte_fr": "Oh ![1205][0008] J'avais presque oublié l'essentiel.[1205][000A]\nMon vrai but sur le Mont Katatsumuri ![NL]Hein ? Vraiment ?[NL]Le [E4][NULL][NULL]Vieux Sauteur[E4][NULL][NULL], c'est lui !\nLe Vieux Sauteur ! J'ai vu un vieux sauter\nde branche en branche l'autre fois. Sérieux ![NL]Un gars aussi vieux qui fait ça, seul\nle vrai Vieux Sauteur le peut !\nJ'arrive pas à croire ma chance ![NL]Voilà pourquoi je voulais une preuve\nphotographique, et peut-être une photo\npour moi.[NL]Mais avec ces militaires,\nma chance est envolée...[NL]Hé, vous pourriez me rapporter une preuve\nque le Vieux Sauteur existe ?\nJe vous donne une récompense ! S'il vous plaîîît !"
+    "texte_fr": "Oh ![0008][1205] J'avais presque oublié l'essentiel.[000A][1205]\nMon vrai but sur le Mont Katatsumuri ![NL]Hein ? Vraiment ?[NL]Le [E4][NULL][NULL]Vieux Sauteur[E4][NULL][NULL], c'est lui !\nLe Vieux Sauteur ! J'ai vu un vieux sauter de branche en branche l'autre fois. Sérieux ![NL]Un gars aussi vieux qui fait ça, seul le vrai Vieux Sauteur le peut ! J'arrive pas à croire ma chance ![NL]Voilà pourquoi je voulais une preuve photographique, et peut-être une photo pour moi.[NL]Mais avec ces militaires, ma chance est envolée...[NL]Hé, vous pourriez me rapporter une preuve que le Vieux Sauteur existe ? Je vous donne une récompense ! S'il vous plaîîît !"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Huh?[1205][000A][SP]You[SP]really[SP]want[SP]to[SP]know?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, [U+1113], on peut utiliser\nce téléphérique ![1106][NL]On le prend ?\n[1208][0002]Oui\nNon[1205][000A]"
+    "texte_fr": "Hé, [U+1113], on peut utiliser\nce téléphérique ![1106][NL]On le prend ?\n[1208][0002]Oui\nNon[000A][1205]"
   },
   {
     "id": 9,
@@ -222,7 +222,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Jumping[SP]Geezer[SP]is[SP]somewhere[SP]in[SP]Mt.[SP]Katatsumuri.[1205][000F]\nBring[SP]back[SP]some[SP]proof[SP]he[SP]exists![1205][000F][SP]I'll[SP]give[SP]you\na[SP]proper[SP]reward,[SP]so[SP]pleeeeeease!",
     "nom_fr": "Randonneur",
-    "texte_fr": "Le Vieux Sauteur est sur le Mont\nKatatsumuri.[1205][000F] Ramenez-moi une preuve ![1205][000F]\nJe vous récompense, s'il vous plaîîît !"
+    "texte_fr": "Le Vieux Sauteur est sur le Mont\nKatatsumuri.[000F][1205] Ramenez-moi une preuve ![000F][1205]\nJe vous récompense, s'il vous plaîîît !"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Wait[SP]a[SP]second...[1205][000F][SP]Are[SP]those[SP]the[SP][E4][NULL][NULL][0006]Jumping[SP]Geta[E4][NULL][NULL][0002]\nthat[SP]the[SP]Jumping[SP]Geezer[SP]wore?",
     "nom_fr": "Randonneur",
-    "texte_fr": "Attendez...[1205][000F] Ce sont les [E4][NULL][NULL][0006]Geta Sauteurs[E4][NULL][NULL][0002]\ndu Vieux Sauteur ?[NL]Ooooooh ! Vous les avez eus !?\nAhhhh, c'est encore mieux qu'une photo !\nMerci ! Oh, c'est trop bien ![NL]Tenez, voici quelque chose pour vous.\nC'est une [E4][NULL][NULL][NULL][NULL]Carte Lumière[E4][NULL][NULL]. Je vous l'offre !"
+    "texte_fr": "Attendez...[000F][1205] Ce sont les [E4][NULL][NULL][0006]Geta Sauteurs[E4][NULL][NULL][0002]\ndu Vieux Sauteur ?[NL]Ooooooh ! Vous les avez eus !?\nAhhhh, c'est encore mieux qu'une photo ! Merci ! Oh, c'est trop bien ![NL]Tenez, voici quelque chose pour vous. C'est une [E4][NULL][NULL][NULL][NULL]Carte Lumière[E4][NULL][NULL]. Je vous l'offre !"
   },
   {
     "id": 16,
@@ -282,7 +282,7 @@
     "nom_orig": "Hiker",
     "texte_orig": "Heheheh,[SP]so[SP]these[SP]are[SP]the[SP]Jumping[SP]Geta...[1205][000F]\nCan[SP]I[SP]move[SP]as[SP]fast[SP]as[SP]that[SP]old[SP]man[SP]with[SP]these\non?[1205][000F][SP]Maybe[SP]I[SP]should[SP]give[SP]'em[SP]a[SP]try.",
     "nom_fr": "Randonneur",
-    "texte_fr": "Héhéhé, ce sont les Geta Sauteurs...[1205][000F]\nJe peux bouger aussi vite que ce vieux\navec eux ?[1205][000F] Je devrais les essayer."
+    "texte_fr": "Héhéhé, ce sont les Geta Sauteurs...[000F][1205]\nJe peux bouger aussi vite que ce vieux\navec eux ?[000F][1205] Je devrais les essayer."
   },
   {
     "id": 19,
@@ -312,7 +312,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP][1113],[SP]it[SP]looks[SP]like[SP]we[SP]can[SP]use[SP]this\ncable[SP]car.",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, [1113], on peut utiliser\nce téléphérique ![NL]On le prend ?\nOui\nNon"
+    "texte_fr": "Hé, [1113], on peut utiliser\nce téléphérique ![NL]On le prend ?\nOui Non"
   },
   {
     "id": 21,

--- a/traduction/MMAP06.json
+++ b/traduction/MMAP06.json
@@ -57,7 +57,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "Do[SP]you[SP]know[SP]the[SP]homeless[SP]man[SP]in[SP]Honmaru[SP]Park?\nI[SP]hear[SP]he[SP]used[SP]to[SP]be[SP]a[SP]college[SP]professor.[1205][000F]\nI[SP]wonder[SP]how[SP]he[SP]became[SP]homeless...",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Tu connais le SDF du parc Honmaru ? Ancien prof.\n Comment en est-il arrivé là ?[1205][000F]"
+    "texte_fr": "Tu connais le SDF du parc Honmaru ? Ancien prof.\n Comment en est-il arrivé là ?[000F][1205]"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "Huh?[1205][000A][SP]The[SP]Masked[SP]Circle?[1205][000F][SP]Can't[SP]say[SP]I've[SP]ever\nheard[SP]of[SP]them,[SP]no.[SP]Is[SP]there[SP]an[SP]organization[SP]in\nSumaru[SP]by[SP]that[SP]name?",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Hein ? Le Cercle Masqué ?[1205][000A] Jamais entendu parler.\n Une organisation à Sumaru porte ce nom ?[1205][000F]"
+    "texte_fr": "Hein ? Le Cercle Masqué ?[000A][1205] Jamais entendu parler.\n Une organisation à Sumaru porte ce nom ?[000F][1205]"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "I[SP]haven't[SP]seen[SP]any[SP]Kasugayama[SP]High[SP]students\naround[SP]lately.[1205][000F][SP]I[SP]wonder[SP]if[SP]they[SP]all[SP]went[SP]on\na[SP]school[SP]trip...",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Je n'ai vu aucun élève de Kasugayama ces temps-ci.[1205][000F]\n En voyage scolaire ?"
+    "texte_fr": "Je n'ai vu aucun élève de Kasugayama ces temps-ci.[000F][1205]\n En voyage scolaire ?"
   },
   {
     "id": 6,
@@ -132,7 +132,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "I[SP]bet[SP]the[SP]Masked[SP]Circle[SP]are[SP]the[SP]terrorists\nhere.[1205][000F][SP]No[SP]sane[SP]man[SP]would[SP]do[SP]these[SP]things...\nSo[SP]the[SP]Masked[SP]Circle[SP]was[SP]sinister[SP]after[SP]all.",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "C'est sûrement le Cercle Masqué les terroristes.[1205][000F]\n Aucun sain d'esprit ne ferait ça...\n Donc ils étaient sinistres."
+    "texte_fr": "C'est sûrement le Cercle Masqué les terroristes.[000F][1205]\n Aucun sain d'esprit ne ferait ça...\n Donc ils étaient sinistres."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "They[SP]posted[SP]the[SP]composite[SP]sketches[SP]of[SP]those\nterrorists,[SP]so[SP]I[SP]went[SP]to[SP]see[SP]for[SP]myself.[1205][000F][SP]All[SP]five\nof[SP]them[SP]were[SP]the[SP]scariest-looking[SP]people...",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Les portraits-robots des terroristes sont affichés, je suis allée voir.[1205][000F]\n Les cinq avaient l'air terrifiant..."
+    "texte_fr": "Les portraits-robots des terroristes sont affichés, je suis allée voir.[000F][1205]\n Les cinq avaient l'air terrifiant..."
   },
   {
     "id": 10,
@@ -192,7 +192,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "I-I[SP]almost[SP]got[SP]attacked[SP]by[SP]those[SP]soldiers[SP]just\nnow...[1205][000F][SP]It[SP]was[SP]terrifying...[1205][000F]",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "J'ai failli me faire attaquer par ces soldats...[1205][000F]\n Terrible...[NL]Un membre du Cercle Masqué m'a sauvée ![1205][000F]\n Que se passe-t-il ?[NL]J'avais mal jugé..."
+    "texte_fr": "J'ai failli me faire attaquer par ces soldats...[000F][1205]\n Terrible...[NL]Un membre du Cercle Masqué m'a sauvée ![000F][1205]\n Que se passe-t-il ?[NL]J'avais mal jugé..."
   },
   {
     "id": 13,
@@ -237,7 +237,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "Hey![1205][000F][SP]S-Some[SP]of[SP]those[SP]Masked[SP]Circle[SP]people\nsaw[SP]the[SP]shooting[SP]stars[SP]and[SP]said,[SP][1432][NULL][NULL][0014]It's[SP]the\nlion's[SP]roar![1432][NULL][NULL][0014][1205][000F]",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Hé ! Des gens du Cercle Masqué ont dit : [1432][NULL][NULL][0014]C'est le rugissement du lion ![1432][NULL][NULL][0014][1205][000F][NL]C'est encore une phrase de l'Oracle, non ?\n L'In Lak'ech est donc vrai ![1205][000F]"
+    "texte_fr": "Hé ! Des gens du Cercle Masqué ont dit : [1432][NULL][NULL][0014]C'est le rugissement du lion ![1432][NULL][NULL][0014][000F][1205][NL]C'est encore une phrase de l'Oracle, non ?\n L'In Lak'ech est donc vrai ![000F][1205]"
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "Have[SP]you[SP]been[SP]to[SP]Honmaru[SP]Park[SP]already?[1205][000A][SP]They're\nhaving[SP]a[SP]gathering[SP]to[SP]evolve[SP]into[SP]Idealians\nright[SP]now!",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Tu es allé au parc Honmaru ?[1205][000A] Ils se rassemblent\n pour devenir Idéaliens là maintenant !"
+    "texte_fr": "Tu es allé au parc Honmaru ?[000A][1205] Ils se rassemblent\n pour devenir Idéaliens là maintenant !"
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "H-Hey![1205][000A][SP]You're[SP]a[SP]Sevens[SP]student,[SP]right?[1205][000A][SP]What's\nthat[SP]light[SP]coming[SP]out[SP]from[SP]your[SP]school?",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "Hé ! Tu es de Seven ?[1205][000A] C'est quoi cette lumière\n qui sort de ton école ?[NL]L'évolution a déjà commencé ?[1205][000A] Oh non,\n je ne suis pas prête !"
+    "texte_fr": "Hé ! Tu es de Seven ?[000A][1205] C'est quoi cette lumière\n qui sort de ton école ?[NL]L'évolution a déjà commencé ?[000A][1205] Oh non,\n je ne suis pas prête !"
   },
   {
     "id": 19,
@@ -312,7 +312,7 @@
     "nom_orig": "Housewife",
     "texte_orig": "*sigh*[1205][0008][SP]I[SP]wish[SP]they'd[SP]get[SP]this[SP]evolution[SP]thing\nover[SP]with...[1205][000A][SP]I[SP]feel[SP]like[SP]the[SP]excitement[SP]has\npassed[SP]and[SP]I'm[SP]losing[SP]interest.",
     "nom_fr": "Femme au foyer",
-    "texte_fr": "*soupir*[1205][0008] J'aimerais en finir avec cette évolution...[1205][000A]\n L'excitation est retombée, ça ne m'intéresse plus."
+    "texte_fr": "*soupir*[0008][1205] J'aimerais en finir avec cette évolution...[000A][1205]\n L'excitation est retombée, ça ne m'intéresse plus."
   },
   {
     "id": 21,
@@ -342,7 +342,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "My[SP]colleagues[SP]have[SP]been[SP]pretty[SP]distant[SP]lately.\nThey[SP]keep[SP]leaving[SP]before[SP]me[SP]because[SP]they[SP]have\nsome[SP]meeting[SP]to[SP]attend.[1205][000F][SP]Are[SP]they[SP]in[SP]some[SP]union?",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Mes collègues sont distants. Ils partent avant moi pour une réunion.[1205][000F]\n Sont-ils syndiqués ?"
+    "texte_fr": "Mes collègues sont distants. Ils partent avant moi pour une réunion.[000F][1205]\n Sont-ils syndiqués ?"
   },
   {
     "id": 23,
@@ -387,7 +387,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Do[SP]you[SP]know[SP]who[SP]the[SP]third[SP]member[SP]of[SP]Muses[SP]is?[1205][000F]\nShe's[SP]apparently[SP]a[SP]Sevens[SP]student[SP]like[SP]you.[SP]If\nyou[SP]know[SP]her,[SP]would[SP]you[SP]mind[SP]introducing[SP]me?",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Tu sais qui est le troisième membre de Muses ?[1205][000F]\n Une élève de Seven comme toi. Tu pourrais me la présenter ?"
+    "texte_fr": "Tu sais qui est le troisième membre de Muses ?[000F][1205]\n Une élève de Seven comme toi. Tu pourrais me la présenter ?"
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "They're[SP]going[SP]to[SP]announce[SP]the[SP]third[SP]member[SP]of\nMuses[SP]at[SP]the[SP]live[SP]recording[SP]at[SP]Giga[SP]Macho.[1205][000F]\nI[SP]wonder[SP]what[SP]she's[SP]like.[SP]I[SP]can't[SP]wait!",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Ils annoncent le 3e membre de Muses au live de Giga Macho.[1205][000F]\n J'ai hâte de voir à quoi elle ressemble !"
+    "texte_fr": "Ils annoncent le 3e membre de Muses au live de Giga Macho.[000F][1205]\n J'ai hâte de voir à quoi elle ressemble !"
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "So[SP]the[SP]third[SP]member's[SP]fluent[SP]in[SP]English...[1205][000F]\nI[SP]see...",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "La 3e parle anglais couramment...[1205][000F]\n Je vois...[NL]Une idole bilingue ? J'aime ça. Ça fait intellectuel.\n J'ai hâte d'entendre son solo."
+    "texte_fr": "La 3e parle anglais couramment...[000F][1205]\n Je vois...[NL]Une idole bilingue ? J'aime ça. Ça fait intellectuel.\n J'ai hâte d'entendre son solo."
   },
   {
     "id": 28,
@@ -447,7 +447,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Fortunately,[SP]there[SP]were[SP]no[SP]casualties[SP]in[SP]the\nconcert[SP]hall[SP]fire.[1205][000F][SP]But[SP]whose[SP]concert[SP]was\nit?[SP]I[SP]can't[SP]really[SP]remember...",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Heureusement, pas de victimes dans l'incendie.[1205][000F]\n C'était le concert de qui ? Je ne me souviens pas."
+    "texte_fr": "Heureusement, pas de victimes dans l'incendie.[000F][1205]\n C'était le concert de qui ? Je ne me souviens pas."
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Wasn't[SP]that[SP]one[SP]of[SP]the[SP]teachers[SP]at[SP]Sevens...?[1205][000F]\nShe[SP]had[SP]this[SP]crazy[SP]expression[SP]and[SP]told[SP]me[SP]that\nthe[SP]terrorists[SP]were[SP]this[SP]Last...[SP]something.",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "C'était une prof de Seven ?[1205][000F] Elle avait l'air folle\n et m'a dit que les terroristes étaient ce... Dernier quelque chose."
+    "texte_fr": "C'était une prof de Seven ?[000F][1205] Elle avait l'air folle\n et m'a dit que les terroristes étaient ce... Dernier quelque chose."
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Some[SP]kids[SP]just[SP]now[SP]said[SP]that[SP]the[SP]five[SP]people[SP]in\nthose[SP]composite[SP]sketches[SP]are[SP]heroes[SP]fighting[SP]the\nMasked[SP]Circle.[1205][000F][SP]Now[SP]how[SP]would[SP]they[SP]know[SP]that?",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Des gamins disent que les 5 personnes des portraits sont des héros.[1205][000F]\n Comment pourraient-ils savoir ça ?"
+    "texte_fr": "Des gamins disent que les 5 personnes des portraits sont des héros.[000F][1205]\n Comment pourraient-ils savoir ça ?"
   },
   {
     "id": 32,
@@ -507,7 +507,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "D-Did[SP]you[SP]see[SP]the[SP]size[SP]of[SP]that[SP]air[SP]fleet?\nThere[SP]were[SP]20[SP]of[SP]them,[SP]easy![1205][000F][SP]Th-They've[SP]come\nto[SP]steal[SP]Sumaru's[SP]hidden[SP]treasure!",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "T'as vu cette flotte aérienne ? 20 appareils, facile ![1205][000F]\n Ils sont venus voler le trésor caché de Sumaru !"
+    "texte_fr": "T'as vu cette flotte aérienne ? 20 appareils, facile ![000F][1205]\n Ils sont venus voler le trésor caché de Sumaru !"
   },
   {
     "id": 34,
@@ -522,7 +522,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "These[SP]weird[SP]temples[SP]showed[SP]up[SP]in[SP]the[SP]other\nwards,[SP]right?[1205][000A][SP]The[SP]Masked[SP]Circle[SP]and[SP]Last\nBattalion[SP]were[SP]going[SP]in[SP]to[SP]fight[SP]each[SP]other!",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Ces étranges temples sont apparus ailleurs, non ?[1205][000A]\n Le Cercle Masqué et le Dernier Bataillon y entraient pour se battre ![NL]Mais pourquoi aucun temple n'est apparu ici ?\n Ça m'inquiète..."
+    "texte_fr": "Ces étranges temples sont apparus ailleurs, non ?[000A][1205]\n Le Cercle Masqué et le Dernier Bataillon y entraient pour se battre ![NL]Mais pourquoi aucun temple n'est apparu ici ?\n Ça m'inquiète..."
   },
   {
     "id": 35,
@@ -552,7 +552,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "You're[SP]safe?[1205][000A][SP]I'd[SP]heard[SP]the[SP]Last[SP]Battalion\ncaptured[SP]all[SP]the[SP]Sevens[SP]students.[1205][000F][SP]Did[SP]you\nmanage[SP]to[SP]escape?",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Tu es sain et sauf ?[1205][000A] Les élèves de Seven ont été capturés.[1205][000F]\n Tu t'es échappé ?"
+    "texte_fr": "Tu es sain et sauf ?[000A][1205] Les élèves de Seven ont été capturés.[000F][1205]\n Tu t'es échappé ?"
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "I[SP]hear[SP]the[SP]students[SP]at[SP]Sevens[SP]got[SP]rescued.[1205][000A]\nI[SP]don't[SP]know[SP]who[SP]pulled[SP]that[SP]off,[SP]but[SP]they're\nsome[SP]damn[SP]brave[SP]people,[SP]whoever[SP]they[SP]are.",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "J'entends que les élèves de Seven ont été secourus.[1205][000A]\n Je ne sais pas qui a fait ça, mais ce sont des gens courageux."
+    "texte_fr": "J'entends que les élèves de Seven ont été secourus.[000A][1205]\n Je ne sais pas qui a fait ça, mais ce sont des gens courageux."
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Um,[SP]I[SP]hear[SP]a[SP]ramen[SP]shop[SP]sells[SP]guns[SP]and[SP]swords\nand[SP]stuff.[SP]I[SP]wonder[SP]if[SP]they[SP]have[SP]a[SP]really\ncool[SP]sword.[E1][E2]\n[E3][E4][NULL][NULL]\"Boy\nDid[SP]the[SP]boys[SP]at[SP]Cuss[SP]High[SP]get[SP]cooler?[1205][000F][SP]That's\nwhat[SP]my[SP]sister[SP]said.[SP]How[SP]do[SP]they[SP]do[SP]that?\nDo[SP]they[SP]transform?",
     "nom_fr": "Garçon",
-    "texte_fr": "Un resto de ramen vend des flingues et des épées.\n Ils ont une épée super cool ?[E1][E2]\n[E3][E4][NULL][NULL]\"Garçon\nLes garçons du lycée Cuss sont plus cools ?[1205][000F]\n C'est ce que ma sœur a dit. Comment ils font ?\n Ils se transforment ?"
+    "texte_fr": "Un resto de ramen vend des flingues et des épées.\n Ils ont une épée super cool ?[E1][E2]\n[E3][E4][NULL][NULL]\"Garçon\nLes garçons du lycée Cuss sont plus cools ?[000F][1205]\n C'est ce que ma sœur a dit. Comment ils font ?\n Ils se transforment ?"
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Waaaaah![1205][000F][SP]I[SP]wanted[SP]to[SP]go[SP]to[SP]Kasuga[SP]Festival!\nMy[SP]sister[SP]said[SP]kids[SP]can't[SP]go.[1205][000F][SP]It's[SP]not[SP]faaaair!",
     "nom_fr": "Garçon",
-    "texte_fr": "Waaaaah ![1205][000F] Je voulais aller au festival Kasuga !\n Les enfants ne peuvent pas.[1205][000F] Pas juste !"
+    "texte_fr": "Waaaaah ![000F][1205] Je voulais aller au festival Kasuga !\n Les enfants ne peuvent pas.[000F][1205] Pas juste !"
   },
   {
     "id": 40,
@@ -672,7 +672,7 @@
     "nom_orig": "Boy",
     "texte_orig": "But[SP]I[SP]think[SP]I[SP]was[SP]waiting[SP]for[SP]someone[SP]here.[1205][000F]\nI[SP]can't[SP]remember[SP]who[SP]though.",
     "nom_fr": "Garçon",
-    "texte_fr": "Bukimi est vraiment au lycée Cuss ?\n Elle fait plus peur qu'Hanako.\n Vous êtes mort si elle vous voit.[1205][000F]"
+    "texte_fr": "Bukimi est vraiment au lycée Cuss ?\n Elle fait plus peur qu'Hanako.\n Vous êtes mort si elle vous voit.[000F][1205]"
   },
   {
     "id": 45,
@@ -702,7 +702,7 @@
     "nom_orig": "Boy",
     "texte_orig": "The[SP]people[SP]in[SP]the[SP]drawings[SP]are[SP]heroes[SP]and\nthey[SP]fight[SP]the[SP]Masked[SP]Circle.[1205][000F][SP]My[SP]friend\ntold[SP]me.",
     "nom_fr": "Garçon",
-    "texte_fr": "Les dessins montrent des héros combattant le Cercle Masqué.[1205][000F]\n Mon ami l'a dit."
+    "texte_fr": "Les dessins montrent des héros combattant le Cercle Masqué.[000F][1205]\n Mon ami l'a dit."
   },
   {
     "id": 47,
@@ -717,7 +717,7 @@
     "nom_orig": "Boy",
     "texte_orig": "What's[SP]Xibalba[SP]like?[1205][000F][SP]Does[SP]it[SP]combine[SP]with\nstuff[SP]and[SP]transform?",
     "nom_fr": "Garçon",
-    "texte_fr": "C'est quoi Xibalba ?[1205][000F]\n Ça se combine et ça se transforme ?"
+    "texte_fr": "C'est quoi Xibalba ?[000F][1205]\n Ça se combine et ça se transforme ?"
   },
   {
     "id": 48,
@@ -732,7 +732,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Waaaaaah![SP]Waaaaaah![1205][000F][SP]I'm[SP]scaaaared![SP]Mommy!\nSister!",
     "nom_fr": "Garçon",
-    "texte_fr": "Waaaaaah ! [1205][000F]J'ai peur !\n Maman ! Ma sœur !"
+    "texte_fr": "Waaaaaah ! [000F][1205]J'ai peur !\n Maman ! Ma sœur !"
   },
   {
     "id": 49,
@@ -747,7 +747,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Woooow...[SP]The[SP]city's[SP]flying![1205][000A][SP]But[SP]the[SP]Earth[SP]is\ngonna[SP]get[SP]uh-nye-a-lated[SP]after[SP]the[SP]Grand[SP]Cross.",
     "nom_fr": "Garçon",
-    "texte_fr": "Woooow... La ville vole ![1205][000A] Mais la Terre va être anéantie\n après la Grande Croix."
+    "texte_fr": "Woooow... La ville vole ![000A][1205] Mais la Terre va être anéantie\n après la Grande Croix."
   },
   {
     "id": 50,
@@ -777,7 +777,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Um,[SP]so,[SP]I[SP]heard[SP]the[SP]Earth's[SP]gonna[SP]split[SP]open\nafter[SP]the[SP]Grand[SP]Cross.[1205][000A][SP]That's[SP]how[SP]it[SP]gets\nuh-nye-a-lated.",
     "nom_fr": "Garçon",
-    "texte_fr": "J'ai entendu que la Terre va se fendre après la Grande Croix.[1205][000A]\n C'est comme ça qu'elle est anéantie."
+    "texte_fr": "J'ai entendu que la Terre va se fendre après la Grande Croix.[000A][1205]\n C'est comme ça qu'elle est anéantie."
   },
   {
     "id": 52,
@@ -837,7 +837,7 @@
     "nom_orig": "Boy",
     "texte_orig": "After[SP]the[SP]Grand[SP]Cross,[SP]the[SP]Earth's[SP]gonna[SP]stop\nspinning.[1205][000A][SP]That's[SP]what[SP]my[SP]daddy[SP]said.",
     "nom_fr": "Garçon",
-    "texte_fr": "Après la Grande Croix, la Terre va s'arrêter.[1205][000A]\n C'est mon papa.[NL]C'est ça, anéanti ? La Terre s'arrête ?\n Je ne comprends pas."
+    "texte_fr": "Après la Grande Croix, la Terre va s'arrêter.[000A][1205]\n C'est mon papa.[NL]C'est ça, anéanti ? La Terre s'arrête ?\n Je ne comprends pas."
   },
   {
     "id": 56,
@@ -852,7 +852,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Is[SP]that[SP]what[SP]uh-nye-a-lated[SP]means?[SP]The[SP]Earth\nstops[SP]spinning?[1205][000F][SP]I[SP]don't[SP]get[SP]it.",
     "nom_fr": "Garçon",
-    "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop.[1106][NL]Ils vendent plein de trucs, mais reprennent pas cher.[1205][000F]"
+    "texte_fr": "Il y a un magasin d'armes à Yumezaki : Tony's Shop.[1106][NL]Ils vendent plein de trucs, mais reprennent pas cher.[000F][1205]"
   },
   {
     "id": 57,
@@ -972,7 +972,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Is[SP]there[SP]really[SP]a[SP]ghost[SP]in[SP]the[SP]park[SP]by[SP]the\nconcert[SP]hall?[SP]Um,[SP]I[SP]heard[SP]it's[SP]an[SP]idol's[SP]ghost.[1205][000F]\nWhat[SP]do[SP]I[SP]do?[SP]My[SP]treasure's[SP]buried[SP]there...",
     "nom_fr": "Garçon",
-    "texte_fr": "Il y a vraiment un fantôme dans le parc près de la salle ?\n C'est le fantôme d'une idole.[1205][000F] Mon trésor est enterré là..."
+    "texte_fr": "Il y a vraiment un fantôme dans le parc près de la salle ?\n C'est le fantôme d'une idole.[000F][1205] Mon trésor est enterré là..."
   },
   {
     "id": 65,
@@ -1707,7 +1707,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Um,[SP]I[SP]heard[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells\nreal[SP]armor.[1205][000F]",
     "nom_fr": "Garçon",
-    "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures.[NL]Une dame a dit : trucs corrects,\n prix normaux.[1205][000F]"
+    "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures.[NL]Une dame a dit : trucs corrects,\n prix normaux.[000F][1205]"
   },
   {
     "id": 114,
@@ -1737,7 +1737,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Um,[SP]I[SP]heard[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells\nreal[SP]armor.[1205][000F]",
     "nom_fr": "Garçon",
-    "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures.[NL]Bon marché, pas terrible.[1205][000F]"
+    "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures.[NL]Bon marché, pas terrible.[000F][1205]"
   },
   {
     "id": 116,
@@ -1767,7 +1767,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Um,[SP]I[SP]heard[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells\nreal[SP]armor.[1205][000F]",
     "nom_fr": "Garçon",
-    "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures.[NL]Une dame a dit beaucoup de choix,\n mais reprises bon marché.[1205][000F]"
+    "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures.[NL]Une dame a dit beaucoup de choix,\n mais reprises bon marché.[000F][1205]"
   },
   {
     "id": 118,
@@ -1797,7 +1797,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Um,[SP]I[SP]heard[SP]Anima[SP]Mundi[SP]in[SP]Yumezaki[SP]sells\nreal[SP]armor.[1205][000F]",
     "nom_fr": "Garçon",
-    "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures.[NL]Une dame a dit de bonnes choses,\n mais cher.[1205][000F]"
+    "texte_fr": "Anima Mundi à Yumezaki vend de vraies armures.[NL]Une dame a dit de bonnes choses,\n mais cher.[000F][1205]"
   },
   {
     "id": 120,
@@ -1857,7 +1857,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][000F][SP]Someone[SP]said\ntheir[SP]stuff's[SP]okay[SP]and[SP]their[SP]prices[SP]are[SP]normal.",
     "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida à Aoba, c'est aussi un magasin d'armures ?[1205][000F]\n Quelqu'un a dit trucs corrects, prix normaux."
+    "texte_fr": "Rosa Candida à Aoba, c'est aussi un magasin d'armures ?[000F][1205]\n Quelqu'un a dit trucs corrects, prix normaux."
   },
   {
     "id": 124,
@@ -1872,7 +1872,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][000F][SP]Someone[SP]said\ntheir[SP]stuff's[SP]great,[SP]but[SP]it[SP]costs[SP]a[SP]lot.",
     "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida à Aoba, armurerie ?[1205][000F]\n Quelqu'un a dit trucs géniaux, mais cher."
+    "texte_fr": "Rosa Candida à Aoba, armurerie ?[000F][1205]\n Quelqu'un a dit trucs géniaux, mais cher."
   },
   {
     "id": 125,
@@ -1887,7 +1887,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][000F][SP]Someone[SP]said\nthey're[SP]cheap,[SP]but[SP]their[SP]stuff's[SP]kinda[SP]bad.",
     "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida à Aoba, magasin d'armures ?[1205][000F]\n Quelqu'un a dit bon marché, mais qualité bof."
+    "texte_fr": "Rosa Candida à Aoba, magasin d'armures ?[000F][1205]\n Quelqu'un a dit bon marché, mais qualité bof."
   },
   {
     "id": 126,
@@ -1902,7 +1902,7 @@
     "nom_orig": "Boy",
     "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Aoba[SP]too.\nAren't[SP]they[SP]also[SP]an[SP]armor[SP]shop?[1205][000F][SP]They[SP]have[SP]a\nlot[SP]of[SP]stuff,[SP]but[SP]trade-ins[SP]are[SP]cheap.",
     "nom_fr": "Garçon",
-    "texte_fr": "Rosa Candida à Aoba, armures ?[1205][000F]\n Beaucoup de choix, mais reprises bon marché."
+    "texte_fr": "Rosa Candida à Aoba, armures ?[000F][1205]\n Beaucoup de choix, mais reprises bon marché."
   },
   {
     "id": 127,
@@ -1917,7 +1917,7 @@
     "nom_orig": "Boy",
     "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][000F][SP]This[SP]lady\nsaid[SP]they[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]trade-ins\nare[SP]cheap.",
     "nom_fr": "Garçon",
-    "texte_fr": "London Clothier fait aussi des armures ?[1205][000F]\n Beaucoup de choix, reprises pas chères."
+    "texte_fr": "London Clothier fait aussi des armures ?[000F][1205]\n Beaucoup de choix, reprises pas chères."
   },
   {
     "id": 128,
@@ -1932,7 +1932,7 @@
     "nom_orig": "Boy",
     "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][000F][SP]This[SP]lady\nsaid[SP]they're[SP]cheap,[SP]but[SP]their[SP]stuff[SP]isn't\nthat[SP]great.",
     "nom_fr": "Garçon",
-    "texte_fr": "London Clothier, armures ?[1205][000F]\n Bon marché, qualité moyenne."
+    "texte_fr": "London Clothier, armures ?[000F][1205]\n Bon marché, qualité moyenne."
   },
   {
     "id": 129,
@@ -1947,7 +1947,7 @@
     "nom_orig": "Boy",
     "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][000F][SP]This[SP]lady\nsaid[SP]their[SP]stuff[SP]is[SP]nice,[SP]but[SP]it's[SP]expensive.",
     "nom_fr": "Garçon",
-    "texte_fr": "London Clothier vend des armures ?[1205][000F]\n Joli mais cher."
+    "texte_fr": "London Clothier vend des armures ?[000F][1205]\n Joli mais cher."
   },
   {
     "id": 130,
@@ -1962,7 +1962,7 @@
     "nom_orig": "Boy",
     "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][000F][SP]This[SP]lady\nsaid[SP]their[SP]stuff[SP]is[SP]okay.[SP]And[SP]she[SP]said[SP]their\nprices[SP]are[SP]normal[SP]too.",
     "nom_fr": "Garçon",
-    "texte_fr": "London Clothier, armures ?[1205][000F]\n Trucs corrects, prix normaux."
+    "texte_fr": "London Clothier, armures ?[000F][1205]\n Trucs corrects, prix normaux."
   },
   {
     "id": 131,
@@ -1977,7 +1977,7 @@
     "nom_orig": "Boy",
     "texte_orig": "London[SP]Clothier[SP]makes[SP]armor[SP]too?[1205][000F][SP]This[SP]lady\nsaid[SP]they[SP]don't[SP]have[SP]a[SP]lot[SP]of[SP]stuff,[SP]but[SP]their\ntrade-ins[SP]are[SP]good.",
     "nom_fr": "Garçon",
-    "texte_fr": "London Clothier fait des armures ?[1205][000F]\n Peu de choix, mais bonnes reprises."
+    "texte_fr": "London Clothier fait des armures ?[000F][1205]\n Peu de choix, mais bonnes reprises."
   },
   {
     "id": 132,
@@ -1992,7 +1992,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]magazine[SP]contests?[1205][000F][SP]I[SP]heard[SP]if\nyou[SP]win[SP]one,[SP]you[SP]get[SP]real[SP]weapons[SP]and[SP]stuff.",
     "nom_fr": "Garçon",
-    "texte_fr": "Tu connais les concours de magazines ?\n [1205][000F]Si on gagne, on a des vraies armes.[NL]On gagne rarement, mais les lots sont sympas."
+    "texte_fr": "Tu connais les concours de magazines ?\n [000F][1205]Si on gagne, on a des vraies armes.[NL]On gagne rarement, mais les lots sont sympas."
   },
   {
     "id": 133,
@@ -2022,7 +2022,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]magazine[SP]contests?[1205][000F][SP]I[SP]heard[SP]if\nyou[SP]win[SP]one,[SP]you[SP]get[SP]real[SP]weapons[SP]and[SP]stuff.",
     "nom_fr": "Garçon",
-    "texte_fr": "Tu connais les concours de magazines ?\n [1205][000F]Si on gagne, on a des vraies armes.[NL]On gagne rarement, mais les lots sont très rares."
+    "texte_fr": "Tu connais les concours de magazines ?\n [000F][1205]Si on gagne, on a des vraies armes.[NL]On gagne rarement, mais les lots sont très rares."
   },
   {
     "id": 135,
@@ -2052,7 +2052,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]magazine[SP]contests?[1205][000F][SP]I[SP]heard[SP]if\nyou[SP]win[SP]one,[SP]you[SP]get[SP]real[SP]weapons[SP]and[SP]stuff.",
     "nom_fr": "Garçon",
-    "texte_fr": "Tu connais les concours de magazines ?\n [1205][000F]Si on gagne, on a des vraies armes.[NL]On gagne souvent, des trucs ennuyeux."
+    "texte_fr": "Tu connais les concours de magazines ?\n [000F][1205]Si on gagne, on a des vraies armes.[NL]On gagne souvent, des trucs ennuyeux."
   },
   {
     "id": 137,
@@ -2172,7 +2172,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Is[SP]there[SP]really[SP]a[SP]legendary[SP]weapon[SP]at[SP]the[SP]ramen\nshop?[1205][000F][SP]Some[SP]lady[SP]said[SP]so[SP]a[SP]minute[SP]ago.[SP]Wow,[SP]I\ndidn't[SP]know[SP]those[SP]really[SP]existed!",
     "nom_fr": "Garçon",
-    "texte_fr": "Une arme légendaire au resto de ramen ?\n [1205][000F]Une dame vient de le dire. Je ne savais pas que ça existait !"
+    "texte_fr": "Une arme légendaire au resto de ramen ?\n [000F][1205]Une dame vient de le dire. Je ne savais pas que ça existait !"
   },
   {
     "id": 145,
@@ -2187,7 +2187,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Is[SP]it[SP]true[SP]there's[SP]a[SP]legendary[SP]weapon[SP]at[SP]the\nrestaurant[SP]in[SP]Aoba?[1205][000F][SP]Would[SP]it[SP]be[SP]in[SP]a[SP]dresser?",
     "nom_fr": "Garçon",
-    "texte_fr": "Une arme légendaire dans le resto d'Aoba ?\n [1205][000F]Dans un buffet ?"
+    "texte_fr": "Une arme légendaire dans le resto d'Aoba ?\n [000F][1205]Dans un buffet ?"
   },
   {
     "id": 146,
@@ -2202,7 +2202,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Why[SP]would[SP]the[SP]man[SP]at[SP]Time[SP]Castle[SP]lie[SP]about\nhaving[SP]a[SP]legendary[SP]weapon?[1205][000F][SP]I[SP]heard[SP]it's[SP]'cause\nhe's[SP]trying[SP]to[SP]charge[SP]a[SP]lot...",
     "nom_fr": "Garçon",
-    "texte_fr": "Pourquoi le gars du Château du Temps mentirait\n sur une arme légendaire ?[1205][000F] Pour faire monter les prix..."
+    "texte_fr": "Pourquoi le gars du Château du Temps mentirait\n sur une arme légendaire ?[000F][1205] Pour faire monter les prix..."
   },
   {
     "id": 147,
@@ -2322,7 +2322,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "The[SP]principal's[SP]statue[SP]at[SP]Sevens[SP]doesn't[SP]like\nto[SP]be[SP]seen[SP]walking[SP]around...[1205][000F][SP]But[SP]there[SP]aren't\nmany[SP]foxes[SP]around[SP]these[SP]days.[SP]Is[SP]it[SP]possible?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "La statue du proviseur à Seven n'aime pas qu'on la voie se promener...[1205][000F]\n Mais il n'y a plus beaucoup de renards. Est-ce possible ?"
+    "texte_fr": "La statue du proviseur à Seven n'aime pas qu'on la voie se promener...[000F][1205]\n Mais il n'y a plus beaucoup de renards. Est-ce possible ?"
   },
   {
     "id": 155,
@@ -2337,7 +2337,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I've[SP]stopped[SP]seeing[SP]young[SP]girls[SP]around[SP]here\nlately.[1205][000F][SP]Is[SP]the[SP]bloom[SP]off[SP]the[SP]rose[SP]for[SP]Sevens\nbecause[SP]of[SP]that[SP]disease?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Je ne vois plus de jeunes filles par ici.[1205][000F]\n Seven a-t-il perdu son attrait à cause de cette maladie ?"
+    "texte_fr": "Je ne vois plus de jeunes filles par ici.[000F][1205]\n Seven a-t-il perdu son attrait à cause de cette maladie ?"
   },
   {
     "id": 156,
@@ -2382,7 +2382,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "If[SP]you[SP]want[SP]to[SP]know[SP]more[SP]about[SP]it,[SP]I'd[SP]say[SP]you\nshould[SP]start[SP]by[SP]visiting[SP]Honmaru[SP]Park.[1205][000F]",
     "nom_fr": "Vieil homme",
-    "texte_fr": "London Clothier : ce coquin vend des armures.\n Excellente qualité, très cher.[1205][000F]"
+    "texte_fr": "London Clothier : ce coquin vend des armures.\n Excellente qualité, très cher.[000F][1205]"
   },
   {
     "id": 159,
@@ -2442,7 +2442,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I'd[SP]rather[SP]steer[SP]clear[SP]of[SP]such[SP]folk[SP]at[SP]my[SP]age.[1205][000F]\nFingers[SP]crossed...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Magazines donnent des armes dans des concours.\n Presque impossibles à gagner, mais ces lots...[1205][000F]"
+    "texte_fr": "Magazines donnent des armes dans des concours.\n Presque impossibles à gagner, mais ces lots...[000F][1205]"
   },
   {
     "id": 163,
@@ -2457,7 +2457,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Sounds[SP]like[SP]it[SP]was[SP]the[SP]Masked[SP]Circle[SP]who[SP]burned\ndown[SP]the[SP]outdoor[SP]concert[SP]hall.[1205][000F][SP]What's[SP]this[SP]world\ncoming[SP]to[SP]if[SP]such[SP]people[SP]really[SP]exist...?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "On dirait que c'est le Cercle Masqué qui a brûlé la salle de concert.[1205][000F]\n Où va le monde si de telles personnes existent vraiment ?"
+    "texte_fr": "On dirait que c'est le Cercle Masqué qui a brûlé la salle de concert.[000F][1205]\n Où va le monde si de telles personnes existent vraiment ?"
   },
   {
     "id": 164,
@@ -2472,7 +2472,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Turns[SP]out[SP]the[SP]real[SP]culprit[SP]was[SP]a[SP]gang[SP]of[SP]five\nterrorists.[1205][000F][SP]That's[SP]more[SP]plausible[SP]than[SP]the\nMasked[SP]Circle,[SP]I'd[SP]say...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Le vrai coupable était une bande de cinq terroristes.[1205][000F]\n Plus plausible que le Cercle Masqué, je dirais..."
+    "texte_fr": "Le vrai coupable était une bande de cinq terroristes.[000F][1205]\n Plus plausible que le Cercle Masqué, je dirais..."
   },
   {
     "id": 165,
@@ -2487,7 +2487,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "There[SP]was[SP]a[SP]fella[SP]I[SP]used[SP]to[SP]play[SP]Go[SP]with...[1205][000F]\nHaven't[SP]seen[SP]him[SP]around[SP]lately.[1205][000F][SP]He[SP]seemed\nawful[SP]depressed,[SP]so[SP]I[SP]worry[SP]about[SP]him.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Il y avait un type avec qui je jouais au go...[1205][000F]\n Je ne l'ai pas vu récemment.[1205][000F] Il avait l'air très déprimé,\n je m'inquiète."
+    "texte_fr": "Il y avait un type avec qui je jouais au go...[000F][1205]\n Je ne l'ai pas vu récemment.[000F][1205] Il avait l'air très déprimé,\n je m'inquiète."
   },
   {
     "id": 166,
@@ -2532,7 +2532,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I'm[SP]too[SP]old[SP]to[SP]evolve![1205][000A][SP]I'm[SP]more[SP]worried[SP]about\nwhat's[SP]happening[SP]down[SP]there.[1205][000A][SP]It'll[SP]all[SP]be\ndestroyed[SP]when[SP]the[SP]stars[SP]align,[SP]no?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Je suis trop vieux pour évoluer ![1205][000A]\n Je m'inquiète pour en bas.[1205][000A] Destruction quand les étoiles s'alignent, non ?[NL]J'ai des amis en bas...\n Rien que je puisse faire pour eux ?"
+    "texte_fr": "Je suis trop vieux pour évoluer ![000A][1205]\n Je m'inquiète pour en bas.[000A][1205] Destruction quand les étoiles s'alignent, non ?[NL]J'ai des amis en bas...\n Rien que je puisse faire pour eux ?"
   },
   {
     "id": 169,
@@ -2547,7 +2547,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I[SP]have[SP]friends[SP]down[SP]there...[1205][000F][SP]Isn't[SP]there\nanything[SP]I[SP]can[SP]do[SP]for[SP]them...?",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Mentir sur son magasin pour faire monter les prix !\n L'idée ! C'est le proprio du Château du Temps.[1205][000F]"
+    "texte_fr": "Mentir sur son magasin pour faire monter les prix !\n L'idée ! C'est le proprio du Château du Temps.[000F][1205]"
   },
   {
     "id": 170,
@@ -2562,7 +2562,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "The[SP]people[SP]in[SP]this[SP]city[SP]are[SP]appalling.[1205][000A][SP]They\nknow[SP]they're[SP]safe,[SP]so[SP]they're[SP]imagining[SP]what\nmight[SP]destroy[SP]the[SP]Earth[SP]below.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Les gens sont épouvantables.[1205][000A]\n En sécurité, ils imaginent la destruction de la Terre.[NL]À quoi bon si des gens comme eux évoluent ?\n Je n'ai pas beaucoup d'espoir..."
+    "texte_fr": "Les gens sont épouvantables.[000A][1205]\n En sécurité, ils imaginent la destruction de la Terre.[NL]À quoi bon si des gens comme eux évoluent ?\n Je n'ai pas beaucoup d'espoir..."
   },
   {
     "id": 171,
@@ -2577,7 +2577,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "What[SP]good[SP]will[SP]it[SP]do[SP]mankind[SP]if[SP]folks[SP]like\nthem[SP]evolve...?[1205][000F][SP]I[SP]don't[SP]hold[SP]out[SP]much[SP]hope...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Des démons ont volé l'arme légendaire du Château du Temps.\n Comment est-ce possible ?[1205][000F]"
+    "texte_fr": "Des démons ont volé l'arme légendaire du Château du Temps.\n Comment est-ce possible ?[000F][1205]"
   },
   {
     "id": 172,
@@ -2592,7 +2592,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Sounds[SP]like[SP]the[SP]Earth's[SP]air[SP]will[SP]evaporate[SP]when\nthe[SP]stars[SP]align.[1205][000F][SP]Criminy...[SP]The[SP]things[SP]those\nkids[SP]think[SP]up[SP]lately[SP]scares[SP]the[SP]life[SP]out[SP]of[SP]me.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "L'air de la Terre va s'évaporer quand les étoiles s'aligneront.[1205][000F]\n Bon sang... Ce que ces gosses inventent me fait une peur bleue."
+    "texte_fr": "L'air de la Terre va s'évaporer quand les étoiles s'aligneront.[000F][1205]\n Bon sang... Ce que ces gosses inventent me fait une peur bleue."
   },
   {
     "id": 173,
@@ -2607,7 +2607,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Sounds[SP]like[SP]the[SP]Earth's[SP]rotation[SP]will[SP]stop[SP]when\nthe[SP]stars[SP]align...[1205][000A][SP]Everything[SP]on[SP]Earth[SP]will[SP]get\nblasted[SP]away...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "La Terre va s'arrêter quand les étoiles s'aligneront...[1205][000A]\n Tout sera pulvérisé...[NL]Pourquoi Dieu nous fait-il ça ?"
+    "texte_fr": "La Terre va s'arrêter quand les étoiles s'aligneront...[000A][1205]\n Tout sera pulvérisé...[NL]Pourquoi Dieu nous fait-il ça ?"
   },
   {
     "id": 174,
@@ -2637,7 +2637,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "Sounds[SP]like[SP]the[SP]Earth's[SP]rotation[SP]will[SP]stop[SP]when\nthe[SP]stars[SP]align...[1205][000A][SP]Everything[SP]on[SP]Earth[SP]will[SP]get\nblasted[SP]away...",
     "nom_fr": "Vieil homme",
-    "texte_fr": "La Terre va s'arrêter quand les étoiles s'aligneront...[1205][000A]\n Tout sera pulvérisé...[NL]Pourquoi Dieu nous fait-il ça ?"
+    "texte_fr": "La Terre va s'arrêter quand les étoiles s'aligneront...[000A][1205]\n Tout sera pulvérisé...[NL]Pourquoi Dieu nous fait-il ça ?"
   },
   {
     "id": 176,
@@ -2697,7 +2697,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "They[SP]talked[SP]about[SP]some[SP]treasure...[1205][000F][SP]But[SP]the\nmore[SP]you[SP]find,[SP]the[SP]greater[SP]the[SP]danger.\nI[SP]wouldn't[SP]go[SP]in[SP]carelessly[SP]if[SP]I[SP]were[SP]you.",
     "nom_fr": "Maya",
-    "texte_fr": "Cet endroit devrait aller. Allez, on y va.[1205][000F]"
+    "texte_fr": "Cet endroit devrait aller. Allez, on y va.[000F][1205]"
   },
   {
     "id": 180,
@@ -2877,7 +2877,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "I-I[SP]can't[SP]believe[SP]it...[SP]My[SP]heart[SP]almost[SP]gave\nout[SP]when[SP]I[SP]heard...[1205][000F][SP]Kudan[SP]is...[1205][000F][SP]Kid,[SP]you[SP]must\nnever[SP]go[SP]near[SP]a[SP]Kudan!",
     "nom_fr": "Vieil homme",
-    "texte_fr": "J'y crois pas... Crise cardiaque...[1205][000F] Kudan...[1205][000F]\n Ne t'approche jamais d'un Kudan, gamin !"
+    "texte_fr": "J'y crois pas... Crise cardiaque...[000F][1205] Kudan...[000F][1205]\n Ne t'approche jamais d'un Kudan, gamin !"
   },
   {
     "id": 192,
@@ -3822,7 +3822,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "J-Joker[SP]told[SP]us[SP]to[SP]protect[SP]the[SP]city,[SP]but\nthere's[SP]no[SP]way[SP]we[SP]can[SP]beat[SP]guys[SP]like[SP]that![1205][000F]\nThis[SP]wasn't[SP]part[SP]of[SP]the[SP]deal!",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Joker nous a dit de protéger la ville,\n mais pas possible ![1205][000F] Pas dans le contrat !"
+    "texte_fr": "Joker nous a dit de protéger la ville,\n mais pas possible ![000F][1205] Pas dans le contrat !"
   },
   {
     "id": 255,
@@ -3837,7 +3837,7 @@
     "nom_orig": "Last[SP]Battalion",
     "texte_orig": "Mt.[SP]Katatsumuri[SP]is[SP]already[SP]ours.[1205][000F][SP]To[SP]resist\nis[SP]futile.[1205][000F][SP]Those[SP]who[SP]do[SP]will[SP]be[SP]killed.",
     "nom_fr": "Dernier Bataillon",
-    "texte_fr": "Le mont Katatsumuri est à nous.[1205][000F]\n Résister est futile.[1205][000F] Les résistants tués."
+    "texte_fr": "Le mont Katatsumuri est à nous.[000F][1205]\n Résister est futile.[000F][1205] Les résistants tués."
   },
   {
     "id": 256,
@@ -3987,7 +3987,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "H-Hey,[SP][1113]?[SP]I[SP]don't[SP]like[SP]it[SP]here...[1205][000F]\nCan[SP]we[SP]go[SP]somewhere[SP]else?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, [1113] ? J'aime pas ici...[1205][000F]\n Ailleurs ?"
+    "texte_fr": "Hé, [1113] ? J'aime pas ici...[000F][1205]\n Ailleurs ?"
   },
   {
     "id": 266,
@@ -4062,7 +4062,7 @@
     "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
     "texte_orig": "I[SP]saw[SP]her[SP]at[SP]Mt.[SP]Iwato.[1205][000F][SP]You[SP]know[SP]who[SP]I[SP]mean...\nThat[SP][E4][NULL][NULL][0006]urban[SP]legend,[SP]Kuchisake-onna[E4][NULL][NULL][0002].[SP]I[SP]saw[SP]a\nwoman[SP]wearing[SP]a[SP]mask[SP]out[SP]there.",
     "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Je l'ai vue au mont Iwato.[1205][000F]\n Cette [E4][NULL][NULL][0006]légende urbaine, Kuchisake-onna[E4][NULL][NULL][0002].\n J'ai vu une femme masquée.[NL]Sous ce masque, une bouche fendue d'une oreille à l'autre.[NL]Ma femme dit que j'en fais trop, elle ne me croit pas.[NL]Gamin, prouve que Kuchisake-onna est là.[NL]Je te revaudrai ça. Compte sur toi !"
+    "texte_fr": "Je l'ai vue au mont Iwato.[000F][1205]\n Cette [E4][NULL][NULL][0006]légende urbaine, Kuchisake-onna[E4][NULL][NULL][0002].\n J'ai vu une femme masquée.[NL]Sous ce masque, une bouche fendue d'une oreille à l'autre.[NL]Ma femme dit que j'en fais trop, elle ne me croit pas.[NL]Gamin, prouve que Kuchisake-onna est là.[NL]Je te revaudrai ça. Compte sur toi !"
   },
   {
     "id": 271,
@@ -4137,7 +4137,7 @@
     "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
     "texte_orig": "Kuchisake-onna[SP]should[SP]still[SP]be[SP]somewhere[SP]on\nMt.[SP]Iwato.[1205][000F][SP]I'm[SP]begging[SP]you,[SP]bring[SP]back[SP]proof\nshe's[SP]really[SP]there!",
     "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Kuchisake-onna est au mont Iwato.[1205][000F]\n Prouve qu'elle est là !"
+    "texte_fr": "Kuchisake-onna est au mont Iwato.[000F][1205]\n Prouve qu'elle est là !"
   },
   {
     "id": 276,
@@ -4152,7 +4152,7 @@
     "nom_orig": "Old[SP]man[SP]playing[SP]dumb",
     "texte_orig": "Hm?[1205][000A][SP]Ohhhhh![1205][000F][SP]That's[SP]it![SP][E4][NULL][NULL][0006]Kuchisake-onna's[SP]mask[E4][NULL][NULL][0002]![1205][000F]\nKid,[SP]I[SP]gotta[SP]thank[SP]you[SP]for[SP]bringing[SP]it[SP]to[SP]me!",
     "nom_fr": "Vieil homme qui fait le sourd",
-    "texte_fr": "Ohhhhh ![000A][1205][1205][000F] C'est ça !\n [E4][NULL][NULL][0006]Le masque de Kuchisake-onna[E4][NULL][NULL][0002] ![1205][000F]\n Merci de me l'avoir apporté ![NL]Comme je l'ai dit, je te revaudrai ça.\n Tiens, une [E4][NULL][NULL][NULL][NULL]Carte Megido[E4][NULL][NULL].\n Elle est à toi !"
+    "texte_fr": "Ohhhhh ![000A][1205][000F][1205] C'est ça !\n [E4][NULL][NULL][0006]Le masque de Kuchisake-onna[E4][NULL][NULL][0002] ![000F][1205]\nMerci de me l'avoir apporté ![NL]Comme je l'ai dit, je te revaudrai ça. Tiens, une [E4][NULL][NULL][NULL][NULL]Carte Megido[E4][NULL][NULL]. Elle est à toi !"
   },
   {
     "id": 277,

--- a/traduction/event_scripts/script_000.json
+++ b/traduction/event_scripts/script_000.json
@@ -57,7 +57,7 @@
     "nom_orig": "Thuggish[SP]student",
     "texte_orig": "Nothin'[SP]to[SP]say,[SP]huh?[1205][001E][SP]I[SP]don't[SP]like[SP]that\nprissy[SP]face[SP]of[SP]yours.[SP]You[SP]think[SP]you're\nhot[SP]shit,[SP]don't[SP]you?",
     "nom_fr": "Délinquant",
-    "texte_fr": "Rien à dire, hein?[1205][001E] Ta tronche me\nrevient pas. Tu te crois plus\nmalin que les autres, c'est ça?"
+    "texte_fr": "Rien à dire, hein?[001E][1205] Ta tronche me\nrevient pas. Tu te crois plus\nmalin que les autres, c'est ça?"
   },
   {
     "id": 4,
@@ -102,7 +102,7 @@
     "nom_orig": "Unknown[SP]voice",
     "texte_orig": "Take...[SP][1205][001E]my...[SP][1205][001E]hand...",
     "nom_fr": "Voix inconnue",
-    "texte_fr": "Prends... [1205][001E]ma [1205][001E]main..."
+    "texte_fr": "Prends... [001E][1205]ma [001E][1205]main..."
   },
   {
     "id": 7,
@@ -267,7 +267,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Ah,[SP]I[SP]should[SP]have[SP]known...[SP][1205][001E]You're[SP]that\n[1113][SP][1112][SP]I've[SP]heard\nrumors[SP]about.",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Ah, j'aurais dû m'en douter...[1205][001E] Les\nrumeurs parlaient bien d'un [1113] [1112]."
+    "texte_fr": "Ah, j'aurais dû m'en douter...[001E][1205] Les\nrumeurs parlaient bien d'un [1113] [1112]."
   },
   {
     "id": 18,
@@ -372,7 +372,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "I[SP]don't[SP]envy[SP]your[SP]long[SP]hair[SP]at[SP]all.[SP]In[SP]the\nyears[SP]to[SP]come,[SP]everyone[SP]will[SP]go[SP]bald\nanyway.[1205][001E][SP]Heh...[1205][001E][SP]I'll[SP]be[SP]waiting,[SP][1113].",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "J'envie pas du tout tes cheveux longs.\nTout le monde finira par être chauve de\ntoute façon.[1205][001E] Héhé...[1205][001E] t'es le prochain, [1113]."
+    "texte_fr": "J'envie pas du tout tes cheveux longs.\nTout le monde finira par être chauve de\ntoute façon.[001E][1205] Héhé...[001E][1205] t'es le prochain, [1113]."
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "Bad[SP]luck,[SP][1113]-senpai.[SP]I'm[SP]surprised\nat[SP]how[SP]popular[SP]Principal[SP]Hanya[SP]is.[1205][001E][SP]He's\nawful,[SP]but[SP]I[SP]like[SP]him...[SP]Why[SP]is[SP]that?",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Pas de bol, [1113]-senpai.[1205][001E]\nSurprenant qu'Hanya soit si populaire.\nIl est détestable, mais je l'adore..."
+    "texte_fr": "Pas de bol, [1113]-senpai.[001E][1205]\nSurprenant qu'Hanya soit si populaire.\nIl est détestable, mais je l'adore..."
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "[1113]-senpai!?[SP]This[SP]is[SP]so[SP]sudden...[1205][001E]\nI'm[SP]inexperienced...[SP]My[SP]heart's[SP]not\nready...[1205][001E][SP]But[SP]maybe[SP]for[SP]you,[SP]I[SP]could...!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "[1113]-senpai!?[1205][001E] C'est si soudain...\nJ'ai pas d'expérience... Mon cœur\nn'est pas prêt...[1205][001E] Mais pour toi...!"
+    "texte_fr": "[1113]-senpai!?[001E][1205] C'est si soudain...\nJ'ai pas d'expérience... Mon cœur\nn'est pas prêt...[001E][1205] Mais pour toi...!"
   },
   {
     "id": 28,
@@ -432,6 +432,6 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "Huh?[SP]Ms.[SP]Saeko?[1205][001E][SP]I[SP]dunno...[SP]Maybe[SP]in[SP]the\nteacher's[SP]lounge[SP]on[SP]the[SP]second[SP]floor?[1205][001E][SP]*sigh*\nOf[SP]course[SP]it[SP]wasn't[SP]me[SP]you're[SP]after...",
     "nom_fr": "",
-    "texte_fr": "Hein ? Mme Saeko ?[1205][001E]\nJ'sais pas... Dans la salle des profs\nau deuxième étage, peut-être ?"
+    "texte_fr": "Hein ? Mme Saeko ?[001E][1205]\nJ'sais pas... Dans la salle des profs\nau deuxième étage, peut-être ?"
   }
 ]

--- a/traduction/event_scripts/script_001.json
+++ b/traduction/event_scripts/script_001.json
@@ -206,7 +206,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Then...[SP]Tell[SP]me,[SP]and[SP]you[SP]don't[SP]have\nto[SP]get[SP]specific.[1205][001E][SP]Is[SP]there[SP]anything\nyou[SP]want[SP]to[SP]do?",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Dis-moi... Sans entrer dans les détails.[1205][001E] Y\na quelque chose que t'as envie de faire?"
+    "texte_fr": "Dis-moi... Sans entrer dans les détails.[001E][1205] Y\na quelque chose que t'as envie de faire?"
   },
   {
     "id": 11,
@@ -329,7 +329,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "[1113]...[1205][001E][SP]Why[SP]do[SP]you[SP]put[SP]up[SP]walls[SP]like\nthat?[SP]You[SP]look[SP]like[SP]you're[SP]in[SP]so[SP]much[SP]pain\nthat[SP]I[SP]can't[SP]bear[SP]to[SP]see[SP]it...",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "[1113]...[1205][001E] Pourquoi tu te restreins\ncomme ça? Tu as l'air d'être en\nsouffrance et je ne peux le supporter..."
+    "texte_fr": "[1113]...[001E][1205] Pourquoi tu te restreins\ncomme ça? Tu as l'air d'être en\nsouffrance et je ne peux le supporter..."
   },
   {
     "id": 17,
@@ -404,7 +404,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Well,[SP]all[SP]right...[1205][001E][SP]See[SP]you,[SP][1113].",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Bon, d'accord...[1205][001E] À plus, [1113]."
+    "texte_fr": "Bon, d'accord...[001E][1205] À plus, [1113]."
   },
   {
     "id": 22,
@@ -449,7 +449,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "I[SP]don't[SP]believe[SP]this![1205][001E][SP]Why[SP]are[SP]you[SP]still\nwearing[SP]your[SP]emblem!?[SP]You[SP]DO[SP]know[SP]about\nthe[SP]emblem[SP]curse,[SP]right?",
     "nom_fr": "Lisa",
-    "texte_fr": "J'y crois pas![1205][001E] Pourquoi tu portes\nencore ton emblème!? Tu sais bien\nqu'il est maudit, non?"
+    "texte_fr": "J'y crois pas![001E][1205] Pourquoi tu portes\nencore ton emblème!? Tu sais bien\nqu'il est maudit, non?"
   },
   {
     "id": 25,
@@ -524,7 +524,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Haime![SP]Seriously!?[SP]Now[SP]that's[SP]old-\nschool...[1205][001E][SP]I[SP]dunno,[SP]though,[SP]rumor[SP]has\nit[SP]this[SP]guy's[SP]really[SP]strong!",
     "nom_fr": "Lisa",
-    "texte_fr": "Sérieux!? C'est trop vieillot...[1205][001E]\nJ'sais pas, mais les rumeurs disent\nque ce mec est vraiment balèze!"
+    "texte_fr": "Sérieux!? C'est trop vieillot...[001E][1205]\nJ'sais pas, mais les rumeurs disent\nque ce mec est vraiment balèze!"
   },
   {
     "id": 30,
@@ -539,7 +539,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "I[SP]also[SP]heard[SP]a[SP]rumor[SP]that[SP]it[SP]was[SP]a[SP]Cuss\nHigh[SP]jerk[SP]who[SP]cursed[SP]our[SP]emblem...[1205][001E]\nI[SP]bet[SP]it[SP]was[SP]this[SP]same[SP]guy!",
     "nom_fr": "Lisa",
-    "texte_fr": "J'ai aussi entendu qu'un con du\nLycée Kasu aurait maudit notre\nemblème...[1205][001E] Je parie que c'est le même!"
+    "texte_fr": "J'ai aussi entendu qu'un con du\nLycée Kasu aurait maudit notre\nemblème...[001E][1205] Je parie que c'est le même!"
   },
   {
     "id": 31,
@@ -554,7 +554,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "[1113]...[1205][001E][SP]You're[SP]going[SP]alone,[SP]huh?",
     "nom_fr": "Lisa",
-    "texte_fr": "[1113]...[1205][001E] T'y vas seul, hein?"
+    "texte_fr": "[1113]...[001E][1205] T'y vas seul, hein?"
   },
   {
     "id": 32,
@@ -569,7 +569,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Knew[SP]it...[1205][001E][SP]But[SP]do[SP]you[SP]know[SP]how[SP]to\nget[SP]to[SP]Sumaru[SP]Prison?",
     "nom_fr": "Lisa",
-    "texte_fr": "Je m'en doutais...[1205][001E] Mais\ntu sais où est la prison?"
+    "texte_fr": "Je m'en doutais...[001E][1205] Mais\ntu sais où est la prison?"
   },
   {
     "id": 33,
@@ -614,7 +614,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "I[SP]see...[1205][001E]",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Ok...[1205][001E]"
+    "texte_fr": "Ok...[001E][1205]"
   },
   {
     "id": 36,
@@ -659,7 +659,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Is[SP]that[SP]so...![1205][001E][SP]If[SP]you're[SP]that[SP]fired\nup,[SP]I'm[SP]sure[SP]you'll[SP]do[SP]just[SP]fine!\nGood[SP]luck![SP]I'll[SP]be[SP]cheering[SP]for[SP]you!",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Dans ce cas...[1205][001E] Avec autant de\nmotivation, t'as rien à craindre!\nJe serai là pour t'encourager!"
+    "texte_fr": "Dans ce cas...[001E][1205] Avec autant de\nmotivation, t'as rien à craindre!\nJe serai là pour t'encourager!"
   },
   {
     "id": 39,
@@ -674,7 +674,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "I[SP]see...[1205][001E][SP]Well,[SP]there's[SP]no[SP]reason[SP]to\nrush[SP]this.[SP]Give[SP]your[SP]future[SP]the[SP]long,\ncareful[SP]consideration[SP]it[SP]deserves.",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Je vois...[1205][001E] Pas besoin de se presser. Prends\nle temps qu'il faut pour\npenser à ton avenir."
+    "texte_fr": "Je vois...[001E][1205] Pas besoin de se presser. Prends\nle temps qu'il faut pour\npenser à ton avenir."
   },
   {
     "id": 40,
@@ -719,7 +719,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Is[SP]that[SP]so...![1205][001E][SP]If[SP]you're[SP]that[SP]fired\nup,[SP]I'm[SP]sure[SP]you'll[SP]do[SP]just[SP]fine!\nGood[SP]luck![SP]I'll[SP]be[SP]cheering[SP]for[SP]you!",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Dans ce cas...[1205][001E] Avec autant de\nmotivation, t'as rien à craindre!\nJe serai là pour t'encourager!"
+    "texte_fr": "Dans ce cas...[001E][1205] Avec autant de\nmotivation, t'as rien à craindre!\nJe serai là pour t'encourager!"
   },
   {
     "id": 43,
@@ -734,7 +734,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "I[SP]see...[1205][001E][SP]Well,[SP]at[SP]least[SP]you[SP]have[SP]a[SP]goal\nyou're[SP]working[SP]towards.",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Je vois...[1205][001E] Et bien, au moins\ntu te fixes des objectifs."
+    "texte_fr": "Je vois...[001E][1205] Et bien, au moins\ntu te fixes des objectifs."
   },
   {
     "id": 44,
@@ -764,7 +764,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Is[SP]that[SP]so...![1205][001E][SP]If[SP]you're[SP]that[SP]fired\nup,[SP]I'm[SP]sure[SP]you'll[SP]do[SP]just[SP]fine!\nGood[SP]luck![SP]I'll[SP]be[SP]cheering[SP]for[SP]you!",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Dans ce cas...[1205][001E] Avec autant de\nmotivation, t'as rien à craindre!\nJe serai là pour t'encourager!"
+    "texte_fr": "Dans ce cas...[001E][1205] Avec autant de\nmotivation, t'as rien à craindre!\nJe serai là pour t'encourager!"
   },
   {
     "id": 46,
@@ -779,7 +779,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "So...[1205][001E][SP]You[SP]have[SP]no[SP]idea[SP]what[SP]to[SP]do[SP]after\ngraduation,[SP]and[SP]there's[SP]nothing[SP]you[SP]want\nto[SP]do[SP]either...",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Du coup...[1205][001E] T'as aucune idée\nde ce que tu veux\nfaire, et rien qui te donne\nenvie non plus..."
+    "texte_fr": "Du coup...[001E][1205] T'as aucune idée\nde ce que tu veux\nfaire, et rien qui te donne envie non plus..."
   },
   {
     "id": 47,

--- a/traduction/event_scripts/script_002.json
+++ b/traduction/event_scripts/script_002.json
@@ -12,7 +12,7 @@
     "nom_orig": "???",
     "texte_orig": "Whew...[1205][001E][SP]Thank[SP]you[SP]for[SP]the[SP]food.",
     "nom_fr": "???",
-    "texte_fr": "Ouf...[1205][001E] Merci pour le repas."
+    "texte_fr": "Ouf...[001E][1205] Merci pour le repas."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "???",
     "texte_orig": "...[1205][000A]...[1205][000A]...[1205][000A]Gah!",
     "nom_fr": "???",
-    "texte_fr": "...[1205][000A]...[1205][000A]...[1205][000A]Gah!"
+    "texte_fr": "...[000A][1205]...[000A][1205]...[000A][1205]Gah!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "???",
     "texte_orig": "H-Hey![SP]Is[SP]this[SP]chica[SP]really[SP]one[SP]of[SP]my\nfans!?[1205][001E][SP]That[SP]ain't[SP]right!",
     "nom_fr": "???",
-    "texte_fr": "Hé! Elle est vraiment une de mes\nfans!?[1205][001E] C'est n'importe quoi!"
+    "texte_fr": "Hé! Elle est vraiment une de mes\nfans!?[001E][1205] C'est n'importe quoi!"
   },
   {
     "id": 3,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey...[1205][001E][SP]What's[SP]this[SP]about[SP][1113]?\nWhat[SP]are[SP]you[SP]three[SP]scheming?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé...[1205][001E] C'est quoi ce délire avec\n[1113]? Vous manigancez quoi?"
+    "texte_fr": "Hé...[001E][1205] C'est quoi ce délire avec\n[1113]? Vous manigancez quoi?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Huh...[1205][001E][SP]So[SP]that's[SP]what[SP]this[SP]is[SP]about?",
     "nom_fr": "Lisa",
-    "texte_fr": "Hein...[1205][001E] Alors c'était ça le but?"
+    "texte_fr": "Hein...[001E][1205] Alors c'était ça le but?"
   },
   {
     "id": 8,
@@ -192,7 +192,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "What...[1205][001E][SP]are[SP]you[SP]smoking?",
     "nom_fr": "Lisa",
-    "texte_fr": "T'as fumé...[1205][001E] quoi?"
+    "texte_fr": "T'as fumé...[001E][1205] quoi?"
   },
   {
     "id": 13,
@@ -222,7 +222,7 @@
     "nom_orig": "Shogo",
     "texte_orig": "Um...[SP]Please[SP]forgive[SP]us![1205][001E][SP]We[SP]used[SP]Kozy-san\nas[SP]a[SP]hostage[SP]to[SP]lure[SP]out[SP][1113]-san!",
     "nom_fr": "Shogo",
-    "texte_fr": "Pardonnez-nous![1205][001E] On a utilisé Kozy\nen otage pour attirer [1113]!"
+    "texte_fr": "Pardonnez-nous![001E][1205] On a utilisé Kozy\nen otage pour attirer [1113]!"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Takeshi",
     "texte_orig": "You[SP]know[SP]how[SP]you[SP]were[SP]pumped[SP]to[SP]start[SP]a\nband,[SP]Michel-san?[SP]We[SP]were[SP]looking[SP]for\nmembers.[1205][001E][SP]You[SP]were[SP]the[SP]only[SP]one,[SP]so...",
     "nom_fr": "Takeshi",
-    "texte_fr": "Vous vouliez tellement monter un\ngroupe, Michel-san. On vous cherchait\ndes membres.[1205][001E] Vous étiez seul, alors..."
+    "texte_fr": "Vous vouliez tellement monter un\ngroupe, Michel-san. On vous cherchait\ndes membres.[001E][1205] Vous étiez seul, alors..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Ken",
     "texte_orig": "We[SP]thought[SP][1113]-san[SP]would[SP]be[SP]a[SP]good\nfit.[1205][001E][SP]And[SP]he's[SP]reliable,[SP]so[SP]we[SP]thought\nyou'd[SP]be[SP]happy[SP]to[SP]have[SP]him[SP]aboard...",
     "nom_fr": "Ken",
-    "texte_fr": "On s'est dit que [1113]-san ferait\nl'affaire.[1205][001E] Et il est fiable, alors on\na pensé que ça vous ferait plaisir..."
+    "texte_fr": "On s'est dit que [1113]-san ferait\nl'affaire.[001E][1205] Et il est fiable, alors on\na pensé que ça vous ferait plaisir..."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Y-You[SP]guys...[1205][001E][SP]You[SP]knew[SP]what[SP]would\nhappen[SP]if[SP]you[SP]violated[SP]Bro[SP]Code[SP]and\nyou[SP]still...",
     "nom_fr": "Eikichi",
-    "texte_fr": "L-Les gars...[1205][001E] Vous saviez ce qui arrive si\non brise le Code et vous l'avez fait..."
+    "texte_fr": "L-Les gars...[001E][1205] Vous saviez ce qui arrive si\non brise le Code et vous l'avez fait..."
   },
   {
     "id": 18,
@@ -297,7 +297,7 @@
     "nom_orig": "Kozy",
     "texte_orig": "Um...[SP]So[SP]that[SP]stuff[SP]about[SP]telling[SP]me[SP]the\nmystery[SP]of[SP]the[SP]emblem[SP]curse...[1205][001E][SP]Was[SP]that\nall[SP]a[SP]lie?[SP]If[SP]so,[SP]then[SP]I'm[SP]going[SP]to[SP]go.",
     "nom_fr": "Kozy",
-    "texte_fr": "Euh... Donc l'histoire sur le mystère de\nla malédiction...[1205][001E] C'était un mensonge?\nSi c'est le cas, je m'en vais."
+    "texte_fr": "Euh... Donc l'histoire sur le mystère de\nla malédiction...[001E][1205] C'était un mensonge?\nSi c'est le cas, je m'en vais."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "*sigh*[1205][001E][SP]We[SP]should[SP]go[SP]too,[SP][1113].[SP]This[SP]is\nso[SP]stupid[SP]I[SP]might[SP]cry.",
     "nom_fr": "Lisa",
-    "texte_fr": "*pff*[1205][001E] Viens, [1113]. C'est si bête."
+    "texte_fr": "*pff*[001E][1205] Viens, [1113]. C'est si bête."
   },
   {
     "id": 21,
@@ -342,7 +342,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]hate[SP]to[SP]stoop[SP]this[SP]low...[1205][001E][SP]But[SP]for[SP]the\nsake[SP]of[SP]my[SP]bros,[SP]I[SP]can't[SP]let[SP]you[SP]go\nthat[SP]easily.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je déteste m'abaisser à ça...[1205][001E] Mais pour\nmes potes, je peux pas te laisser partir."
+    "texte_fr": "Je déteste m'abaisser à ça...[001E][1205] Mais pour\nmes potes, je peux pas te laisser partir."
   },
   {
     "id": 23,

--- a/traduction/event_scripts/script_003.json
+++ b/traduction/event_scripts/script_003.json
@@ -12,7 +12,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "Welcome[SP]to[SP]the[SP]gulf[SP]between[SP]consciousness\nand[SP]unconsciousness...[1205][001E][SP]My[SP]name[SP]is[SP]Philemon.[1205][001E]\nHave[SP]you[SP]forgotten?",
     "nom_fr": "Philémon",
-    "texte_fr": "Bienvenue dans l'abîme entre\nconscience et inconscience...[1205][001E] Mon\nnom est Philémon.[1205][001E] Avez-vous oublié?"
+    "texte_fr": "Bienvenue dans l'abîme entre\nconscience et inconscience...[001E][1205] Mon\nnom est Philémon.[001E][1205] Avez-vous oublié?"
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "The[SP]power[SP]you[SP]hold[SP]is[SP]called[SP][E4][NULL][NULL][0006]Persona[E4][NULL][NULL][0002].[1205][001E][SP]It\nis[SP]the[SP]power[SP]to[SP]summon[SP]the[SP]selves[SP]within\nyou,[SP]the[SP]gods[SP]and[SP]the[SP]demons[SP]you[SP]harbor.",
     "nom_fr": "Philémon",
-    "texte_fr": "Ce pouvoir s'appelle [E4][NULL][NULL][0006]Persona[E4][NULL][NULL][0002].[1205][001E] Il\npermet d'invoquer les entités en\nvous, vos dieux et démons intérieurs."
+    "texte_fr": "Ce pouvoir s'appelle [E4][NULL][NULL][0006]Persona[E4][NULL][NULL][0002].[001E][1205] Il\npermet d'invoquer les entités en\nvous, vos dieux et démons intérieurs."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "The[SP]self[SP]suffused[SP]with[SP]divine[SP]love...[1205][001E]\nThe[SP]self[SP]capable[SP]of[SP]demonic[SP]cruelty...[1205][001E]\nPeople[SP]live[SP]by[SP]wearing[SP]different[SP]masks.",
     "nom_fr": "Philémon",
-    "texte_fr": "Le moi baigné d'amour divin...[1205][001E] Le moi\ncapable de cruauté démoniaque...[1205][001E] Les\ngens vivent en portant des masques."
+    "texte_fr": "Le moi baigné d'amour divin...[001E][1205] Le moi\ncapable de cruauté démoniaque...[001E][1205] Les\ngens vivent en portant des masques."
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That's...[SP]me...?[1205][001E]\nWhat[SP]are[SP]you...?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est... moi...?[1205][001E] T'es qui...?"
+    "texte_fr": "C'est... moi...?[001E][1205] T'es qui...?"
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "From[SP]time[SP]out[SP]of[SP]mind,[SP]beyond[SP]oblivion...\nThe[SP]land[SP]of[SP]Sumaru[SP]is[SP]now[SP]a[SP]netherworld[SP]where\nrumors[SP]are[SP]reality.[1205][001E][SP]The[SP]battle[SP]is[SP]begun...",
     "nom_fr": "Philémon",
-    "texte_fr": "Depuis la nuit des temps, par-delà \nl'oubli... Sumaru est devenu une terre \noù les rumeurs sont\nréalité.[1205][001E] La bataille commence..."
+    "texte_fr": "Depuis la nuit des temps, par-delà \nl'oubli... Sumaru est devenu une terre \noù les rumeurs sont réalité.[001E][1205] La bataille commence..."
   },
   {
     "id": 8,
@@ -132,6 +132,6 @@
     "nom_orig": "Philemon",
     "texte_orig": "I[SP]summoned[SP]you[SP]here[SP]to[SP]tell[SP]you[SP]this.[1205][001E]\nNow[SP]go,[SP]and[SP]with[SP]your[SP]Personas[SP]break[SP]the\nchains[SP]of[SP]karma[SP]laid[SP]against[SP]you...",
     "nom_fr": "",
-    "texte_fr": "Je vous ai convoqués ici pour vous dire ceci.[1205][001E]\nAllez maintenant, et avec vos Personas,\naffronte ce destin."
+    "texte_fr": "Je vous ai convoqués ici pour vous dire ceci.[001E][1205]\nAllez maintenant, et avec vos Personas,\naffronte ce destin."
   }
 ]

--- a/traduction/event_scripts/script_004.json
+++ b/traduction/event_scripts/script_004.json
@@ -12,7 +12,7 @@
     "nom_orig": "Kozy",
     "texte_orig": "Eikichi-ku--[1205][001E]I[SP]mean,[SP]Boss-san!\nAre[SP]you[SP]okay!?",
     "nom_fr": "Kozy",
-    "texte_fr": "Eikichi-ku--[1205][001E] Boss-san! Vous allez bien!?"
+    "texte_fr": "Eikichi-ku--[001E][1205] Boss-san! Vous allez bien!?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That...[1205][001E][SP]wasn't[SP]a[SP]dream,[SP]was[SP]it?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'était...[1205][001E] pas un rêve, hein?"
+    "texte_fr": "C'était...[001E][1205] pas un rêve, hein?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "I[SP]knew[SP]it...![1205][001E][SP]I[SP]saw[SP]it,[SP]too.[SP]It[SP]called\nthose[SP]things[SP]Personas...?",
     "nom_fr": "Lisa",
-    "texte_fr": "Je le savais![1205][001E] Je l'ai vu aussi. Il\nappelait ça des Personae...?"
+    "texte_fr": "Je le savais![001E][1205] Je l'ai vu aussi. Il\nappelait ça des Personae...?"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Even[SP]the[SP]part[SP]about[SP]rumors[SP]coming[SP]true,\nand[SP]the[SP]stuff[SP]about[SP]the[SP]future...?[1205][001E][SP]That's\ntoo[SP]much[SP]for[SP]it[SP]to[SP]be[SP]a[SP]coincidence.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Même les rumeurs qui deviennent\nréalité, et les trucs sur l'avenir...?[1205][001E]\nC'est trop pour que ça soit\nune coïncidence."
+    "texte_fr": "Même les rumeurs qui deviennent\nréalité, et les trucs sur l'avenir...?[001E][1205]\nC'est trop pour que ça soit\nune coïncidence."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Hey,[SP]I[SP]know...[1205][001E][SP]You[SP]wanna[SP]try[SP]the\nJoker[SP]Game?",
     "nom_fr": "Lisa",
-    "texte_fr": "Je sais...[1205][001E] Tu veux tenter le Jeu du Joker?"
+    "texte_fr": "Je sais...[001E][1205] Tu veux tenter le Jeu du Joker?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]thing[SP]where[SP]you[SP]call[SP]your[SP]own[SP]cell\nand[SP]it[SP]shows[SP]up?[1205][001E][SP]Why[SP]would[SP]I[SP]want[SP]to\ntry[SP]that?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le truc où t'appelles ton portable et\nil se pointe?[1205][001E] Pourquoi\nje voudrais essayer ça?"
+    "texte_fr": "Le truc où t'appelles ton portable et\nil se pointe?[001E][1205] Pourquoi\nje voudrais essayer ça?"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "To[SP]test[SP]if[SP]that[SP]was[SP]just[SP]a[SP]dream[SP]or\nsomething[SP]more.[1205][001E][SP]If[SP]the[SP]rumor[SP]really\ncomes[SP]true,[SP]then[SP]it[SP]was[SP]all[SP]real...",
     "nom_fr": "Lisa",
-    "texte_fr": "Pour voir si c'était un rêve ou\nautre chose.[1205][001E] Si la rumeur se\nréalise, alors c'était bien vrai..."
+    "texte_fr": "Pour voir si c'était un rêve ou\nautre chose.[001E][1205] Si la rumeur se\nréalise, alors c'était bien vrai..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I'll[SP]pass.[1205][001E][SP]There's[SP]no[SP]way[SP]all[SP]that\ncould[SP]be[SP]possible...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je passe.[1205][001E] C'est impossible\nque tout ça soit vrai..."
+    "texte_fr": "Je passe.[001E][1205] C'est impossible\nque tout ça soit vrai..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "That's[SP]why[SP]I'll[SP]prove[SP]it.[1205][001E][SP]Hey...[1205][001E][SP]Are[SP]you\nscared[SP]or[SP]something...?",
     "nom_fr": "Lisa",
-    "texte_fr": "C'est pour ça que je vais le\nprouver.[1205][001E] Hé...[1205][001E] T'as peur ou quoi?"
+    "texte_fr": "C'est pour ça que je vais le\nprouver.[001E][1205] Hé...[001E][1205] T'as peur ou quoi?"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "If[SP]you[SP]say[SP]so...[1205][001E][SP]It[SP]does[SP]feel[SP]like[SP]we\nshould[SP]be[SP]doing[SP]something[SP]after[SP]a[SP]dream\nlike[SP]that.[SP]Let's[SP]see[SP]if[SP]this[SP]is[SP]for[SP]real.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Si tu le dis...[1205][001E] C'est vrai qu'on devrait\nfaire quelque chose après un rêve\npareil. Voyons voir si c'est vrai."
+    "texte_fr": "Si tu le dis...[001E][1205] C'est vrai qu'on devrait\nfaire quelque chose après un rêve\npareil. Voyons voir si c'est vrai."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ken",
     "texte_orig": "*sigh*[1205][001E][SP]Why[SP]are[SP]we[SP]the[SP]ones[SP]who[SP]have\nto[SP]do[SP]this...?",
     "nom_fr": "Ken",
-    "texte_fr": "*soupir*[1205][001E] Pourquoi on doit faire ça...?"
+    "texte_fr": "*soupir*[001E][1205] Pourquoi on doit faire ça...?"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Well[SP]then,[SP]here[SP]goes...[1205][001E][SP]Joker,[SP]Joker,\nplease[SP]come[SP]here...",
     "nom_fr": "Lisa",
-    "texte_fr": "Bon, on y va...[1205][001E] Joker, Joker,\ns'il te plaît, viens ici..."
+    "texte_fr": "Bon, on y va...[001E][1205] Joker, Joker,\ns'il te plaît, viens ici..."
   },
   {
     "id": 12,
@@ -252,7 +252,7 @@
     "nom_orig": "Joker",
     "texte_orig": "I[SP]am[SP]Joker...[1205][001E][SP]The[SP]final[SP]trump[SP]card[SP]drawn\nby[SP]those[SP]anguished[SP]over[SP]their[SP]dreams...",
     "nom_fr": "Joker",
-    "texte_fr": "Je suis le Joker...[1205][001E] L'atout final tiré\npar ceux tourmentés par leurs rêves..."
+    "texte_fr": "Je suis le Joker...[001E][1205] L'atout final tiré\npar ceux tourmentés par leurs rêves..."
   },
   {
     "id": 17,
@@ -312,7 +312,7 @@
     "nom_orig": "Joker",
     "texte_orig": "The[SP]bet[SP]on[SP]the[SP]table[SP]was[SP]your[SP]inner,\ndreaming[SP]heart...[1205][001E][SP]In[SP]accordance[SP]with[SP]the\nritual,[SP]I[SP]will[SP]now[SP]claim[SP]the[SP]pot.",
     "nom_fr": "Joker",
-    "texte_fr": "La mise était votre cœur rêveur...[1205][001E]\nConformément au rituel, je vais \nréclamer le gain."
+    "texte_fr": "La mise était votre cœur rêveur...[001E][1205]\nConformément au rituel, je vais \nréclamer le gain."
   },
   {
     "id": 21,
@@ -357,7 +357,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]bastard...[1205][001E][SP]What[SP]did[SP]you[SP]do!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Enfoiré...[1205][001E] Qu'as-tu fait!?"
+    "texte_fr": "Enfoiré...[001E][1205] Qu'as-tu fait!?"
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Ideals[SP]only[SP]cause[SP]pain[SP]to[SP]the[SP]powerless.\nI[SP]have[SP]freed[SP]them[SP]from[SP]that[SP]anguish...[1205][001E]\nBetter[SP]not[SP]to[SP]yearn[SP]for[SP]impossible[SP]dreams.",
     "nom_fr": "Joker",
-    "texte_fr": "Les idéaux font souffrir les faibles. Je\nles ai libérés de cette angoisse...[1205][001E]\nMieux vaut ne pas rêver de l'impossible."
+    "texte_fr": "Les idéaux font souffrir les faibles. Je\nles ai libérés de cette angoisse...[001E][1205]\nMieux vaut ne pas rêver de l'impossible."
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Joker",
     "texte_orig": "They[SP]are[SP]lifeless[SP]shells[SP]of[SP]dreams...[1205][001E]\nThey[SP]can[SP]be[SP]seen,[SP]but[SP]are[SP]not.[SP]They[SP]will\nbe[SP]forgotten[SP]and[SP]become[SP]true[SP]shadows.",
     "nom_fr": "Joker",
-    "texte_fr": "Ces coquilles vides de rêves...[1205][001E] Ils sont\nvisibles mais ne sont plus. Oubliés,\nils deviendront de vraies ombres."
+    "texte_fr": "Ces coquilles vides de rêves...[001E][1205] Ils sont\nvisibles mais ne sont plus. Oubliés,\nils deviendront de vraies ombres."
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "I[SP]can't[SP]move...![1205][001E][SP]Is[SP]it[SP]the[SP]fear...!?",
     "nom_fr": "Lisa",
-    "texte_fr": "J'suis figée...![1205][001E] C'est la peur...!?"
+    "texte_fr": "J'suis figée...![001E][1205] C'est la peur...!?"
   },
   {
     "id": 28,
@@ -432,6 +432,6 @@
     "nom_orig": "Joker",
     "texte_orig": "It's[SP]been[SP]ages,[SP][1113][SP][1112]...[1205][001E]\nI've[SP]been[SP]waiting...[1205][001E][SP]for[SP]the[SP]moment[SP]you\nwould[SP]all[SP]summon[SP]me!",
     "nom_fr": "",
-    "texte_fr": "Ça fait un bail, [1113] [1112]...[1205][001E]\nJ'ai attendu...[1205][001E] J'ai attendu le\nmoment de vous revoir, tous."
+    "texte_fr": "Ça fait un bail, [1113] [1112]...[001E][1205]\nJ'ai attendu...[001E][1205] J'ai attendu le\nmoment de vous revoir, tous."
   }
 ]

--- a/traduction/event_scripts/script_005.json
+++ b/traduction/event_scripts/script_005.json
@@ -12,7 +12,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Those[SP]eyes...[1205][001E][SP]You[SP]haven't[SP]changed.[1205][001E]\nWhat[SP]kind[SP]of[SP]dreams[SP]did[SP]you[SP]build[SP]on\nthe[SP]corpses[SP]of[SP]other[SP]people's[SP]ideals?",
     "nom_fr": "Joker",
-    "texte_fr": "Ces yeux...[1205][001E] Tu n'as pas changé.[1205][001E]\nQuel genre de rêves as-tu bâti sur\nles cadavres des idéaux d'autrui?"
+    "texte_fr": "Ces yeux...[001E][1205] Tu n'as pas changé.[001E][1205]\nQuel genre de rêves as-tu bâti sur\nles cadavres des idéaux d'autrui?"
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Hahaha...[1205][001E][SP]Aaaaahahahaha![SP]I'll[SP]never[SP]let\nyour[SP]dreams[SP]come[SP]true!",
     "nom_fr": "Joker",
-    "texte_fr": "Hahaha...[1205][001E] Aaaaahahahaha! Tes\nrêves ne se réaliseront jamais!"
+    "texte_fr": "Hahaha...[001E][1205] Aaaaahahahaha! Tes\nrêves ne se réaliseront jamais!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Joker",
     "texte_orig": "You[SP]should[SP]know[SP]by[SP]now...[1205][001E][SP]why[SP]I[SP]came[SP]to\nyou[SP]all[SP]today!",
     "nom_fr": "Joker",
-    "texte_fr": "Tu sais maintenant...[1205][001E] pourquoi je suis ici!"
+    "texte_fr": "Tu sais maintenant...[001E][1205] pourquoi je suis ici!"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Hahaha...[1205][001E][SP]Aaaaahahahaha![SP]I'll[SP]never[SP]let\nyour[SP]dreams[SP]come[SP]true!",
     "nom_fr": "Joker",
-    "texte_fr": "Hahaha...[1205][001E] Aaaaahahahaha! Tes\nrêves ne se réaliseront jamais!"
+    "texte_fr": "Hahaha...[001E][1205] Aaaaahahahaha! Tes\nrêves ne se réaliseront jamais!"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Joker",
     "texte_orig": "You[SP]should[SP]know[SP]by[SP]now...[1205][001E][SP]why[SP]I[SP]came[SP]to\nyou[SP]all[SP]today!",
     "nom_fr": "Joker",
-    "texte_fr": "Tu sais maintenant...[1205][001E] pourquoi je suis ici!"
+    "texte_fr": "Tu sais maintenant...[001E][1205] pourquoi je suis ici!"
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Hahaha...[1205][001E][SP]Aaaaahahahaha![SP]I'll[SP]never[SP]let\nyour[SP]dreams[SP]come[SP]true!",
     "nom_fr": "Joker",
-    "texte_fr": "Hahaha...[1205][001E] Aaaaahahahaha! Tes\nrêves ne se réaliseront jamais!"
+    "texte_fr": "Hahaha...[001E][1205] Aaaaahahahaha! Tes\nrêves ne se réaliseront jamais!"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Joker",
     "texte_orig": "You[SP]should[SP]know[SP]by[SP]now...[1205][001E][SP]why[SP]I[SP]came[SP]to\nyou[SP]all[SP]today!",
     "nom_fr": "Joker",
-    "texte_fr": "Tu sais maintenant...[1205][001E] pourquoi je suis ici!"
+    "texte_fr": "Tu sais maintenant...[001E][1205] pourquoi je suis ici!"
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Hahaha...[1205][001E][SP]Aaaaahahahaha!\nThat's[SP]right...[SP]You[SP]have[SP]no[SP]right\nto[SP]be[SP]dreaming!",
     "nom_fr": "Joker",
-    "texte_fr": "Hahaha...[1205][001E] Aaaaahahahaha! C'est\nça... Tu n'as aucun droit de rêver!"
+    "texte_fr": "Hahaha...[001E][1205] Aaaaahahahaha! C'est\nça... Tu n'as aucun droit de rêver!"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Joker",
     "texte_orig": "You[SP]should[SP]know[SP]by[SP]now...[1205][001E][SP]why[SP]I[SP]came[SP]to\nyou[SP]all[SP]today!",
     "nom_fr": "Joker",
-    "texte_fr": "Tu sais maintenant...[1205][001E] pourquoi je suis ici!"
+    "texte_fr": "Tu sais maintenant...[001E][1205] pourquoi je suis ici!"
   },
   {
     "id": 13,
@@ -222,7 +222,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Hahaha...[1205][001E][SP]Aaaaahahahaha![SP]I'll[SP]never[SP]let\nyou[SP]find[SP]that[SP]dream!",
     "nom_fr": "Joker",
-    "texte_fr": "Hahaha...[1205][001E] Aaaaahahahaha! Tu\nne trouveras jamais ce rêve!"
+    "texte_fr": "Hahaha...[001E][1205] Aaaaahahahaha! Tu\nne trouveras jamais ce rêve!"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Joker",
     "texte_orig": "You[SP]should[SP]know[SP]by[SP]now...[1205][001E][SP]why[SP]I[SP]came[SP]to\nyou[SP]all[SP]today!",
     "nom_fr": "Joker",
-    "texte_fr": "Tu sais maintenant...[1205][001E] pourquoi je suis ici!"
+    "texte_fr": "Tu sais maintenant...[001E][1205] pourquoi je suis ici!"
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Wh-What...?[1205][001E][SP]What[SP]did[SP]we[SP]ever[SP]do[SP]to[SP]you?",
     "nom_fr": "Lisa",
-    "texte_fr": "Qu-Quoi...?[1205][001E] Qu'est-ce qu'on t'a fait?"
+    "texte_fr": "Qu-Quoi...?[001E][1205] Qu'est-ce qu'on t'a fait?"
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Joker",
     "texte_orig": "No...[1205][001E][SP]Do[SP]you[SP]not[SP]remember!?",
     "nom_fr": "Joker",
-    "texte_fr": "Non...[1205][001E] Vous avez oublié!?"
+    "texte_fr": "Non...[001E][1205] Vous avez oublié!?"
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Impossible![1205][001E][SP]This[SP]can't[SP]be...[1205][001E][SP]How[SP]could\nthis[SP]happen!?",
     "nom_fr": "Joker",
-    "texte_fr": "Impossible![1205][001E] Pas possible...[1205][001E]\nComment ça se fait!?"
+    "texte_fr": "Impossible![001E][1205] Pas possible...[001E][1205]\nComment ça se fait!?"
   },
   {
     "id": 20,
@@ -327,7 +327,7 @@
     "nom_orig": "Joker",
     "texte_orig": "You[SP]escaped[SP]your[SP]fate[SP]this[SP]time...[1205][001E]\nBut[SP]you[SP]will[SP]get[SP]no[SP]rest.[1205][001E][SP]My[SP]demons\nwill[SP]be[SP]your[SP]assassins.",
     "nom_fr": "Joker",
-    "texte_fr": "Vous avez échappé au destin...[1205][001E] Mais vous\nn'aurez aucun répit.[1205][001E] Mes démons vous\nassassineront."
+    "texte_fr": "Vous avez échappé au destin...[001E][1205] Mais vous\nn'aurez aucun répit.[001E][1205] Mes démons vous\nassassineront."
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Let[SP]this[SP][E4][NULL][NULL][0006]Iris[E4][NULL][NULL][0002][SP]be[SP]my[SP]testament...[1205][001E][SP]Now[SP]go,\nand[SP]remember[SP]the[SP]sins[SP]you[SP]have[SP]committed!\nThen[SP]will[SP]I[SP]claim[SP]my[SP]revenge!",
     "nom_fr": "Joker",
-    "texte_fr": "Que cet [E4][NULL][NULL][0006]Iris[E4][NULL][NULL][0002] soit mon testament...[1205][001E]\nPartez, souvenez-vous de vos péchés!\nAlors seulement, j'aurai ma revanche!"
+    "texte_fr": "Que cet [E4][NULL][NULL][0006]Iris[E4][NULL][NULL][0002] soit mon testament...[001E][1205]\nPartez, souvenez-vous de vos péchés!\nAlors seulement, j'aurai ma revanche!"
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I'm[SP]sorry,[SP]Ken...[1205][001E][SP]If[SP]I[SP]hadn't[SP]made[SP]you\nplay[SP]the[SP]game...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pardon, Ken...[1205][001E] Si je t'avais\npas forcé à jouer..."
+    "texte_fr": "Pardon, Ken...[001E][1205] Si je t'avais\npas forcé à jouer..."
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Kozy",
     "texte_orig": "Um...[1205][001E][SP]Who[SP]is[SP]Eikichi-ku--I[SP]mean,\nBoss-san[SP]talking[SP]to?",
     "nom_fr": "Kozy",
-    "texte_fr": "Euh...[1205][001E] À qui Eikichi-ku--\nenfin, Boss-san parle-t-il?"
+    "texte_fr": "Euh...[001E][1205] À qui Eikichi-ku--\nenfin, Boss-san parle-t-il?"
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "They've[SP]really[SP]been[SP]forgotten...[1205][001E]",
     "nom_fr": "Lisa",
-    "texte_fr": "Ils ont vraiment été oubliés...[1205][001E]"
+    "texte_fr": "Ils ont vraiment été oubliés...[001E][1205]"
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "I[SP]can't[SP]believe[SP]Joker[SP]is[SP]real...[1205][001E]\nBut[SP]why[SP]does[SP]he[SP]want[SP]revenge[SP]on[SP]us?",
     "nom_fr": "Lisa",
-    "texte_fr": "Le Joker est bien réel...[1205][001E] Mais\npourquoi nous en veut-il?"
+    "texte_fr": "Le Joker est bien réel...[001E][1205] Mais\npourquoi nous en veut-il?"
   },
   {
     "id": 27,
@@ -432,7 +432,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ken...[1205][001E][SP]You[SP]were[SP]going[SP]to[SP]be[SP]a[SP]boxing\nchamp,[SP]right...?[1205][001E][SP]I[SP]was[SP]gonna[SP]cut[SP]a[SP]cool\ntheme[SP]song[SP]for[SP]you...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ken...[1205][001E] Tu devais être champion de boxe...[1205][001E]\nJ'allais te faire une super chanson\nd'entrée..."
+    "texte_fr": "Ken...[001E][1205] Tu devais être champion de boxe...[001E][1205]\nJ'allais te faire une super chanson\nd'entrée..."
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I'm[SP]sorry...[SP]And[SP]after[SP]I[SP]promised...![1205][001E]\nIf[SP]only[SP]I[SP]hadn't[SP]made[SP]you[SP]do[SP]that...[1205][001E]\nDammit!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Désolé... Après l'avoir promis![1205][001E] Si je\nt'avais pas forcé à faire ça...[1205][001E] Putain!"
+    "texte_fr": "Désolé... Après l'avoir promis![001E][1205] Si je\nt'avais pas forcé à faire ça...[001E][1205] Putain!"
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "She's[SP]got[SP]a[SP]point...[1205][001E][SP]We[SP]don't[SP]stand\na[SP]chance[SP]against[SP]him[SP]yet.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Elle a raison...[1205][001E] On fait\npas le poids contre lui."
+    "texte_fr": "Elle a raison...[001E][1205] On fait\npas le poids contre lui."
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We've[SP]both[SP]been[SP]called[SP]out[SP]on[SP]a[SP]grudge\nwe[SP]know[SP]nothing[SP]about.[SP]Let's[SP]call[SP]a[SP]truce\nuntil[SP]that[SP]guy's[SP]out[SP]of[SP]the[SP]picture.[1205][001E]",
     "nom_fr": "Eikichi",
-    "texte_fr": "On nous accuse tous deux pour une\nrancœur inconnue. Trêve entre nous\njusqu'à ce que ce type soit hors jeu.[1205][001E]"
+    "texte_fr": "On nous accuse tous deux pour une\nrancœur inconnue. Trêve entre nous\njusqu'à ce que ce type soit hors jeu.[001E][1205]"
   },
   {
     "id": 32,
@@ -492,7 +492,7 @@
     "nom_orig": "Kozy",
     "texte_orig": "Umm...[SP]About[SP]my[SP]real[SP]name...[1205][001E][SP]Could[SP]you\nkeep[SP]it[SP]a[SP]secret[SP]from[SP]Boss-san?[SP]Please...",
     "nom_fr": "Kozy",
-    "texte_fr": "Mon vrai nom...[1205][001E] N'en parlez pas à\nBoss-san, ok? S'il vous plaît..."
+    "texte_fr": "Mon vrai nom...[001E][1205] N'en parlez pas à\nBoss-san, ok? S'il vous plaît..."
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Ken",
     "texte_orig": "My...[SP]dream...?[1205][001E][SP]I[SP]don't[SP]care[SP]anymore...[1205][001E]\nIt's[SP]not[SP]like[SP]it'll...",
     "nom_fr": "Ken",
-    "texte_fr": "Mon... rêve...?[1205][001E] Je m'en fiche\nplus...[1205][001E] C'est pas comme si..."
+    "texte_fr": "Mon... rêve...?[001E][1205] Je m'en fiche\nplus...[001E][1205] C'est pas comme si..."
   },
   {
     "id": 34,
@@ -522,7 +522,7 @@
     "nom_orig": "Takeshi",
     "texte_orig": "I[SP]wanted...[SP]to[SP]be[SP]a[SP]doctor...[1205][001E][SP]But[SP]that'll\nnever[SP]happen...[1205][001E][SP]I[SP]don't[SP]want[SP]to[SP]think\nanymore...",
     "nom_fr": "Takeshi",
-    "texte_fr": "Je voulais... devenir médecin...[1205][001E] Mais ça\nn'arrivera jamais...[1205][001E] Je ne\nveux plus y penser..."
+    "texte_fr": "Je voulais... devenir médecin...[001E][1205] Mais ça\nn'arrivera jamais...[001E][1205] Je ne\nveux plus y penser..."
   },
   {
     "id": 35,
@@ -537,7 +537,7 @@
     "nom_orig": "Shogo",
     "texte_orig": "I[SP]have[SP]to...[1205][001E][SP]take[SP]over[SP]the[SP]family\nbusiness...[1205][001E][SP]But...[SP]why...?",
     "nom_fr": "Shogo",
-    "texte_fr": "Je dois...[1205][001E] reprendre l'affaire\nfamiliale...[1205][001E] Pourquoi...?"
+    "texte_fr": "Je dois...[001E][1205] reprendre l'affaire\nfamiliale...[001E][1205] Pourquoi...?"
   },
   {
     "id": 36,
@@ -552,7 +552,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Wait[SP]a[SP]sec,[SP][1113]...[1205][001E][SP]You're[SP]going\nafter[SP]that[SP]guy,[SP]right?[1205][001E][SP]You[SP]should[SP]stay\nout[SP]of[SP]this.[SP]I'll[SP]deal[SP]with[SP]him.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Attends, [1113]...[1205][001E] Tu vas partir\nà sa poursuite, hein?[1205][001E] Reste en\ndehors de ça. Je m'en charge."
+    "texte_fr": "Attends, [1113]...[001E][1205] Tu vas partir\nà sa poursuite, hein?[001E][1205] Reste en\ndehors de ça. Je m'en charge."
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Whoa[SP]there,[SP]both[SP]of[SP]you![1205][001E][SP]You're[SP]up[SP]against\na[SP]real[SP]monster[SP]here![SP]If[SP]we[SP]don't[SP]stick\ntogether,[SP]you'll[SP]die!",
     "nom_fr": "Lisa",
-    "texte_fr": "Doucement, vous deux![1205][001E]\nC'est un vrai monstre!\nSi on reste pas ensemble, vous allez\ncrever!"
+    "texte_fr": "Doucement, vous deux![001E][1205]\nC'est un vrai monstre!\nSi on reste pas ensemble, vous allez crever!"
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Plus,[SP]we[SP]don't[SP]know[SP]where[SP]to[SP]start[SP]looking.[1205][001E]\nLet's[SP]get[SP]someone[SP]else[SP]to[SP]do[SP]something\nabout[SP]him--like[SP]the[SP]police!",
     "nom_fr": "Lisa",
-    "texte_fr": "En plus, on sait même pas par où\nchercher.[1205][001E] Laissons quelqu'un d'autre\ns'en charger... comme la police!"
+    "texte_fr": "En plus, on sait même pas par où\nchercher.[001E][1205] Laissons quelqu'un d'autre\ns'en charger... comme la police!"
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Who'd[SP]believe[SP]us!?[1205][001E][SP]We[SP]gotta[SP]arm[SP]up[SP]and\nkill[SP]that[SP]guy,[SP]or[SP]we're[SP]all[SP]screwed.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Qui nous croirait!?[1205][001E] Faut s'armer et\ntuer ce type sinon on est tous foutus."
+    "texte_fr": "Qui nous croirait!?[001E][1205] Faut s'armer et\ntuer ce type sinon on est tous foutus."
   },
   {
     "id": 40,
@@ -612,7 +612,7 @@
     "nom_orig": "Kozy",
     "texte_orig": "If[SP]that's[SP]the[SP]case,[SP]maybe[SP]I[SP]can\nhelp...[1205][001E][SP]I'll[SP]go[SP]see[SP]what[SP]I[SP]can[SP]find\nout[SP]about[SP]Joker.",
     "nom_fr": "Kozy",
-    "texte_fr": "Dans ce cas, je peux sûrement aider...[1205][001E] Je\nvais voir ce que je trouve sur le Joker."
+    "texte_fr": "Dans ce cas, je peux sûrement aider...[001E][1205] Je\nvais voir ce que je trouve sur le Joker."
   },
   {
     "id": 41,
@@ -642,7 +642,7 @@
     "nom_orig": "Kozy",
     "texte_orig": "That[SP]reminds[SP]me...[1205][001E][SP]Rumor[SP]has[SP]it[SP]that[SP][E4][NULL][NULL][0006]the\nramen[SP]shop[SP]in[SP]Kameya[SP]Alley[SP]sells[SP]weapons[E4][NULL][NULL][0002]...",
     "nom_fr": "Kozy",
-    "texte_fr": "Ça me rappelle...[1205][001E] La rumeur dit que [E4][NULL][NULL][0006]le\nramen de l'allée Kameya vend des armes[E4][NULL][NULL][0002]..."
+    "texte_fr": "Ça me rappelle...[001E][1205] La rumeur dit que [E4][NULL][NULL][0006]le\nramen de l'allée Kameya vend des armes[E4][NULL][NULL][0002]..."
   },
   {
     "id": 43,
@@ -657,7 +657,7 @@
     "nom_orig": "Kozy",
     "texte_orig": "Something[SP]about[SP]the[SP]owner[SP]being[SP]a[SP]former\nspy...[1205][001E][SP]With[SP]everything[SP]that's[SP]going[SP]on,\nwhy[SP]not[SP]start[SP]there?",
     "nom_fr": "Kozy",
-    "texte_fr": "Le proprio serait un ancien\nespion...[1205][001E] Avec tout ce qui se passe,\npourquoi pas commencer par là?"
+    "texte_fr": "Le proprio serait un ancien\nespion...[001E][1205] Avec tout ce qui se passe,\npourquoi pas commencer par là?"
   },
   {
     "id": 44,
@@ -672,6 +672,6 @@
     "nom_orig": "Lisa",
     "texte_orig": "If[SP]rumors[SP]are[SP]coming[SP]true,[SP]it's[SP]worth[SP]a\nshot...[1205][001E][SP]Having[SP]just[SP]our[SP]Personas[SP]makes\nme[SP]nervous,[SP]so[SP]to[SP]the[SP]ramen[SP]shop[SP]it[SP]is!",
     "nom_fr": "",
-    "texte_fr": "Si les rumeurs se réalisent, ça vaut\nla peine d'essayer...[1205][001E] N'avoir que\nnos Personas ne suffira pas."
+    "texte_fr": "Si les rumeurs se réalisent, ça vaut\nla peine d'essayer...[001E][1205] N'avoir que\nnos Personas ne suffira pas."
   }
 ]

--- a/traduction/event_scripts/script_007.json
+++ b/traduction/event_scripts/script_007.json
@@ -87,7 +87,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Are[SP]you[SP]talking[SP]about...[1205][0014][SP]that[SP]teacher[SP]who\ndied[SP]in[SP]the[SP]clock[SP]tower?",
     "nom_fr": "Lisa",
-    "texte_fr": "Vous parlez de...[1205][0014] ce prof mort\ndans la tour de l'horloge?"
+    "texte_fr": "Vous parlez de...[0014][1205] ce prof mort\ndans la tour de l'horloge?"
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "No...[SP]This[SP]can't[SP]be![SP][1432][NULL][NULL][0014]The[SP]seven[SP]Pleiades[SP]set\nthe[SP]frozen[SP]time[SP]free[1432][NULL][NULL][0014]...[1205][001E][SP]Has[SP]it[SP]begun!?[E1][E2]\n[E3][E4][NULL][NULL]\"Ms.[SP]Ideal\n*gasp*[1205][0014][SP]The[SP]Narurato[SP]Stone![SP]What[SP]about\nthe[SP]Narurato[SP]Stone!?",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Non... Impossible! [1432][NULL][NULL][0014]Les sept Pléiades ont\nlibéré le temps figé[1432][NULL][NULL][0014]...[1205][001E] Ça a commencé!?[E1][E2]\n[E3][E4][NULL][NULL]\"Mme Ideal\n*halète*[1205][0014] La Pierre Narurato!\nEt la Pierre Narurato!?"
+    "texte_fr": "Non... Impossible! [1432][NULL][NULL][0014]Les sept Pléiades ont\nlibéré le temps figé[1432][NULL][NULL][0014]...[001E][1205] Ça a commencé!?[E1][E2]\n[E3][E4][NULL][NULL]\"Mme Ideal\n*halète*[0014][1205] La Pierre Narurato!\nEt la Pierre Narurato!?"
   },
   {
     "id": 8,

--- a/traduction/event_scripts/script_008.json
+++ b/traduction/event_scripts/script_008.json
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]great[SP]Michel[SP]comes[SP]all[SP]the[SP]way[SP]to\nSevens[SP]and[SP]its[SP]own[SP]principal[SP]isn't[SP]here!?\n*sigh*[1205][001E][SP]The[SP]great[SP]rock[SP]'n[SP]roll[SP]swindle!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le grand Michel se déplace jusqu'à\nSeven et son propre proviseur n'est pas\nlà!? *soupir*[1205][001E] Quelle belle arnaque!"
+    "texte_fr": "Le grand Michel se déplace jusqu'à\nSeven et son propre proviseur n'est pas\nlà!? *soupir*[001E][1205] Quelle belle arnaque!"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Huh?[SP]Are[SP]you[SP]a[SP]student[SP]from[SP]Cuss...[1205][001E]\nI[SP]mean,[SP]Kasugayama[SP]High?",
     "nom_fr": "Lycéen",
-    "texte_fr": "Hein? T'es un élève de Kasu...[1205][001E]\nenfin, du Lycée Kasugayama?"
+    "texte_fr": "Hein? T'es un élève de Kasu...[001E][1205]\nenfin, du Lycée Kasugayama?"
   },
   {
     "id": 6,
@@ -387,7 +387,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Me,[SP]I'm[SP]Yukino[SP]Mayuzumi.[SP]I'm[SP]a[SP]freelance\nphotographer...[1205][001E][SP]An[SP]apprentice[SP]one,[SP]anyway.",
     "nom_fr": "Yukino",
-    "texte_fr": "Moi, c'est Yukino Mayuzumi. Photographe\nindépendante...[1205][001E] Apprentie, en tout cas."
+    "texte_fr": "Moi, c'est Yukino Mayuzumi. Photographe\nindépendante...[001E][1205] Apprentie, en tout cas."
   },
   {
     "id": 26,
@@ -492,7 +492,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What's[SP]going[SP]on[SP]here!?[1205][001E][SP]Can[SP]you[SP]tell[SP]us\nwhat[SP]you[SP]know?[SP]Is[SP]it[SP]related[SP]to[SP]what\nwe[SP]came[SP]to[SP]interview[SP]people[SP]about?",
     "nom_fr": "Maya",
-    "texte_fr": "Qu'est-ce qui se passe!?[1205][001E] Vous\npouvez nous dire ce que vous savez?\nC'est lié à notre sujet d'enquête?"
+    "texte_fr": "Qu'est-ce qui se passe!?[001E][1205] Vous\npouvez nous dire ce que vous savez?\nC'est lié à notre sujet d'enquête?"
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Uhhhmm...[1205][001E][SP]A-About[SP]that...[1205][001E][SP]We[SP]don't[SP]really\nknow[SP]anything...",
     "nom_fr": "Ginko",
-    "texte_fr": "Euuuuuh...[1205][001E] À ce propos...[1205][001E]\nOn sait vraiment rien..."
+    "texte_fr": "Euuuuuh...[001E][1205] À ce propos...[001E][1205]\nOn sait vraiment rien..."
   },
   {
     "id": 34,
@@ -537,7 +537,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmmmmm...[1205][001E][SP]I'm[SP]not[SP]sure[SP]I[SP]buy[SP]that.",
     "nom_fr": "Maya",
-    "texte_fr": "Hum...[1205][001E] J'y crois pas trop."
+    "texte_fr": "Hum...[001E][1205] J'y crois pas trop."
   },
   {
     "id": 36,
@@ -567,7 +567,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Stomped...?[1205][001E][SP]So[SP]you[SP]kids[SP]DO[SP]know[SP]something!",
     "nom_fr": "Yukino",
-    "texte_fr": "Rétamer?[1205][001E] Donc vous savez quelque chose!"
+    "texte_fr": "Rétamer?[001E][1205] Donc vous savez quelque chose!"
   },
   {
     "id": 38,
@@ -597,7 +597,7 @@
     "nom_orig": "Maya",
     "texte_orig": "In[SP]which[SP]case...[1205][001E][SP]We're[SP]definitely[SP]not\nletting[SP]you[SP]go!",
     "nom_fr": "Maya",
-    "texte_fr": "Dans ce cas...[1205][001E] On ne vous lâche plus!"
+    "texte_fr": "Dans ce cas...[001E][1205] On ne vous lâche plus!"
   },
   {
     "id": 40,

--- a/traduction/event_scripts/script_009.json
+++ b/traduction/event_scripts/script_009.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Whew...[1205][001E][SP]Is[SP]everyone[SP]okay?",
     "nom_fr": "Maya",
-    "texte_fr": "Ouf..[1205][001E] Vous allez bien?"
+    "texte_fr": "Ouf..[001E][1205] Vous allez bien?"
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh...?[1205][0014][SP]Why[SP]am[SP]I[SP]crying?[SP]It's[SP]so[SP]strange,\nbut...[SP]*sniff*[1205][0014][SP]I[SP]can't[SP]stop...",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein?[1205][0014] Pourquoi je pleure? C'est\nétrange. *pleurs*[1205][0014] J'peux pas m'arrêter."
+    "texte_fr": "Hein?[0014][1205] Pourquoi je pleure? C'est\nétrange. *pleurs*[0014][1205] J'peux pas m'arrêter."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's...[1205][001E][SP]like[SP]a[SP]nice[SP]memory...[SP]Warmer[SP]than\nwhat[SP]I[SP]felt[SP]with[SP][1113][SP]and[SP]Ginko...[1205][001E]\nLike[SP]a[SP]hug[SP]from[SP]my[SP]mom...",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est...[1205][001E] si chaleureux... Plus\nque ce que j'ai\nressenti avec [1113] et Ginko...[1205][001E] Comme un\ncâlin..."
+    "texte_fr": "C'est...[001E][1205] si chaleureux... Plus\nque ce que j'ai\nressenti avec [1113] et Ginko...[001E][1205] Comme un\ncâlin..."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "How[SP]weird...[1205][0014][SP]I[SP]felt[SP]it,[SP]too.[SP]What[SP]was\nthat[SP]wave[SP]of[SP]nostalgia...?",
     "nom_fr": "Maya",
-    "texte_fr": "Bizarre...[1205][0014] Je l'ai aussi senti. Était-ce de\nla nostalgie..?"
+    "texte_fr": "Bizarre...[0014][1205] Je l'ai aussi senti. Était-ce de\nla nostalgie..?"
   },
   {
     "id": 5,
@@ -132,7 +132,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I've[SP]been[SP]a[SP]Persona-user[SP]since[SP]I[SP]played\nthe[SP][1432][NULL][NULL][0014]Persona[SP]Game[1432][NULL][NULL][0014][SP]back[SP]in[SP]high[SP]school...[1205][0014]\nThat[SP]was[SP]three[SP]years[SP]ago.",
     "nom_fr": "Yukino",
-    "texte_fr": "J'ai une Persona depuis que\nj'ai fait le [1432][NULL][NULL][0014]Jeu de la Persona[1432][NULL][NULL][0014]\nau lycée...[1205][0014] Y'a trois ans de ça."
+    "texte_fr": "J'ai une Persona depuis que\nj'ai fait le [1432][NULL][NULL][0014]Jeu de la Persona[1432][NULL][NULL][0014]\nau lycée...[0014][1205] Y'a trois ans de ça."
   },
   {
     "id": 9,
@@ -447,7 +447,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Like...[1205][001E][SP]the[SP]clocks[SP]in[SP]the[SP]classrooms?\nTheir[SP]faces[SP]have[SP]the[SP]same[SP]design[SP]as\nour[SP]emblem.",
     "nom_fr": "Ginko",
-    "texte_fr": "Genre..[1205][001E] les horloges? Leurs\ncadrans ont le même motif."
+    "texte_fr": "Genre..[001E][1205] les horloges? Leurs\ncadrans ont le même motif."
   },
   {
     "id": 30,
@@ -492,7 +492,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]memories[SP]evoked[SP]by[SP]the[SP]lady[SP]Maya-san...[1205][001E]\nThey[SP]were[SP]warm,[SP]sad,[SP]and[SP]painful,[SP]all[SP]at\nonce...[1205][001E][SP]Like[SP]the[SP]wringing[SP]of[SP]my[SP]heart...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Les souvenirs que Maya-san a\néveillé...[1205][001E] Chauds, tristes et douloureux à\nla fois...[1205][001E] Comme si mon cœur se tordait..."
+    "texte_fr": "Les souvenirs que Maya-san a\néveillé...[001E][1205] Chauds, tristes et douloureux à\nla fois...[001E][1205] Comme si mon cœur se tordait..."
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]felt[SP]it[SP]too,[SP]right,[SP][1113]?[SP]And[SP]yet,\nthis[SP]is[SP]our[SP]first[SP]meeting...[1205][001E][SP]Is[SP]this[SP]a\nlove[SP]that's[SP]destined[SP]to[SP]be?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tu l'as resenti aussi, hein, [1113]? Pourtant on\nvient de se\nrencontrer...[1205][001E] Serait-ce le destin?"
+    "texte_fr": "Tu l'as resenti aussi, hein, [1113]? Pourtant on\nvient de se\nrencontrer...[001E][1205] Serait-ce le destin?"
   },
   {
     "id": 34,
@@ -537,7 +537,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Nah,[SP]that's[SP]impossible![1205][001E][SP]We've[SP]never\neven[SP]met[SP]before.",
     "nom_fr": "Ginko",
-    "texte_fr": "Non, c'est impossible![1205][001E] On\ns'est jamais vues avant."
+    "texte_fr": "Non, c'est impossible![001E][1205] On\ns'est jamais vues avant."
   },
   {
     "id": 36,
@@ -552,7 +552,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]were[SP]actually[SP]looking[SP]for[SP]you[SP]earlier.[1205][001E]\nI[SP]mean,[SP]there's[SP]no[SP]way[SP]we'd[SP]leave[SP]without\ninterviewing[SP]the[SP]famous[SP][1113]-kun!",
     "nom_fr": "Maya",
-    "texte_fr": "En fait, on te cherchait tout à l'heure.[1205][001E]\nHors de question qu'on reparte sans\ninterviewer le célèbre [1113]-kun!"
+    "texte_fr": "En fait, on te cherchait tout à l'heure.[001E][1205]\nHors de question qu'on reparte sans\ninterviewer le célèbre [1113]-kun!"
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Maya",
     "texte_orig": "*staaa[1205][000F]a[1205][000F]a[1205][000F]a[1205][000F]a[1205][000F]re*[1205][001E]\nBut[SP]that[SP]aside,[SP][1113]-kun...[1205][001E]\nHave[SP]we[SP]met[SP]somewhere[SP]before?",
     "nom_fr": "Maya",
-    "texte_fr": "*regaaaaaarde*[1205][001E] Mais bon, à part ça,\n[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1113]-kun...[1205][001E] On s'est déjà vus quelque part?"
+    "texte_fr": "*regaaaaaarde*[001E][1205] Mais bon, à part ça,\n[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][1113]-kun...[001E][1205] On s'est déjà vus quelque part?"
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Nah,[SP]just[SP]kidding![1205][001E][SP]Like[SP]that'd[SP]even[SP]be\npossible![1205][001E][SP]You're[SP]just[SP]such[SP]a[SP]fine-lookin'\nguy[SP]that[SP]I[SP]had[SP]to[SP]get[SP]a[SP]good[SP]ogle[SP]in!",
     "nom_fr": "Maya",
-    "texte_fr": "Ha, je rigole![1205][001E] Comme si c'était possible![1205][001E]\nT'es juste tellement beau gosse que je\npouvais pas m'empêcher de mater!"
+    "texte_fr": "Ha, je rigole![001E][1205] Comme si c'était possible![001E][1205]\nT'es juste tellement beau gosse que je\npouvais pas m'empêcher de mater!"
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "This[SP]is[SP]a[SP]surprise.[1205][001E][SP]I[SP]never[SP]knew[SP]there\nwere[SP]other[SP]Persona-users[SP]besides[SP]us...[1205][001E]\nBy[SP]which[SP]I[SP]mean[SP]my[SP]old[SP]pals.",
     "nom_fr": "Yukino",
-    "texte_fr": "Quelle surprise.[1205][001E] D'autres utilisateurs\nde Persona..[1205][001E] Comme mes anciens amis."
+    "texte_fr": "Quelle surprise.[001E][1205] D'autres utilisateurs\nde Persona..[001E][1205] Comme mes anciens amis."
   },
   {
     "id": 40,
@@ -627,7 +627,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "It's[SP]a[SP]long[SP]story,[SP]but...[1205][001E][SP]That's[SP]when[SP]I\nawoke[SP]to[SP]my[SP]Persona.[1205][001E][SP]There[SP]was[SP]me[SP]and\neight[SP]other[SP]guys...",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est long, mais..[1205][001E] j'ai éveillé ma\nPersona là-bas.[1205][001E] On était neuf en tout.."
+    "texte_fr": "C'est long, mais..[001E][1205] j'ai éveillé ma\nPersona là-bas.[001E][1205] On était neuf en tout.."
   },
   {
     "id": 42,
@@ -657,7 +657,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "The[SP]news[SP]called[SP]it[SP]an[SP]accident,[SP]but[SP]that\nwasn't[SP]it[SP]at[SP]all.[1205][001E][SP]SEBEC's[SP]Kandori...[1205][001E]\nHaha,[SP]never[SP]mind.[SP]Water[SP]under[SP]the[SP]bridge.",
     "nom_fr": "Yukino",
-    "texte_fr": "Ce n'était pas un accident.[1205][001E] Kandori\nde la SEBEC...[1205][001E] Bref, c'est du passé."
+    "texte_fr": "Ce n'était pas un accident.[001E][1205] Kandori\nde la SEBEC...[001E][1205] Bref, c'est du passé."
   },
   {
     "id": 44,
@@ -672,7 +672,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Oh[SP]yeah![1205][0014][SP]Wait[SP]a[SP]second,[SP][1113]!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ah oui![1205][0014] Attends, [1113]!"
+    "texte_fr": "Ah oui![0014][1205] Attends, [1113]!"
   },
   {
     "id": 45,
@@ -732,7 +732,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Sorry...[1205][001E][SP]But[SP]I'm[SP]already[SP]carrying[SP]my\nfavorite[SP]weapon!",
     "nom_fr": "Yukino",
-    "texte_fr": "Désolée...[1205][001E] Mais j'ai déjà mon arme fétiche!"
+    "texte_fr": "Désolée...[001E][1205] Mais j'ai déjà mon arme fétiche!"
   },
   {
     "id": 49,

--- a/traduction/event_scripts/script_010.json
+++ b/traduction/event_scripts/script_010.json
@@ -27,7 +27,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Enough[SP]is[SP]enough![SP]Stop[SP]letting[SP]random\nrumors[SP]push[SP]you[SP]around![1205][001E][SP]Honestly...\nWhat[SP]a[SP]headache...",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Ça suffit! Cessez de suivre ces rumeurs![1205][001E]\nFranchement... Quelle migraine..."
+    "texte_fr": "Ça suffit! Cessez de suivre ces rumeurs![001E][1205]\nFranchement... Quelle migraine..."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Y-Yukino...?[1205][001E][SP]It[SP]really[SP]is[SP]you,[SP]Yukino!",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Yu-Yukino...?[1205][001E] C'est bien toi!"
+    "texte_fr": "Yu-Yukino...?[001E][1205] C'est bien toi!"
   },
   {
     "id": 4,
@@ -162,7 +162,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "A[SP]rumor[SP]caused[SP]all[SP]this!?[SP]Then[SP]the[SP]curse\nwill[SP]lift[SP]when[SP]the[SP]emblems[SP]are[SP]gone...[1205][001E]\nIn[SP]that[SP]case,[SP]I'll[SP]help[SP]too!",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Une rumeur a fait ça!? Alors brisons les\nemblèmes pour lever le sort![1205][001E] Je vais vous\naider!"
+    "texte_fr": "Une rumeur a fait ça!? Alors brisons les\nemblèmes pour lever le sort![001E][1205] Je vais vous\naider!"
   },
   {
     "id": 11,
@@ -237,7 +237,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Oh[SP]man,[SP]I[SP]think[SP]we're[SP]forgetting[SP]the\nbiggest[SP]one...[1205][001E][SP]The[SP]enormous[SP]clock[SP]in\nthe[SP]clock[SP]tower![SP]It's[SP]still[SP]there!",
     "nom_fr": "Ginko",
-    "texte_fr": "Oh non, je crois qu'on a oublié\nle plus grand...[1205][001E] L'énorme horloge\nde la tour! Elle est toujours là!"
+    "texte_fr": "Oh non, je crois qu'on a oublié\nle plus grand...[001E][1205] L'énorme horloge\nde la tour! Elle est toujours là!"
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Principal[SP]Hanya's[SP]voice",
     "texte_orig": "As[SP]principal,[SP]everyone[SP]must[SP]obey[SP]my\norders.[SP]Do[SP]you[SP]hear[SP]me?[1205][001E][SP]You[SP]will[SP]treat\nMY[SP]Seven[SP]Sisters[SP]High[SP]with[SP]respect![E1][E2]\n[E3][E4][NULL][NULL]\"Ms.[SP]Saeko\nI[SP]suppose[SP]we[SP]have[SP]no[SP]choice,[SP]if[SP]the\nprincipal[SP]says[SP]so...",
     "nom_fr": "Voix du directeur Hanya",
-    "texte_fr": "Tout le monde doit obéir à mes ordres.\nVous m'entendez?[1205][001E] Vous\nallez respectez MON lycée\nSeven Sisters![E1][E2]\n[E3][E4][NULL][NULL]\"Mme Saeko\nSi le directeur\nl'ordonne, on n'a pas le choix..."
+    "texte_fr": "Tout le monde doit obéir à mes ordres.\nVous m'entendez?[001E][1205] Vous\nallez respectez MON lycée\nSeven Sisters![E1][E2]\n[E3][E4][NULL][NULL]\"Mme Saeko\nSi le directeur\nl'ordonne, on n'a pas le choix..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Come[SP]on,[SP]everyone.[SP]The[SP]emblem[SP]hunt\nis[SP]over![1205][001E][SP]Let's[SP]start[SP]cleaning[SP]up.",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "La chasse est finie![1205][001E]\nAllez, on nettoie tout."
+    "texte_fr": "La chasse est finie![001E][1205]\nAllez, on nettoie tout."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Damn[SP]Hamya...[1205][001E][SP]But[SP]if[SP]everyone's[SP]like\nthis,[SP]there's[SP]not[SP]much[SP]we[SP]can[SP]do.",
     "nom_fr": "Yukino",
-    "texte_fr": "Maudit Hanya...[1205][001E] Dans cet\nétat, on ne peut rien faire."
+    "texte_fr": "Maudit Hanya...[001E][1205] Dans cet\nétat, on ne peut rien faire."
   },
   {
     "id": 20,
@@ -357,7 +357,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We're[SP]finally[SP]on[SP]the[SP]last[SP]emblem...[1205][001E]\nWe[SP]need[SP]to[SP]hurry[SP]and[SP]find[SP]Mr.[SP]Hanya.\nC'mon,[SP][1113]![SP]Time[SP]for[SP]the[SP]big[SP]finish!",
     "nom_fr": "Eikichi",
-    "texte_fr": "On est enfin au dernier emblème...[1205][001E]\nFaut trouver M. Hanya vite fait.\nAllez, [1113]! Le grand final!"
+    "texte_fr": "On est enfin au dernier emblème...[001E][1205]\nFaut trouver M. Hanya vite fait.\nAllez, [1113]! Le grand final!"
   },
   {
     "id": 24,
@@ -447,7 +447,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Looks[SP]like[SP]the[SP]principal's[SP]making[SP]his\nmove,[SP]right[SP]on[SP]cue![1205][001E][SP]Let's[SP]hurry[SP]and[SP]find\nthe[SP]key[SP]to[SP]the[SP]clock[SP]tower!",
     "nom_fr": "Maya",
-    "texte_fr": "Le directeur passe à l'action,\npile au bon moment![1205][001E] Dépéchons-nous\nde trouver la clé de la tour!"
+    "texte_fr": "Le directeur passe à l'action,\npile au bon moment![001E][1205] Dépéchons-nous\nde trouver la clé de la tour!"
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Ms.[SP]Saeko's[SP]as[SP]cool[SP]as[SP]ever.[SP]I[SP]never\nthought[SP]I'd[SP]see[SP]her[SP]again[SP]here...[1205][001E]\nGood[SP]thing[SP]I[SP]took[SP]this[SP]assignment!",
     "nom_fr": "Yukino",
-    "texte_fr": "Mme Saeko est si classe.\nHeureuse de l'avoir revue ici![1205][001E]"
+    "texte_fr": "Mme Saeko est si classe.\nHeureuse de l'avoir revue ici![001E][1205]"
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "That[SP]goddamn[SP]Hamya...[SP]How[SP]dare[SP]he\nbrainwash[SP]my[SP]Ms.[SP]Saeko![SP][1205][001E][SP]Now[SP]how[SP]should\nI[SP]settle[SP]the[SP]score...?",
     "nom_fr": "Yukino",
-    "texte_fr": "Hanya... Il a osé laver le cerveau\nde Saeko![1205][001E] Il va me le payer!"
+    "texte_fr": "Hanya... Il a osé laver le cerveau\nde Saeko![001E][1205] Il va me le payer!"
   },
   {
     "id": 32,
@@ -522,7 +522,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Still,[SP]this[SP]chaos[SP]inside[SP]the[SP]school\nreminds[SP]me[SP]of[SP]St.[SP]Hermelin[SP]High[SP]three\nyears[SP]ago...[1205][001E][SP]Oh,[SP]sorry![SP]It's[SP]nothing.",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Quand même, ce chaos me rappelle\nle lycée St. Hermelin il y a trois\nans...[1205][001E] Oh, pardon! C'est rien."
+    "texte_fr": "Quand même, ce chaos me rappelle\nle lycée St. Hermelin il y a trois\nans...[001E][1205] Oh, pardon! C'est rien."
   },
   {
     "id": 35,
@@ -537,7 +537,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "The[SP]clock[SP]tower?[SP]Why[SP]would[SP]you[SP]go[SP]there?\nIf[SP]you[SP]have[SP]time,[SP]you[SP]should[SP]be[SP]cleaning![1205][001E]\nWe[SP]must[SP]obey[SP]our[SP]principal.",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "La tour de l'horloge? Pourquoi y aller?\nSi vous avez du temps, nettoyez![1205][001E] On\ndoit obéir à notre directeur."
+    "texte_fr": "La tour de l'horloge? Pourquoi y aller?\nSi vous avez du temps, nettoyez![001E][1205] On\ndoit obéir à notre directeur."
   },
   {
     "id": 36,
@@ -552,7 +552,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "It[SP]really[SP]makes[SP]me[SP]mad[SP]for[SP]some[SP]reason,\nbut[SP]that[SP]bald[SP]buf--[1205][001E]I[SP]mean,[SP]errr...[1205][001E][SP]Y-You\nlike[SP]Principal[SP]Hanya[SP]too,[SP]right,[SP][1113]?",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Ce vieux chauv--[1205][001E] je veux dire.[001E][1205]..\nTu aimes aussi Hanya, pas [1113]vrai?"
+    "texte_fr": "Ce vieux chauv--[001E][1205] je veux dire.[001E][1205]..\nTu aimes aussi Hanya, pas [1113]vrai?"
   },
   {
     "id": 37,
@@ -642,7 +642,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "Th-This[SP]is[SP]tough...[SP]I[SP]shouldn't[SP]have[SP]been\nso[SP]sloppy...[1205][001E][SP]Not[SP]even[SP]I[SP]could[SP]have\npredicted[SP]this[SP]turn[SP]of[SP]events!",
     "nom_fr": "Élève bandagé",
-    "texte_fr": "Dur... J'ai été négligent...[1205][001E] Je\nn'avais pas vu venir ce retournement!"
+    "texte_fr": "Dur... J'ai été négligent...[001E][1205] Je\nn'avais pas vu venir ce retournement!"
   },
   {
     "id": 43,

--- a/traduction/event_scripts/script_011.json
+++ b/traduction/event_scripts/script_011.json
@@ -72,7 +72,7 @@
     "nom_orig": "Janitor",
     "texte_orig": "The[SP]clock[SP]tower[SP]key...[1205][001E][SP]Hmmm,[SP]where[SP]did\nI[SP]put[SP]it?",
     "nom_fr": "Concierge",
-    "texte_fr": "La clé de la tour...[1205][001E] Hmmm, où l'ai-je mise?"
+    "texte_fr": "La clé de la tour...[001E][1205] Hmmm, où l'ai-je mise?"
   },
   {
     "id": 5,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Uhh...[SP]The[SP]tag[SP]on[SP]it[SP]says...\nClock...[1205][000A][SP]Tow...[1205][000A]er...",
     "nom_fr": "Michel",
-    "texte_fr": "Euh... l'étiquette dit... Hor...[1205][000A] loge...[1205][000A]..."
+    "texte_fr": "Euh... l'étiquette dit... Hor...[000A][1205] loge...[000A][1205]..."
   },
   {
     "id": 12,
@@ -252,7 +252,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Whoa![1205][001E]",
     "nom_fr": "Maya",
-    "texte_fr": "Oh![1205][001E]"
+    "texte_fr": "Oh![001E][1205]"
   },
   {
     "id": 17,
@@ -282,7 +282,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "No[SP]key[SP]here,[SP]but[SP]plenty[SP]of[SP]side[SP]dishes.[1205][001E]\nWhatever[SP]she[SP]says,[SP]that[SP]lady[SP]seems[SP]to[SP]be\ntaking[SP]good[SP]care[SP]of[SP]gramps.",
     "nom_fr": "Yukino",
-    "texte_fr": "Aucune clé ici, il y a que des plats.[1205][001E]\nQu'importe ce qu'elle dit, cette femme\ns'occupe bien de papy."
+    "texte_fr": "Aucune clé ici, il y a que des plats.[001E][1205]\nQu'importe ce qu'elle dit, cette femme\ns'occupe bien de papy."
   },
   {
     "id": 19,
@@ -312,7 +312,7 @@
     "nom_orig": "Janitor",
     "texte_orig": "The[SP]key...[SP]the[SP]key...[SP]I[SP]feel[SP]like[SP]I\nalways[SP]see[SP]it[SP]around...[SP]Oh[SP]well,\nI[SP]oughtta[SP]eat[SP]my[SP]dinner.",
     "nom_fr": "Concierge",
-    "texte_fr": "La clé... La clé... Je la vois souvent...\nTant pis, je vais\ndîner. Poster de l'actrice\nSaiyuri Yoshikawa. Ses\nlèvres sont usées sans\nraison... Calendrier de l'actrice Saiyuri\nYoshikawa... d'il y a\n30 ans! Ses lèvres sont\nusées... Cordes et\nbougies dans la boîte...\nPour les urgences... Vieille\nTV. Elle a même\nun bouton pour les chaînes. Cachées parmi\nles photos de Saiyuri\ndans le tiroir...< des\ncoupures de la même actrice. Le frigo est\nplein de plats sous film plastique. Rien\ndans le placard.  Il\ny a des futons au fond."
+    "texte_fr": "La clé... La clé... Je la vois souvent...\nTant pis, je vais\ndîner. Poster de l'actrice Saiyuri Yoshikawa. Ses lèvres sont usées sans raison... Calendrier de l'actrice Saiyuri Yoshikawa... d'il y a 30 ans! Ses lèvres sont usées... Cordes et bougies dans la boîte... Pour les urgences... Vieille TV. Elle a même un bouton pour les chaînes. Cachées parmi les photos de Saiyuri dans le tiroir...< des coupures de la même actrice. Le frigo est plein de plats sous film plastique. Rien dans le placard.  Il y a des futons au fond."
   },
   {
     "id": 21,

--- a/traduction/event_scripts/script_012.json
+++ b/traduction/event_scripts/script_012.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "*cough*[SP]It's[SP]so[SP]dusty[SP]here...[1205][001E][SP]My[SP]perfect\nhair[SP]is[SP]going[SP]to[SP]get[SP]mussed.",
     "nom_fr": "Eikichi",
-    "texte_fr": "*tousse* Quelle poussière...[1205][001E] Mes\ncheveux vont être décoiffés."
+    "texte_fr": "*tousse* Quelle poussière...[001E][1205] Mes\ncheveux vont être décoiffés."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "But[SP]that[SP]feeling[SP]a[SP]moment[SP]ago...[1205][001E]\nWhat[SP]was[SP]it...?",
     "nom_fr": "Ginko",
-    "texte_fr": "Cette sensation...[1205][001E] C'était quoi...?"
+    "texte_fr": "Cette sensation...[001E][1205] C'était quoi...?"
   },
   {
     "id": 3,
@@ -102,7 +102,7 @@
     "nom_orig": "Teacher's[SP]ghost",
     "texte_orig": "I[SP]said...[1205][001E][SP]that[SP]time...[1205][001E][SP]must[SP]not[SP]be[SP]set\nfree...[1205][001E][SP]I[SP]said[SP]it...[1205][001E][SP]so[SP]often...\n[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nHe[SP]disappeared![1205][001E][SP]But...[SP]I[SP]feel[SP]like[SP]I've...",
     "nom_fr": "Fantôme du prof",
-    "texte_fr": "J'ai dit.[1205].[001E].[1205][001E] que le\ntemps...[1205][001E] doit rester figé...[1205][001E]\nJe le disais... [E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nIl a disparu![1205][001E]\nJ'ai l'impression... que je l'ai..."
+    "texte_fr": "J'ai dit.[1205].[001E].[001E][1205] que le\ntemps...[001E][1205] doit rester figé...[001E][1205]\nJe le disais... [E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nIl a disparu![001E][1205]\nJ'ai l'impression... que je l'ai..."
   },
   {
     "id": 7,
@@ -312,7 +312,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Hahaha![SP]Me,[SP]you[SP]ask?[SP]My[SP]wish[SP]was[SP]to[SP]become\na[SP]principal[SP]beloved[SP]by[SP]his[SP]students...[1205][001E]\nAs[SP]well[SP]as[SP]this[SP]fine[SP]mane[SP]you[SP]now[SP]see!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Hahaha! Moi? Mon vœu était de devenir\nun directeur aimé de ses\nélèves...[1205][001E]Ainsi que d'avoir cette magnifique\nchevelure!"
+    "texte_fr": "Hahaha! Moi? Mon vœu était de devenir\nun directeur aimé de ses\nélèves...[001E][1205]Ainsi que d'avoir cette magnifique\nchevelure!"
   },
   {
     "id": 21,
@@ -372,7 +372,7 @@
     "nom_orig": "Joker",
     "texte_orig": "This[SP]is[SP]between[SP]myself,[SP]the[SP]Giver,[SP]and\nyou,[SP]the[SP]Thief...[1205][001E][SP]A[SP]battle[SP]with\n[1113][SP][1112][SP]for[SP]my[SP]dream!",
     "nom_fr": "Joker",
-    "texte_fr": "C'est entre moi, le Donneur, et\ntoi, le Voleur...[1205][001E] Un combat contre\n[1113][1112] pour mon rêve!"
+    "texte_fr": "C'est entre moi, le Donneur, et\ntoi, le Voleur...[001E][1205] Un combat contre\n[1113][1112] pour mon rêve!"
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Joker",
     "texte_orig": "I'll[SP]never[SP]let[SP]you[SP]destroy[SP]my[SP]dream\nagain...[1205][001E][SP]I[SP]won't[SP]make[SP]the[SP]same\nmistake[SP]twice!",
     "nom_fr": "Joker",
-    "texte_fr": "Je te laisserai plus détruire mon\nrêve...[1205][001E] Je ne referai pas cette erreur!"
+    "texte_fr": "Je te laisserai plus détruire mon\nrêve...[001E][1205] Je ne referai pas cette erreur!"
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Time[SP]is[SP]free[SP]again...[1205][001E][SP]Heed[SP]the[SP]sound[SP]of[SP]the\nbells[SP]that[SP]toll[SP]for[SP]your[SP]dreams!",
     "nom_fr": "Joker",
-    "texte_fr": "Le temps a repris...[1205][001E] Écoutez les cloches\nsonner le glas de vos rêves!"
+    "texte_fr": "Le temps a repris...[001E][1205] Écoutez les cloches\nsonner le glas de vos rêves!"
   },
   {
     "id": 28,

--- a/traduction/event_scripts/script_013.json
+++ b/traduction/event_scripts/script_013.json
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Isn't[SP]this[SP]the[SP]fourth[SP]floor!?[SP]Eh...[1205][001E]\nI[SP]doubt[SP]even[SP]that[SP]would[SP]kill[SP]him.",
     "nom_fr": "Eikichi",
-    "texte_fr": "On est pas au 4e étage!? Bah...[1205][001E]\nÇa suffirait même pas à le tuer."
+    "texte_fr": "On est pas au 4e étage!? Bah...[001E][1205]\nÇa suffirait même pas à le tuer."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Joker...[SP]He's[SP]so[SP]alone.[1205][001E][SP]He's[SP]struggling\nwith[SP]a[SP]sin[SP]in[SP]the[SP]depths[SP]of[SP]his[SP]heart...",
     "nom_fr": "Maya",
-    "texte_fr": "Joker... Il est tellement seul.[1205][001E] Il combat\nun péché caché au fond de son cœur..."
+    "texte_fr": "Joker... Il est tellement seul.[001E][1205] Il combat\nun péché caché au fond de son cœur..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "He[SP]reminds[SP]me[SP]somehow[SP]of[SP][1113]-kun...[1205][001E]\nI[SP]feel[SP]like[SP]I[SP]know[SP]him[SP]from[SP]somewhere.",
     "nom_fr": "Maya",
-    "texte_fr": "Il me rappelle [1113]...[1205][001E] J'ai\nl'impression de le connaître."
+    "texte_fr": "Il me rappelle [1113]...[001E][1205] J'ai\nl'impression de le connaître."
   },
   {
     "id": 10,
@@ -207,7 +207,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Uh,[SP]Maya-san...[1205][001E][SP]You're[SP]not[SP]suggesting\nthat[SP]Joker[SP]is[SP][1113]'s[SP]doppelganger,\nare[SP]you?",
     "nom_fr": "Yukino",
-    "texte_fr": "Euh, Maya...[1205][001E] T'insinues quand même pas que\nJoker est le doppelganger de [1113]?"
+    "texte_fr": "Euh, Maya...[001E][1205] T'insinues quand même pas que\nJoker est le doppelganger de [1113]?"
   },
   {
     "id": 14,
@@ -372,7 +372,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "W-Wait...[1205][001E][SP]Was[SP]he[SP]here[SP]when[SP]the[SP]clock\ntower[SP]was[SP]collapsing?[SP]No...[1205][001E][SP]He's[SP]not\ndead,[SP]is[SP]he!?",
     "nom_fr": "Lycéenne",
-    "texte_fr": "A-Attendez...[1205][001E] Il était là quand la tour\ns'effondrait? Non...[1205][001E] Il est pas mort, quand\nmême!?"
+    "texte_fr": "A-Attendez...[001E][1205] Il était là quand la tour\ns'effondrait? Non...[001E][1205] Il est pas mort, quand\nmême!?"
   },
   {
     "id": 25,
@@ -413,7 +413,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "No...![SP]He[SP]died[SP]trying[SP]to[SP]protect[SP]us...?[1205][001E]\nThank[SP]you,[SP]dear[SP]principal...[1205][001E]\nAnd[SP]farewell...",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Non...! Il est mort en nous protégeant...\n?[1205][001E] Merci, cher directeur...[1205][001E] Adieu..."
+    "texte_fr": "Non...! Il est mort en nous protégeant...\n?[001E][1205] Merci, cher directeur...[001E][1205] Adieu..."
   },
   {
     "id": 27,
@@ -443,6 +443,6 @@
     "nom_orig": "Yukino",
     "texte_orig": "What[SP]was[SP]that[SP]about?[SP]I[SP]hope[SP]this[SP]doesn't\nstart[SP]any[SP]weird[SP]rumors...[1205][001E][SP]C'mon,[SP]let's\nhead[SP]for[SP]Peace[SP]Diner.",
     "nom_fr": "",
-    "texte_fr": "C'était quoi, ça ? J'espère que ça\nneva pas lancer de rumeurs bizarres...[1205][001E]\nAllez, on rentre !"
+    "texte_fr": "C'était quoi, ça ? J'espère que ça\nneva pas lancer de rumeurs bizarres...[001E][1205]\nAllez, on rentre !"
   }
 ]

--- a/traduction/event_scripts/script_014.json
+++ b/traduction/event_scripts/script_014.json
@@ -12,7 +12,7 @@
     "nom_orig": "Noriko",
     "texte_orig": "Sister![SP]I[SP]had[SP]a[SP]feeling[SP]you'd[SP]be[SP]here...[1205][001E]\nCome[SP]on,[SP]let's[SP]go[SP]back[SP]together!",
     "nom_fr": "Noriko",
-    "texte_fr": "Grande sœur! Je savais que tu serais\nici...[1205][001E] Allez, on rentre ensemble!"
+    "texte_fr": "Grande sœur! Je savais que tu serais\nici...[001E][1205] Allez, on rentre ensemble!"
   },
   {
     "id": 1,
@@ -87,7 +87,7 @@
     "nom_orig": "Noriko",
     "texte_orig": "Sister...[1205][001E][SP]Am[SP]I[SP]that[SP]much[SP]of[SP]an[SP]annoyance\nto[SP]you?",
     "nom_fr": "Noriko",
-    "texte_fr": "Grande sœur...[1205][001E] Je te dérange à ce point-là?"
+    "texte_fr": "Grande sœur...[001E][1205] Je te dérange à ce point-là?"
   },
   {
     "id": 6,
@@ -252,7 +252,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That's[SP]enough,[SP]everyone![1205][001E][SP]I[SP]think[SP]we[SP]all\nneed[SP]to[SP]be[SP]shinier,[SP]happier[SP]people[SP]here.\nYou[SP]don't[SP]want[SP]to[SP]make[SP]me[SP]mad,[SP]do[SP]you?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ça suffit![1205][001E] Je pense\nqu'on devrait tous être plus\nradieux et heureux ici. Vous ne voudriez\npas me mettre en colère, si?"
+    "texte_fr": "Ça suffit![001E][1205] Je pense\nqu'on devrait tous être plus\nradieux et heureux ici. Vous ne voudriez pas me mettre en colère, si?"
   },
   {
     "id": 17,
@@ -297,7 +297,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What...?[1205][001E][SP]You[SP]want[SP]to[SP]repeat[SP]that,\nyou[SP]worthless[SP]punk!?",
     "nom_fr": "Michel",
-    "texte_fr": "Quoi...?[1205][001E] Répète voir, espèce de voyou\nà deux balles!?"
+    "texte_fr": "Quoi...?[001E][1205] Répète voir, espèce de voyou\nà deux balles!?"
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Cuss[SP]High[SP]student",
     "texte_orig": "We[SP]got[SP]a[SP]new[SP]Leader![1205][001E][SP]And[SP]he's[SP]way,[SP]WAY\nstronger[SP]than[SP]any[SP]Boss![E1][E2]\n[E3][E4][NULL][NULL]\"Cuss[SP]High[SP]student\nAll[SP]your[SP]cronies[SP]at[SP]Cuss[SP]High[SP]have\nswitched[SP]sides[SP]for[SP]our[SP]new[SP]Leader,\nSugimoto-san!",
     "nom_fr": "Élève de Kasu",
-    "texte_fr": "On a un nouveau Leader![1205][001E] Bien plus fort que\nn'importe quel Boss![E1][E2] [E3][E4][NULL][NULL]\"Élève de Kasu\nTous tes potes de Kasu\nont rejointSugimoto-san, notre nouveau Leader!"
+    "texte_fr": "On a un nouveau Leader![001E][1205] Bien plus fort que\nn'importe quel Boss![E1][E2] [E3][E4][NULL][NULL]\"Élève de Kasu\nTous tes potes de Kasu\nont rejoint Sugimoto-san, notre nouveau Leader!"
   },
   {
     "id": 21,
@@ -402,7 +402,7 @@
     "nom_orig": "Maya",
     "texte_orig": "So[SP]there's[SP]a[SP]new[SP]head[SP]honcho[SP]right[SP]under\nthe[SP]old[SP]one's[SP]nose...?[1205][001E][SP]Doesn't[SP]that[SP]sound\na[SP]little[SP]sudden?",
     "nom_fr": "Maya",
-    "texte_fr": "Un nouveau chef apparaît sans que l'ancien\nne le sache...?[1205][001E] Ça ne\nvous semble pas un peu soudain?"
+    "texte_fr": "Un nouveau chef apparaît sans que l'ancien\nne le sache...?[001E][1205] Ça ne\nvous semble pas un peu soudain?"
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Sounds[SP]like[SP]the[SP]result[SP]of[SP]another\nrumor...[1205][001E][SP]Maybe[SP]that[SP]Sugimoto's[SP]in[SP]league\nwith[SP]Joker[SP]too.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est sûrement dû à une autre\nrumeur...[1205][001E] Sugimoto est peut-être de mèche avec\nJoker."
+    "texte_fr": "C'est sûrement dû à une autre\nrumeur...[001E][1205] Sugimoto est peut-être de mèche avec\nJoker."
   },
   {
     "id": 28,
@@ -612,7 +612,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "WHAT!?[1205][001E][SP]Did[SP]you[SP]just[SP]say[SP]Miyabi\nHanakouji?[SP]Hanakouji-san[SP]went[SP]to\nsee[SP]Hiroki!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "QUOI!?[1205][001E] Miyabi Hanakouji?\nHanakouji-san est allée voir Hiroki!?"
+    "texte_fr": "QUOI!?[001E][1205] Miyabi Hanakouji?\nHanakouji-san est allée voir Hiroki!?"
   },
   {
     "id": 41,
@@ -687,7 +687,7 @@
     "nom_orig": "Maya",
     "texte_orig": "If[SP]the[SP]rumor[SP]that[SP]the[SP]Leader[SP]is[SP]stronger\nthan[SP]the[SP]Boss[SP]has[SP]spread[SP]far[SP]enough...[1205][001E]\nEikichi-kun[SP]might[SP]be[SP]in[SP]trouble.",
     "nom_fr": "Maya",
-    "texte_fr": "Si la rumeur du Leader plus fort que le \nBoss s'est trop répandue...[1205][001E]\nEikichi-kun pourrait avoir\ndes ennuis."
+    "texte_fr": "Si la rumeur du Leader plus fort que le \nBoss s'est trop répandue...[001E][1205]\nEikichi-kun pourrait avoir\ndes ennuis."
   },
   {
     "id": 46,
@@ -822,7 +822,7 @@
     "nom_orig": "Employee",
     "texte_orig": "I[SP]wonder[SP]if[SP]the[SP]rumor[SP]about[SP][E4][NULL][NULL][0006]the[SP]maze[SP]on[SP]the\nsecond[SP]floor[E4][NULL][NULL][0002][SP]is[SP]true...[1205][000F][SP]I[SP]hear[SP][E4][NULL][NULL][0006]there's[SP]good\nstuff[SP]up[SP]there[E4][NULL][NULL][0002],[SP]but[SP]I[SP]can't[SP]go[SP]on[SP]my[SP]own.",
     "nom_fr": "Employé",
-    "texte_fr": "La rumeur sur [E4][NULL][NULL][0006]le labyrinthe[E4][NULL][NULL][0002] est vraie?\n[1205][000F]Il paraît qu'[E4][NULL][NULL][0006]il y a des trésors[E4][NULL][NULL][0002], mais\nje peux pas y aller seul."
+    "texte_fr": "La rumeur sur [E4][NULL][NULL][0006]le labyrinthe[E4][NULL][NULL][0002] est vraie?\n[000F][1205]Il paraît qu'[E4][NULL][NULL][0006]il y a des trésors[E4][NULL][NULL][0002], mais\nje peux pas y aller seul."
   },
   {
     "id": 55,
@@ -852,6 +852,6 @@
     "nom_orig": "Employee",
     "texte_orig": "Try[SP]not[SP]to[SP]cause[SP]any[SP]trouble[SP]here.[SP]Ever\nsince[SP]Cuss[SP]High[SP]students[SP]started[SP]coming\naround,[SP]this[SP]place[SP]has[SP]gone[SP]to[SP]the[SP]dogs.",
     "nom_fr": "",
-    "texte_fr": "Évitez de faire des bêtises ici.\nDepuis que les élèves de Cuss High\nse sont mis à traîner, c'est le bazar."
+    "texte_fr": "Évitez de faire des bêtises ici.\nDepuis que les élèves de Lycée Kasu\nse sont mis à traîner, c'est le bazar."
   }
 ]

--- a/traduction/event_scripts/script_015.json
+++ b/traduction/event_scripts/script_015.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I'd[SP]heard[SP]the[SP]rumor[SP]about[SP]this[SP]secret\nlounge,[SP]too...[1205][001E][SP]But[SP]actually[SP]seeing[SP]it\nfor[SP]myself[SP]is[SP]kinda[SP]weird.",
     "nom_fr": "Ginko",
-    "texte_fr": "J'avais moi aussi entendu la rumeur sur ce\nsalon secret...[1205][001E] Mais le voir en vrai, c'est\nassez bizarre."
+    "texte_fr": "J'avais moi aussi entendu la rumeur sur ce\nsalon secret...[001E][1205] Mais le voir en vrai, c'est\nassez bizarre."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "A[SP]gathering...?[SP]I[SP]wonder[SP]what[SP]that's\nabout.[SP]It[SP]seems[SP]like[SP]someone[SP]summoned[SP]them\nhere...[1205][001E][SP]I[SP]don't[SP]like[SP]the[SP]sound[SP]of[SP]this.",
     "nom_fr": "Maya",
-    "texte_fr": "Un rassemblement? Je me demande quelle en\nest la raison. Qui les\na convoqués ici?[1205][001E] Ça sent mauvais."
+    "texte_fr": "Un rassemblement? Je me demande quelle en\nest la raison. Qui les\na convoqués ici?[001E][1205] Ça sent mauvais."
   },
   {
     "id": 3,

--- a/traduction/event_scripts/script_018.json
+++ b/traduction/event_scripts/script_018.json
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Whatever...[1205][001E][SP]She[SP]was[SP]only[SP]tagging[SP]along!\nBut[SP]if[SP]anything[SP]happens[SP]to[SP]Hanakouji-san,\nyou[SP]punks[SP]are[SP]in[SP]for[SP]a[SP]world[SP]of[SP]pain!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Qu'importe...[1205][001E] Elle faisait que me suivre!\nMais si vous touchez à Hanakouji-san, vous\nallez le regretter!"
+    "texte_fr": "Qu'importe...[001E][1205] Elle faisait que me suivre!\nMais si vous touchez à Hanakouji-san, vous\nallez le regretter!"
   },
   {
     "id": 7,
@@ -192,7 +192,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Why...[1205][001E][SP]Why[SP]did[SP]you[SP]never[SP]say[SP]anything!?\nI-I...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pourquoi...[1205][001E] Pourquoi avoir\nrien dit!? J-Je..."
+    "texte_fr": "Pourquoi...[001E][1205] Pourquoi avoir\nrien dit!? J-Je..."
   },
   {
     "id": 13,
@@ -282,7 +282,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]bastard...[1205][001E][SP]Say[SP]whatever[SP]you[SP]want[SP]about\nme,[SP]I[SP]don't[SP]care.[1205][001E][SP]But[SP]anyone[SP]who[SP]laughs[SP]at\nher[SP]is[SP]a[SP]dead[SP]man!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Enfoiré...[1205][001E] Dis ce que tu veux sur\nmoi, je m'en fous.[1205][001E] Mais quiconque\nse moque d'elle est un homme mort!"
+    "texte_fr": "Enfoiré...[001E][1205] Dis ce que tu veux sur\nmoi, je m'en fous.[001E][1205] Mais quiconque\nse moque d'elle est un homme mort!"
   },
   {
     "id": 19,
@@ -342,7 +342,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ngh...[SP][1205][001E]Hirokiiiii!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ngh... [1205][001E]Hirokiiiii!"
+    "texte_fr": "Ngh... [001E][1205]Hirokiiiii!"
   },
   {
     "id": 23,
@@ -387,7 +387,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]know[SP]it's[SP]tough[SP]to[SP]watch...[1205][001E][SP]But[SP]this[SP]is\nhis[SP]moment!",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est dur à voir...[1205][001E] Mais c'est son combat!"
+    "texte_fr": "C'est dur à voir...[001E][1205] Mais c'est son combat!"
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "You[SP]want[SP]us[SP]to[SP]just[SP]sit[SP]back...!?[SP]Fanna!\nNo[SP]way![SP]Let's[SP]go[SP]save[SP]them,[SP][1113]!",
     "nom_fr": "Ginko",
-    "texte_fr": "On doit rien faire...!? Fanna! Jamais!\nAllons les aider, [1113]!"
+    "texte_fr": "On doit rien faire...!? Fanna! Jamais!\nAllons l'aider, [1113]!"
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Let's[SP]go[SP]save[SP]them!\n[1208][0002]Save[SP]them\nWait[SP]and[SP]see[SP]what[SP]happens",
     "nom_fr": "Ginko",
-    "texte_fr": "Allons les aider!\n[1208][0002]Les aider\nAttendre et regarder",
+    "texte_fr": "Allons l'aider!\n[1208][0002]Les aider\nAttendre et regarder",
     "question_orig": "Let's[SP]go[SP]save[SP]them!",
     "choix_orig": [
       "Save[SP]them",
@@ -487,7 +487,7 @@
     "nom_orig": "Leader",
     "texte_orig": "You[SP]bastards...[SP]How[SP]dare[SP]you[SP]make[SP]a[SP]fool\noutta[SP]me...[1205][001E][SP]Check[SP]this!",
     "nom_fr": "Leader",
-    "texte_fr": "Enfoirés... Comment osez-vous\nvous foutre de moi...[1205][001E] Matez ça!"
+    "texte_fr": "Enfoirés... Comment osez-vous\nvous foutre de moi...[001E][1205] Matez ça!"
   },
   {
     "id": 32,
@@ -502,7 +502,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "All[SP]right,[SP]Hiroki.[1205][001E][SP]You[SP]got[SP]me.[SP]Do[SP]your[SP]worst.\nJust[SP]let[SP]her[SP]go.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ok, Hiroki.[1205][001E] Tu m'as eu. Fais\nde ton pire. Mais lâche-la."
+    "texte_fr": "Ok, Hiroki.[001E][1205] Tu m'as eu. Fais\nde ton pire. Mais lâche-la."
   },
   {
     "id": 33,
@@ -517,7 +517,7 @@
     "nom_orig": "Leader",
     "texte_orig": "Looks[SP]like[SP]you're[SP]finally[SP]gettin'[SP]the\npicture.[SP]Ahyahahahaha...[1205][001E][SP]Fine!",
     "nom_fr": "Leader",
-    "texte_fr": "On dirait que tu piges enfin la\nsituation. Ahahahah...[1205][001E] Très bien!"
+    "texte_fr": "On dirait que tu piges enfin la\nsituation. Ahahahah...[001E][1205] Très bien!"
   },
   {
     "id": 34,
@@ -562,7 +562,7 @@
     "nom_orig": "Leader",
     "texte_orig": "O-Of[SP]course[SP]I[SP]am![SP]It's[SP]your[SP]fault[SP]that...[1205][001E]\nMy[SP]girl[SP]dumped[SP]me[SP]for[SP]that!",
     "nom_fr": "Leader",
-    "texte_fr": "B-Bien sûr! C'est ta faute si...[1205][001E]\nMa copine m'a largué pour ça!"
+    "texte_fr": "B-Bien sûr! C'est ta faute si...[001E][1205]\nMa copine m'a largué pour ça!"
   },
   {
     "id": 37,
@@ -607,7 +607,7 @@
     "nom_orig": "Leader",
     "texte_orig": "*pant*[SP]*pant*[1205][001E][SP]That's[SP]right,[SP]dammit![SP]The\nLeader[SP]is[SP]stronger[SP]than[SP]the[SP]Boss,[SP]you[SP]hear!?",
     "nom_fr": "Leader",
-    "texte_fr": "*halète* *halète*[1205][001E] C'est\nça, bordel! Le Leader\nest plus fort que le Boss, t'entends!?"
+    "texte_fr": "*halète* *halète*[001E][1205] C'est\nça, bordel! Le Leader\nest plus fort que le Boss, t'entends!?"
   },
   {
     "id": 40,

--- a/traduction/event_scripts/script_019.json
+++ b/traduction/event_scripts/script_019.json
@@ -12,7 +12,7 @@
     "nom_orig": "Leader",
     "texte_orig": "Bluhhh![SP]I-I'm[SP]zorry...[1205][001E][SP]J-Just[SP]dun[SP]yank\nmuh[SP]pansssss!",
     "nom_fr": "Leader",
-    "texte_fr": "Bleuuuh! D-Désolé...[1205][001E] B-Baisse pas mon froc!"
+    "texte_fr": "Bleuuuh! D-Désolé...[001E][1205] B-Baisse pas mon froc!"
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Really,[SP]it[SP]was[SP]just[SP]an[SP]excuse[SP]to[SP]beat[SP]people\nup[SP]with[SP]my[SP]Persona...[1205][001E][SP]And[SP]that[SP]ain't[SP]how[SP]a\nman[SP]should[SP]act!",
     "nom_fr": "Michel",
-    "texte_fr": "C'était juste une excuse pour\nfrapper les gens avec ma Persona...[1205][001E]\nC'est pas digne d'un homme!"
+    "texte_fr": "C'était juste une excuse pour\nfrapper les gens avec ma Persona...[001E][1205]\nC'est pas digne d'un homme!"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "If[SP]nothing[SP]else,[SP]that[SP]stuff[SP]you[SP]said[SP]a[SP]second\nago[SP]was...[1205][001E][SP]Uhh...[SP]I-It[SP]was[SP]pretty[SP]cool!",
     "nom_fr": "Ginko",
-    "texte_fr": "En tout cas, ce que tu as dit à l'instant\nétait...[1205][001E] Euh... C-C'était plutôt cool!"
+    "texte_fr": "En tout cas, ce que tu as dit à l'instant\nétait...[001E][1205] Euh... C-C'était plutôt cool!"
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Sorry[SP]for[SP]being[SP]so[SP]mopey...[1205][001E][SP]Anyway,[SP]I'm[SP]done\nbeing[SP]Boss,[SP]starting[SP]now.",
     "nom_fr": "Michel",
-    "texte_fr": "Désolé d'être si mou...[1205][001E] Bref,\nj'arrête d'être le Boss à présent."
+    "texte_fr": "Désolé d'être si mou...[001E][1205] Bref,\nj'arrête d'être le Boss à présent."
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Miyabi",
     "texte_orig": "I'm[SP]sorry,[SP]Eikichi-kun![SP]I'm...[1205][001E][SP]I'm[SP]so[SP]sorry\nto[SP]have[SP]caused[SP]you[SP]all[SP]this[SP]trouble!",
     "nom_fr": "Miyabi",
-    "texte_fr": "Désolée, Michel! Je...[1205][001E] Je suis vraiment\ndésolée d'avoir causé tous ces ennuis!"
+    "texte_fr": "Désolée, Michel! Je...[001E][1205] Je suis vraiment\ndésolée d'avoir causé tous ces ennuis!"
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Miyabi",
     "texte_orig": "No![SP]Don't[SP]look,[SP]Eikichi-kun...[1205][001E][SP]I'm[SP]sorry!",
     "nom_fr": "Miyabi",
-    "texte_fr": "Non! Ne me regarde pas, Michel...[1205][001E] Pardon!"
+    "texte_fr": "Non! Ne me regarde pas, Michel...[001E][1205] Pardon!"
   },
   {
     "id": 12,
@@ -267,7 +267,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That[SP]Yasuo...[1205][001E][SP]I[SP]turned[SP]him[SP]down,[SP]so[SP]he\nwent[SP]with[SP]the[SP]next[SP]name[SP]on[SP]his[SP]list!",
     "nom_fr": "Michel",
-    "texte_fr": "Ce Yasuo...[1205][001E] Je l'ai rejeté, alors il\na pris le nom suivant sur sa liste!"
+    "texte_fr": "Ce Yasuo...[001E][1205] Je l'ai rejeté, alors il\na pris le nom suivant sur sa liste!"
   },
   {
     "id": 18,
@@ -297,7 +297,7 @@
     "nom_orig": "Leader",
     "texte_orig": "There's[SP]an[SP]organization[SP]you[SP]have[SP]to[SP]join[SP]once\nMaster[SP]Joker[SP]grants[SP]your[SP]ideal.[SP]I[SP]heard[SP]the\ngathering[SP]was[SP]an[SP]initiation[SP]ceremony[SP]for[SP]it.",
     "nom_fr": "Leader",
-    "texte_fr": "Il y a une orga\nà rejoindre quand Maître Joker\nexauce ton vœu. Apparemment, cette\nréunion était une cérémonied'initiation."
+    "texte_fr": "Il y a une orga\nà rejoindre quand Maître Joker\nexauce ton vœu. Apparemment, cette réunion était une cérémonied'initiation."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Leader",
     "texte_orig": "Wh-Which[SP]reminds[SP]me...[1205][001E][SP]I[SP]also[SP]heard[SP]that[SP]one\nof[SP]their[SP]executives,[SP][1432][NULL][NULL][0014]Lady[SP]Scorpio,[1432][NULL][NULL][0014][SP]was[SP]gonna\nbe[SP]at[SP]the[SP]gathering.",
     "nom_fr": "Leader",
-    "texte_fr": "C-Ce qui me rappelle...[1205][001E] J'ai aussi\nentendu qu'un de leurs cadres, [1432][NULL][NULL][0014]Dame\nScorpion,[1432][NULL][NULL][0014] serait à ce rassemblement."
+    "texte_fr": "C-Ce qui me rappelle...[001E][1205] J'ai aussi\nentendu qu'un de leurs cadres, [1432][NULL][NULL][0014]Dame\nScorpion,[1432][NULL][NULL][0014] serait à ce rassemblement."
   },
   {
     "id": 21,
@@ -342,7 +342,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Looks[SP]like[SP]you're[SP]telling[SP]the[SP]truth...[1205][001E]\nAlright,[SP]you're[SP]off[SP]the[SP]hook.[SP]But[SP]you[SP]better\nnot[SP]go[SP]near[SP]Joker[SP]ever[SP]again,[SP]got[SP]it!?",
     "nom_fr": "Michel",
-    "texte_fr": "On dirait que tu dis la vérité...[1205][001E] Ok, tu\nt'en tires. Mais t'as intérêt à ne plus\njamais t'approcher du Joker, pigé!?"
+    "texte_fr": "On dirait que tu dis la vérité...[001E][1205] Ok, tu\nt'en tires. Mais t'as intérêt à ne plus\njamais t'approcher du Joker, pigé!?"
   },
   {
     "id": 23,
@@ -357,6 +357,6 @@
     "nom_orig": "Ginko",
     "texte_orig": "Well,[SP]we[SP]have[SP]our[SP]culprit.[SP]Next[SP]stop,[SP]the\nCuss[SP]High[SP]student[SP]council[SP]president![SP]I'm\ngonna[SP]beat[SP]the[SP]stuffing[SP]outta[SP]that[SP]guy!",
     "nom_fr": "",
-    "texte_fr": "Bon, on a notre coupable. Prochaine\nétape, le président du conseil étudiant\nde Cuss High ! Je vais lui régler son compte !"
+    "texte_fr": "Bon, on a notre coupable. Prochaine\nétape, le président du conseil étudiant\nde Lycée Kasu ! Je vais lui régler son compte !"
   }
 ]

--- a/traduction/event_scripts/script_020.json
+++ b/traduction/event_scripts/script_020.json
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Umm...[1205][001E][SP]Huh.[SP]I[SP]was[SP]sure[SP]I[SP]had[SP]a[SP]flashlight...",
     "nom_fr": "Maya",
-    "texte_fr": "Euh...[1205][001E] J'étais sûre d'avoir une lampe..."
+    "texte_fr": "Euh...[001E][1205] J'étais sûre d'avoir une lampe..."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Grazie![1205][001E][SP]Now[SP]I[SP]can[SP]see--\n[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\n...You[SP]know,[SP][1113]-kun...[1205][001E][SP]I[SP]think[SP]next\ntime[SP]you[SP]have[SP]something[SP]useful[SP]like[SP]that,\nyou[SP]should[SP]take[SP]it[SP]out[SP]a[SP]little[SP]sooner.",
     "nom_fr": "Maya",
-    "texte_fr": "Grazie![1205][001E] J'y vois clair maintenant-- [E1][E2] [E3][E4][NULL][NULL]\"Maya\n ... Tu\nsais, [1113]...[1205][001E] La prochaine fois que t'asun\ntruc utile, sors-le un peu plus tôt."
+    "texte_fr": "Grazie![001E][1205] J'y vois clair maintenant-- [E1][E2] [E3][E4][NULL][NULL]\"Maya\n ... Tu\nsais, [1113]...[001E][1205] La prochaine fois que t'asun\ntruc utile, sors-le un peu plus tôt."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Yasuo",
     "texte_orig": "Gheeeheehehehe![1205][001E][SP]You[SP]fell[SP]for[SP]it!",
     "nom_fr": "Yasuo",
-    "texte_fr": "Ghihihi![1205][001E] Vous êtes piégés!"
+    "texte_fr": "Ghihihi![001E][1205] Vous êtes piégés!"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "A[SP]walkie-talkie...?[1205][001E][SP]What[SP]a[SP]dirty[SP]trick!",
     "nom_fr": "Yukino",
-    "texte_fr": "Un talkie-walkie...?[1205][001E] Quel sale coup!"
+    "texte_fr": "Un talkie-walkie...?[001E][1205] Quel sale coup!"
   },
   {
     "id": 7,
@@ -327,7 +327,7 @@
     "nom_orig": "Yasuo",
     "texte_orig": "Grrrr...![1205][001E][SP]Fine![SP]Starve[SP]to[SP]death[SP]in[SP]there\nfor[SP]all[SP]I[SP]care![SP]Ghehee![SP]Gheeeheheehehe!",
     "nom_fr": "Yasuo",
-    "texte_fr": "Grrrr...![1205][001E] Très bien! Mourez de faim\nlà-dedans, je m'en fiche! Ghihihi!"
+    "texte_fr": "Grrrr...![001E][1205] Très bien! Mourez de faim\nlà-dedans, je m'en fiche! Ghihihi!"
   },
   {
     "id": 22,
@@ -432,7 +432,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "There[SP]was[SP]a[SP]rumor[SP]that[SP]someone[SP]did[SP]get\noutta[SP]here[SP]alive,[SP]but...[1205][001E][SP]Guh.[SP]Sorry,[SP]it's[SP]my\nfault[SP]that[SP]we're[SP]stuck[SP]in[SP]here...",
     "nom_fr": "Michel",
-    "texte_fr": "Une rumeur dit que quelqu'un s'en est\nsorti vivant, mais...[1205][001E] Argh. Désolé,\nc'est ma faute si on est coincés ici..."
+    "texte_fr": "Une rumeur dit que quelqu'un s'en est\nsorti vivant, mais...[001E][1205] Argh. Désolé,\nc'est ma faute si on est coincés ici..."
   },
   {
     "id": 29,
@@ -462,7 +462,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ohhhh...[1205][001E][SP]I[SP]can't[SP]die[SP]here![SP]What[SP]would[SP]my\nmillions[SP]of[SP]adoring[SP]fans[SP]think...?",
     "nom_fr": "Michel",
-    "texte_fr": "Ohhhh...[1205][001E] Je peux pas mourir ici! Que\npenseraient mes millions de fans...?"
+    "texte_fr": "Ohhhh...[001E][1205] Je peux pas mourir ici! Que\npenseraient mes millions de fans...?"
   },
   {
     "id": 31,
@@ -507,7 +507,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]is[SP]the[SP]first[SP]room[SP]we[SP]were[SP]in...[1205][001E]\nLook,[SP]you[SP]can[SP]see[SP]my[SP]mark[SP]on[SP]the[SP]wall.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est notre première salle...[1205][001E]\nRegardez, ma marque est au mur."
+    "texte_fr": "C'est notre première salle...[001E][1205]\nRegardez, ma marque est au mur."
   },
   {
     "id": 34,
@@ -537,7 +537,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Back[SP]to[SP]square[SP]one...?[1205][001E][SP]I[SP]think[SP]we're[SP]just\ngoing[SP]in[SP]circles.",
     "nom_fr": "Maya",
-    "texte_fr": "Retour à la case départ...?[1205][001E] Je crois\nqu'on tourne en rond."
+    "texte_fr": "Retour à la case départ...?[001E][1205] Je crois\nqu'on tourne en rond."
   },
   {
     "id": 36,
@@ -582,7 +582,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah...[1205][001E][SP]Is[SP]it[SP]just[SP]me,[SP]or[SP]is[SP]Maya-san\nsounding[SP]a[SP]little[SP]forced?",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiyah...[1205][001E] C'est moi, ou Maya a\nl'air d'un peu se forcer?"
+    "texte_fr": "Aiyah...[001E][1205] C'est moi, ou Maya a\nl'air d'un peu se forcer?"
   },
   {
     "id": 39,
@@ -612,7 +612,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]think...[1205][001E][SP]that's[SP]the[SP]way[SP]we[SP]came[SP]in.\nOr[SP]is[SP]it...?",
     "nom_fr": "Yukino",
-    "texte_fr": "Je crois...[1205][001E] qu'on est\nentré par là. Ou pas...?"
+    "texte_fr": "Je crois...[001E][1205] qu'on est\nentré par là. Ou pas...?"
   },
   {
     "id": 41,
@@ -642,7 +642,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Maya-san...[1205][001E][SP]You[SP]really[SP]need[SP]to[SP]stop[SP]smiling\nwhen[SP]you're[SP]boiling[SP]over[SP]with[SP]rage...",
     "nom_fr": "Yukino",
-    "texte_fr": "Maya...[1205][001E] Faut vraiment que tu arrêtes\nde sourire quand tu bous de rage..."
+    "texte_fr": "Maya...[001E][1205] Faut vraiment que tu arrêtes\nde sourire quand tu bous de rage..."
   },
   {
     "id": 43,

--- a/traduction/event_scripts/script_021.json
+++ b/traduction/event_scripts/script_021.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]compass[SP]is[SP]off...[1205][001E][SP]My[SP]sense[SP]of[SP]direction\nfeels[SP]out[SP]of[SP]whack,[SP]too.[SP]If[SP]we[SP]didn't[SP]have\nany[SP]light,[SP]we'd[SP]be[SP]lost[SP]for[SP]sure.",
     "nom_fr": "Maya",
-    "texte_fr": "Boussole HS...[1205][001E] Mon sens de\nl'orientation aussi. Sans lumière,\non serait perdus depuis longtemps."
+    "texte_fr": "Boussole HS...[001E][1205] Mon sens de\nl'orientation aussi. Sans lumière,\non serait perdus depuis longtemps."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Maya",
     "texte_orig": "No[SP]one[SP]knows[SP]where[SP]the[SP]exit[SP]is,[SP]huh...?[1205][001E]\nNo[SP]one[SP]knows...[SP]Hmm...",
     "nom_fr": "Maya",
-    "texte_fr": "Personne ne sait où est la sortie...[1205][001E] Hmm..."
+    "texte_fr": "Personne ne sait où est la sortie...[001E][1205] Hmm..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "A[SP]mirror...[1205][001E][SP]One[SP]rumor[SP]that[SP]no[SP]one[SP]knows[SP]where\nthe[SP]exit[SP]is,[SP]and[SP]one[SP]about[SP]someone[SP]escaping\nwith[SP]a[SP]mirror...",
     "nom_fr": "Maya",
-    "texte_fr": "Un miroir...[1205][001E] Une rumeur dit que\nla sortie est inconnue, l'autre\nqu'on peut fuir avec un miroir..."
+    "texte_fr": "Un miroir...[001E][1205] Une rumeur dit que\nla sortie est inconnue, l'autre\nqu'on peut fuir avec un miroir..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "There's[SP]a[SP]door,[SP]but[SP]there's[SP]no[SP]way[SP]it's[SP]the\nexit.[1205][001E][SP]The[SP]rumor[SP]is[SP]that[SP]no[SP]one[SP]knows[SP]where\nthe[SP]exit[SP]is...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Y'a une porte, mais ça peut pas être la\nsortie.[1205][001E] La rumeur dit que personne ne la\nconnaît..."
+    "texte_fr": "Y'a une porte, mais ça peut pas être la\nsortie.[001E][1205] La rumeur dit que personne ne la\nconnaît..."
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "There[SP]was[SP]that[SP]rumor[SP]that[SP]someone[SP]with[SP]a\nmirror[SP]got[SP]out,[SP]but...[1205][001E][SP]If[SP]there's[SP]no[SP]exit,\nwe're[SP]screwed.[1205][001E][SP]Could[SP]this[SP]be[SP]it[SP]for[SP]us...?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Il y a la rumeur de celui qui a fui\navec un miroir, mais...[1205][001E] Sans sortie, on\nest foutus.[1205][001E] C'est la fin pour nous...?"
+    "texte_fr": "Il y a la rumeur de celui qui a fui\navec un miroir, mais...[001E][1205] Sans sortie, on\nest foutus.[001E][1205] C'est la fin pour nous...?"
   },
   {
     "id": 6,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "*gulp*[SP]Maybe...[1205][001E][SP]Wait,[SP]no![SP]Ugh![SP]I'd[SP]die[SP]if\nI[SP]drank[SP]something[SP]that[SP]nasty!",
     "nom_fr": "Ginko",
-    "texte_fr": "*glou* Peut-être...[1205][001E] Non! Agh! Je\npréfère mourir que boire ce truc!"
+    "texte_fr": "*glou* Peut-être...[001E][1205] Non! Agh! Je\npréfère mourir que boire ce truc!"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Look,[SP]water's[SP]trickling[SP]out[SP]here.[1205][001E][SP]At[SP]least\nwe[SP]won't[SP]die[SP]of[SP]thirst.",
     "nom_fr": "Yukino",
-    "texte_fr": "L'eau coule par ici.[1205][001E] Au moins,\non ne mourra pas de soif."
+    "texte_fr": "L'eau coule par ici.[001E][1205] Au moins,\non ne mourra pas de soif."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "*sigh*[SP]Don't[SP]be[SP]such[SP]a[SP]lightweight.[SP]Relax...[1205][001E]\nYou[SP]can[SP]tell[SP]by[SP]the[SP]bugs[SP]in[SP]it[SP]that[SP]this\nwater's[SP]perfectly[SP]drinkable.",
     "nom_fr": "Yukino",
-    "texte_fr": "*soupire* Ne fais pas ta chochotte.\nRelax...[1205][001E] Vu les insectes qui y\nnagent, cette eau est très saine."
+    "texte_fr": "*soupire* Ne fais pas ta chochotte.\nRelax...[001E][1205] Vu les insectes qui y\nnagent, cette eau est très saine."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]think[SP]we[SP]might've[SP]underestimated[SP]that[SP]Yasuo\nguy...[1205][001E][SP]The[SP]bedrock's[SP]thick[SP]enough[SP]that[SP]we\ncan't[SP]dig[SP]our[SP]way[SP]out[SP]with[SP]our[SP]Personas.",
     "nom_fr": "Yukino",
-    "texte_fr": "Je crois qu'on a sous-estimé ce Yasuo...[1205][001E]\nLe sol est assez épais pour nous\nempêcher de creuser avec nos Personae."
+    "texte_fr": "Je crois qu'on a sous-estimé ce Yasuo...[001E][1205]\nLe sol est assez épais pour nous\nempêcher de creuser avec nos Personae."
   },
   {
     "id": 12,

--- a/traduction/event_scripts/script_022.json
+++ b/traduction/event_scripts/script_022.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Houshounah...[1205][001E][SP]I'm[SP]so[SP]tired...[SP]There's[SP]no\nexit[SP]to[SP]this[SP]place!",
     "nom_fr": "Ginko",
-    "texte_fr": "Houshounah...[1205][001E] Je suis crevée...\nY'a pas de sortie ou quoi!"
+    "texte_fr": "Houshounah...[001E][1205] Je suis crevée...\nY'a pas de sortie ou quoi!"
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Ng[SP]Hai,[SP]I[SP]don't[SP]have[SP]one[SP]with[SP]me[SP]now...[1205][001E]\nI[SP]usually[SP]keep[SP]it[SP]in[SP]my[SP]bookbag.",
     "nom_fr": "Ginko",
-    "texte_fr": "J'en ai pas avec moi maintenant...[1205][001E]\nJ'en ai normalement un dans mon sac."
+    "texte_fr": "J'en ai pas avec moi maintenant...[001E][1205]\nJ'en ai normalement un dans mon sac."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "My[SP]my,[SP]hey[SP]hey...[1205][001E][SP]Three[SP]ladies[SP]here[SP]and\nnone[SP]of[SP]them[SP]has[SP]a[SP]mirror!?[SP]*sigh*[SP]Good\nthing[SP]I'm[SP]so[SP]beautiful...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Oh la la...[1205][001E] Trois demoiselles ici\net aucune n'a de miroir!? *soupire*\nHeureusement que je suis si beau..."
+    "texte_fr": "Oh la la...[001E][1205] Trois demoiselles ici\net aucune n'a de miroir!? *soupire*\nHeureusement que je suis si beau..."
   },
   {
     "id": 5,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Ai...[1205][000F][SP]yah...[1205][001E][SP]What[SP]now!?[SP]You[SP]better[SP]take\nresponsibility[SP]for[SP]this,[SP]jackass!",
     "nom_fr": "Ginko",
-    "texte_fr": "Aill.[1205][1205][000F].[001E]. euh... Quoi!? T'as intérêt à\nte tenir responsable pour ça, abruti!"
+    "texte_fr": "Aill.[1205][000F][1205].[001E]. euh... Quoi!? T'as intérêt à\nte tenir responsable pour ça, abruti!"
   },
   {
     "id": 8,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Think[SP]positive,[SP]guys![SP]This[SP]isn't[SP]over[SP]until\nwe[SP]decide[SP]it[SP]is.[1205][001E][SP]Let's[SP]brainstorm![SP]There[SP]has\nto[SP]be[SP]a[SP]way!",
     "nom_fr": "Maya",
-    "texte_fr": "Pensez positif! C'est pas fini tant\nque l'on le décide.[1205][001E] Réfléchissons!\nIl y a forcément une solution!"
+    "texte_fr": "Pensez positif! C'est pas fini tant\nque l'on le décide.[001E][1205] Réfléchissons!\nIl y a forcément une solution!"
   },
   {
     "id": 12,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]couldn't[SP]sleep[SP]for[SP]some[SP]reason...[1205][001E]\nMind[SP]if[SP]I[SP]sit[SP]here?",
     "nom_fr": "Maya",
-    "texte_fr": "J'arrive pas à dormir...[1205][001E] Ça\ndérange si je m'assois là?"
+    "texte_fr": "J'arrive pas à dormir...[001E][1205] Ça\ndérange si je m'assois là?"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Maya",
     "texte_orig": "You[SP]really[SP]think...[1205][001E][SP]we[SP]can[SP]get[SP]out[SP]of[SP]here...?",
     "nom_fr": "Maya",
-    "texte_fr": "Tu crois vraiment...[1205][001E]\nqu'on va sortir d'ici...?"
+    "texte_fr": "Tu crois vraiment...[001E][1205]\nqu'on va sortir d'ici...?"
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Maya",
     "texte_orig": "If[SP]I[SP]start[SP]to[SP]complain,[SP]Mr.[SP]Bunbun[SP]will\nlaugh[SP]at[SP]me.[SP]Uh-oh,[SP]here[SP]he[SP]comes![SP]Bouncy\nbounce[SP]bounce!",
     "nom_fr": "Maya",
-    "texte_fr": "Si je commence à me plaindre, Mr.\nBunbun se moquerera de moi. Oh\nnon, il arrive! Cache-toi vite!"
+    "texte_fr": "Si je commence à me plaindre, Mr.\nBunbun se moquera de moi. Oh\nnon, il arrive! Cache-toi vite!"
   },
   {
     "id": 18,
@@ -297,7 +297,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]guy's[SP]my[SP]good[SP]luck[SP]charm.[1205][001E][SP]When[SP]times\nare[SP]hard,[SP]like[SP]now...[SP]I[SP]always[SP]ask[SP]him\nwhat[SP]to[SP]do.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est mon porte-bonheur.[1205][001E] Dans les moments\ndurs, comme là... Je lui demande que faire."
+    "texte_fr": "C'est mon porte-bonheur.[001E][1205] Dans les moments\ndurs, comme là... Je lui demande que faire."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Maya",
     "texte_orig": "So[SP]many[SP]terrible[SP]things[SP]have[SP]happened...[1205][001E]\nRumors[SP]are[SP]becoming[SP]reality,[SP]and[SP]we're\nunder[SP]attack[SP]from[SP]actual[SP]demons...",
     "nom_fr": "Maya",
-    "texte_fr": "Il y a eu tellement d'atrocités...[1205][001E] Les\nrumeurs deviennent réelles, et on se\nfait attaquer par des vrais démons..."
+    "texte_fr": "Il y a eu tellement d'atrocités...[001E][1205] Les\nrumeurs deviennent réelles, et on se\nfait attaquer par des vrais démons..."
   },
   {
     "id": 21,
@@ -357,7 +357,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]just[SP]can't[SP]bring[SP]myself[SP]to[SP]believe[SP]that\nJoker[SP]really[SP]is[SP]a[SP]bad[SP]guy.[1205][001E][SP]It[SP]was[SP]like[SP]he[SP]was\na[SP]child[SP]crying[SP]after[SP]having[SP]a[SP]nightmare...",
     "nom_fr": "Maya",
-    "texte_fr": "J'arrive pas à croire\nque Joker est vraiment\nmauvais.[1205][001E] On aurait dit\nun enfant en train de\npleurer après avoir eu un cauchemar..."
+    "texte_fr": "J'arrive pas à croire\nque Joker est vraiment\nmauvais.[001E][1205] On aurait dit\nun enfant en train de\npleurer après avoir eu un cauchemar..."
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]like[SP]how[SP]you[SP]guys[SP]get[SP]into[SP]fights[SP]and[SP]try\nto[SP]act[SP]cool,[SP]but[SP]my[SP]Persona[SP]tells[SP]me[SP]you're[SP]a\nbunch[SP]of[SP]good[SP]kids.[1205][001E][SP]I[SP]sense[SP]it[SP]the[SP]same[SP]way...",
     "nom_fr": "Maya",
-    "texte_fr": "C'est comme quand vous vous battez et vous\nfaites les durs, mais ma Persona me dit que\nvous êtes de \nbons gosses.[1205][001E] Je le senspareil..."
+    "texte_fr": "C'est comme quand vous vous battez et vous\nfaites les durs, mais ma Persona me dit que\nvous êtes de bons gosses.[001E][1205] Je le senspareil..."
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Is[SP]that[SP]your[SP]good[SP]luck[SP]charm,[SP][1113]-kun?[1205][001E]\nWhat's[SP]this[SP]in[SP]English[SP]here...?[1205][001E][SP][1432][NULL][NULL][0014]What's[SP]most\nimportant[SP]can't[SP]be[SP]seen[SP]with[SP]one's[SP]eyes.[1432][NULL][NULL][0014]",
     "nom_fr": "Maya",
-    "texte_fr": "Est-ce ton porte-bonheur, [1113]-kun?\n[001E][1205]Comment on dit déjà...?[1205][001E] [1432][NULL][NULL][0014]L'essentiel\nest invisible pour les yeux.[1432][NULL][NULL][0014]"
+    "texte_fr": "Est-ce ton porte-bonheur, [1113]-kun?\n[001E][1205]Comment on dit déjà...?[001E][1205] [1432][NULL][NULL][0014]L'essentiel\nest invisible pour les yeux.[1432][NULL][NULL][0014]"
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Maya",
     "texte_orig": "True[SP]indeed...[1205][001E][SP]Sometimes,[SP]I[SP]wonder[SP]if[SP]what\nwe[SP]think[SP]of[SP]as[SP]real[SP]could[SP]just[SP]all[SP]be\na[SP]dream.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est vrai...[1205][001E] Parfois, je me demande si ce\nque l'on croit vrai n'est pas qu'un rêve..."
+    "texte_fr": "C'est vrai...[001E][1205] Parfois, je me demande si ce\nque l'on croit vrai n'est pas qu'un rêve..."
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]I'm[SP]watching[SP]a[SP]dream[SP]go[SP]by[SP]while\nforgetting[SP]something[SP]important[SP]to[SP]me...[1205][001E]\nJoker,[SP]too,[SP]maybe.\n[E1][E2]\n\n[E3][E4][NULL][NULL]\"[1113]\n......",
     "nom_fr": "",
-    "texte_fr": "Comme si je regardais un rêve défiler\nen oubliant quelque chose...[1205][001E] Joker\naussi, peut-être. [E1][E2] [E3][E4][NULL][NULL]\"[1113] ......"
+    "texte_fr": "Comme si je regardais un rêve défiler\nen oubliant quelque chose...[001E][1205] Joker\naussi, peut-être. [E1][E2] [E3][E4][NULL][NULL]\"[1113] ......"
   },
   {
     "id": 28,
@@ -447,6 +447,6 @@
     "nom_orig": "Maya",
     "texte_orig": "Goodnight,[SP][1113]-kun...[1205][001E]\nSweet[SP]dreams...",
     "nom_fr": "",
-    "texte_fr": "Bonne nuit, [1113]-kun...[1205][001E]\nFais de beaux rêves..."
+    "texte_fr": "Bonne nuit, [1113]-kun...[001E][1205]\nFais de beaux rêves..."
   }
 ]

--- a/traduction/event_scripts/script_023.json
+++ b/traduction/event_scripts/script_023.json
@@ -12,7 +12,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Hey,[SP][1113].[1205][001E][SP]Do[SP]you[SP]think[SP]we're[SP]alike?",
     "nom_fr": "Gamin",
-    "texte_fr": "Hé, [1113].[1205][001E] On se ressemble?"
+    "texte_fr": "Hé, [1113].[001E][1205] On se ressemble?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Boy",
     "texte_orig": "Yeah...[1205][001E][SP]I[SP]don't[SP]mind,[SP]either.",
     "nom_fr": "Gamin",
-    "texte_fr": "Ouais...[1205][001E] Ça me va aussi."
+    "texte_fr": "Ouais...[001E][1205] Ça me va aussi."
   },
   {
     "id": 2,
@@ -222,6 +222,6 @@
     "nom_orig": "Boy",
     "texte_orig": "Hey,[SP][1113].[SP]Did[SP]you[SP]see?[1205][0005][SP]Grown-ups[SP]drink\nto[SP]forget[SP]their[SP]dreams.[SP]I[SP]don't[SP]want[SP]to\ngrow[SP]up[SP]to[SP]be[SP]like[SP]that...",
     "nom_fr": "",
-    "texte_fr": "Hé, [1113]. T'as vu ?[1205][0005] Les adultes\nboivent pour oublier leurs rêves. Moi,\nje veux pas finir comme ça..."
+    "texte_fr": "Hé, [1113]. T'as vu ?[0005][1205] Les adultes\nboivent pour oublier leurs rêves. Moi,\nje veux pas finir comme ça..."
   }
 ]

--- a/traduction/event_scripts/script_024.json
+++ b/traduction/event_scripts/script_024.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Ho[SP]Oi[SP]Dik![1205][001E][SP][1113]'s[SP]so[SP]cute\nwhen[SP]he's[SP]asleep!",
     "nom_fr": "Ginko",
-    "texte_fr": "Ho Oi Dik![1205][001E] [1113] est mignon quand il dort!"
+    "texte_fr": "Ho Oi Dik![001E][1205] [1113] est mignon quand il dort!"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Well,[SP]looks[SP]like[SP]everyone's[SP]feeling[SP]much\nbetter.[SP]Should[SP]we[SP]start[SP]thinking[SP]seriously\nabout[SP]how[SP]to[SP]get[SP]out[SP]of[SP]here?",
     "nom_fr": "Yukino",
-    "texte_fr": "Eh bien, on dirait que\ntout le monde va mieux.\nDevrait-on réfléchir à\ncomment sortir d'ici?"
+    "texte_fr": "Eh bien, on dirait que\ntout le monde va mieux.\nDevrait-on réfléchir à comment sortir d'ici?"
   },
   {
     "id": 2,
@@ -367,7 +367,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Right![SP][1432][NULL][NULL][0014]Not[SP]knowing[1432][NULL][NULL][0014][SP]isn't[SP]the[SP]same[SP]thing\nas[SP][1432][NULL][NULL][0014]not[SP]existing[1432][NULL][NULL][0014]...[1205][001E][SP]That[SP]was[SP]just[SP]us[SP]jumping\nto[SP]conclusions.",
     "nom_fr": "Maya",
-    "texte_fr": "Exact! [1432][NULL][NULL][0014]Ne pas savoir[1432][NULL][NULL][0014] n'est pas\npareil que [1432][NULL][NULL][0014]ne pas exister[1432][NULL][NULL][0014]...[1205][001E] On\na juste sauté aux conclusions."
+    "texte_fr": "Exact! [1432][NULL][NULL][0014]Ne pas savoir[1432][NULL][NULL][0014] n'est pas\npareil que [1432][NULL][NULL][0014]ne pas exister[1432][NULL][NULL][0014]...[001E][1205] On\na juste sauté aux conclusions."
   },
   {
     "id": 21,

--- a/traduction/event_scripts/script_025.json
+++ b/traduction/event_scripts/script_025.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Wow![SP]Looks[SP]like[SP]the[SP]party's[SP]in[SP]full[SP]swing.\nThis[SP]seems[SP]pretty[SP]upscale[SP]for[SP]a[SP]high[SP]school\nfestival.",
     "nom_fr": "Maya",
-    "texte_fr": "Woah! La fête bat son\nplein à ce que je vois.\nÇa a l'air luxueux pour\nun festival de lycée."
+    "texte_fr": "Woah! La fête bat son\nplein à ce que je vois.\nÇa a l'air luxueux pour un festival de lycée."
   },
   {
     "id": 1,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]can't[SP]believe[SP]he's[SP]turning[SP]the[SP]whole[SP]school\ninto[SP]shadowmen...[1205][001E][SP]What[SP]is[SP]he[SP]thinking!?\nHe's[SP]done[SP]it[SP]for[SP]the[SP]last[SP]time!",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'arrive pas à croire qu'il veuille\ntransformer tous les élèves en ombres...\n[1205][001E] Cette fois il dépasse les bornes!"
+    "texte_fr": "J'arrive pas à croire qu'il veuille\ntransformer tous les élèves en ombres...\n[001E][1205] Cette fois il dépasse les bornes!"
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "What[SP]was[SP]Anna[SP]doing[SP]here?[SP]And[SP]that[SP]feeling\nI[SP]had[SP]a[SP]moment[SP]ago...[1205][001E][SP]Nah,[SP]it[SP]can't[SP]be...",
     "nom_fr": "Yukino",
-    "texte_fr": "Que faisait Anna ici? Et cette sensation\ntout à l'heure...[1205][001E] Non, impossible..."
+    "texte_fr": "Que faisait Anna ici? Et cette sensation\ntout à l'heure...[001E][1205] Non, impossible..."
   },
   {
     "id": 14,

--- a/traduction/event_scripts/script_026.json
+++ b/traduction/event_scripts/script_026.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]hope[SP]you're[SP]ready,[SP]Yas--[1205][001E]Huh?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Yasuo! Tu-[1205][001E] Hein?"
+    "texte_fr": "Yasuo! Tu-[001E][1205] Hein?"
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]bastard...[1205][001E][SP]What's[SP]your[SP]game,[SP]making\neveryone[SP]into[SP]shadowmen!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Espèce de...[1205][001E] Pourquoi\ntransformer les gens en ombres!?"
+    "texte_fr": "Espèce de...[001E][1205] Pourquoi\ntransformer les gens en ombres!?"
   },
   {
     "id": 3,
@@ -177,7 +177,7 @@
     "nom_orig": "Yasuo",
     "texte_orig": "Hmph...[1205][001E][SP]Say[SP]what[SP]you[SP]will,[SP]but[SP]if[SP]this[SP]school\nfestival[SP]succeeds,[SP]there's[SP]no[SP]doubt[SP]that[SP]my\nreputation[SP]will[SP]soar[SP]even[SP]higher.",
     "nom_fr": "Yasuo",
-    "texte_fr": "Hmph...[1205][001E] Dites ce que vous voulez:\nsi ce festival réussit, ma\nréputation n'en sera que meilleure."
+    "texte_fr": "Hmph...[001E][1205] Dites ce que vous voulez:\nsi ce festival réussit, ma\nréputation n'en sera que meilleure."
   },
   {
     "id": 12,
@@ -372,6 +372,6 @@
     "nom_orig": "Yasuo",
     "texte_orig": "I[SP]detest[SP]violence...[1205][001E][SP]But[SP]I[SP]suppose[SP]I[SP]don't\nhave[SP]a[SP]choice[SP]now.[SP]You'll[SP]die[SP]regretting[SP]your\ndecision[SP]to[SP]meddle![SP]Gheeeheeheheheeeeee!",
     "nom_fr": "",
-    "texte_fr": "Je déteste la violence...[1205][001E] Mais\nje suppose que je n'ai plus le choix.\nTu mourras en regrettant de t'être mêlé de ça ! Gueueueueueue !"
+    "texte_fr": "Je déteste la violence...[001E][1205] Mais\nje suppose que je n'ai plus le choix.\nTu mourras en regrettant de t'être mêlé de ça ! Gueueueueueue !"
   }
 ]

--- a/traduction/event_scripts/script_027.json
+++ b/traduction/event_scripts/script_027.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]knew[SP]it...[1205][001E][SP]The[SP]color's[SP]different,[SP]but[SP]apart\nfrom[SP]that[SP]this[SP]is[SP]the[SP]same[SP]skull[SP]Joker[SP]had.",
     "nom_fr": "Ginko",
-    "texte_fr": "Je le savais...[1205][001E] La couleur diffère mais\nc'est bien le même crâne qu'avait Joker."
+    "texte_fr": "Je le savais...[001E][1205] La couleur diffère mais\nc'est bien le même crâne qu'avait Joker."
   },
   {
     "id": 1,
@@ -87,7 +87,7 @@
     "nom_orig": "Yasuo",
     "texte_orig": "But[SP]there's[SP]a[SP]rule[SP]that[SP]anyone[SP]who[SP]joins[SP]the\nMasked[SP]Circle[SP]must[SP]present[SP]its[SP]executives[SP]with\nIdeal[SP]Energy,[SP]derived[SP]from[SP]dreaming[SP]hearts.",
     "nom_fr": "Yasuo",
-    "texte_fr": "Mais une règle stipule que toute personne\nayant rejoint le\nCercle Masqué doit apporter\nde l'Énergie idéale\nissue de coeurs rêveurs."
+    "texte_fr": "Mais une règle stipule que toute personne\nayant rejoint le\nCercle Masqué doit apporter de l'Énergie idéale issue de coeurs rêveurs."
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That's...[1205][001E][SP]from[SP]some[SP]kid's[SP]game[SP]that[SP]shows[SP]up\nin[SP]my[SP]dreams...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ça vient...[1205][001E] d'un jeu\napparaissant dans mes rêves..."
+    "texte_fr": "Ça vient...[001E][1205] d'un jeu\napparaissant dans mes rêves..."
   },
   {
     "id": 8,
@@ -162,7 +162,7 @@
     "nom_orig": "Yasuo",
     "texte_orig": "If[SP]the[SP]masquerade[SP]had[SP]succeeded[SP]and[SP]I[SP]gave\nenough[SP]energy[SP]to[SP]the[SP]Lady,[SP]I[SP]thought[SP]I'd[SP]reach\na[SP]higher[SP]position[SP]in[SP]the[SP]Masked[SP]Circle...",
     "nom_fr": "Yasuo",
-    "texte_fr": "Si tout s'était passé comme prévu et que\nj'avais donné assez\nd'énergie à Lady, j'aurais\npu être promu au sein du Cercle Masqué..."
+    "texte_fr": "Si tout s'était passé comme prévu et que\nj'avais donné assez\nd'énergie à Lady, j'aurais pu être promu au sein du Cercle Masqué..."
   },
   {
     "id": 11,
@@ -252,7 +252,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "That[SP]feeling[SP]again...[1205][001E][SP]Anna!?",
     "nom_fr": "Yukino",
-    "texte_fr": "Cette sensation...[1205][001E] Anna!?"
+    "texte_fr": "Cette sensation...[001E][1205] Anna!?"
   },
   {
     "id": 17,
@@ -462,7 +462,7 @@
     "nom_orig": "King[SP]Leo",
     "texte_orig": "...[1205][001E]Very[SP]well.[SP]But[SP]you[SP]will[SP]deal[SP]with[SP]the\nconsequences[SP]of[SP]the[SP]party's[SP]interruption.",
     "nom_fr": "Roi Lion",
-    "texte_fr": "...[1205][001E] Très bien. Mais tu paieras\npour avoir interrompu le festival."
+    "texte_fr": "...[001E][1205] Très bien. Mais tu paieras\npour avoir interrompu le festival."
   },
   {
     "id": 31,
@@ -582,7 +582,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "A[SP]pyromaniac...[1205][001E][SP]Kehhei![SP]That's[SP]the[SP]worst!",
     "nom_fr": "Ginko",
-    "texte_fr": "Un pyromane...[1205][001E] C'est Kehhei! Bordel!"
+    "texte_fr": "Un pyromane...[001E][1205] C'est Kehhei! Bordel!"
   },
   {
     "id": 39,
@@ -612,7 +612,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Remember[SP]how[SP]that[SP]King[SP]guy[SP]told[SP]Anna[SP]to\n[1432][NULL][NULL][0014]deal[SP]with[SP]the[SP]consequences[1432][NULL][NULL][0014]?[1205][001E][SP]That's[SP]been\nbugging[SP]me[SP]ever[SP]since...",
     "nom_fr": "Yukino",
-    "texte_fr": "Ce roi a dit à Anna de [1432][NULL][NULL][0014]faire face aux\nconséquences[1432][NULL][NULL][0014]?[1205][001E] Ça me travaille depuis..."
+    "texte_fr": "Ce roi a dit à Anna de [1432][NULL][NULL][0014]faire face aux\nconséquences[1432][NULL][NULL][0014]?[001E][1205] Ça me travaille depuis..."
   },
   {
     "id": 41,

--- a/traduction/event_scripts/script_028.json
+++ b/traduction/event_scripts/script_028.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Wow![SP]Look[SP]at[SP]this[SP]crowd...[1205][001E][SP]I'd[SP]say[SP]Muses'\nreputation[SP]precedes[SP]them.",
     "nom_fr": "Maya",
-    "texte_fr": "Wow! Regardez cette foule...[1205][001E] Les\nMuses sont vraiment populaires."
+    "texte_fr": "Wow! Regardez cette foule...[001E][1205] Les\nMuses sont vraiment populaires."
   },
   {
     "id": 1,
@@ -192,7 +192,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP]are[SP]we[SP]really[SP]going?[SP]I[SP]know[SP]what[SP]I[SP]said\nat[SP]the[SP]detective[SP]agency,[SP]but...[1205][001E][SP]Can[SP]we[SP]not\ngo[SP]after[SP]all?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, on y va vraiment?\nJe sais ce que j'ai dit\nà l'agence, mais...[1205][001E] On\npeut pas y aller après?"
+    "texte_fr": "Hé, on y va vraiment?\nJe sais ce que j'ai dit\nà l'agence, mais...[001E][1205] On\npeut pas y aller après?"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "It's[SP]not[SP]like[SP]I[SP]want[SP]to[SP]go[SP]into[SP]showbiz...[1205][001E]\nAnd[SP]I'm[SP]not[SP]in[SP]the[SP]mood[SP]to[SP]see[SP]either[SP]of\nthose[SP]two[SP]right[SP]now.",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est pas comme si je voulais faire\ndu showbiz...[1205][001E] Et je n'ai pas vraiment\nenvie de voir qui que ce soit."
+    "texte_fr": "C'est pas comme si je voulais faire\ndu showbiz...[001E][1205] Et je n'ai pas vraiment\nenvie de voir qui que ce soit."
   },
   {
     "id": 14,
@@ -432,7 +432,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine\nn°3 de la rangée des bornes Wild 9."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°3 de la rangée des bornes Wild 9."
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine\nn°4 de la rangée des bornes Wild 9."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°4 de la rangée des bornes Wild 9."
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine\nn°5 de la rangée des bornes Wild 9."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°5 de la rangée des bornes Wild 9."
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine\nn°6 de la rangée des bornes Wild 9."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°6 de la rangée des bornes Wild 9."
   },
   {
     "id": 32,
@@ -492,7 +492,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine\nn°7 de la rangée des bornes Wild 9."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°7 de la rangée des bornes Wild 9."
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine\nn°8 de la rangée des bornes Wild 9."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°8 de la rangée des bornes Wild 9."
   },
   {
     "id": 34,
@@ -522,7 +522,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine\nn°9 de la rangée des bornes Wild 9."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°9 de la rangée des bornes Wild 9."
   },
   {
     "id": 35,
@@ -537,7 +537,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine\nn°10 de la rangée des bornes Wild 9."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez\npas jouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°10 de la rangée des bornes Wild 9."
   },
   {
     "id": 36,
@@ -552,7 +552,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous\nne pouvez pas jouer\nmaintenant. C'est un peu chaotique en ce\nmoment.  Machine de blackjack [NULL][NULL]Unissons nos\nForces[NULL][NULL]."
+    "texte_fr": "Oh désolé, monsieur! Vous\nne pouvez pas jouer\nmaintenant. C'est un peu chaotique en ce moment.  Machine de blackjack [NULL][NULL]Unissons nos Forces[NULL][NULL]."
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°1\nde la rangée des machines Arouse Blank."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°1 de la rangée des machines Arouse Blank."
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°2\nde la rangée des machines Arouse Blank."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°2 de la rangée des machines Arouse Blank."
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°3\nde la rangée des machines Arouse Blank."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°3 de la rangée des machines Arouse Blank."
   },
   {
     "id": 40,
@@ -612,7 +612,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°4\nde la rangée des machines Arouse Blank."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°4 de la rangée des machines Arouse Blank."
   },
   {
     "id": 41,
@@ -627,7 +627,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°5\nde la rangée des machines Arouse Blank."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°5 de la rangée des machines Arouse Blank."
   },
   {
     "id": 42,
@@ -642,7 +642,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°6\nde la rangée des machines Arouse Blank."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°6 de la rangée des machines Arouse Blank."
   },
   {
     "id": 43,
@@ -657,7 +657,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°7\nde la rangée des machines Arouse Blank."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°7 de la rangée des machines Arouse Blank."
   },
   {
     "id": 44,
@@ -672,7 +672,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Oh,[SP]I'm[SP]sorry,[SP]sir![SP]You[SP]can't[SP]play[SP]that\nright[SP]now.[SP]Sorry,[SP]but[SP]things[SP]are[SP]too\nhectic[SP]at[SP]the[SP]moment.",
     "nom_fr": "Manager",
-    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°8\nde la rangée des machines Arouse Blank."
+    "texte_fr": "Oh désolé, monsieur! Vous ne pouvez pas\njouer maintenant. C'est un peu\nchaotique en ce moment.  Machine n°8 de la rangée des machines Arouse Blank."
   },
   {
     "id": 45,

--- a/traduction/event_scripts/script_029.json
+++ b/traduction/event_scripts/script_029.json
@@ -12,7 +12,7 @@
     "nom_orig": "Director",
     "texte_orig": "Alright,[SP]this[SP]take's[SP]for[SP]real![1205][001E][SP]And...[SP]Action!",
     "nom_fr": "Directeur",
-    "texte_fr": "C'est la bonne prise![1205][001E] Et... action!"
+    "texte_fr": "C'est la bonne prise![001E][1205] Et... action!"
   },
   {
     "id": 1,
@@ -207,7 +207,7 @@
     "nom_orig": "Miho",
     "texte_orig": "Wha...?[1205][001E][SP]That's[SP]horrible,[SP]Lisa...[SP]Do[SP]you[SP]not\nlike[SP]us[SP]anymore?",
     "nom_fr": "Miho",
-    "texte_fr": "Quoi...?[1205][001E] T'es terrible\nLisa... Tu ne nous aime plus?"
+    "texte_fr": "Quoi...?[001E][1205] T'es terrible\nLisa... Tu ne nous aime plus?"
   },
   {
     "id": 14,

--- a/traduction/event_scripts/script_030.json
+++ b/traduction/event_scripts/script_030.json
@@ -27,7 +27,7 @@
     "nom_orig": "Meteor[SP]Masa",
     "texte_orig": "By[SP]the[SP]way,[SP]Ginji-san,[SP]you[SP]said[SP]you[SP]had[SP]an\nimportant[SP]announcement[SP]to[SP]make[SP]during[SP]our\nshow[SP]today.[SP]You[SP]don't[SP]mean...?[1205][001E]",
     "nom_fr": "Meteor Masa",
-    "texte_fr": "À ce propos, Ginji, tu as dit que tu\navais une annonce importante à faire\naujourd'hui. Tu ne veux pas dire...?[1205][001E]"
+    "texte_fr": "À ce propos, Ginji, tu as dit que tu\navais une annonce importante à faire\naujourd'hui. Tu ne veux pas dire...?[001E][1205]"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "???",
     "texte_orig": "Ahahah...[1205][001E][SP]You've[SP]got[SP]me[SP]there.[SP]Yeah,[SP]I'd[SP]say\nit's[SP]about[SP]time.[SP]Looks[SP]like[SP]our[SP]last[SP]guest\nhas[SP]just[SP]arrived.",
     "nom_fr": "???",
-    "texte_fr": "Ahahah...[1205][001E] Là tu m'as eu. Ouais, c'est\nle moment. Il semblerait que notre\ndernière invitée vient d'arriver."
+    "texte_fr": "Ahahah...[001E][1205] Là tu m'as eu. Ouais, c'est\nle moment. Il semblerait que notre\ndernière invitée vient d'arriver."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginji",
     "texte_orig": "It's[SP]time[SP]I[SP]gave[SP]the[SP]people[SP]what[SP]they[SP]want\nand[SP]announced[SP]the[SP]third[SP]member[SP]of[SP]Muses![1205][001E]\nLisa[SP]Silverman![SP]There[SP]you[SP]are!",
     "nom_fr": "Ginji",
-    "texte_fr": "Je vais donné aux gens ce qu'ils veulent\net que j'annonce le troisième membre de\nMuses![1205][001E] Lisa Silverman! Te voilà!"
+    "texte_fr": "Je vais donné aux gens ce qu'ils veulent\net que j'annonce le troisième membre de\nMuses![001E][1205] Lisa Silverman! Te voilà!"
   },
   {
     "id": 4,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hey,[SP][1113]-kun.[1205][001E][SP]Do[SP]you[SP]detect[SP]a[SP]faint\nPersona[SP]resonance[SP]in[SP]that[SP]Sasaki[SP]guy?",
     "nom_fr": "Maya",
-    "texte_fr": "Hey, [1113].[1205][001E] tu sens une légère\nrésonance de Persona chez ce Sasaki?"
+    "texte_fr": "Hey, [1113].[001E][1205] tu sens une légère\nrésonance de Persona chez ce Sasaki?"
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "But[SP]if[SP]we[SP]go[SP]along[SP]with[SP]the[SP]plan,[SP]we[SP]might\nget[SP]some[SP]juicy[SP]details[SP]on[SP]the[SP]Masked[SP]Circle.[1205][001E]\nWell,[SP]it's[SP]all[SP]up[SP]to[SP]Lisa[SP]now.",
     "nom_fr": "Maya",
-    "texte_fr": "Si on s'en tient au plan, on peut\npeut-être obtenir quelques détails sur\nle Cercle Masqué.[1205][001E] Tout dépend de Lisa."
+    "texte_fr": "Si on s'en tient au plan, on peut\npeut-être obtenir quelques détails sur\nle Cercle Masqué.[001E][1205] Tout dépend de Lisa."
   },
   {
     "id": 11,
@@ -252,7 +252,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Awww,[SP]you[SP]should've[SP]said[SP]so[SP]before...[1205][001E]\nBaby[SP]be[SP]mine![SP]I'm[SP]gonna[SP]give[SP]you[SP]a[SP]whole\nlotta[SP]love!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Awww, tu aurais dû le dire avant...[1205][001E] Chérie\ndeviens mienne! Voilà\nune bonne dose d'amour!"
+    "texte_fr": "Awww, tu aurais dû le dire avant...[001E][1205] Chérie\ndeviens mienne! Voilà\nune bonne dose d'amour!"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Why...[1205][001E][SP]on[SP]Earth[SP]would[SP]I[SP]have[SP]meant[SP]you!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Mais...[1205][001E] pourquoi ce serait toi d'abord!?"
+    "texte_fr": "Mais...[001E][1205] pourquoi ce serait toi d'abord!?"
   },
   {
     "id": 18,

--- a/traduction/event_scripts/script_031.json
+++ b/traduction/event_scripts/script_031.json
@@ -162,7 +162,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Man,[SP]were[SP]those[SP]guys[SP]irresponsible,[SP]though!\nThey[SP]don't[SP]have[SP]what[SP]it[SP]takes[SP]to[SP]work[SP]a[SP]job.\nThough[SP]we[SP]were[SP]the[SP]ones[SP]who[SP]egged[SP]them[SP]on...",
     "nom_fr": "Yukino",
-    "texte_fr": "Pff, ces types\nsont vraiment irresponsables!\nIls n'ont pas l'étoffe\npour ce travail. Même\nsi c'est nous qui les avons encouragés..."
+    "texte_fr": "Pff, ces types\nsont vraiment irresponsables!\nIls n'ont pas l'étoffe pour ce travail. Même si c'est nous qui les avons encouragés..."
   },
   {
     "id": 11,
@@ -192,7 +192,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]big[SP]future[SP]star,[SP]going[SP]out[SP]to[SP]do[SP]grunt\nwork...[1205][001E][SP]I[SP]wanted[SP]to[SP]take[SP]the[SP]stage[SP]with[SP]pride,\nbut[SP]they[SP]say[SP]it's[SP]important[SP]to[SP]start[SP]small.",
     "nom_fr": "Eikichi",
-    "texte_fr": "La future super star,\nqui part faire le sale\nboulot...[1205][001E] Je voulais monter sur scène avec\nfierté, mais faut commencer par voir petit."
+    "texte_fr": "La future super star,\nqui part faire le sale\nboulot...[001E][1205] Je voulais monter sur scène avec\nfierté, mais faut commencer par voir petit."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Concert[SP]staff",
     "texte_orig": "*sigh*[SP]Ughhhh...[1205][001E][SP]I[SP]drank[SP]too[SP]much[SP]at[SP]the\nclub[SP]party[SP]yesterday...[1205][001E][SP]I[SP]wish[SP]someone\nwould[SP]take[SP]over[SP]my[SP]shift[SP]today.",
     "nom_fr": "Personnel",
-    "texte_fr": "*soupir* Ughhhh...[1205][001E] J'ai trop bu hier\nsoir...[1205][001E] Si seulement quelqu'un\npouvait prendre ma place aujourd'hui."
+    "texte_fr": "*soupir* Ughhhh...[001E][1205] J'ai trop bu hier\nsoir...[001E][1205] Si seulement quelqu'un\npouvait prendre ma place aujourd'hui."
   },
   {
     "id": 14,
@@ -267,7 +267,7 @@
     "nom_orig": "Concert[SP]staff",
     "texte_orig": "Huh...?[SP]You[SP]don't[SP]mind[SP]taking[SP]over[SP]our\nshifts?[SP]You[SP]want[SP]to[SP]see[SP]the[SP]show[SP]but[SP]couldn't\nget[SP]tickets?[SP]Hrgh,[SP]this[SP]is[SP]weird[SP]timing...",
     "nom_fr": "Personnel",
-    "texte_fr": "Euh...? Tu veux récupérer\nnos tâches? Tu veux\nvoir le concert mais tu\nn'as pas pu avoir de\ntickets? Quelle drôle de coincidence..."
+    "texte_fr": "Euh...? Tu veux récupérer\nnos tâches? Tu veux\nvoir le concert mais tu n'as pas pu avoir de tickets? Quelle drôle de coincidence..."
   },
   {
     "id": 18,

--- a/traduction/event_scripts/script_032.json
+++ b/traduction/event_scripts/script_032.json
@@ -27,7 +27,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "SPADE...?[1205][001E][SP]What[SP]the[SP]hell[SP]kind[SP]of[SP]name[SP]is[SP]that?\nDo[SP]they[SP]really[SP]hope[SP]to[SP]sell[SP]records?",
     "nom_fr": "Yukino",
-    "texte_fr": "SPADE...?[1205][001E] C'est quoi ce nom à la noix?\nElles espèrent vendre des disques?"
+    "texte_fr": "SPADE...?[001E][1205] C'est quoi ce nom à la noix?\nElles espèrent vendre des disques?"
   },
   {
     "id": 2,

--- a/traduction/event_scripts/script_033.json
+++ b/traduction/event_scripts/script_033.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginji-sounding[SP]man",
     "texte_orig": "Ahaha...[SP]My[SP]darling[SP]butterflies...[1205][001E][SP]The[SP]energy\nfrom[SP]your[SP]ideals[SP]will[SP]bring[SP]fruition[SP]to[SP]the\nMasked[SP]Circle's[SP]dreams...",
     "nom_fr": "Voix de Ginji",
-    "texte_fr": "Ahaha... Mes jolis papillons...[1205][001E]\nL'énergie de vos idéaux va concrétiser\nles rêves du Cercle Masqué..."
+    "texte_fr": "Ahaha... Mes jolis papillons...[001E][1205]\nL'énergie de vos idéaux va concrétiser\nles rêves du Cercle Masqué..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginji-sounding[SP]man",
     "texte_orig": "Flutter[SP]even[SP]harder[SP]now...[SP]Higher...\nand[SP]further...[1205][001E][SP]Don't[SP]let[SP]those[SP]dreams\nbe[SP]exhausted...",
     "nom_fr": "Voix de Ginji",
-    "texte_fr": "Voletez encore plus fort... Plus\nhaut... et plus loin...[1205][001E] Ne laissez\npas ces rêves s'épuiser..."
+    "texte_fr": "Voletez encore plus fort... Plus\nhaut... et plus loin...[001E][1205] Ne laissez\npas ces rêves s'épuiser..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Mami[1121]&[SP]Miho",
     "texte_orig": "Glory[SP]to[SP]the[SP]Mask...\n[E1][E2]\n[E3][E4][NULL][NULL]\"Prince[SP]Taurus\nI,[SP]Ginji[SP]Sasaki...[1205][001E][SP]rather,[SP]Prince[SP]Taurus,\nwould[SP]like[SP]to[SP]introduce[SP]a[SP]new[SP]member[SP]to\nyour[SP]group.",
     "nom_fr": "Mami[1121]& Miho",
-    "texte_fr": "Gloire au Masque... [E1][E2] [E3][E4][NULL][NULL]\"Prince Taureau\nGinji Sasaki...[1205][001E] ou plutôt Prince\nTaureau,vous présente un nouveau membre."
+    "texte_fr": "Gloire au Masque... [E1][E2] [E3][E4][NULL][NULL]\"Prince Taureau\nGinji Sasaki...[001E][1205] ou plutôt Prince\nTaureau,vous présente un nouveau membre."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Prince[SP]Taurus",
     "texte_orig": "Now,[SP]Lisa-kun...[1205][001E][SP]Call[SP]Master[SP]Joker.",
     "nom_fr": "Prince Taureau",
-    "texte_fr": "Lisa...[1205][001E] Appelle Maître Joker."
+    "texte_fr": "Lisa...[001E][1205] Appelle Maître Joker."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Mami",
     "texte_orig": "Lisa...[1205][001E][SP]Let's[SP]take[SP]flight[SP]together,[SP]okay?",
     "nom_fr": "Mami",
-    "texte_fr": "Lisa...[1205][001E] On s'envole ensemble, ok?"
+    "texte_fr": "Lisa...[001E][1205] On s'envole ensemble, ok?"
   },
   {
     "id": 5,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I'm[SP]sorry,[SP]Sheba,[SP]Mee-ho...[SP]I'm[SP]really[SP]glad\nto[SP]know[SP]how[SP]you[SP]two[SP]felt[SP]about[SP]me...[1205][001E][SP]But[SP]I\ncan't[SP]go[SP]with[SP]you.",
     "nom_fr": "Ginko",
-    "texte_fr": "Désolée, Sheba, Mee-ho... Je suis\ncontente de savoir ce que vous\nressentez...[1205][001E] Mais je viens pas."
+    "texte_fr": "Désolée, Sheba, Mee-ho... Je suis\ncontente de savoir ce que vous\nressentez...[001E][1205] Mais je viens pas."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "[1113][SP]and[SP]the[SP]others[SP]are[SP]my[SP]friends[SP]too...\nI[SP]can't[SP]betray[SP]them![1205][001E][SP]Plus...[SP]I[SP]can't[SP]be[SP]happy\nliving[SP]a[SP]secondhand[SP]dream!",
     "nom_fr": "Ginko",
-    "texte_fr": "[1113]et les autres sont aussi mes\namis... Je peux pas les trahir![1205][001E] Et je\nrefuse de vivre un rêve d'emprunt!"
+    "texte_fr": "[1113]et les autres sont aussi mes\namis... Je peux pas les trahir![001E][1205] Et je\nrefuse de vivre un rêve d'emprunt!"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Maya-san[SP]and[SP]the[SP]others[SP]will[SP]be[SP]here\nsoon![SP]You[SP]don't[SP]have[SP]to[SP]stay![SP]We[SP]can[SP]get\nout[SP]of[SP]here[SP]together!",
     "nom_fr": "Ginko",
-    "texte_fr": "Maya-san et les\nautres arrivent! Vous n'avez\npas à rester! On\npeut sortir d'ici ensemble!"
+    "texte_fr": "Maya-san et les\nautres arrivent! Vous n'avez\npas à rester! On peut sortir d'ici ensemble!"
   },
   {
     "id": 11,
@@ -177,6 +177,6 @@
     "nom_orig": "Prince[SP]Taurus",
     "texte_orig": "Hah...[SP]Looks[SP]like[SP]I[SP]got[SP]played.[1205][001E][SP]Well,[SP]no\nmatter.[SP]SPADE,[SP]get[SP]onstage.[1205][001E][SP]You'll[SP]be\nsinging[SP]a[SP]foreign[SP]song...[SP][1432][NULL][NULL][0014]Joker.[1432][NULL][NULL][0014]\n[E1][E2]\n[E3][E4][NULL][NULL]\"Prince[SP]Taurus\nNow...[1205][001E][SP]A[SP]butterfly[SP]that[SP]refuses[SP]to[SP]take\nflight[SP]must[SP]be[SP]pinned[SP]and[SP]mounted!",
     "nom_fr": "",
-    "texte_fr": "Hah... On dirait que je me suis fait\navoir.[1205][001E] Peu importe. SPADE, sur scène.[1205][001E]\nVous chanterez une chanson étrangère... [1432][NULL][NULL][0014]Joker.[1432][NULL][NULL][0014]\n[E1][E2]\n[E3][E4][NULL][NULL]Prince Taurus\nMaintenant...[1205][001E] Un papillon qui refuse de\ns'envoler doit être épinglé et exposé !"
+    "texte_fr": "Hah... On dirait que je me suis fait\navoir.[001E][1205] Peu importe. SPADE, sur scène.[001E][1205]\nVous chanterez une chanson étrangère... [1432][NULL][NULL][0014]Joker.[1432][NULL][NULL][0014]\n[E1][E2]\n[E3][E4][NULL][NULL]Prince Taurus\nMaintenant...[001E][1205] Un papillon qui refuse de\ns'envoler doit être épinglé et exposé !"
   }
 ]

--- a/traduction/event_scripts/script_034.json
+++ b/traduction/event_scripts/script_034.json
@@ -12,7 +12,7 @@
     "nom_orig": "King[SP]Leo",
     "texte_orig": "It[SP]seems[SP]things[SP]have[SP]gone[SP]awry,[SP]Taurus.[1205][001E][SP]He[SP]is\nindeed[SP]the[SP]Cursed[SP]Star[SP]the[SP]heavens[SP]foretold...[1205][001E]\nYou[SP]should[SP]not[SP]dismiss[SP]them[SP]as[SP]mere[SP]children.",
     "nom_fr": "Roi Lion",
-    "texte_fr": "Il semble que les\nchoses ont dérapé, Taurus.[1205][001E]\nC'est bien l'Étoile Maudite prédite par les\ncieux...[1205][001E] Tu ne devrais\npas les prendre dehaut."
+    "texte_fr": "Il semble que les\nchoses ont dérapé, Taurus.[001E][1205]\nC'est bien l'Étoile Maudite prédite par les\ncieux...[001E][1205] Tu ne devrais\npas les prendre dehaut."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Prince[SP]Taurus",
     "texte_orig": "Ngh...[1205][001E][SP]The[SP][1432][NULL][NULL][0014]foreign[SP]song[1432][NULL][NULL][0014][SP]was[SP]fulfilled...[1205][001E]\nHalf[SP]of[SP]my[SP]job[SP]is[SP]done.\n[E1][E2]\n[E3][E4][NULL][NULL]\"Prince[SP]Taurus\nThe[SP]Earth[SP]crystal[SP]skull[SP]will[SP]be[SP]full[SP]soon...[1205][001E]\nI'll[SP]make[SP]sure[SP]that[SP]everything[SP]is[SP]complete\nin[SP]time[SP]for[SP]the[SP]End[SP]of[SP]Nahui-Ollin...",
     "nom_fr": "Prince Taureau",
-    "texte_fr": "Ngh...[1205][001E] La [1432][NULL][NULL][0014]chanson étrangère[1432][NULL][NULL][0014] s'est finie...[1205][001E]\nMa tâche va finir.[E1][E2]\n[E3][E4][NULL][NULL]\"Prince Taureau\nLe crâne de cristal\nde la Terre sera bientôt\nplein...[1205][001E] Je m'assurerai que tout\nsoit prêtpour la Fin de Nahui-Ollin..."
+    "texte_fr": "Ngh...[001E][1205] La [1432][NULL][NULL][0014]chanson étrangère[1432][NULL][NULL][0014] s'est finie...[001E][1205]\nMa tâche va finir.[E1][E2]\n[E3][E4][NULL][NULL]\"Prince Taureau\nLe crâne de cristal\nde la Terre sera bientôt\nplein...[001E][1205] Je m'assurerai que tout\nsoit prêtpour la Fin de Nahui-Ollin..."
   },
   {
     "id": 2,
@@ -117,7 +117,7 @@
     "nom_orig": "King[SP]Leo",
     "texte_orig": "It[SP]is[SP]I[SP]you[SP]face,[SP]not[SP]he...[1205][001E][SP]I[SP]could[SP]rend\nyou[SP]to[SP]pieces[SP]now,[SP]but[SP]why[SP]not[SP]play[SP]a\nlittle[SP]game...?",
     "nom_fr": "Roi Lion",
-    "texte_fr": "C'est à moi que\ntu as affaire...[1205][001E] Je pourrais\nte tuer, mais pourquoi\nne pas jouer un peu...?"
+    "texte_fr": "C'est à moi que\ntu as affaire...[001E][1205] Je pourrais\nte tuer, mais pourquoi\nne pas jouer un peu...?"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "King[SP]Leo",
     "texte_orig": "My[SP]duty[SP]is[SP]to[SP]ignite[SP]the[SP]flames[SP]of[SP]expiation\nto[SP]the[SP]lands[SP]shown[SP]by[SP]the[SP]celestial[SP]heavens.[1205][001E]\nFour[SP]pillars[SP]of[SP]fire[SP]will[SP]rise...[1205][001E]",
     "nom_fr": "Roi Lion",
-    "texte_fr": "Je dois allumer les flammes de l'expiation\nsur les terres désignées par les cieux.[1205][001E]\nQuatre piliers de feu s'élèveront...[1205][001E]"
+    "texte_fr": "Je dois allumer les flammes de l'expiation\nsur les terres désignées par les cieux.[001E][1205]\nQuatre piliers de feu s'élèveront...[001E][1205]"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "King[SP]Leo",
     "texte_orig": "Hahahaaa![SP]One[SP]is[SP]here...[1205][001E][SP]Scour[SP]this[SP]hall[SP]to\ndiscover[SP]the[SP]next[SP]target...[1205][001E][SP]Somewhere[SP]here,\nyou[SP]shall[SP]find[SP]a[SP]gracious[SP]riddle!",
     "nom_fr": "Roi Lion",
-    "texte_fr": "Hahaha! L'un d'eux\nest ici...[1205][001E] Fouillez cette\nsalle pour trouver la cible...[1205][001E] Quelque part\nici, vous trouverez une énigme!"
+    "texte_fr": "Hahaha! L'un d'eux\nest ici...[001E][1205] Fouillez cette\nsalle pour trouver la cible...[001E][1205] Quelque part\nici, vous trouverez une énigme!"
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "That[SP]bastard...[SP]He's[SP]set[SP]bombs[SP]in[SP]town,\ntoo![SP]There's[SP]not[SP]much[SP]time...[1205][001E][SP]We[SP]need[SP]to\nfind[SP]the[SP]next[SP]target[SP]and[SP]get[SP]out[SP]of[SP]here!",
     "nom_fr": "Yukino",
-    "texte_fr": "L'enfoiré... Il a aussi posé des bombes\nen ville! On a peu de temps...[1205][001E] Faut\ntrouver la prochaine cible et filer!\n Sauvegarder?\nOuiNon",
+    "texte_fr": "L'enfoiré... Il a aussi posé des bombes\nen ville! On a peu de temps...[001E][1205] Faut\ntrouver la prochaine cible et filer!\nSauvegarder? OuiNon",
     "choix_fr": [
       ""
     ]
@@ -195,7 +195,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I...[SP]I[SP]never[SP]believed[SP]in[SP]my[SP]friends...[1205][001E]\nBut[SP]Sheba[SP]and[SP]Mee-ho[SP]believed[SP]in[SP]me...[1205][001E]\nI...[SP]I...!",
     "nom_fr": "Ginko",
-    "texte_fr": "Je... J'ai jamais cru en mes amis...[1205][001E] Mais\nSheba et Mee-ho croyaient en moi...[1205][001E] Je...!"
+    "texte_fr": "Je... J'ai jamais cru en mes amis...[001E][1205] Mais\nSheba et Mee-ho croyaient en moi...[001E][1205] Je...!"
   },
   {
     "id": 13,
@@ -270,7 +270,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Those[SP]bastards...![1205][001E][SP]I'll[SP]stomp[SP]all[SP]over[SP]'em!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ces enfoirés...![1205][001E] Je vais les écraser!"
+    "texte_fr": "Ces enfoirés...![001E][1205] Je vais les écraser!"
   },
   {
     "id": 18,
@@ -330,7 +330,7 @@
     "nom_orig": "Mami[SP]shadowman",
     "texte_orig": "Promised...[SP]with[SP]Lisa...[1205][001E][SP]My...[SP]dream...[1205][001E]\nNo[SP]more...",
     "nom_fr": "Ombre de Mami",
-    "texte_fr": "Promis... à Lisa...[1205][001E] Mon...\nrêve...[1205][001E] C'est fini..."
+    "texte_fr": "Promis... à Lisa...[001E][1205] Mon...\nrêve...[001E][1205] C'est fini..."
   },
   {
     "id": 22,
@@ -345,7 +345,7 @@
     "nom_orig": "Mami[SP]shadowman",
     "texte_orig": "Death...?[1205][001E][SP]That's...[SP]fine...",
     "nom_fr": "Ombre de Mami",
-    "texte_fr": "La mort...?[1205][001E] Ça me... va..."
+    "texte_fr": "La mort...?[001E][1205] Ça me... va..."
   },
   {
     "id": 23,
@@ -360,7 +360,7 @@
     "nom_orig": "Miho[SP]shadowman",
     "texte_orig": "Lisa's[SP]crying...[1205][001E][SP]I[SP]guess...[SP]it[SP]doesn't\nmatter...",
     "nom_fr": "Ombre de Miho",
-    "texte_fr": "Lisa pleure...[1205][001E] Ça\nn'a... plus d'importance..."
+    "texte_fr": "Lisa pleure...[001E][1205] Ça\nn'a... plus d'importance..."
   },
   {
     "id": 24,
@@ -375,6 +375,6 @@
     "nom_orig": "Miho[SP]shadowman",
     "texte_orig": "Where...[SP]are[SP]we[SP]going...?[1205][001E][SP]I[SP]don't[SP]wanna\ngo[SP]anywhere...",
     "nom_fr": "",
-    "texte_fr": "Où... on va...?[1205][001E]\nJe veux... aller nulle part..."
+    "texte_fr": "Où... on va...?[001E][1205]\nJe veux... aller nulle part..."
   }
 ]

--- a/traduction/event_scripts/script_035.json
+++ b/traduction/event_scripts/script_035.json
@@ -12,6 +12,6 @@
     "nom_orig": "Prince[SP]Taurus",
     "texte_orig": "Tch...[SP]Pointless[SP]interference...[1205][001E][SP]Well,[SP]now\nyou[SP]know,[SP]Lisa-kun.[SP]With[SP]what[SP]little[SP]time\nremains,[SP]let[SP]us[SP]dance!",
     "nom_fr": "",
-    "texte_fr": "Tch... Quelle interférence inutile...[1205][001E]\nBon, maintenant tu sais, Lisa-kun.\nDans le peu de temps qu'il reste, dansons !"
+    "texte_fr": "Tch... Quelle interférence inutile...[001E][1205]\nBon, maintenant tu sais, Lisa-kun.\nDans le peu de temps qu'il reste, dansons !"
   }
 ]

--- a/traduction/event_scripts/script_038.json
+++ b/traduction/event_scripts/script_038.json
@@ -27,7 +27,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]can[SP]kind[SP]of[SP]relate...[1205][001E][SP]Getting[SP]pushed\naround[SP]and[SP]ignored[SP]just[SP]'cause[SP]you're\ndifferent...",
     "nom_fr": "Yukino",
-    "texte_fr": "Je compatis un peu...[1205][001E] Se faire bousculer et\nignorer juste parce qu'on est différent..."
+    "texte_fr": "Je compatis un peu...[001E][1205] Se faire bousculer et\nignorer juste parce qu'on est différent..."
   },
   {
     "id": 2,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Have[SP]some[SP]faith[SP]in[SP]Lisa...[1205][001E][SP]Dreams[SP]aren't[SP]a\ncrutch[SP]you[SP]can[SP]lean[SP]on[SP]or[SP]a[SP]gift[SP]you[SP]can[SP]be\ngiven.[SP]I'm[SP]sure[SP]she'll[SP]figure[SP]that[SP]out.",
     "nom_fr": "Maya",
-    "texte_fr": "Faites confiance à Lisa...[1205][001E] Un rêve n'est\npas une béquille ni un cadeau qu'on\nreçoit. Je suis sûre qu'elle comprendra."
+    "texte_fr": "Faites confiance à Lisa...[001E][1205] Un rêve n'est\npas une béquille ni un cadeau qu'on\nreçoit. Je suis sûre qu'elle comprendra."
   },
   {
     "id": 5,

--- a/traduction/event_scripts/script_039.json
+++ b/traduction/event_scripts/script_039.json
@@ -42,7 +42,7 @@
     "nom_orig": "Miho",
     "texte_orig": "Y-You're[SP]not[SP]weird[SP]at[SP]all...[1205][001E][SP]You're[SP]cool\nbecause[SP]you[SP]stand[SP]out,[SP]Lisa.",
     "nom_fr": "Miho",
-    "texte_fr": "T-T'es pas bizarre...[1205][001E] T'es cool\ncar tu te démarques, Lisa."
+    "texte_fr": "T-T'es pas bizarre...[001E][1205] T'es cool\ncar tu te démarques, Lisa."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Oh,[SP]so[SP]I[SP]was[SP]bullied[SP]for[SP]it[SP]as[SP]a[SP]kid,[SP]but\nnow[SP]it's[SP][1432][NULL][NULL][0014]cool[1432][NULL][NULL][0014]?[SP]It's[SP][1432][NULL][NULL][0014]unique[1432][NULL][NULL][0014]?[1205][001E][SP]I'm[SP]tired\nof[SP]other[SP]people[SP]deciding[SP]how[SP]to[SP]define[SP]me!",
     "nom_fr": "Ginko",
-    "texte_fr": "Donc j'étais harcelée pour ça avant, mais\ndésormais c'est [1432][NULL][NULL][0014]cool[1432][NULL][NULL][0014]? C'est [1432][NULL][NULL][0014]unique[1432][NULL][NULL][0014]?[1205][001E] J'en\nai marre que les autres me définissent!"
+    "texte_fr": "Donc j'étais harcelée pour ça avant, mais\ndésormais c'est [1432][NULL][NULL][0014]cool[1432][NULL][NULL][0014]? C'est [1432][NULL][NULL][0014]unique[1432][NULL][NULL][0014]?[001E][1205] J'en\nai marre que les autres me définissent!"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "My[SP]dad[SP]never[SP]taught[SP]me[SP]a[SP]word[SP]of[SP]English...[1205][001E]\nBut[SP]everyone[SP]assumes[SP]all[SP]foreigners[SP]can\nspeak[SP]it...[1205][001E][SP]They[SP]have[SP]to[SP]stand[SP]out...",
     "nom_fr": "Ginko",
-    "texte_fr": "Mon père ne m'a jamais appris l'anglais...[1205][001E]\nMais tous croient que les étrangers le\nparlent...[1205][001E] Faut se démarquer..."
+    "texte_fr": "Mon père ne m'a jamais appris l'anglais...[001E][1205]\nMais tous croient que les étrangers le\nparlent...[001E][1205] Faut se démarquer..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What[SP]am[SP]I[SP]supposed[SP]to[SP]do?[1205][001E][SP]I'm...[SP]I'm[SP]just\nlike[SP]anyone[SP]else...[1205][001E][SP]Just[SP]a[SP]normal[SP]girl...",
     "nom_fr": "Ginko",
-    "texte_fr": "Que dois-je faire?[1205][001E] Je... Je suis comme tout\nle monde...[1205][001E] Juste une fille normale..."
+    "texte_fr": "Que dois-je faire?[001E][1205] Je... Je suis comme tout\nle monde...[001E][1205] Juste une fille normale..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Mami",
     "texte_orig": "I'm[SP]so,[SP]so[SP]sorry,[SP]Lisa...[1205][001E][SP]I[SP]never[SP]noticed\nwe[SP]were[SP]hurting[SP]you[SP]like[SP]that...",
     "nom_fr": "Mami",
-    "texte_fr": "Désolée, Lisa...[1205][001E] J'avais pas\nremarqué qu'on te blessait..."
+    "texte_fr": "Désolée, Lisa...[001E][1205] J'avais pas\nremarqué qu'on te blessait..."
   },
   {
     "id": 7,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "W-Well...[1205][001E][SP]It[SP]was[SP]so[SP]sudden...",
     "nom_fr": "Ginko",
-    "texte_fr": "Euh...[1205][001E] C'était si soudain..."
+    "texte_fr": "Euh...[001E][1205] C'était si soudain..."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Ginji",
     "texte_orig": "No.[SP]You[SP]had[SP]no[SP]dream[SP]to[SP]tell[SP]him.[1205][001E][SP]It[SP]must\nhave[SP]been[SP]painful[SP]for[SP]you,[SP]being[SP]with\n[1112]-kun[SP]and[SP]the[SP]others.",
     "nom_fr": "Ginji",
-    "texte_fr": "Non. Tu n'avais aucun rêve à lui\ndire.[1205][001E] Ça a dû être douloureux\nd'être avec [1112] et les autres."
+    "texte_fr": "Non. Tu n'avais aucun rêve à lui\ndire.[001E][1205] Ça a dû être douloureux\nd'être avec [1112] et les autres."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Ginji",
     "texte_orig": "The[SP]reporter,[SP]the[SP]photographer...[1205][001E][SP]Even[SP]that\ngang[SP]boss[SP]is[SP]pursuing[SP]a[SP]dream.[SP]Yet[SP]you[SP]have\nnone[SP]to[SP]call[SP]your[SP]own.",
     "nom_fr": "Ginji",
-    "texte_fr": "La journaliste, la photographe...[1205][001E]\nMême ce chef de gang a un rêve.\nPourtant, tu n'en as aucun à toi."
+    "texte_fr": "La journaliste, la photographe...[001E][1205]\nMême ce chef de gang a un rêve.\nPourtant, tu n'en as aucun à toi."
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I-I[SP]had[SP]a[SP]dream![1205][001E][SP]But...[SP]I[SP]lost[SP]it,[SP]so...",
     "nom_fr": "Ginko",
-    "texte_fr": "J-J'avais un rêve![1205][001E] Mais je l'ai perdu..."
+    "texte_fr": "J-J'avais un rêve![001E][1205] Mais je l'ai perdu..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Ginji",
     "texte_orig": "I[SP]know[SP]your[SP]pain[SP]all[SP]too[SP]well.[SP]Those[SP]who've\nbeen[SP]defeated[SP]by[SP]their[SP]dreams[SP]are[SP]pitiful...[1205][001E]\nBut[SP]you[SP]can[SP]always[SP]pursue[SP]another[SP]dream.",
     "nom_fr": "Ginji",
-    "texte_fr": "Je connais bien ta douleur. Ceux vaincus\npar leurs rêves font pitié...[1205][001E] Mais on\npeut toujours en poursuivre un autre."
+    "texte_fr": "Je connais bien ta douleur. Ceux vaincus\npar leurs rêves font pitié...[001E][1205] Mais on\npeut toujours en poursuivre un autre."
   },
   {
     "id": 17,
@@ -312,7 +312,7 @@
     "nom_orig": "Ginji",
     "texte_orig": "You[SP]know[SP]the[SP]pain[SP]of[SP]living[SP]without[SP]dreams...[1205][001E]\nThey[SP]have[SP]been[SP]released[SP]from[SP]that[SP]pain.\nIsn't[SP]that[SP]another[SP]form[SP]of[SP]happiness?",
     "nom_fr": "Ginji",
-    "texte_fr": "Tu connais la douleur de vivre sans\nrêves...[1205][001E] Ils ont été libérés de ça.\nN'est-ce pas une autre forme de bonheur?"
+    "texte_fr": "Tu connais la douleur de vivre sans\nrêves...[001E][1205] Ils ont été libérés de ça.\nN'est-ce pas une autre forme de bonheur?"
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Ginji",
     "texte_orig": "But[SP]whenever[SP]possible,[SP]those[SP]without[SP]dreams\nwill[SP]be[SP]granted[SP]new[SP]ones...[SP]That[SP]is[SP]what[SP]the\nExalted[SP]One[SP]thinks.[1205][001E][SP]For[SP]that,[SP]we[SP]need[SP]you.",
     "nom_fr": "Ginji",
-    "texte_fr": "Mais si possible, ceux\nsans rêves en recevront\nde nouveaux... C'est ce\nque pense l'Exalté.[1205][001E] Et\npour ça, nous avons besoin de toi."
+    "texte_fr": "Mais si possible, ceux\nsans rêves en recevront\nde nouveaux... C'est ce que pense l'Exalté.[001E][1205] Et\npour ça, nous avons besoin de toi."
   },
   {
     "id": 22,
@@ -342,6 +342,6 @@
     "nom_orig": "Ginji",
     "texte_orig": "Join[SP]the[SP]Masked[SP]Circle.[1205][001E][SP]With[SP]us[SP]is[SP]where[SP]you\nwill[SP]find[SP]friends[SP]who[SP]truly[SP]worry[SP]for[SP]you...\nWhere[SP]you[SP]will[SP]know[SP]belonging[SP]at[SP]last.",
     "nom_fr": "",
-    "texte_fr": "Rejoins le Cercle Masqué.[1205][001E] Avec nous,\ntu trouveras des amis qui se soucient\nvraiment de toi... L'appartenance, enfin."
+    "texte_fr": "Rejoins le Cercle Masqué.[001E][1205] Avec nous,\ntu trouveras des amis qui se soucient\nvraiment de toi... L'appartenance, enfin."
   }
 ]

--- a/traduction/event_scripts/script_040.json
+++ b/traduction/event_scripts/script_040.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I...[SP]I[SP]never[SP]believed[SP]in[SP]my[SP]friends...[1205][001E]\nBut[SP]Sheba[SP]and[SP]Mee-ho[SP]believed[SP]in[SP]me...[1205][001E]\nI...[SP]I...!",
     "nom_fr": "Ginko",
-    "texte_fr": "J'ai jamais cru en mes amis...[1205][001E] Mais Sheba\net Mee-ho croyaient en moi...[1205][001E] Je... Je...!"
+    "texte_fr": "J'ai jamais cru en mes amis...[001E][1205] Mais Sheba\net Mee-ho croyaient en moi...[001E][1205] Je... Je...!"
   },
   {
     "id": 1,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Those[SP]bastards...![1205][001E][SP]I'll[SP]stomp[SP]all[SP]over[SP]'em!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ces enfoirés...![1205][001E] Je vais les écraser!"
+    "texte_fr": "Ces enfoirés...![001E][1205] Je vais les écraser!"
   },
   {
     "id": 6,
@@ -147,7 +147,7 @@
     "nom_orig": "Mami[SP]shadowman",
     "texte_orig": "Promised...[SP]with[SP]Lisa...[1205][001E][SP]My...[SP]dream...[1205][001E]\nNo[SP]more...",
     "nom_fr": "Ombre de Mami",
-    "texte_fr": "La promesse... avec Lisa...[1205][001E]\nMon... rêve...[1205][001E] Fini..."
+    "texte_fr": "La promesse... avec Lisa...[001E][1205]\nMon... rêve...[001E][1205] Fini..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Mami[SP]shadowman",
     "texte_orig": "Death...?[1205][001E][SP]That's...[SP]fine...",
     "nom_fr": "Ombre de Mami",
-    "texte_fr": "La mort...?[1205][001E] Ça me... va..."
+    "texte_fr": "La mort...?[001E][1205] Ça me... va..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Miho[SP]shadowman",
     "texte_orig": "Lisa's[SP]crying...[1205][001E][SP]I[SP]guess...[SP]it[SP]doesn't\nmatter...",
     "nom_fr": "Ombre de Miho",
-    "texte_fr": "Lisa pleure...[1205][001E] Ça\nn'a... plus d'importance..."
+    "texte_fr": "Lisa pleure...[001E][1205] Ça\nn'a... plus d'importance..."
   },
   {
     "id": 12,
@@ -192,6 +192,6 @@
     "nom_orig": "Miho[SP]shadowman",
     "texte_orig": "Where...[SP]are[SP]we[SP]going...?[1205][001E][SP]I[SP]don't[SP]wanna\ngo[SP]anywhere...",
     "nom_fr": "",
-    "texte_fr": "Où... on va...?[1205][001E]\nJe veux... aller nulle part..."
+    "texte_fr": "Où... on va...?[001E][1205]\nJe veux... aller nulle part..."
   }
 ]

--- a/traduction/event_scripts/script_041.json
+++ b/traduction/event_scripts/script_041.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I-I'm[SP]not[SP]worried[SP]about[SP]her,[SP]but...[1205][001E][SP]If[SP]she\nleaves[SP]now,[SP]we're[SP]down[SP]a[SP]man.[SP]It'll[SP]be[SP]too\nlate[SP]if[SP]the[SP]crowd[SP]starts[SP]filing[SP]in!",
     "nom_fr": "Eikichi",
-    "texte_fr": "J-je ne suis pas inquiêt pour elle,\nmais...[1205][001E] si elle part, on sera un de moins.\nIl sera trop tard si la foule arrive!"
+    "texte_fr": "J-je ne suis pas inquiêt pour elle,\nmais...[001E][1205] si elle part, on sera un de moins.\nIl sera trop tard si la foule arrive!"
   },
   {
     "id": 2,
@@ -131,7 +131,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Fine...[1205][001E][SP]But[SP]we[SP]don't[SP]have[SP]much[SP]time,[SP]so[SP]hurry\nup[SP]and[SP]decide,[SP]okay?",
     "nom_fr": "Eikichi",
-    "texte_fr": "D'accord...[1205][001E] On a pas beaucoup de\ntemps, magne-toi et choisi, okay?"
+    "texte_fr": "D'accord...[001E][1205] On a pas beaucoup de\ntemps, magne-toi et choisi, okay?"
   },
   {
     "id": 8,

--- a/traduction/event_scripts/script_042.json
+++ b/traduction/event_scripts/script_042.json
@@ -27,7 +27,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "The[SP]Oracle...?[1205][001E][SP]You[SP]mean[SP]whatever[SP]thing[SP]that\nKing[SP]Leo[SP]scumbag[SP]was[SP]talking[SP]about!?",
     "nom_fr": "Yukino",
-    "texte_fr": "L- l'Oracle...?[1205][001E] tu veux dire la chose\ndont l'ordure de Roi Lion parlait!?"
+    "texte_fr": "L- l'Oracle...?[001E][1205] tu veux dire la chose\ndont l'ordure de Roi Lion parlait!?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I'm[SP]sorry[SP]if[SP]this[SP]comes[SP]as[SP]a[SP]shock,[SP]but[SP]to\nbe[SP]honest...[1205][001E][SP]I[SP]can't[SP]speak[SP]English[SP]at[SP]all.",
     "nom_fr": "Ginko",
-    "texte_fr": "Je suis désolée que cela arrive comme ca,\npour être honnête...[1205][001E] je parle pas anglais."
+    "texte_fr": "Je suis désolée que cela arrive comme ca,\npour être honnête...[001E][1205] je parle pas anglais."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]know[SP]that's[SP]weird,[SP]given[SP]what[SP]I[SP]look[SP]like.\nBut[SP]I[SP]feel[SP]like[SP]lying[SP]to[SP]you[SP]all...[SP]and[SP]lying\nto[SP]myself,[SP]wasn't[SP]cool.[SP]So[SP]I[SP]won't[SP]anymore.",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est étrange, surtout\nen me regardant. Mais\nj'ai l'impression que vous mentir... et à\nmoi-même, c'est pas cool.\nJe ne le feraisplus."
+    "texte_fr": "C'est étrange, surtout\nen me regardant. Mais\nj'ai l'impression que vous mentir... et à moi-même, c'est pas cool. Je ne le feraisplus."
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Owww...[1205][001E][SP]Huh?[SP]What's[SP]this?[1205][001E][SP]They're[SP]all[SP]over\nthe[SP]place...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Aww...[1205][001E]? C'est quoi?[1205][001E] Y'en a\npartout dans cet endroit..."
+    "texte_fr": "Aww...[001E][1205]? C'est quoi?[001E][1205] Y'en a\npartout dans cet endroit..."
   },
   {
     "id": 6,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginji's[SP]voice",
     "texte_orig": "A[SP]moving[SP]performance,[SP]Lisa-kun.[SP]The[SP]more[SP]a\ncatch[SP]struggles,[SP]the[SP]more[SP]endearing[SP]she[SP]is...[1205][001E]\nYou[SP]really[SP]know[SP]how[SP]to[SP]light[SP]my[SP]fire.",
     "nom_fr": "Voix de Ginki",
-    "texte_fr": "Une performance émouvante, Lisa. Plus une\nproie se débat, plus elle devient\nattachante...[1205][001E] Tu sais\ncomment attiser mondésir."
+    "texte_fr": "Une performance émouvante, Lisa. Plus une\nproie se débat, plus elle devient\nattachante...[001E][1205] Tu sais\ncomment attiser mondésir."
   },
   {
     "id": 10,
@@ -207,7 +207,7 @@
     "nom_orig": "King[SP]Leo",
     "texte_orig": "You[SP]boasted[SP]of[SP]converting[SP]the[SP]entire[SP]crowd\nto[SP]the[SP]Circle,[SP]gathering[SP]all[SP]their[SP]energy[SP]at\nonce,[SP]and[SP]this[SP]is[SP]the[SP]result?[SP]Fine[SP]words...",
     "nom_fr": "Roi Lion",
-    "texte_fr": "Tu t'es vanté d'avoir converti la foule au\nCercle, ramassant toute\nleur energies en même\ntemps, pour ca? Que des belles paroles..."
+    "texte_fr": "Tu t'es vanté d'avoir converti la foule au\nCercle, ramassant toute\nleur energies en même temps, pour ca? Que des belles paroles..."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Prince[SP]Taurus",
     "texte_orig": "Hmph...[1205][001E][SP]Regardless,[SP]the[SP]crystal[SP]skull[SP]will\nsoon[SP]be[SP]filled.",
     "nom_fr": "Prince Taureau",
-    "texte_fr": "Mhmm...[1205][001E] Quand même, le\ncristal skull va être rempli."
+    "texte_fr": "Mhmm...[001E][1205] Quand même, le\ncristal skull va être rempli."
   },
   {
     "id": 15,
@@ -282,7 +282,7 @@
     "nom_orig": "King[SP]Leo",
     "texte_orig": "My[SP]duty[SP]is[SP]to[SP]ignite[SP]the[SP]flames[SP]of[SP]expiation\nto[SP]the[SP]lands[SP]shown[SP]by[SP]the[SP]celestial[SP]heavens.[1205][001E]\nFour[SP]pillars[SP]of[SP]fire[SP]will[SP]rise...",
     "nom_fr": "Roi Lion",
-    "texte_fr": "Mon devoir est d'allumer les flammes\nd'expiations sur les\nterres montrées par les\ncieux.[1205][001E] Les pilliers vont alors s'elever..."
+    "texte_fr": "Mon devoir est d'allumer les flammes\nd'expiations sur les\nterres montrées par les cieux.[001E][1205] Les pilliers vont alors s'elever..."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "King[SP]Leo",
     "texte_orig": "Hahahaaa![SP]One[SP]is[SP]here...[1205][001E][SP]Scour[SP]this[SP]hall[SP]to\ndiscover[SP]the[SP]next[SP]target...[1205][001E][SP]Somewhere[SP]here,\nyou[SP]shall[SP]find[SP]a[SP]gracious[SP]riddle!",
     "nom_fr": "Roi Lion",
-    "texte_fr": "Hahahaaa! Un est arrivé...[1205][001E] fouille cette\nsalle pour découvrir la prochaine cible...[1205][001E]\nIci, tu devrais trouver un mystère!"
+    "texte_fr": "Hahahaaa! Un est arrivé...[001E][1205] fouille cette\nsalle pour découvrir la prochaine cible...[001E][1205]\nIci, tu devrais trouver un mystère!"
   },
   {
     "id": 20,
@@ -327,6 +327,6 @@
     "nom_orig": "Prince[SP]Taurus",
     "texte_orig": "Tch...[SP]Pointless[SP]interference...[1205][001E][SP]Well,[SP]now\nyou[SP]know,[SP]Lisa-kun.[SP]With[SP]what[SP]little[SP]time\nremains,[SP]let[SP]us[SP]dance!",
     "nom_fr": "",
-    "texte_fr": "Tch... Quelle interférence inutile...[1205][001E]\nBon, maintenant tu sais, Lisa-kun.\nDans le peu de temps qu'il reste, dansons !"
+    "texte_fr": "Tch... Quelle interférence inutile...[001E][1205]\nBon, maintenant tu sais, Lisa-kun.\nDans le peu de temps qu'il reste, dansons !"
   }
 ]

--- a/traduction/event_scripts/script_043.json
+++ b/traduction/event_scripts/script_043.json
@@ -12,7 +12,7 @@
     "nom_orig": "Prince[SP]Taurus",
     "texte_orig": "Ngh...[1205][001E][SP]I[SP]underestimated[SP]you...[1205][001E]\nHowever...!",
     "nom_fr": "Prince Taureau",
-    "texte_fr": "Ngh...[1205][001E] Je t'ai sous-estimé[1205][001E] Cependant...!"
+    "texte_fr": "Ngh...[001E][1205] Je t'ai sous-estimé[001E][1205] Cependant...!"
   },
   {
     "id": 1,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I...[SP]I[SP]never[SP]believed[SP]in[SP]my[SP]friends...[1205][001E]\nBut[SP]Sheba[SP]and[SP]Mee-ho[SP]believed[SP]in[SP]me...[1205][001E]\nI...[SP]I...!",
     "nom_fr": "Ginko",
-    "texte_fr": "Je... Je n'ai jamais\ncru en mes amis...[1205][001E] Mais\nSheba et Mee-ho ont cru en moi...[1205][001E] Je...!"
+    "texte_fr": "Je... Je n'ai jamais\ncru en mes amis...[001E][1205] Mais\nSheba et Mee-ho ont cru en moi...[001E][1205] Je...!"
   },
   {
     "id": 6,
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Those[SP]bastards...![1205][001E][SP]I'll[SP]stomp[SP]all[SP]over[SP]'em!",
     "nom_fr": "Michel",
-    "texte_fr": "Ces salauds...![1205][001E] Je vais les écraser!"
+    "texte_fr": "Ces salauds...![001E][1205] Je vais les écraser!"
   },
   {
     "id": 11,
@@ -222,7 +222,7 @@
     "nom_orig": "Mami[SP]shadowman",
     "texte_orig": "Promised...[SP]with[SP]Lisa...[1205][001E][SP]My...[SP]dream...[1205][001E]\nNo[SP]more...",
     "nom_fr": "Ombre de Mami",
-    "texte_fr": "Promis... avec Lisa...[1205][001E]\nMon... rêve...[1205][001E] Plus rien..."
+    "texte_fr": "Promis... avec Lisa...[001E][1205]\nMon... rêve...[001E][1205] Plus rien..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Mami[SP]shadowman",
     "texte_orig": "Death...?[1205][001E][SP]That's...[SP]fine...",
     "nom_fr": "Ombre de Mami",
-    "texte_fr": "La mort...?[1205][001E] C'est... bien..."
+    "texte_fr": "La mort...?[001E][1205] C'est... bien..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Miho[SP]shadowman",
     "texte_orig": "Lisa's[SP]crying...[1205][001E][SP]I[SP]guess...[SP]it[SP]doesn't\nmatter...",
     "nom_fr": "Ombre de Miho",
-    "texte_fr": "Lisa pleure...[1205][001E] Tant pis..."
+    "texte_fr": "Lisa pleure...[001E][1205] Tant pis..."
   },
   {
     "id": 17,
@@ -267,6 +267,6 @@
     "nom_orig": "Miho[SP]shadowman",
     "texte_orig": "Where...[SP]are[SP]we[SP]going...?[1205][001E][SP]I[SP]don't[SP]wanna\ngo[SP]anywhere...",
     "nom_fr": "",
-    "texte_fr": "Où... on va...?[1205][001E]\nJe veux... aller nulle part..."
+    "texte_fr": "Où... on va...?[001E][1205]\nJe veux... aller nulle part..."
   }
 ]

--- a/traduction/event_scripts/script_044.json
+++ b/traduction/event_scripts/script_044.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That[SP]was[SP]close...[1205][001E][SP]We[SP]made[SP]it[SP]just[SP]in[SP]the\nnick[SP]of[SP]time.",
     "nom_fr": "Michel",
-    "texte_fr": "On l'a échappé belle...[1205][001E]\nArrivés juste à temps."
+    "texte_fr": "On l'a échappé belle...[001E][1205]\nArrivés juste à temps."
   },
   {
     "id": 1,
@@ -112,7 +112,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I'm[SP]sorry...[SP]I'm...[SP]I'm[SP]okay[SP]now...[1205][001E]\nI'm[SP]just...[SP]so[SP]scared[SP]of[SP]his[SP]fires...[1205][001E]\nShameful,[SP]isn't[SP]it...?",
     "nom_fr": "Maya",
-    "texte_fr": "Pardon... Ça va\nmaintenant...[1205][001E] C'est juste...\nj'ai si peur de\nses feux...[1205][001E] C'est honteux...?"
+    "texte_fr": "Pardon... Ça va\nmaintenant...[001E][1205] C'est juste...\nj'ai si peur de\nses feux...[001E][1205] C'est honteux...?"
   },
   {
     "id": 7,
@@ -153,7 +153,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Thanks,[SP][1113]-kun...[1205][001E][SP]I'm...[SP]still[SP]kinda\nashamed[SP]of[SP]myself...[1205][001E][SP]I'm[SP]sorry[SP]to[SP]have\nworried[SP]you.",
     "nom_fr": "Maya",
-    "texte_fr": "Merci, [1113]-kun...[1205][001E] J'ai... un peu honte\nencore...[1205][001E] Désolée de t'avoir inquiété."
+    "texte_fr": "Merci, [1113]-kun...[001E][1205] J'ai... un peu honte\nencore...[001E][1205] Désolée de t'avoir inquiété."
   },
   {
     "id": 9,
@@ -168,7 +168,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Thanks,[SP][1113]-kun.[1205][001E][SP]You're[SP]so[SP]kind...[1205][001E]\nI'm[SP]okay[SP]now.",
     "nom_fr": "Maya",
-    "texte_fr": "Merci, [1113]-kun.[1205][001E] T'es gentil... [1205][001E] Ça va."
+    "texte_fr": "Merci, [1113]-kun.[001E][1205] T'es gentil... [001E][1205] Ça va."
   },
   {
     "id": 10,
@@ -228,7 +228,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP][1432][NULL][NULL][0014]foreign[SP]song[1432][NULL][NULL][0014]...[SP]the[SP][1432][NULL][NULL][0014]flames[SP]of\nexpiation[1432][NULL][NULL][0014]...[1205][001E][SP]It[SP]can't[SP]be[SP]anything[SP]but\nthe[SP]Oracle[SP]of[SP]Maia![SP]B-But[SP]who...!?\n[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nExcuse[SP]me...[SP]You're[SP]Ms.[SP]Okamura[SP]from[SP]Sevens,\nright?[SP]My[SP]name[SP]is[SP]Maya[SP]Amano,[SP]I'm[SP]with\nCoolest's[SP]editorial[SP]division.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "La [1432][NULL][NULL][0014]chanson étrangere[1432][NULL][NULL][0014]... Les [1432][NULL][NULL][0014]flammes de\nl'expiation[1432][NULL][NULL][0014]...[1205][001E] C'est sûrement l'Oracle de\nMaia! M-Mais qui...!? [E1][E2] [E3][E4][NULL][NULL]\"Maya Excusez-moi...\nVous êtes Mme Okamura\nde Seven, n'est-ce pas?\nJe suis Maya Amano,\nde la redaction deCoolest."
+    "texte_fr": "La [1432][NULL][NULL][0014]chanson étrangere[1432][NULL][NULL][0014]... Les [1432][NULL][NULL][0014]flammes de\nl'expiation[1432][NULL][NULL][0014]...[001E][1205] C'est sûrement l'Oracle de\nMaia! M-Mais qui...!? [E1][E2] [E3][E4][NULL][NULL]\"Maya Excusez-moi...\nVous êtes Mme Okamura\nde Seven, n'est-ce pas?\nJe suis Maya Amano,\nde la redaction deCoolest."
   },
   {
     "id": 14,
@@ -243,7 +243,7 @@
     "nom_orig": "Maya",
     "texte_orig": "You[SP]mentioned[SP]the[SP]Oracle[SP]of[SP]Maia[SP]just[SP]now...[1205][001E]\nDo[SP]you[SP]know[SP]something[SP]about[SP]it?[SP]If[SP]you[SP]don't\nmind,[SP]I'd[SP]like--",
     "nom_fr": "Maya",
-    "texte_fr": "Vous avez parlé de l'Oracle de\nMaia...[1205][001E] Vous en savez quelque chose?\nSi ça ne vous dit rien, j'aimerais--"
+    "texte_fr": "Vous avez parlé de l'Oracle de\nMaia...[001E][1205] Vous en savez quelque chose?\nSi ça ne vous dit rien, j'aimerais--"
   },
   {
     "id": 15,
@@ -258,7 +258,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "H-How[SP]do[SP]you[SP]know[SP]about[SP]the[SP]Oracle!?[SP]Only\nKashihara[SP]and[SP]I[SP]know[SP]about[SP]it...[1205][001E][SP]Us[SP]and\nSudou-kun...!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Comment savez vous pour l'Oracle!? Seuls\nKashihara et moi savons...[1205][001E] Nous et\nSudou-kun...!"
+    "texte_fr": "Comment savez vous pour l'Oracle!? Seuls\nKashihara et moi savons...[001E][1205] Nous et\nSudou-kun...!"
   },
   {
     "id": 16,
@@ -288,7 +288,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Lisa[SP]Silverman...!?[1205][001E][SP]S-So[SP]that's[SP]it...!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Lisa Silverman...!?[1205][001E] Donc c'est ça...!"
+    "texte_fr": "Lisa Silverman...!?[001E][1205] Donc c'est ça...!"
   },
   {
     "id": 18,

--- a/traduction/event_scripts/script_045.json
+++ b/traduction/event_scripts/script_045.json
@@ -42,7 +42,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "These[SP]are[SP]the[SP]guys[SP]I[SP]told[SP]you[SP]about[SP]over[SP]the\nphone.[SP]My[SP]partner[SP]Maya[1205][000F],[SP]Lisa[1205][000F],[SP]Eikichi[1205][000F],[SP]and[1205][000F]\n[1113].",
     "nom_fr": "Yukino",
-    "texte_fr": "Voici ceux dont je t'ai parlé. Ma\n[1205][000F][1205][000F][1205][000F][1205][000F]partenaire Maya, Lisa, Eikichi et [1113]."
+    "texte_fr": "Voici ceux dont je t'ai parlé. Ma\n[000F][1205][000F][1205][000F][1205][000F][1205]partenaire Maya, Lisa, Eikichi et [1113]."
   },
   {
     "id": 3,
@@ -117,7 +117,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "That's...[1205][001E][SP]an[SP]overhead[SP]view[SP]of[SP]Sumaru[SP]City,\nyeah?",
     "nom_fr": "Yukino",
-    "texte_fr": "Une...[1205][001E] une vue aérienne de Sumaru City?"
+    "texte_fr": "Une...[001E][1205] une vue aérienne de Sumaru City?"
   },
   {
     "id": 8,
@@ -222,7 +222,7 @@
     "nom_orig": "Elly",
     "texte_orig": "The[SP]second[SP]line[SP]most[SP]likely[SP]indicates[SP]a\ndirection.[1205][001E][SP]There's[SP]a[SP]particular[SP]wind[SP]sign\nthat[SP]presides[SP]over[SP]aspects[SP]of[SP]change...",
     "nom_fr": "Elly",
-    "texte_fr": "La seconde ligne indique sûrement une\ndirection.[1205][001E] Un signe de vent particulier\npréside aux aspects du changement..."
+    "texte_fr": "La seconde ligne indique sûrement une\ndirection.[001E][1205] Un signe de vent particulier\npréside aux aspects du changement..."
   },
   {
     "id": 15,
@@ -282,7 +282,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]get[SP]it.[SP]The[SP]descent[SP]into[SP]the[SP]netherworld\nis[SP]about[SP]Yomotsu[SP]Hirasaka[SP]from[SP]Japanese\nmyth...[1205][001E][SP]It's[SP]a[SP]play[SP]on[SP]words.",
     "nom_fr": "Maya",
-    "texte_fr": "Je vois. La descente vers l'au-delà\nrenvoie au Yomotsu Hirasaka de la\nmythologie...[1205][001E] C'est un jeu de mots."
+    "texte_fr": "Je vois. La descente vers l'au-delà\nrenvoie au Yomotsu Hirasaka de la\nmythologie...[001E][1205] C'est un jeu de mots."
   },
   {
     "id": 19,
@@ -312,7 +312,7 @@
     "nom_orig": "Elly",
     "texte_orig": "Unfortunately,[SP]I'm[SP]not[SP]that[SP]familiar[SP]with\nSumaru[SP]City's[SP]environs.[1205][000F][SP]So[SP]I[SP]can't[SP]deduce\nanything[SP]further[SP]as[SP]yet...",
     "nom_fr": "Elly",
-    "texte_fr": "Hélas, je connais mal les environs\nde Sumaru City. [1205][000F]Je ne peux rien\ndéduire de plus pour le moment..."
+    "texte_fr": "Hélas, je connais mal les environs\nde Sumaru City. [000F][1205]Je ne peux rien\ndéduire de plus pour le moment..."
   },
   {
     "id": 21,

--- a/traduction/event_scripts/script_047.json
+++ b/traduction/event_scripts/script_047.json
@@ -162,7 +162,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "For[SP]work,[SP]huh...?[1205][001E][SP]I[SP]don't[SP]really[SP]know[SP]what\nmost[SP]people[SP]live[SP]for,[SP]I[SP]guess.",
     "nom_fr": "Yukino",
-    "texte_fr": "Pour le travail...?[1205][001E] Je ne sais pas\nce qui pousse les autres à vivre."
+    "texte_fr": "Pour le travail...?[001E][1205] Je ne sais pas\nce qui pousse les autres à vivre."
   },
   {
     "id": 11,
@@ -192,7 +192,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]strange...[1205][001E][SP]When[SP]I'm[SP]with[SP]Maya-san,\nI'm[SP]reminded[SP]of[SP]the[SP][1432][NULL][NULL][0014]Big[SP]Sis[1432][NULL][NULL][0014][SP]I[SP]see[SP]in[SP]my\ndreams.",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est bizarre...[1205][001E] Maya-san me rappelle\nla [1432][NULL][NULL][0014]Grande Sœur[1432][NULL][NULL][0014] de mes rêves."
+    "texte_fr": "C'est bizarre...[001E][1205] Maya-san me rappelle\nla [1432][NULL][NULL][0014]Grande Sœur[1432][NULL][NULL][0014] de mes rêves."
   },
   {
     "id": 13,
@@ -252,7 +252,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Pardon[SP]them[SP]for[SP]my[SP]sake,[SP]sweets.[SP]C'mon...[1205][001E]\nCan't[SP]you[SP]forgive[SP]and[SP]forget[SP]at[SP]the[SP]request\nof[SP]such[SP]a[SP]beautiful[SP]specimen?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pardonnez-les pour moi, ma belle.\nAllez...[1205][001E] Vous ne pouvez pas oublier\nà la demande d'un si beau spécimen?"
+    "texte_fr": "Pardonnez-les pour moi, ma belle.\nAllez...[001E][1205] Vous ne pouvez pas oublier\nà la demande d'un si beau spécimen?"
   },
   {
     "id": 17,

--- a/traduction/event_scripts/script_051.json
+++ b/traduction/event_scripts/script_051.json
@@ -72,7 +72,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "What's[SP]the[SP]matter,[SP][1113]?[1205][001E]\nHuh?[SP]That[SP]sound...",
     "nom_fr": "Yukino",
-    "texte_fr": "Quoi de neuf, [1113]?[1205][001E] Hein? Ce bruit..."
+    "texte_fr": "Quoi de neuf, [1113]?[001E][1205] Hein? Ce bruit..."
   },
   {
     "id": 5,
@@ -342,7 +342,7 @@
     "nom_orig": "Belphegor",
     "texte_orig": "Master,[SP]that's[SP]your[SP]cue...[1205]<[SP]Master![1205][001E][SP]MASTER!",
     "nom_fr": "Belphegor",
-    "texte_fr": "Maître, c'est à vous...[1205]< Maître![1205][001E] MAÎTRE!"
+    "texte_fr": "Maître, c'est à vous...[1205]< Maître![001E][1205] MAÎTRE!"
   },
   {
     "id": 23,
@@ -402,7 +402,7 @@
     "nom_orig": "Ixquic",
     "texte_orig": "You...[1205][000A][SP]uh...[1205][000A][SP]umm...[1205][000A][SP]hm?[1205][001E][SP]Hold[SP]on[SP]a[SP]sec.",
     "nom_fr": "Ixquic",
-    "texte_fr": "Vous...[1205][000A] euh...[1205][000A] hum...[1205][000A] hein?[1205][001E] Attendez."
+    "texte_fr": "Vous...[000A][1205] euh...[000A][1205] hum...[000A][1205] hein?[001E][1205] Attendez."
   },
   {
     "id": 27,
@@ -597,7 +597,7 @@
     "nom_orig": "Ixquic",
     "texte_orig": "...[1205][001E]Now[SP]I'm[SP]mad![SP]If[SP]that's[SP]how[SP]it's[SP]gonna\nbe,[SP]I'll[SP]blow[SP]the[SP]whole[SP]building[SP]with[SP]this\nremote[SP]transmitter!",
     "nom_fr": "Ixquic",
-    "texte_fr": "...[1205][001E] J'suis en colère! Je fais\ntout sauter avec ce détonateur!"
+    "texte_fr": "...[001E][1205] J'suis en colère! Je fais\ntout sauter avec ce détonateur!"
   },
   {
     "id": 40,
@@ -642,7 +642,7 @@
     "nom_orig": "Ixquic",
     "texte_orig": "My[SP]family[SP]and[SP]classes[SP]are[SP]all[SP]just[SP]a[SP]pain...[1205][001E]\nThere's[SP]nothing[SP]good[SP]about[SP]being[SP]alive!",
     "nom_fr": "Ixquic",
-    "texte_fr": "Ma famille, les cours, tout est\nchiant...[1205][001E] Y a rien de bien dans la vie!"
+    "texte_fr": "Ma famille, les cours, tout est\nchiant...[001E][1205] Y a rien de bien dans la vie!"
   },
   {
     "id": 43,
@@ -672,7 +672,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Don't...[1205][001E][SP]Don't[SP]you[SP]ever[SP]treat[SP]death[SP]like\na[SP]joke!",
     "nom_fr": "Maya",
-    "texte_fr": "Ne...[1205][001E] Ne prends jamais la mort à la légère!"
+    "texte_fr": "Ne...[001E][1205] Ne prends jamais la mort à la légère!"
   },
   {
     "id": 45,

--- a/traduction/event_scripts/script_052.json
+++ b/traduction/event_scripts/script_052.json
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "She[SP]must[SP]never[SP]have[SP]had[SP]any[SP]proper[SP]adults\nplay[SP]with[SP]her...[1205][001E][SP]Don't[SP]worry![SP]If[SP]that[SP]ever\nhappens,[SP]I[SP]take[SP]full[SP]responsibility.",
     "nom_fr": "Maya",
-    "texte_fr": "Elle n'a jamais dû avoir d'adultes\nresponsables pour jouer avec...[1205][001E] Ne paniquez\npas! Si jamais ça arrive, j'assumerais."
+    "texte_fr": "Elle n'a jamais dû avoir d'adultes\nresponsables pour jouer avec...[001E][1205] Ne paniquez\npas! Si jamais ça arrive, j'assumerais."
   },
   {
     "id": 4,
@@ -132,7 +132,7 @@
     "nom_orig": "Elly's[SP]voice",
     "texte_orig": "Going[SP]by[SP]the[SP]same[SP]logic[SP]as[SP]before,[SP]the[SP]sign\nof[SP]water[SP]that[SP]presides[SP]over[SP]death[SP]and\nrebirth...",
     "nom_fr": "Voix d'Elly",
-    "texte_fr": "En suivant la même\nlogique, le signe de l'eau\nqui préside à la\nmort et à la renaissance..."
+    "texte_fr": "En suivant la même\nlogique, le signe de l'eau\nqui préside à la mort et à la renaissance..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Elly's[SP]voice",
     "texte_orig": "That[SP]would[SP]be[SP]Scorpio.[SP]In[SP]other[SP]words,[SP]head\nnorth[SP]by[SP]northeast[SP]from[SP]Seven[SP]Sisters[SP]High,\nso[SP]the[SP]next[SP]target[SP]is[SP]in[SP]Yumezaki!",
     "nom_fr": "Voix d'Elly",
-    "texte_fr": "Ce serait le Scorpion. Du coup, cap au\nnord-nord-est depuis le\nlycée de Septs Sœurs,\nainsi la prochaine cible est Yumezaki!"
+    "texte_fr": "Ce serait le Scorpion. Du coup, cap au\nnord-nord-est depuis le\nlycée de Septs Sœurs, ainsi la prochaine cible est Yumezaki!"
   },
   {
     "id": 10,

--- a/traduction/event_scripts/script_055.json
+++ b/traduction/event_scripts/script_055.json
@@ -42,7 +42,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "Huh!?[1205][001E][SP]You're[SP]kinda[SP]young[SP]to[SP]be[SP]going[SP]senile,\nMa-ya.[SP]Come[SP]on,[SP]there's[SP]no[SP]way[SP]there'd[SP]be\nbombs[SP]here.",
     "nom_fr": "Ulala",
-    "texte_fr": "Hein!?[1205][001E] T'es jeune pour être sénile, Ma-ya.\nImpossible qu'il y ait des bombes ici."
+    "texte_fr": "Hein!?[001E][1205] T'es jeune pour être sénile, Ma-ya.\nImpossible qu'il y ait des bombes ici."
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Huh?[1205][001E][SP]What's[SP]this?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hein?[1205][001E] Quoi?"
+    "texte_fr": "Hein?[001E][1205] Quoi?"
   },
   {
     "id": 6,
@@ -162,7 +162,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "That,[SP]I've[SP]heard[SP]of...[SP]Makimura[SP]used[SP]to\ntalk[SP]about[SP]them[SP]all[SP]the[SP]time.[1205][001E][SP]Let[SP]me[SP]guess,\nhe's[SP]out[SP]for[SP]my[SP]blood[SP]now!?",
     "nom_fr": "Ulala",
-    "texte_fr": "J'en ai entendu\nparler... Makimura en parlait\nsouvent.[1205][001E] Laisse-moi deviner,\nil veut ma peau!?"
+    "texte_fr": "J'en ai entendu\nparler... Makimura en parlait\nsouvent.[001E][1205] Laisse-moi deviner,\nil veut ma peau!?"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "Sounds[SP]like[SP]the[SP]time[SP]has[SP]come[SP]to[SP]put[SP]these\nfists[SP]to[SP]use...[1205][001E][SP]He[SP]took[SP]my[SP]savings,[SP]but[SP]I\nwon't[SP]let[SP]him[SP]take[SP]my[SP]life!",
     "nom_fr": "Ulala",
-    "texte_fr": "L'heure d'utiliser mes poings a sonné...[1205][001E] Il\na pris mes économies, il n'aura pas ma vie!"
+    "texte_fr": "L'heure d'utiliser mes poings a sonné...[001E][1205] Il\na pris mes économies, il n'aura pas ma vie!"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "...There[SP]she[SP]goes.[1205][001E][SP]I[SP]hope[SP]she[SP]remembers[SP]to\nget[SP]out[SP]of[SP]the[SP]gym.",
     "nom_fr": "Maya",
-    "texte_fr": "... Elle est partie.[1205][001E] J'espère\nqu'elle sortira d'ici."
+    "texte_fr": "... Elle est partie.[001E][1205] J'espère\nqu'elle sortira d'ici."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Anyway,[SP]now[SP]that[SP]we[SP]know[SP]this[SP]is[SP]the[SP]next\ntarget,[SP]we[SP]don't[SP]have[SP]a[SP]second[SP]to[SP]lose.\nLet's[SP]find[SP]that[SP]transmitter!",
     "nom_fr": "Maya",
-    "texte_fr": "Bref, puisqu'on sait que\nc'est la cible, pas\nune seconde à perdre. Trouvons ce\ntransmetteur!"
+    "texte_fr": "Bref, puisqu'on sait que\nc'est la cible, pas\nune seconde à perdre. Trouvons ce transmetteur!"
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That[SP]chica's[SP]strength[SP]was[SP]amazing.\nI[SP]thought[SP]she[SP]was[SP]boxing[SP]to[SP]lose[SP]weight,\nbut[SP]she[SP]was[SP]dead[SP]serious[SP]about[SP]it.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Cette chica est très\nforte. Je croyais qu'elle\nboxait pour maigrir,\nmais elle est sérieuse."
+    "texte_fr": "Cette chica est très\nforte. Je croyais qu'elle\nboxait pour maigrir, mais elle est sérieuse."
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "She[SP]packs[SP]a[SP]punch...[1205][001E][SP]Once[SP]this[SP]business[SP]is\nover,[SP]I'd[SP]like[SP]to[SP]go[SP]a[SP]few[SP]rounds[SP]with[SP]her.",
     "nom_fr": "Yukino",
-    "texte_fr": "Elle a de la poigne...[1205][001E] Après ça, j'aimerais\nfaire quelques rounds avec elle."
+    "texte_fr": "Elle a de la poigne...[001E][1205] Après ça, j'aimerais\nfaire quelques rounds avec elle."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Sakai-kun",
     "texte_orig": "One,[SP]two,[SP]one,[SP]two...[SP]My[SP]goal[1205][000A][SP]is[SP]to[SP]lose[1205][000A]\n60[SP]pounds![SP]I[SP]don't[1205][000A][SP]have[SP]time[1205][000A][SP]to[SP]run!",
     "nom_fr": "Sakai-kun",
-    "texte_fr": "Un, deux... Mon but[1205][000A] est de[1205][000A] perdre\n30kg! Pas[1205][000A] le temps[1205][000A] de fuir!"
+    "texte_fr": "Un, deux... Mon but[000A][1205] est de[000A][1205] perdre\n30kg! Pas[000A][1205] le temps[000A][1205] de fuir!"
   },
   {
     "id": 19,
@@ -312,7 +312,7 @@
     "nom_orig": "GOLD[SP]staffer",
     "texte_orig": "Even[SP]a[SP]club[SP]like[SP]this[SP]has[SP]become[SP]a[SP]target\nfor[SP]terrorists...[1205][001E][SP]*gasp*[SP]What[SP]am[SP]I[SP]doing\nstanding[SP]here?[SP]I[SP]need[SP]to[SP]evacuate[SP]everyone!",
     "nom_fr": "Staff",
-    "texte_fr": "Même ce club est la cible de terroristes...[1205][001E]\n*gasp* Je dois évacuer tout le monde!"
+    "texte_fr": "Même ce club est la cible de terroristes...[001E][1205]\n*gasp* Je dois évacuer tout le monde!"
   },
   {
     "id": 21,
@@ -357,6 +357,6 @@
     "nom_orig": "GOLD[SP]staffer",
     "texte_orig": "Even[SP]a[SP]club[SP]like[SP]this[SP]has[SP]become[SP]a[SP]target\nfor[SP]terrorists...[1205][001E][SP]*gasp*[SP]What[SP]am[SP]I[SP]doing\nstanding[SP]here?[SP]I[SP]need[SP]to[SP]evacuate[SP]everyone!",
     "nom_fr": "Staff",
-    "texte_fr": "Même ce club est la cible de terroristes...[1205][001E]\n*gasp* Je dois évacuer tout le monde!"
+    "texte_fr": "Même ce club est la cible de terroristes...[001E][1205]\n*gasp* Je dois évacuer tout le monde!"
   }
 ]

--- a/traduction/event_scripts/script_057.json
+++ b/traduction/event_scripts/script_057.json
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]guy...[1205][001E][SP]I[SP]feel[SP]like[SP]I've[SP]seen[SP]him\nsomewhere.[SP]Well,[SP]after[SP]him,[SP]I[SP]guess!",
     "nom_fr": "Maya",
-    "texte_fr": "Cet homme...[1205][001E] J'ai l'impression de\nl'avoir déjà vu. Allez, on le suit!"
+    "texte_fr": "Cet homme...[001E][1205] J'ai l'impression de\nl'avoir déjà vu. Allez, on le suit!"
   },
   {
     "id": 8,

--- a/traduction/event_scripts/script_058.json
+++ b/traduction/event_scripts/script_058.json
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "When[SP]you[SP]look[SP]at[SP]how[SP]these[SP]bombs[SP]are[SP]set,\nit's[SP]detailed[SP]to[SP]the[SP]point[SP]of[SP]being[SP]neurotic.[1205][001E]\nDon't[SP]you[SP]think[SP]that's[SP]strange?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le réglage de ces bombes est d'une minutie\nnévrotique.[1205][001E] Tu ne trouves pas ça étrange?"
+    "texte_fr": "Le réglage de ces bombes est d'une minutie\nnévrotique.[001E][1205] Tu ne trouves pas ça étrange?"
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]guy...[1205][001E][SP]I[SP]feel[SP]like[SP]I've[SP]seen[SP]him\nsomewhere.[SP]Well,[SP]after[SP]him,[SP]I[SP]guess!",
     "nom_fr": "Maya",
-    "texte_fr": "Ce type...[1205][001E] J'ai l'impression de\nl'avoir déjà vu. Bon, après lui!"
+    "texte_fr": "Ce type...[001E][1205] J'ai l'impression de\nl'avoir déjà vu. Bon, après lui!"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Uh,[SP]Eikichi...[1205][001E][SP]You[SP]think[SP]he's[SP]trying[SP]to\nsay[SP][1432][NULL][NULL][0014]paranoid[1432][NULL][NULL][0014]?",
     "nom_fr": "Yukino",
-    "texte_fr": "Euh, Eikichi...[1205][001E] Tu penses\nqu'il veut dire [1432][NULL][NULL][0014]parano[1432][NULL][NULL][0014]?"
+    "texte_fr": "Euh, Eikichi...[001E][1205] Tu penses\nqu'il veut dire [1432][NULL][NULL][0014]parano[1432][NULL][NULL][0014]?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "If[SP]that[SP]guy's[SP]in[SP]the[SP]Masked[SP]Circle,[SP]this[SP]is\nour[SP]chance[SP]to[SP]pump[SP]him[SP]for[SP]information[SP]about\nJoker.[SP]Let's[SP]hunt[SP]him[SP]down.",
     "nom_fr": "Yukino",
-    "texte_fr": "S'il est du Cercle\nmasqué, on peut lui tirer\ndes infos sur Joker. Traquons-le.  Le\ncasier contient un mot: [NULL][NULL]stupide[NULL][NULL]... et une\n[E4][NULL][NULL]bombe[E4][NULL][NULL].[E4][NULL][NULL]  Juste une [E4][NULL][NULL]bombe[E4][NULL][NULL] dans la poubelle.[E4][NULL][NULL]"
+    "texte_fr": "S'il est du Cercle\nmasqué, on peut lui tirer\ndes infos sur Joker. Traquons-le.  Le casier contient un mot: [NULL][NULL]stupide[NULL][NULL]... et une [E4][NULL][NULL]bombe[E4][NULL][NULL].[E4][NULL][NULL]  Juste une [E4][NULL][NULL]bombe[E4][NULL][NULL] dans la poubelle.[E4][NULL][NULL]"
   },
   {
     "id": 8,

--- a/traduction/event_scripts/script_059.json
+++ b/traduction/event_scripts/script_059.json
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah![SP]Check[SP]out[SP]those[SP]swimsuits!\nIf[SP][1113][SP]ever[SP]wore[SP]something[SP]like\nthat...[1205][001E][SP]Eeeee!",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiyah! Regardez ces maillots de bain! Si\n[1113]portait un truc pareil...[1205][001E] Aaaaaa!"
+    "texte_fr": "Aiyah! Regardez ces maillots de bain! Si\n[1113]portait un truc pareil...[001E][1205] Aaaaaa!"
   },
   {
     "id": 3,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]guy...[1205][001E][SP]I[SP]feel[SP]like[SP]I've[SP]seen[SP]him\nsomewhere.[SP]Well,[SP]after[SP]him,[SP]I[SP]guess!",
     "nom_fr": "Maya",
-    "texte_fr": "Ce type...[1205][001E] J'ai l'impression de\nl'avoir déjà vu. Bon, on le poursuit!"
+    "texte_fr": "Ce type...[001E][1205] J'ai l'impression de\nl'avoir déjà vu. Bon, on le poursuit!"
   },
   {
     "id": 7,

--- a/traduction/event_scripts/script_060.json
+++ b/traduction/event_scripts/script_060.json
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Th-This[SP]leotard...[1205][001E][SP]How[SP]scandalous...![1205][001E]\nHrrrghhhh...[1205][001E][SP]*gasp*",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ce justaucorps...[1205][001E] C'est\nscandaleux...![1205][001E] Hrrrghhh...[1205][001E]*gasp*"
+    "texte_fr": "Ce justaucorps...[001E][1205] C'est\nscandaleux...![001E][1205] Hrrrghhh...[001E][1205]*gasp*"
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm,[SP]no[SP]luck[SP]here[SP]either.[SP]Hey[SP]Yukki,[SP]what\nabout--[1205][001E]Uhh,[SP]I'll[SP]leave[SP]her[SP]to[SP]that...",
     "nom_fr": "Maya",
-    "texte_fr": "Rien ici non plus. Hé Yukki, et\ntoi--[1205][001E]Euh, je vais la laisser faire..."
+    "texte_fr": "Rien ici non plus. Hé Yukki, et\ntoi--[001E][1205]Euh, je vais la laisser faire..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]guy...[1205][001E][SP]I[SP]feel[SP]like[SP]I've[SP]seen[SP]him\nsomewhere.[SP]Well,[SP]after[SP]him,[SP]I[SP]guess!",
     "nom_fr": "Maya",
-    "texte_fr": "Cet homme...[1205][001E] J'ai l'impression\nde l'avoir déjà vu. Suivons-le!"
+    "texte_fr": "Cet homme...[001E][1205] J'ai l'impression\nde l'avoir déjà vu. Suivons-le!"
   },
   {
     "id": 7,

--- a/traduction/event_scripts/script_061.json
+++ b/traduction/event_scripts/script_061.json
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "In[SP]that[SP]case...[1205][001E][SP]I[SP]bet[SP]he's[SP]a[SP]Masked[SP]Circle\nmember[SP]who[SP]was[SP]guarding[SP]the[SP]transmitter!\nC'mon,[SP][1113],[SP]let's[SP]get[SP]him!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Donc...[1205][001E] C'est sûrement un membre du Cercle\nmasqué qui gardait le transmetteur! Allez,\n[1113], attrapons-le!"
+    "texte_fr": "Donc...[001E][1205] C'est sûrement un membre du Cercle\nmasqué qui gardait le transmetteur! Allez,\n[1113], attrapons-le!"
   },
   {
     "id": 4,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]guy...[1205][001E][SP]I[SP]feel[SP]like[SP]I've[SP]seen[SP]him\nsomewhere.[SP]Well,[SP]after[SP]him,[SP]I[SP]guess!",
     "nom_fr": "Maya",
-    "texte_fr": "Ce type...[1205][001E] Je crois l'avoir\ndéjà vu. Bref, rattrapons-le!"
+    "texte_fr": "Ce type...[001E][1205] Je crois l'avoir\ndéjà vu. Bref, rattrapons-le!"
   },
   {
     "id": 7,

--- a/traduction/event_scripts/script_062.json
+++ b/traduction/event_scripts/script_062.json
@@ -102,7 +102,7 @@
     "nom_orig": "Handsome[SP]man",
     "texte_orig": "H...[SP]Honey!?[1205][001E][SP]I-I'm[SP]so[SP]glad[SP]to[SP]see[SP]you[SP]again!\nNot[SP]a[SP]day[SP]went[SP]by[SP]that[SP]I[SP]didn't[SP]think[SP]of[SP]you!",
     "nom_fr": "Bel homme",
-    "texte_fr": "Ch... Chérie!?[1205][001E] Q-Quelle joie de te revoir !\nJe n'ai pas passé un\njour sans penser à toi!"
+    "texte_fr": "Ch... Chérie!?[001E][1205] Q-Quelle joie de te revoir !\nJe n'ai pas passé un\njour sans penser à toi!"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "Can[SP]it,[SP]creep.[SP]Now[SP]that[SP]I[SP]found[SP]you,\nyou're[SP]a[SP]dead[SP]man...[1205][001E][SP]This[SP]is[SP]for[SP]all\nthe[SP]wedding[SP]funds[SP]you[SP]stole!",
     "nom_fr": "Ulala",
-    "texte_fr": "La ferme, ordure. Je te tiens:\nt'es mort...[1205][001E] Ça, c'est pour\nl'argent du mariage que t'as volé!"
+    "texte_fr": "La ferme, ordure. Je te tiens:\nt'es mort...[001E][1205] Ça, c'est pour\nl'argent du mariage que t'as volé!"
   },
   {
     "id": 8,

--- a/traduction/event_scripts/script_064.json
+++ b/traduction/event_scripts/script_064.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Heheh...[1205][001E][SP]That[SP]Ginji[SP]Sasaki[SP]guy's[SP]as[SP]nasty\nas[SP]I[SP]thought[SP]he[SP]was.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Eheh...[1205][001E] Ce Ginji Sasaki est aussi\nrelou que ce que je pensais."
+    "texte_fr": "Eheh...[001E][1205] Ce Ginji Sasaki est aussi\nrelou que ce que je pensais."
   },
   {
     "id": 1,
@@ -72,7 +72,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Eikichi...[1205][001E][SP]Pot.[SP]Kettle.[SP]Black.",
     "nom_fr": "Yukino",
-    "texte_fr": "Eikichi...[1205][001E] T'es pas sérieux."
+    "texte_fr": "Eikichi...[001E][1205] T'es pas sérieux."
   },
   {
     "id": 5,

--- a/traduction/event_scripts/script_066.json
+++ b/traduction/event_scripts/script_066.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Dammit...[1205][001E][SP]We[SP]were[SP]too[SP]late!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Bon sang...[1205][001E] Trop tard!"
+    "texte_fr": "Bon sang...[001E][1205] Trop tard!"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Anna![1205][001E][SP]She's[SP]not[SP]here...[SP]Why[SP]would[SP]she\ndo[SP]this!?",
     "nom_fr": "Yukino",
-    "texte_fr": "Anna![1205][001E] Elle n'est pas\nlà... Pourquoi faire ça!?"
+    "texte_fr": "Anna![001E][1205] Elle n'est pas\nlà... Pourquoi faire ça!?"
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yasuo's[SP]dead,[SP]too...[1205][001E][SP]Does[SP]this[SP]mean[SP]we've\nhit[SP]a[SP]wall[SP]in[SP]our[SP]search[SP]for[SP]Joker!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Yasuo est mort aussi...[1205][001E] Sommes-nous\nbloqués dans la recherche de Joker!?"
+    "texte_fr": "Yasuo est mort aussi...[001E][1205] Sommes-nous\nbloqués dans la recherche de Joker!?"
   },
   {
     "id": 4,
@@ -102,7 +102,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "There[SP]must[SP]be[SP]a[SP]reason[SP]why[SP]Anna[SP]became[SP]an\nexecutive[SP]in[SP]the[SP]Masked[SP]Circle...[1205][001E]",
     "nom_fr": "Yukino",
-    "texte_fr": "Il y a forcément une raison pour\nqu'Anna soit cadre du Cercle masqué...[1205][001E]"
+    "texte_fr": "Il y a forcément une raison pour\nqu'Anna soit cadre du Cercle masqué...[001E][1205]"
   },
   {
     "id": 7,

--- a/traduction/event_scripts/script_067.json
+++ b/traduction/event_scripts/script_067.json
@@ -12,7 +12,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Uh-oh...[1205][001E][SP]Looks[SP]like[SP]some[SP]kids[SP]are[SP]here[SP]on\na[SP]field[SP]trip.[SP]What[SP]should[SP]we[SP]do,[SP]Maya-san?",
     "nom_fr": "Yukino",
-    "texte_fr": "Oh...[1205][001E] On dirait qu'il y a des enfants en\nsortie scolaire. Qu'est-ce qu'on fait Maya?"
+    "texte_fr": "Oh...[001E][1205] On dirait qu'il y a des enfants en\nsortie scolaire. Qu'est-ce qu'on fait Maya?"
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "???",
     "texte_orig": "Hahaha...[1205][001E][SP]Heaven[SP]calls![SP]Earth[SP]calls![SP]The\npeople[SP]call![1205][001E][SP]...Uhh,[SP]what[SP]was[SP]my[SP]next[SP]line?",
     "nom_fr": "???",
-    "texte_fr": "Hahaha...[1205][001E] Le ciel! La Terre! Le peuple! Ils\nm'appellent[1205][001E]... Euh, c'est quoi la suite?"
+    "texte_fr": "Hahaha...[001E][1205] Le ciel! La Terre! Le peuple! Ils\nm'appellent[001E][1205]... Euh, c'est quoi la suite?"
   },
   {
     "id": 3,
@@ -237,7 +237,7 @@
     "nom_orig": "King[SP]Leo's[SP]voice",
     "texte_orig": "I've[SP]been[SP]waiting[SP]for[SP]you,[SP]Cursed[SP]Star.[1205][001E]\nAllow[SP]me[SP]to[SP]ignite[SP]a[SP]welcoming[SP]flame[SP]as\ncongratulations[SP]for[SP]making[SP]it[SP]here.",
     "nom_fr": "Voix du Roi Lion",
-    "texte_fr": "Je t'attendais, Étoile Maudite.[1205][001E] Laisse-moi\nallumer un feu de bienvenue pour te\nféliciter d'être arrivé jusqu'ici."
+    "texte_fr": "Je t'attendais, Étoile Maudite.[001E][1205] Laisse-moi\nallumer un feu de bienvenue pour te\nféliciter d'être arrivé jusqu'ici."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Ah...[1205][001E][SP]Ah...![1205][001E][SP]Noooooo!",
     "nom_fr": "Maya",
-    "texte_fr": "Ah...[1205][001E] Ah...![1205][001E] Noooooo!"
+    "texte_fr": "Ah...[001E][1205] Ah...![001E][1205] Noooooo!"
   },
   {
     "id": 17,
@@ -282,7 +282,7 @@
     "nom_orig": "King[SP]Leo's[SP]voice",
     "texte_orig": "Witch...[1205][001E][SP]You[SP]will[SP]not[SP]escape[SP]me[SP]this[SP]time!",
     "nom_fr": "Voix du Roi Lion",
-    "texte_fr": "Sorcière...[1205][001E] Tu ne m'échapperas pas!"
+    "texte_fr": "Sorcière...[001E][1205] Tu ne m'échapperas pas!"
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "King[SP]Leo's[SP]voice",
     "texte_orig": "Everything[SP]is[SP]destined[SP]to[SP]perish[SP]regardless.[1205][001E]\nYou[SP]and[SP]these[SP]brats[SP]will[SP]be[SP]an[SP]early\nsacrifice!",
     "nom_fr": "Voix du Roi Lion",
-    "texte_fr": "De toute façon, tout est voué à périr.[1205][001E] Toi\net ces gamins ferez un sacrifice anticipé !"
+    "texte_fr": "De toute façon, tout est voué à périr.[001E][1205] Toi\net ces gamins ferez un sacrifice anticipé !"
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "King[SP]Leo's[SP]voice",
     "texte_orig": "Heh...[1205][001E][SP]Heehee...[1205][001E][SP]Hyahaha![1205][001E][SP]Hyaaaahahahahaaaa!",
     "nom_fr": "Voix du Roi Lion",
-    "texte_fr": "Heh...[1205][001E] Heehee...[1205][001E] Hyahaha![1205][001E] Hyaaaahahahaaaa !"
+    "texte_fr": "Heh...[001E][1205] Heehee...[001E][1205] Hyahaha![001E][1205] Hyaaaahahahaaaa !"
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Maya",
     "texte_orig": "...I[SP]won't...[1205][001E][SP]run[SP]anymore...[1205][001E][SP]I[SP]won't[SP]give[SP]in!",
     "nom_fr": "Maya",
-    "texte_fr": "... Je ne...[1205][001E] fuis plus...[1205][001E]\nJe ne céderai pas !"
+    "texte_fr": "... Je ne...[001E][1205] fuis plus...[001E][1205]\nJe ne céderai pas !"
   },
   {
     "id": 22,
@@ -357,7 +357,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]remember[SP]this[SP]place[SP]being[SP]made[SP]up[SP]of[SP]four\npretty[SP]big[SP]floors...[1205][001E][SP]You[SP]two,[SP]find[SP]the\nteacher[SP]and[SP]head[SP]to[SP]the[SP]rooftop!",
     "nom_fr": "Maya",
-    "texte_fr": "Ce musée a 4 grands étages...[1205][001E] Vous deux,\nallez trouver la prof\net montez sur le toit!"
+    "texte_fr": "Ce musée a 4 grands étages...[001E][1205] Vous deux,\nallez trouver la prof\net montez sur le toit!"
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Our[SP]job[SP]will[SP]be[SP]to[SP]check[SP]each[SP]floor's\nexhibition[SP]rooms[SP]and[SP]make[SP]sure[SP]there[SP]are\nno[SP]kids[SP]who[SP]haven't[SP]evacuated[SP]yet.",
     "nom_fr": "Maya",
-    "texte_fr": "Notre rôle: vérifier les salles d'expo\nde chaque étage et s'assurer qu'aucun\nenfant n'y reste.\n Sauvegarder?\nOuiNon",
+    "texte_fr": "Notre rôle: vérifier les salles d'expo\nde chaque étage et s'assurer qu'aucun\nenfant n'y reste. Sauvegarder? OuiNon",
     "choix_fr": [
       ""
     ]

--- a/traduction/event_scripts/script_069.json
+++ b/traduction/event_scripts/script_069.json
@@ -27,7 +27,7 @@
     "nom_orig": "Sailor-suited[SP]girl",
     "texte_orig": "[1113]-kun,[SP]can[SP]you[SP]hear[SP]me!?[SP]Please...[1205][001E]\nAnswer[SP]me![SP][1113]-kun!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "[1113], tu m'entends!? S'il te\nplaît...[1205][001E] Réponds-moi! [1113]!"
+    "texte_fr": "[1113], tu m'entends!? S'il te\nplaît...[001E][1205] Réponds-moi! [1113]!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Insane[SP]young[SP]man",
     "texte_orig": "Heh...[1205][001E][SP]Heehee...[1205][001E][SP]Hyahaha![1205][001E][SP]Hyaaaahahahahaaaa!",
     "nom_fr": "Jeune homme fou",
-    "texte_fr": "Heh...[1205][001E] Heehee...[1205][001E]\nHyahaha![1205][001E] Hyaaaahahahahaaaa!"
+    "texte_fr": "Heh...[001E][1205] Heehee...[001E][1205]\nHyahaha![001E][1205] Hyaaaahahahahaaaa!"
   },
   {
     "id": 3,
@@ -57,6 +57,6 @@
     "nom_orig": "Sailor-suited[SP]girl",
     "texte_orig": "[1113]-kun...[1205][001E][SP]Run![SP]You[SP]have[SP]to[SP]run!",
     "nom_fr": "",
-    "texte_fr": "[1113]-kun...[1205][001E] Fuis ! Tu dois fuir !"
+    "texte_fr": "[1113]-kun...[001E][1205] Fuis ! Tu dois fuir !"
   }
 ]

--- a/traduction/event_scripts/script_071.json
+++ b/traduction/event_scripts/script_071.json
@@ -72,7 +72,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Talk[SP]about[SP]an[SP]odd[SP]situation...[SP]Oh[SP]well,\nwe'll[SP]just[SP]have[SP]to[SP]pull[SP]him[SP]out.[SP]I[SP]need\nyour[SP]help[SP]here,[SP][1113]!",
     "nom_fr": "Yukino",
-    "texte_fr": "Tu parles d'une situation...\nBon, on va juste\nle sortir de là. J'ai\nbesoin de ton aide là, [1113][u+1113]!"
+    "texte_fr": "Tu parles d'une situation...\nBon, on va juste\nle sortir de là. J'ai besoin de ton aide là, [1113][u+1113]!"
   },
   {
     "id": 5,

--- a/traduction/event_scripts/script_077.json
+++ b/traduction/event_scripts/script_077.json
@@ -27,7 +27,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "You've[SP]really[SP]pissed[SP]me[SP]off.[1205][001E][SP]I'm[SP]giving[SP]you\nfive[SP]more[SP]seconds[SP]to[SP]live![SP]Rrraaaaaaagh!",
     "nom_fr": "Tadashi",
-    "texte_fr": "Tu m'as vraiment mis hors de moi.[1205][001E] Il te\nreste cinq secondes à vivre! Rrraaaaaaagh!"
+    "texte_fr": "Tu m'as vraiment mis hors de moi.[001E][1205] Il te\nreste cinq secondes à vivre! Rrraaaaaaagh!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "King[SP]Leo",
     "texte_orig": "You've[SP]come...[1205][001E][SP]As[SP]I[SP]expected[SP]the[SP]Cursed\nStar[SP]to.",
     "nom_fr": "Roi Lion",
-    "texte_fr": "Tu es venu...[1205][001E] Comme prévu, Étoile Maudite."
+    "texte_fr": "Tu es venu...[001E][1205] Comme prévu, Étoile Maudite."
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "King[SP]Leo",
     "texte_orig": "Why?[1205][001E][SP]Because...",
     "nom_fr": "Roi Lion",
-    "texte_fr": "Pourquoi...[1205][001E]"
+    "texte_fr": "Pourquoi...[001E][1205]"
   },
   {
     "id": 6,
@@ -132,7 +132,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "You[SP]witch...[1205][001E][SP]I[SP]won't[SP]listen[SP]to[SP]you[SP]tell[SP]me\nyou've[SP]forgotten[SP]this[SP]face![SP]It's[SP]you[SP]and[SP]your\nbrat[SP]friend[SP]who[SP]did[SP]this[SP]to[SP]me!",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "Sorcière...[1205][001E] Tu n'as pas oublié ce\nvisage, n'essaie même pas! Toi et\nton petit ami m'avez fait ça!"
+    "texte_fr": "Sorcière...[001E][1205] Tu n'as pas oublié ce\nvisage, n'essaie même pas! Toi et\nton petit ami m'avez fait ça!"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Me[SP]and...[1205][001E][SP][1113]-kun!?[SP]I...[SP]don't[SP]know\nwhat[SP]you're[SP]talking[SP]about!",
     "nom_fr": "Maya",
-    "texte_fr": "Moi et...[1205][001E] [1113]-kun!? Je... je\nne vois pas de quoi tu parles!"
+    "texte_fr": "Moi et...[001E][1205] [1113]-kun!? Je... je\nne vois pas de quoi tu parles!"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "Still[SP]feigning[SP]ignorance,[SP]eh?[1205][001E][SP]Well,[SP]fine.",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "Tu fais encore l'ignorante?[1205][001E] Très bien."
+    "texte_fr": "Tu fais encore l'ignorante?[001E][1205] Très bien."
   },
   {
     "id": 11,
@@ -237,7 +237,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "If[SP]you[SP]had[SP]died[SP]on[SP]that[SP]day,[SP]he[SP]wouldn't\nhave[SP]to[SP]go[SP]through[SP]this...[1205][001E][SP]It's[SP]all[SP]the\nwitch's[SP]fault[SP]for[SP]spreading[SP]misfortune!",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "Si tu étais morte ce jour-là, il\nn'aurait pas à souffrir...[1205][001E] C'est\nla sorcière qui répand le malheur!"
+    "texte_fr": "Si tu étais morte ce jour-là, il\nn'aurait pas à souffrir...[001E][1205] C'est\nla sorcière qui répand le malheur!"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "I[SP]refuse[SP]to[SP]wait[SP]until[SP]the[SP]End[SP]of[SP]Nahui-\nOllin...[1205][001E][SP]Burn[SP]to[SP]ashes[SP]here,[SP]as[SP]befits\na[SP]witch[SP]like[SP]you!",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "Je refuse d'attendre la Fin de\nNahui- Ollin...[1205][001E] Brûle ici, comme\nil sied à une sorcière comme toi!"
+    "texte_fr": "Je refuse d'attendre la Fin de\nNahui- Ollin...[001E][1205] Brûle ici, comme\nil sied à une sorcière comme toi!"
   },
   {
     "id": 17,
@@ -282,7 +282,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "The[SP]fulfillment[SP]of[SP]the[SP]Oracle[SP]of[SP]Maia...[1205][001E]\nWhat[SP]the[SP]Exalted[SP]One[SP]truly[SP]desires[SP]is[SP]the\nmeans[SP]to[SP]sublimate[SP]mankind[SP]to[SP]the[SP]Idealians.",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "L'accomplissement de l'Oracle de Maia...[1205][001E]\nCe que le Vénéré désire vraiment, c'est le\nmoyen de sublimer l'humanité en Idéaliens."
+    "texte_fr": "L'accomplissement de l'Oracle de Maia...[001E][1205]\nCe que le Vénéré désire vraiment, c'est le\nmoyen de sublimer l'humanité en Idéaliens."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "When[SP]the[SP]Holy[SP]Cross[SP]forms[SP]in[SP]the[SP]sky,\nHell[SP]will[SP]climb[SP]to[SP]the[SP]heavens...[1205][001E][SP]Our[SP]one\nchance[SP]in[SP]15,000[SP]years[SP]is[SP]nearly[SP]upon[SP]us!",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "Quand la Croix Cosmique paraîtra,\nl'Enfer montera aux cieux...[1205][001E] Notre\nchance en 15 000 ans est proche!"
+    "texte_fr": "Quand la Croix Cosmique paraîtra,\nl'Enfer montera aux cieux...[001E][1205] Notre\nchance en 15 000 ans est proche!"
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "From[SP]that[SP]day[SP]forth,[SP]we[SP]members[SP]of[SP]the[SP]new\nrace[SP]will[SP]be[SP]close[SP]to[SP]gods![1205][001E][SP]This[SP]rotten[SP]world\nwill[SP]be[SP]obliterated!",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "Dès ce jour, nous, membres de la\nnouvelle race, serons proches des\ndieux![1205][001E] Ce monde pourri sera anéanti!"
+    "texte_fr": "Dès ce jour, nous, membres de la\nnouvelle race, serons proches des\ndieux![001E][1205] Ce monde pourri sera anéanti!"
   },
   {
     "id": 21,

--- a/traduction/event_scripts/script_078.json
+++ b/traduction/event_scripts/script_078.json
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Ngh...[1205][001E][SP]I've[SP]had[SP]enough[SP]of[SP]this!\nLet[SP]go[SP]of[SP]that[SP]girl!",
     "nom_fr": "Maya",
-    "texte_fr": "Urgh...[1205][001E] J'en ai assez! Lâchez cette fille!"
+    "texte_fr": "Urgh...[001E][1205] J'en ai assez! Lâchez cette fille!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "If[SP]you[SP]had[SP]died[SP]on[SP]that[SP]day,[SP]he[SP]wouldn't\nhave[SP]to[SP]go[SP]through[SP]this...[1205][001E][SP]It's[SP]all[SP]the\nwitch's[SP]fault[SP]for[SP]spreading[SP]misfortune!",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "Si tu étais morte ce jour-là, il\nn'aurait pas eu à souffrir...[1205][001E] Tout\nest la faute de cette sorcière!"
+    "texte_fr": "Si tu étais morte ce jour-là, il\nn'aurait pas eu à souffrir...[001E][1205] Tout\nest la faute de cette sorcière!"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "I[SP]refuse[SP]to[SP]wait[SP]until[SP]the[SP]End[SP]of[SP]Nahui-\nOllin...[1205][001E][SP]Burn[SP]to[SP]ashes[SP]here,[SP]as[SP]befits\na[SP]witch[SP]like[SP]you!",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "Je n'attendrai pas la Fin du Nahui-Ollin...[1205][001E]\nBrûle en cendres, comme une sorcière!"
+    "texte_fr": "Je n'attendrai pas la Fin du Nahui-Ollin...[001E][1205]\nBrûle en cendres, comme une sorcière!"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "The[SP]fulfillment[SP]of[SP]the[SP]Oracle[SP]of[SP]Maia...[1205][001E]\nWhat[SP]the[SP]Exalted[SP]One[SP]truly[SP]desires[SP]is[SP]the\nmeans[SP]to[SP]sublimate[SP]mankind[SP]to[SP]the[SP]Idealians.",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "L'accomplissement de l'Oracle de Maia...[1205][001E]\nCe que l'Exaltée désire vraiment, c'est\nde sublimer l'humanité en Idéaliens."
+    "texte_fr": "L'accomplissement de l'Oracle de Maia...[001E][1205]\nCe que l'Exaltée désire vraiment, c'est\nde sublimer l'humanité en Idéaliens."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "When[SP]the[SP]Holy[SP]Cross[SP]forms[SP]in[SP]the[SP]sky,\nHell[SP]will[SP]climb[SP]to[SP]the[SP]heavens...[1205][001E][SP]Our[SP]one\nchance[SP]in[SP]15,000[SP]years[SP]is[SP]nearly[SP]upon[SP]us!",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "Quand la Croix Cosmique se formera,\nl'Enfer s'élèvera vers les cieux...[1205][001E]\nNotre chance en 15 000 ans est là!"
+    "texte_fr": "Quand la Croix Cosmique se formera,\nl'Enfer s'élèvera vers les cieux...[001E][1205]\nNotre chance en 15 000 ans est là!"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "From[SP]that[SP]day[SP]forth,[SP]we[SP]members[SP]of[SP]the[SP]new\nrace[SP]will[SP]be[SP]close[SP]to[SP]gods![1205][001E][SP]This[SP]rotten[SP]world\nwill[SP]be[SP]obliterated!",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "À partir de ce jour, nous, la\nnouvelle race, serons proches des\ndieux![1205][001E] Ce monde pourri sera anéanti!"
+    "texte_fr": "À partir de ce jour, nous, la\nnouvelle race, serons proches des\ndieux![001E][1205] Ce monde pourri sera anéanti!"
   },
   {
     "id": 9,

--- a/traduction/event_scripts/script_080.json
+++ b/traduction/event_scripts/script_080.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Umm,[SP]I[SP]guess[SP]this[SP]is[SP]the[SP]steering[SP]wheel...\nHuh?[SP]There's[SP]no[SP]brakes...[1205][001E][SP]Well,[SP]I'll[SP]make[SP]do.",
     "nom_fr": "Maya",
-    "texte_fr": "Umm, je suppose que\nc'est le volant... Hein?\nIl n'y a pas de freins... [1205][001E] Bon, tant pis."
+    "texte_fr": "Umm, je suppose que\nc'est le volant... Hein?\nIl n'y a pas de freins... [001E][1205] Bon, tant pis."
   },
   {
     "id": 1,

--- a/traduction/event_scripts/script_081.json
+++ b/traduction/event_scripts/script_081.json
@@ -27,7 +27,7 @@
     "nom_orig": "Maya",
     "texte_orig": "A-About[SP]that...[1205][001E][SP]I[SP]think[SP]this[SP]thing[SP]broke!\nI[SP]can't[SP]control[SP]it!",
     "nom_fr": "Maya",
-    "texte_fr": "E-Eh bien...[1205][001E] Je crois que c'est\ncassé! Je ne contrôle rien!"
+    "texte_fr": "E-Eh bien...[001E][1205] Je crois que c'est\ncassé! Je ne contrôle rien!"
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "King[SP]Leo!?[SP]So[SP]he's[SP]alive...[1205][001E][SP]The[SP]kids[SP]are[SP]in\ndanger![SP]Let's[SP]go,[SP]guys!",
     "nom_fr": "Maya",
-    "texte_fr": "Roi Lion!? Il est en vie...[1205][001E] Les\nenfants sont en danger! Allons-y!"
+    "texte_fr": "Roi Lion!? Il est en vie...[001E][1205] Les\nenfants sont en danger! Allons-y!"
   },
   {
     "id": 4,

--- a/traduction/event_scripts/script_082.json
+++ b/traduction/event_scripts/script_082.json
@@ -27,7 +27,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "Hyaaaaahahahahaaaa![SP]The[SP]pain...[SP]It[SP]hurts,\ndammit![1205][001E][SP]You[SP]goddamn[SP]brats...[SP]You[SP]did[SP]it\nto[SP]me[SP]again...!",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "Hyaaaaahahaahaaaa! La douleur... Ça\nfait mal, bordel![1205][001E] Maudits gosses...\nVous m'avez encore eu...!"
+    "texte_fr": "Hyaaaaahahaahaaaa! La douleur... Ça\nfait mal, bordel![001E][1205] Maudits gosses...\nVous m'avez encore eu...!"
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "It's[SP]everyone[SP]else's[SP]fault[SP]for[SP]not[SP]accepting\nme...[1205][001E][SP]I[SP]won't[SP]be[SP]my[SP]dad's[SP]frickin'[SP]puppet!\nI'll[SP]leave[SP]however[SP]the[SP]hell[SP]I[SP]want!",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "C'est la faute des autres s'ils ne\nm'acceptent pas...[1205][001E] Je serai\npas le pantin de\nmon père! Je partirai comme je l'entends!"
+    "texte_fr": "C'est la faute des autres s'ils ne\nm'acceptent pas...[001E][1205] Je serai\npas le pantin de\nmon père! Je partirai comme je l'entends!"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "AaaaaaAAAAAH![SP]Stop...[1205][001E][SP]The[SP]voices!\nThevoicesthevoicesthevoicesthevoices!\nStop[SP]talking[SP]in[SP]my[SP]head!",
     "nom_fr": "Tatsuya Sudou",
-    "texte_fr": "AaaaaaAAAAAH! Arrêtez...[1205][001E] Les voix!\nLesvoixlesvoixlesvoixlesvoix!\nArrêtez de parler dans ma tête!"
+    "texte_fr": "AaaaaaAAAAAH! Arrêtez...[001E][1205] Les voix!\nLesvoixlesvoixlesvoixlesvoix!\nArrêtez de parler dans ma tête!"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "You[SP]sad[SP]man...[1205][001E][SP]You[SP]can't[SP]exist[SP]without\nblaming[SP]everything[SP]around[SP]you.",
     "nom_fr": "Maya",
-    "texte_fr": "Triste sire...[1205][001E] Tu ne peux exister\nsans blâmer tout ce qui t'entoure."
+    "texte_fr": "Triste sire...[001E][1205] Tu ne peux exister\nsans blâmer tout ce qui t'entoure."
   },
   {
     "id": 6,
@@ -117,6 +117,6 @@
     "nom_orig": "Tatsuya[SP]Sudou",
     "texte_orig": "Heh...[1205][001E][SP]Heehee...[1205][001E][SP]Hyahaha![1205][001E][SP]Hyaaaahahahahaaaa!",
     "nom_fr": "",
-    "texte_fr": "Heh...[1205][001E] Hihi...[1205][001E] Hyahaha !"
+    "texte_fr": "Heh...[001E][1205] Hihi...[001E][1205] Hyahaha !"
   }
 ]

--- a/traduction/event_scripts/script_084.json
+++ b/traduction/event_scripts/script_084.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Sheesh...[1205][001E][SP]What[SP]did[SP]we[SP]do[SP]to[SP]deserve[SP]all[SP]that?\nI[SP]can't[SP]believe[SP]we're[SP]still[SP]alive!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pfiou...[1205][001E] Qu'a-t-on fait pour mériter\nça? Dur de croire qu'on est en vie!"
+    "texte_fr": "Pfiou...[001E][1205] Qu'a-t-on fait pour mériter\nça? Dur de croire qu'on est en vie!"
   },
   {
     "id": 2,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "No[SP]worries![1205][001E][SP]Just[SP]promise[SP]me[SP]one[SP]thing.\nNever[SP]throw[SP]away[SP]your[SP]life[SP]like[SP]you[SP]almost\ndid[SP]before!",
     "nom_fr": "Maya",
-    "texte_fr": "Pas de souci![1205][001E] Promets-moi juste de\nne plus jamais gâcher ta vie ainsi!"
+    "texte_fr": "Pas de souci![001E][1205] Promets-moi juste de\nne plus jamais gâcher ta vie ainsi!"
   },
   {
     "id": 6,
@@ -132,7 +132,7 @@
     "nom_orig": "Akari",
     "texte_orig": "But[SP]I've[SP]made[SP]up[SP]my[SP]mind[SP]now![SP]I'm[SP]gonna[SP]BE\na[SP]manga[SP]artist![SP]And[SP]I'll[SP]do[SP]a[SP]comic[SP]about\nyou[SP]and[SP]your[SP]friends!",
     "nom_fr": "Akari",
-    "texte_fr": "Mais maintenant je suis décidée! Je SERAI\nmangaka! Et je ferai un\nmanga sur toi et tes\namis!"
+    "texte_fr": "Mais maintenant je suis décidée! Je SERAI\nmangaka! Et je ferai un\nmanga sur toi et tes amis!"
   },
   {
     "id": 9,
@@ -297,7 +297,7 @@
     "nom_orig": "Ulala's[SP]voice",
     "texte_orig": "What[SP]did[SP]I[SP]do?[1205][001E][SP]Well,[SP]I[SP]went[SP]to[SP]GOLD[SP]to[SP]help\nfight[SP]the[SP]fire...[SP]But[SP]the[SP]flames[SP]were[SP]too\nstrong...",
     "nom_fr": "Voix d'Ulala",
-    "texte_fr": "Moi?[1205][001E] J'ai aidé au GOLD contre le feu...\nMais les flammes étaient trop fortes..."
+    "texte_fr": "Moi?[001E][1205] J'ai aidé au GOLD contre le feu...\nMais les flammes étaient trop fortes..."
   },
   {
     "id": 20,
@@ -417,7 +417,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Oh[SP]no...[1205][001E][SP]This[SP]must[SP]be[SP]because[SP]of[SP]that[SP]rumor!\nThe[SP]one[SP]about[SP]the[SP]five[SP]terrorists[SP]going\naround[SP]the[SP]city![SP]It[SP]was[SP]about[SP]us...",
     "nom_fr": "Ginko",
-    "texte_fr": "Oh non...[1205][001E] Ça doit être à cause de cette\nrumeur! Celle sur les cinq terroristes\nqui rôdent en ville! C'était sur nous..."
+    "texte_fr": "Oh non...[001E][1205] Ça doit être à cause de cette\nrumeur! Celle sur les cinq terroristes\nqui rôdent en ville! C'était sur nous..."
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Wh...[SP]What[SP]the[SP]hell,[SP]man!?[SP]We[SP]put[SP]ourselves\nthrough[SP]the[SP]wringer[SP]stopping[SP]those[SP]bombings!\nHow[SP]dare[SP]they[SP]treat[SP]us[SP]like[SP]the[SP]culprits!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Qu... C'est quoi ce bordel!? On s'est\ndécarcassés pour arrêter ces attentats!\nComment osent-ils nous\ntraiter en coupables!"
+    "texte_fr": "Qu... C'est quoi ce bordel!? On s'est\ndécarcassés pour arrêter ces attentats!\nComment osent-ils nous traiter en coupables!"
   },
   {
     "id": 29,
@@ -462,7 +462,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "This[SP]is[SP]bad...[SP]Lisa's[SP]right.[1205][001E][SP]We[SP]need[SP]to[SP]think\nof[SP]something...",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est mal... Lisa a raison.[1205][001E]\nTrouvons une idée..."
+    "texte_fr": "C'est mal... Lisa a raison.[001E][1205]\nTrouvons une idée..."
   },
   {
     "id": 31,
@@ -537,7 +537,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]just[SP]hope[SP]it[SP]works...[1205][001E][SP]Well,[SP]there's\nnothing[SP]more[SP]we[SP]can[SP]do[SP]here.[SP]Let's[SP]head\nout[SP]to[SP]the[SP]detective[SP]agency.",
     "nom_fr": "Maya",
-    "texte_fr": "J'espère juste que ça marchera...[1205][001E]\nBon, on n'a plus rien à faire ici.\nAllons à l'agence de détectives."
+    "texte_fr": "J'espère juste que ça marchera...[001E][1205]\nBon, on n'a plus rien à faire ici.\nAllons à l'agence de détectives."
   },
   {
     "id": 36,

--- a/traduction/event_scripts/script_085.json
+++ b/traduction/event_scripts/script_085.json
@@ -27,7 +27,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "I[SP]see...[1205][001E][SP]So[SP]you[SP]weren't[SP]part[SP]of[SP]the\nLast[SP]Battalion.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Je vois...[1205][001E] Vous n'étiez pas du Bataillon."
+    "texte_fr": "Je vois...[001E][1205] Vous n'étiez pas du Bataillon."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We[SP]keep[SP]asking[SP]you...[1205][001E][SP]What[SP]is[SP]this...\nbattle...[SP]lion...[SP]thing!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "On vous le demande...[1205][001E] C'est quoi\nce... bata... lion... machin!?"
+    "texte_fr": "On vous le demande...[001E][1205] C'est quoi\nce... bata... lion... machin!?"
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]can't[SP]make[SP]sense[SP]of[SP]this[SP]woman's[SP]ravings...[1205][001E]\nSeriously,[SP]what's[SP]going[SP]on?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je pige rien aux délires de cette\nfemme...[1205][001E] Sérieux, il se passe quoi?"
+    "texte_fr": "Je pige rien aux délires de cette\nfemme...[001E][1205] Sérieux, il se passe quoi?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "We[SP]spread[SP]the[SP]rumor,[SP]like[SP]Maya-san[SP]suggested,\nbut...[1205][001E][SP]The[SP]rest[SP]is[SP]still[SP]up[SP]in[SP]the[SP]air.[SP]We[SP]should\nbrace[SP]ourselves[SP]for[SP]the[SP]worst.",
     "nom_fr": "Yukino",
-    "texte_fr": "On a répandu la rumeur, comme Maya l'a\nsuggéré, mais...[1205][001E] Le reste est incertain.\nOn devrait se préparer au pire."
+    "texte_fr": "On a répandu la rumeur, comme Maya l'a\nsuggéré, mais...[001E][1205] Le reste est incertain.\nOn devrait se préparer au pire."
   },
   {
     "id": 6,
@@ -132,7 +132,7 @@
     "nom_orig": "Anchorman",
     "texte_orig": "One[SP]side[SP]of[SP]the[SP]story[SP]paints[SP]them[SP]as[SP]vicious\nterrorists,[SP]while[SP]the[SP]other[SP]portrays[SP]them[SP]as\nheroes...[1205][001E][SP]But[SP]which[SP]of[SP]the[SP]rumors[SP]is[SP]true?",
     "nom_fr": "Présentateur",
-    "texte_fr": "Une version les dépeint comme de vicieux\nterroristes, l'autre en fait des héros...[1205][001E]\nMais laquelle de ces rumeurs est vraie?"
+    "texte_fr": "Une version les dépeint comme de vicieux\nterroristes, l'autre en fait des héros...[001E][1205]\nMais laquelle de ces rumeurs est vraie?"
   },
   {
     "id": 9,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Ciaaao...[1205][001E][SP]Sorry[SP]I'm[SP]late...",
     "nom_fr": "Maya",
-    "texte_fr": "Ciaaao...[1205][001E] Pardon..."
+    "texte_fr": "Ciaaao...[001E][1205] Pardon..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Oh,[SP]uh...[1205][001E][SP]Okay,[SP]I[SP]guess[SP]everyone's[SP]here\nnow,[SP]so[SP]could[SP]you[SP]start[SP]by[SP]telling[SP]us[SP]what\nyou[SP]know?",
     "nom_fr": "Yukino",
-    "texte_fr": "Oh, euh...[1205][001E] Bien, tout le monde est là.\nPourriez-vous commencer par\ndire ce que vous\nsavez?"
+    "texte_fr": "Oh, euh...[001E][1205] Bien, tout le monde est là.\nPourriez-vous commencer par\ndire ce que vous savez?"
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "S-So[SP]that's[SP]it!?[1205][001E][SP]Then[SP]there's[SP]no[SP]denying[SP]that\nthe[SP]Masked[SP]Circle[SP]is[SP]the[SP]Last[SP]Battalion!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "A-Alors c'est ça!?[1205][001E] Il est donc indéniable\nque le Cercle masqué est le Bataillon!"
+    "texte_fr": "A-Alors c'est ça!?[001E][1205] Il est donc indéniable\nque le Cercle masqué est le Bataillon!"
   },
   {
     "id": 18,
@@ -297,7 +297,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "An[SP]insane[SP]army[SP]with[SP]cutting-edge[SP]weaponry[SP]and\na[SP]powerful[SP]relic[SP]that[SP]absorbed[SP]Christ's[SP]blood,\nbent[SP]on[SP]enacting[SP]the[SP]Fuhrer's[SP]grudge!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Une armée folle avec des armes de pointe et\nune relique ayant absorbé\nle sang du Christ,\nrésolue à assouvir la rancune du Führer!"
+    "texte_fr": "Une armée folle avec des armes de pointe et\nune relique ayant absorbé\nle sang du Christ, résolue à assouvir la rancune du Führer!"
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Th-That's[SP]impossible...[1205][001E][SP]I[SP]mean,[SP]the[SP]Masked\nCircle[SP]is...",
     "nom_fr": "Ginko",
-    "texte_fr": "C-C'est impossible...[1205][001E] Bref,\nle Cercle masqué est..."
+    "texte_fr": "C-C'est impossible...[001E][1205] Bref,\nle Cercle masqué est..."
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "It's[SP]all[SP]in[SP]this[SP]book...[SP]Everything[SP]they're\ndoing[SP]is[SP]in[SP]accordance[SP]with[SP]the[SP]Oracle[SP]of\nMaia[SP]in[SP]the[SP][1432][NULL][NULL][0014]In[SP]Lak'ech[1432][NULL][NULL][0014]!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Tout est dans ce\nlivre... Ce qu'ils font est\nconforme à l'Oracle de\nMaia dans l'[1432][NULL][NULL][0014]In Lak'ech[1432][NULL][NULL][0014]!"
+    "texte_fr": "Tout est dans ce\nlivre... Ce qu'ils font est\nconforme à l'Oracle de Maia dans l'[1432][NULL][NULL][0014]In Lak'ech[1432][NULL][NULL][0014]!"
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]Oracle[SP]of[SP]Maia[SP]was[SP]left[SP]by[SP]the[SP]Pleiades\naliens[SP]who[SP]gifted[SP]humans[SP]with[SP]civilization...[1205][001E]\nIt's[SP]a[SP]message[SP]entrusted[SP]to[SP]us[SP]by[SP]the[SP]Maians!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "L'Oracle de Maia fut laissé par les aliens\nPléiadiens qui ont civilisé les humains...[1205][001E]\nC'est un message confié par les Maïens!"
+    "texte_fr": "L'Oracle de Maia fut laissé par les aliens\nPléiadiens qui ont civilisé les humains...[001E][1205]\nC'est un message confié par les Maïens!"
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Eikichi[SP]&[SP]Yukino",
     "texte_orig": "Huh!?[1205][001E][SP]Aliens!?",
     "nom_fr": "Eikichi/Yukino",
-    "texte_fr": "Quoi!?[1205][001E] Aliens!?"
+    "texte_fr": "Quoi!?[001E][1205] Aliens!?"
   },
   {
     "id": 24,
@@ -417,7 +417,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "I[SP]worked[SP]with[SP]Sudou-kun,[SP]the[SP]medium,[SP]and\nKashihara...[1205][001E][SP]This[SP]book[SP]is[SP]the[SP]fruit[SP]of\nwe[SP]three's[SP]dream...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "J'ai travaillé avec le médium Sudou et\nKashihara...[1205][001E] Ce livre est le fruit de notre\nrêve..."
+    "texte_fr": "J'ai travaillé avec le médium Sudou et\nKashihara...[001E][1205] Ce livre est le fruit de notre\nrêve..."
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "S-So...[SP]This[SP]cockama--[1205][001E]I[SP]mean,[SP]this[SP]fruit[SP]of\nyour[SP]dreams...[SP]What[SP]does[SP]that[SP]have[SP]to[SP]do\nwith[SP]Sumaru[SP]City?",
     "nom_fr": "Yukino",
-    "texte_fr": "A-Alors... Ces fou--[1205][001E] Je veux dire,\nce fruit de vos rêves... Qu'est-ce\nque ça a à voir avec Sumaru?"
+    "texte_fr": "A-Alors... Ces fou--[001E][1205] Je veux dire,\nce fruit de vos rêves... Qu'est-ce\nque ça a à voir avec Sumaru?"
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Underneath[SP]us[SP]is[SP]the[SP]netherworld[SP]where[SP]the\nMaians[SP]sleep...[1205][001E][SP]The[SP]Starship[SP]Xibalba[SP]is[SP]there!\nAll[SP]sorts[SP]of[SP]civilizations[SP]originated[SP]here...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Sous nous, le monde souterrain où dorment\nles Maïens...[1205][001E] Le Vaisseau Xibalba y est!\nDe nombreuses civilisations y sont nées..."
+    "texte_fr": "Sous nous, le monde souterrain où dorment\nles Maïens...[001E][1205] Le Vaisseau Xibalba y est!\nDe nombreuses civilisations y sont nées..."
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "But[SP]the[SP]ancient[SP]Maians[SP]that[SP]thrived[SP]here[SP]died\nin[SP]an[SP]intergalactic[SP]civil[SP]war...[1205][001E][SP]The[SP]victors[SP]were\nthe[SP]Bolontiku[SP]race[SP]that[SP]controls[SP]Xibalba...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Mais les anciens Maïens\nd'ici sont morts dans\nune guerre civile intergalactique...[1205][001E] Les\nvainqueurs, les\nBolontiku, contrôlentXibalba..."
+    "texte_fr": "Mais les anciens Maïens\nd'ici sont morts dans\nune guerre civile intergalactique...[001E][1205] Les\nvainqueurs, les\nBolontiku, contrôlentXibalba..."
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]Mayan[SP]myths[SP]of[SP]South[SP]America[SP]prove[SP]it.\nThough[SP]that[SP]civilization[SP]is[SP]an[SP]ancient[SP]memory\nnow...[1205][001E][SP]Their[SP]ruins[SP]were[SP]all[SP]modeled[SP]on[SP]Sumaru.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Les mythes mayas le\nprouvent. Bien que cette\ncivilisation soit un souvenir ancien...[1205][001E]\nLeurs ruines étaient modelées sur Sumaru."
+    "texte_fr": "Les mythes mayas le\nprouvent. Bien que cette\ncivilisation soit un souvenir ancien...[001E][1205]\nLeurs ruines étaient modelées sur Sumaru."
   },
   {
     "id": 32,
@@ -492,7 +492,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "T-Talk[SP]about[SP]a[SP]fertile[SP]imagination...[1205][001E]\nSo[SP]why[SP]is[SP]the[SP]Masked[SP]Circle[SP]and[SP]Last\nBattalion[SP]after[SP]this[SP]Xibalba?\n[E1][E2]\n[E3][E4][NULL][NULL]\"Ms.[SP]Ideal\nBecause[SP]when[SP]the[SP]Oracle[SP]is[SP]fulfilled,\nXibalba[SP]and[SP]the[SP]crystal[SP]skulls[SP]will[SP]grant\nmankind's[SP]ultimate[SP]dream...",
     "nom_fr": "Tamaki",
-    "texte_fr": "Q-Quelle imagination...[1205][001E] Pourquoi le Cercle\nmasqué et le Bataillon veulent ce Xibalba?\n[NULL][NULL]\"Mme Idéale\nCar quand l'Oracle sera\naccompli, Xibalba et les crânes de cristal\nexauceront le rêve de l'humanité...[E1][E2][E3][E4]"
+    "texte_fr": "Q-Quelle imagination...[001E][1205] Pourquoi le Cercle\nmasqué et le Bataillon veulent ce Xibalba?\n[NULL][NULL]\"Mme Idéale\nCar quand l'Oracle sera\naccompli, Xibalba et les crânes de cristal\nexauceront le rêve de l'humanité...[E1][E2][E3][E4]"
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "It[SP]will[SP]end[SP]in[SP]us[SP]becoming[SP]Idealians...[1205][001E]\nA[SP]transhuman[SP]state[SP]where[SP]we[SP]will[SP]understand\nthe[SP]true[SP]meaning[SP]of[SP]life.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Ça fera de nous des Idéaliens...[1205][001E] Un état\ntranshumain où on saisira\nle vrai sens de la\nvie."
+    "texte_fr": "Ça fera de nous des Idéaliens...[001E][1205] Un état\ntranshumain où on saisira\nle vrai sens de la vie."
   },
   {
     "id": 34,
@@ -522,7 +522,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Sounds[SP]good[SP]to[SP]me...[1205][001E][SP]Then[SP]we[SP]wouldn't[SP]be\nso[SP]upset[SP]by[SP]trifles[SP]anymore.",
     "nom_fr": "Maya",
-    "texte_fr": "Ça me semble bien...[1205][001E] On ne serait\nplus contrariés par des broutilles."
+    "texte_fr": "Ça me semble bien...[001E][1205] On ne serait\nplus contrariés par des broutilles."
   },
   {
     "id": 35,
@@ -552,7 +552,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "When[SP]the[SP]Bolontiku[SP]thoughtforms[SP]take[SP]physical\nbodies,[SP]they[SP]will[SP]bring[SP]destruction[SP]to[SP]all![1205][001E]\nThat's[SP]why[SP]we[SP]didn't[SP]go[SP]public[SP]with[SP]this!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Quand les formes-pensées Bolontiku\nprendront corps, ils détruiront tout![1205][001E]\nC'est pour ça qu'on a gardé ça secret!"
+    "texte_fr": "Quand les formes-pensées Bolontiku\nprendront corps, ils détruiront tout![001E][1205]\nC'est pour ça qu'on a gardé ça secret!"
   },
   {
     "id": 37,
@@ -582,7 +582,7 @@
     "nom_orig": "Occult[SP]magazine[SP]EIC",
     "texte_orig": "It's[SP]full[SP]of[SP]shocking[SP]truths,[SP]from[SP]the[SP]Last\nBattalion[SP]to[SP]a[SP]giant[SP]UFO[SP]that[SP]ties[SP]into[SP]these\nincidents.[SP]Read[SP]it,[SP]or[SP]you'll[SP]be[SP]missing[SP]out!",
     "nom_fr": "Éditeur Occulte",
-    "texte_fr": "Il est rempli de vérités choquantes, du\nBataillon au gigantesque OVNI lié à ces\nincidents. Lisez-le, ou\nvous raterez quelquechose!"
+    "texte_fr": "Il est rempli de vérités choquantes, du\nBataillon au gigantesque OVNI lié à ces\nincidents. Lisez-le, ou vous raterez quelquechose!"
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "N-No...![1205][001E][SP]D-Did[SP]Sudou-kun[SP]do[SP]this...?[1205][001E]\nWe[SP]were[SP]under[SP]strict[SP]orders[SP]never[SP]to[SP]go\npublic[SP]with[SP]it!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "N-Non...![1205][001E] S-Sudou a fait ça...?[1205][001E] Nous avions\nl'ordre strict de ne\njamais le rendre public!"
+    "texte_fr": "N-Non...![001E][1205] S-Sudou a fait ça...?[001E][1205] Nous avions\nl'ordre strict de ne\njamais le rendre public!"
   },
   {
     "id": 40,
@@ -612,7 +612,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "No![SP]No![1205][001E][SP]This[SP]is[SP]all[SP]a[SP]lie!\nThe[SP]Masked[SP]Circle[SP]is...!",
     "nom_fr": "Ginko",
-    "texte_fr": "Non![1205][001E] C'est un mensonge!\nLe Cercle masqué est...!"
+    "texte_fr": "Non![001E][1205] C'est un mensonge!\nLe Cercle masqué est...!"
   },
   {
     "id": 41,
@@ -657,7 +657,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "......![1205][001E][SP]W-Wait...[1205][001E][SP]What[SP]did[SP]you[SP]just[SP]say...?",
     "nom_fr": "Eikichi",
-    "texte_fr": "......![1205][001E] Attends...[1205][001E] Tu as dit quoi...?"
+    "texte_fr": "......![001E][1205] Attends...[001E][1205] Tu as dit quoi...?"
   },
   {
     "id": 44,
@@ -672,7 +672,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That[SP]reminds[SP]me...[1205][001E][SP]Your[SP]actual[SP]name[SP]is[SP]Lisa,\nright...!?[1205][001E][SP]D-Don't[SP]tell[SP]me,[SP]him[SP]too...!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ça me rappelle...[1205][001E] Ton vrai nom est Lisa,\nnon...!?[1205][001E] M-Me dis pas que lui aussi...!?"
+    "texte_fr": "Ça me rappelle...[001E][1205] Ton vrai nom est Lisa,\nnon...!?[001E][1205] M-Me dis pas que lui aussi...!?"
   },
   {
     "id": 45,
@@ -687,7 +687,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I've[SP]been[SP]desperately[SP]trying[SP]to[SP]convince\nmyself[SP]that[SP]it[SP]was[SP]just[SP]a[SP]dream...[1205][001E][SP]But...[1205][001E]\nIt[SP]was[SP]real!",
     "nom_fr": "Ginko",
-    "texte_fr": "J'ai désespérément essayé de me\nconvaincre que ce n'était qu'un\nrêve...[1205][001E] Mais...[1205][001E] C'était réel!"
+    "texte_fr": "J'ai désespérément essayé de me\nconvaincre que ce n'était qu'un\nrêve...[001E][1205] Mais...[001E][1205] C'était réel!"
   },
   {
     "id": 46,
@@ -702,7 +702,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Please...[SP]Come[SP]with[SP]me[SP]to[SP]the[SP]Alaya[SP]Shrine![1205][001E]\nI'll[SP]tell[SP]you[SP]the[SP]truth...[SP]about[SP]the[SP]Masked\nCircle...[SP]about[SP]Joker...[1205][001E][SP]everything!",
     "nom_fr": "Ginko",
-    "texte_fr": "Pitié... Venez au Sanctuaire Alaya\navec moi![1205][001E] Je dirai la vérité... sur le\nCercle masqué... sur Joker...[1205][001E] tout!"
+    "texte_fr": "Pitié... Venez au Sanctuaire Alaya\navec moi![001E][1205] Je dirai la vérité... sur le\nCercle masqué... sur Joker...[001E][1205] tout!"
   },
   {
     "id": 47,
@@ -717,7 +717,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I...[1205][001E][SP]I[SP]understand[SP]everything...![1205][001E][SP]The[SP]Masked\nCircle[SP]isn't[SP]some[SP]weird[SP]army[SP]like[SP]she[SP]said!",
     "nom_fr": "Ginko",
-    "texte_fr": "Je...[1205][001E] Je comprends...![1205][001E]\nLe Cercle masqué n'est\npas une armée bizarre comme elle l'a dit!"
+    "texte_fr": "Je...[001E][1205] Je comprends...![001E][1205]\nLe Cercle masqué n'est\npas une armée bizarre comme elle l'a dit!"
   },
   {
     "id": 48,
@@ -732,7 +732,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Please,[SP]we[SP]need[SP]to[SP]go[SP]to[SP]the[SP]Alaya[SP]Shrine![1205][001E]\nIf[SP]we[SP]go,[SP]I'm[SP]sure[SP]you'll[SP]remember[SP]too...!",
     "nom_fr": "Ginko",
-    "texte_fr": "Allons au Sanctuaire Alaya![1205][001E] Je suis sûre\nque vous vous rappellerez aussi...!"
+    "texte_fr": "Allons au Sanctuaire Alaya![001E][1205] Je suis sûre\nque vous vous rappellerez aussi...!"
   },
   {
     "id": 49,
@@ -747,7 +747,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "[1113]...[1205][001E][SP]I've[SP]done[SP]a[SP]terrible[SP]thing...[1205][001E]\nHow[SP]can[SP]I[SP]make[SP]up[SP]for[SP]it...?",
     "nom_fr": "Ginko",
-    "texte_fr": "[1113]...[1205][001E] J'ai fait une chose\nhorrible...[1205][001E] Comment me racheter...?"
+    "texte_fr": "[1113]...[001E][1205] J'ai fait une chose\nhorrible...[001E][1205] Comment me racheter...?"
   },
   {
     "id": 50,
@@ -762,7 +762,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What's[SP]wrong?[SP]Is[SP]there[SP]something[SP]on[SP]my\nface?[1205][001E][SP]Little[SP]boy...",
     "nom_fr": "Maya",
-    "texte_fr": "Qu'y a-t-il? J'ai un truc\nsur le visage?[1205][001E] P'tit gars..."
+    "texte_fr": "Qu'y a-t-il? J'ai un truc\nsur le visage?[001E][1205] P'tit gars..."
   },
   {
     "id": 51,
@@ -777,7 +777,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Heh...[SP]Let's[SP]leave[SP]this[SP]dump[SP]and[SP]get[SP]to[SP]the\nAlaya[SP]Shrine.[1205][001E][SP]I[SP]can't[SP]wait[SP]to[SP]hear[SP]the[SP]yarn\nLisa's[SP]going[SP]to[SP]spin[SP]there...",
     "nom_fr": "Maya",
-    "texte_fr": "Hé... Quittons ce taudis pour le\nSanctuaire Alaya.[1205][001E] J'ai hâte d'entendre\nl'histoire que Lisa va nous y raconter..."
+    "texte_fr": "Hé... Quittons ce taudis pour le\nSanctuaire Alaya.[001E][1205] J'ai hâte d'entendre\nl'histoire que Lisa va nous y raconter..."
   },
   {
     "id": 52,
@@ -792,7 +792,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Sometimes[SP]things[SP]are[SP]best[SP]left[SP]forgotten.[1205][001E]\nEspecially[SP]sins[SP]that[SP]can[SP]never[SP]be[SP]cleansed...",
     "nom_fr": "Maya",
-    "texte_fr": "Parfois, mieux vaut oublier.[1205][001E] Surtout les\npéchés qui ne peuvent jamais être lavés..."
+    "texte_fr": "Parfois, mieux vaut oublier.[001E][1205] Surtout les\npéchés qui ne peuvent jamais être lavés..."
   },
   {
     "id": 53,
@@ -807,7 +807,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Sadly,[SP]though,[SP]that's[SP]not[SP]how[SP]it[SP]goes[SP]in\nlife.[SP]Sins[SP]must[SP]be[SP]atoned[SP]for,[SP]no...?[1205][001E]\nNow[SP]let's[SP]go[SP]to[SP]Mt.[SP]Iwato.",
     "nom_fr": "Maya",
-    "texte_fr": "Hélas, ça ne marche pas ainsi. Il\nfaut expier ses péchés, non...?[1205][001E]\nMaintenant, allons au Mt. Iwato."
+    "texte_fr": "Hélas, ça ne marche pas ainsi. Il\nfaut expier ses péchés, non...?[001E][1205]\nMaintenant, allons au Mt. Iwato."
   },
   {
     "id": 54,
@@ -822,7 +822,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "This...[SP]This[SP]is[SP]crazy...[1205][001E][SP]You...[1205][001E][SP]You're\nTHAT[SP][1114]...!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est... C'est dingue...[1205][001E] Tu...[1205][001E]\nTu es CE [1114]...!?"
+    "texte_fr": "C'est... C'est dingue...[001E][1205] Tu...[001E][1205]\nTu es CE [1114]...!?"
   },
   {
     "id": 55,
@@ -837,7 +837,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "She[SP]understands[SP]everything...?[1205][001E][SP]What's[SP]gotten\ninto[SP]you[SP]all?[1205][001E][SP]Even[SP]Maya-san's[SP]not[SP]her[SP]usual\nself...",
     "nom_fr": "Yukino",
-    "texte_fr": "Elle comprend tout...?[1205][001E]\nQue vous prend-il tous?[1205][001E]\nMême Maya n'est pas dans son état normal..."
+    "texte_fr": "Elle comprend tout...?[001E][1205]\nQue vous prend-il tous?[001E][1205]\nMême Maya n'est pas dans son état normal..."
   },
   {
     "id": 56,
@@ -852,7 +852,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Aliens...[SP]The[SP]Fuhrer...[1205][001E][SP]And[SP]now[SP]this[SP]about\n[1432][NULL][NULL][0014]playing[SP]the[SP]Masked[SP]Circle[1432][NULL][NULL][0014]...!?[1205][001E][SP]There's[SP]so\nmuch[SP]I[SP]don't[SP]understand...",
     "nom_fr": "Yukino",
-    "texte_fr": "Les aliens... Le Führer...[1205][001E] Et maintenant\njouer au [1432][NULL][NULL][0014]Cercle masqué[1432][NULL][NULL][0014]...!?[1205][001E] Il y a tant\nde choses que je saisis pas..."
+    "texte_fr": "Les aliens... Le Führer...[001E][1205] Et maintenant\njouer au [1432][NULL][NULL][0014]Cercle masqué[1432][NULL][NULL][0014]...!?[001E][1205] Il y a tant\nde choses que je saisis pas..."
   },
   {
     "id": 57,
@@ -962,7 +962,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Oh,[SP]did[SP]you[SP]check[SP]the[SP]ones[SP]you[SP]entered[SP]last\ntime?[SP]You[SP]get[SP]the[SP]prizes[SP]at[SP]Lisa-chan's[SP]house,\nso[SP]come[SP]back[SP]after[SP]you've[SP]seen[SP]if[SP]you[SP]won.",
     "nom_fr": "Tamaki",
-    "texte_fr": "Avez-vous vérifié vos précédents concours?\nLes prix sont\nenvoyés chez Lisa-chan, revenez\nquand vous aurez vu si vous avez gagné."
+    "texte_fr": "Avez-vous vérifié vos précédents concours?\nLes prix sont\nenvoyés chez Lisa-chan, revenez quand vous aurez vu si vous avez gagné."
   },
   {
     "id": 62,
@@ -977,7 +977,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Okay![1205][001E][SP]Wait...[SP]you[SP]don't[SP]have[SP]any[SP]magazines.\nThey[SP]sell[SP]them[SP]at[SP]Satomi[SP]Tadashi,[SP]so[SP]come\nback[SP]when[SP]you've[SP]bought[SP]some.",
     "nom_fr": "Tamaki",
-    "texte_fr": "D'accord![1205][001E] Attendez... vous n'avez\npas de magazines. Satomi Tadashi en\nvend, revenez quand vous en aurez."
+    "texte_fr": "D'accord![001E][1205] Attendez... vous n'avez\npas de magazines. Satomi Tadashi en\nvend, revenez quand vous en aurez."
   },
   {
     "id": 63,
@@ -1092,7 +1092,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "There[SP]are[SP]a[SP]few[SP]rules![SP]You[SP]can[SP]only[SP]enter[SP]one\ncontest[SP]at[SP]a[SP]time.[SP]No[SP]more[SP]entries[SP]until[SP]the\nlast[SP]results[SP]are[SP]in.[SP]That's[SP]just[SP]how[SP]it[SP]works.",
     "nom_fr": "Tamaki",
-    "texte_fr": "Y a quelques\nrègles! Une seule participation\nà la fois. Pas\nde nouvelles entrées tant que\nles résultats ne sont\npas là. C'est comme ça."
+    "texte_fr": "Y a quelques\nrègles! Une seule participation\nà la fois. Pas de nouvelles entrées tant que les résultats ne sont pas là. C'est comme ça."
   },
   {
     "id": 70,
@@ -1152,7 +1152,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Even[SP]if[SP]this[SP]teacher[SP]is[SP]wrong[SP]and[SP]the[SP]Masked\nCircle[SP]isn't[SP]the[SP]same[SP]as[SP]the[SP]Last[SP]Battalion...[1205][001E]\nIs[SP]the[SP]Masked[SP]Circle[SP]following[SP]that[SP]book?",
     "nom_fr": "Tamaki",
-    "texte_fr": "Même si cette prof a tort et que le\nCercle masqué n'est pas le Bataillon...[1205][001E]\nLe Cercle masqué suit-il ce livre?"
+    "texte_fr": "Même si cette prof a tort et que le\nCercle masqué n'est pas le Bataillon...[001E][1205]\nLe Cercle masqué suit-il ce livre?"
   },
   {
     "id": 74,
@@ -1167,7 +1167,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Mayan[SP]ruins...[SP]an[SP]ancient[SP]spaceship...[1205][001E][SP]I[SP]have\na[SP]hard[SP]time[SP]believing[SP]this[SP]stuff[SP]exists.[1205][001E]\nBut[SP]I[SP]have[SP]a[SP]bad[SP]feeling[SP]anyway...",
     "nom_fr": "Tamaki",
-    "texte_fr": "Ruines mayas... un vieux vaisseau...[1205][001E] J'ai\ndu mal à croire que ça existe.[1205][001E] Mais j'ai\nun mauvais pressentiment quand même..."
+    "texte_fr": "Ruines mayas... un vieux vaisseau...[001E][1205] J'ai\ndu mal à croire que ça existe.[001E][1205] Mais j'ai\nun mauvais pressentiment quand même..."
   },
   {
     "id": 75,
@@ -1197,7 +1197,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "W-We've[SP]learned[SP]a[SP]terrible[SP]secret![SP]It's[SP]this\ntaste[SP]of[SP]danger[SP]and[SP]violence[SP]that[SP]calls[SP]to\na[SP]man...",
     "nom_fr": "Tadashi",
-    "texte_fr": "O-On a appris un\nterrible secret! Ce goût du\ndanger et de la\nviolence appelle un homme..."
+    "texte_fr": "O-On a appris un\nterrible secret! Ce goût du\ndanger et de la violence appelle un homme..."
   },
   {
     "id": 77,
@@ -1212,7 +1212,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "Heh...[1205][001E][SP]I-It[SP]seems[SP]the[SP]time[SP]to[SP]reveal[SP]my[SP]true\npowers[SP]has[SP]come...[1205][001E][SP]Ooh,[SP]I[SP]should[SP]get[SP]a[SP]new\ncombat[SP]outfit!",
     "nom_fr": "Tadashi",
-    "texte_fr": "Hé...[1205][001E] L'heure de révéler mes vrais\npouvoirs a sonné...[1205][001E] Oh, je devrais\ntrouver une tenue de combat!"
+    "texte_fr": "Hé...[001E][1205] L'heure de révéler mes vrais\npouvoirs a sonné...[001E][1205] Oh, je devrais\ntrouver une tenue de combat!"
   },
   {
     "id": 78,
@@ -1326,7 +1326,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "He[SP]was[SP]a[SP]dreamer,[SP]who[SP]loved[SP]his[SP]students[SP]very\nmuch.[1205][001E][SP]Yet[SP]he[SP]died[SP]in[SP]such[SP]a[SP]dreadful[SP]way...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "C'était un rêveur\naimant ses élèves.[1205][001E] Pourtant\nil est mort de façon si épouvantable..."
+    "texte_fr": "C'était un rêveur\naimant ses élèves.[001E][1205] Pourtant\nil est mort de façon si épouvantable..."
   },
   {
     "id": 84,
@@ -1371,7 +1371,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Sudou-kun[SP]was[SP]at[SP]Sevens[SP]too,[SP]as[SP]a[SP]student...[1205][001E]\nHe[SP]was[SP]a[SP]timid[SP]boy,[SP]afraid[SP]of[SP]his[SP]extremely\nstrict[SP]father.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Sudou était élève à Septs Sœurs...[1205][001E]\nC'était un garçon timide, effrayé\npar son père très strict."
+    "texte_fr": "Sudou était élève à Septs Sœurs...[001E][1205]\nC'était un garçon timide, effrayé\npar son père très strict."
   },
   {
     "id": 87,
@@ -1386,7 +1386,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "He[SP]was[SP]a[SP]troublemaker[SP]who[SP]complained[SP]of\nhearing[SP]voices,[SP]and[SP]was[SP]rumored[SP]to[SP]be[SP]an\narsonist.[SP]But[SP]he[SP]was[SP]devoted[SP]to[SP]Kashihara...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Il faisait des\nproblèmes, disait entendre des\nvoix, et la rumeur en faisait un pyromane.\nMais il était dévoué à Kashihara..."
+    "texte_fr": "Il faisait des\nproblèmes, disait entendre des\nvoix, et la rumeur en faisait un pyromane. Mais il était dévoué à Kashihara..."
   },
   {
     "id": 88,
@@ -1446,7 +1446,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "[1432][NULL][NULL][0014]In[SP]Lak'ech[1432][NULL][NULL][0014][SP]means[SP][1432][NULL][NULL][0014]you[SP]are[SP]another[SP]me[1432][NULL][NULL][0014][SP]in\nMayan.[1205][001E][SP]It's[SP]what[SP]we[SP]called[SP]the[SP]oracle[SP]that\nSudou-kun[SP]channeled.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "[1432][NULL][NULL][0014]In Lak'ech[1432][NULL][NULL][0014] signifie [1432][NULL][NULL][0014]tu es un autre\nmoi[1432][NULL][NULL][0014] en maya.[1205][001E] C'est ainsi qu'on dit\nde l'oracle canalisé par Sudou."
+    "texte_fr": "[1432][NULL][NULL][0014]In Lak'ech[1432][NULL][NULL][0014] signifie [1432][NULL][NULL][0014]tu es un autre\nmoi[1432][NULL][NULL][0014] en maya.[001E][1205] C'est ainsi qu'on dit\nde l'oracle canalisé par Sudou."
   },
   {
     "id": 92,
@@ -1461,7 +1461,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]Maians[SP]guided[SP]our[SP]evolution[SP]once,[SP]though\nthat[SP]stage[SP]is[SP]now[SP]lost.[1205][001E][SP]Our[SP]civilization[SP]as\nit[SP]stands[SP]is[SP]a[SP]remnant[SP]from[SP]then...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Les Maïens ont jadis guidé notre\névolution, bien que cette ère soit finie.[1205][001E]\nNotre civilisation en est un vestige..."
+    "texte_fr": "Les Maïens ont jadis guidé notre\névolution, bien que cette ère soit finie.[001E][1205]\nNotre civilisation en est un vestige..."
   },
   {
     "id": 93,
@@ -1491,7 +1491,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Xibalba[SP]is[SP]the[SP]key[SP]to[SP]our[SP]evolution.[SP]We[SP]can't\nevolve[SP]without[SP]it...[1205][001E][SP]But[SP]it[SP]will[SP]come[SP]at[SP]the\ncost[SP]of[SP]this[SP]world's[SP]extinction!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Xibalba est la clé de notre évolution. On\nne peut évoluer sans lui...[1205][001E] Mais ce sera\nau prix de l'extinction de ce monde!"
+    "texte_fr": "Xibalba est la clé de notre évolution. On\nne peut évoluer sans lui...[001E][1205] Mais ce sera\nau prix de l'extinction de ce monde!"
   },
   {
     "id": 95,
@@ -1536,7 +1536,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]Mayans[SP]worshipped[SP]the[SP]Oxlahuntiku[SP]as[SP]gods\nof[SP]light...[1205][001E][SP]While[SP]they[SP]feared[SP]the[SP]Bolontiku\nas[SP]gods[SP]of[SP]the[SP]netherworld...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Les Mayas vénéraient les Oxlahuntiku\ncomme dieux de lumière...[1205][001E] Et craignaient\nles Bolontiku comme dieux des enfers..."
+    "texte_fr": "Les Mayas vénéraient les Oxlahuntiku\ncomme dieux de lumière...[001E][1205] Et craignaient\nles Bolontiku comme dieux des enfers..."
   },
   {
     "id": 98,
@@ -1551,7 +1551,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Their[SP]war[SP]consumed[SP]this[SP]solar[SP]system,[SP]and[SP]the\nOxlahuntiku[SP]perished...[1205][001E][SP]Those[SP]events[SP]are[SP]the\nsource[SP]of[SP]common[SP]legends[SP]of[SP]the[SP]flood.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Leur guerre a consumé notre système solaire\net les Oxlahuntiku ont péri...[1205][001E] C'est la\nsource des mythes courants sur le Déluge."
+    "texte_fr": "Leur guerre a consumé notre système solaire\net les Oxlahuntiku ont péri...[001E][1205] C'est la\nsource des mythes courants sur le Déluge."
   },
   {
     "id": 99,
@@ -1596,7 +1596,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Ideal[SP]Energy[SP]is[SP]the[SP]power[SP]of[SP]thought[SP]held[SP]by\nus[SP]living[SP]beings...[1205][001E][SP]It's[SP]a[SP]psychological\nenergy[SP]based[SP]on[SP]one's[SP]ideals.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "L'Énergie Idéale est le pouvoir de\npensée des vivants...[1205][001E] C'est une énergie\npsychologique basée sur les idéaux."
+    "texte_fr": "L'Énergie Idéale est le pouvoir de\npensée des vivants...[001E][1205] C'est une énergie\npsychologique basée sur les idéaux."
   },
   {
     "id": 102,
@@ -1611,7 +1611,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]energy[SP]is[SP]heightened[SP]most[SP]when[SP]one[SP]is\npassionate[SP]about[SP]one's[SP]ideals,[SP]or[SP]when[SP]one's\ndream[SP]comes[SP]true.[1205][001E][SP]It's[SP]fed[SP]by[SP]joie[SP]de[SP]vivre.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "L'énergie augmente quand on est passionné\npar ses idéaux ou\nquand son rêve se réalise.[1205][001E]\nElle se nourrit de la joie de vivre."
+    "texte_fr": "L'énergie augmente quand on est passionné\npar ses idéaux ou\nquand son rêve se réalise.[001E][1205]\nElle se nourrit de la joie de vivre."
   },
   {
     "id": 103,
@@ -1626,7 +1626,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Ideal[SP]Energy[SP]is[SP]the[SP]Maian[SP]source[SP]of[SP]power...[1205][001E]\nAnd[SP]the[SP]crystal[SP]skulls[SP]are[SP]OOPArts[SP]planted\nin[SP]mankind's[SP]history[SP]to[SP]collect[SP]it!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "C'est la source de pouvoir maïenne...[1205][001E] Les\ncrânes de cristal sont des Ooparts placés\ndans notre histoire pour la récolter!"
+    "texte_fr": "C'est la source de pouvoir maïenne...[001E][1205] Les\ncrânes de cristal sont des Ooparts placés\ndans notre histoire pour la récolter!"
   },
   {
     "id": 104,
@@ -1696,7 +1696,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]greatest[SP]and[SP]worst[SP]dictator[SP]of[SP]the\ncentury![1205][001E][SP]You[SP]know[SP]that[SP]much,[SP]I[SP]hope.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Le plus grand et pire dictateur du\nsiècle![1205][001E] Vous savez ça, j'espère."
+    "texte_fr": "Le plus grand et pire dictateur du\nsiècle![001E][1205] Vous savez ça, j'espère."
   },
   {
     "id": 108,
@@ -1726,7 +1726,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "He[SP]said[SP]so[SP]himself![1205][001E][SP]He's[SP]an[SP]immortal[SP]sorcerer\nwho[SP]learned[SP]magic[SP]from[SP]Mayan[SP]mystics.[SP]He\ncraved[SP]the[SP]secrets[SP]of[SP]ruins[SP]around[SP]the[SP]world!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Il l'a dit! [001E][1205]C'est un sorcier immortel ayant\nappris la magie de mystiques mayas. Il\nconvoitait les secrets\ndes ruines du mondeentier!"
+    "texte_fr": "Il l'a dit! [001E][1205]C'est un sorcier immortel ayant\nappris la magie de mystiques mayas. Il\nconvoitait les secrets des ruines du mondeentier!"
   },
   {
     "id": 110,
@@ -1816,7 +1816,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "This[SP]Order[SP]of[SP]the[SP]Holy[SP]Lance[SP]has[SP]supposedly\ndiscovered[SP]the[SP]Spear[SP]of[SP]Destiny,[SP]a[SP]relic[SP]of\nChrist's[SP]miracle!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Cet Ordre aurait\nsoi-disant découvert la Lance\ndu Destin, une relique\ndu miracle du Christ!"
+    "texte_fr": "Cet Ordre aurait\nsoi-disant découvert la Lance\ndu Destin, une relique du miracle du Christ!"
   },
   {
     "id": 116,
@@ -1861,7 +1861,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "The[SP]Masked[SP]Circle[SP]and[SP]the[SP]Last[SP]Battalion...[1205][001E]\nThis[SP]could[SP]be[SP]a[SP]problem.[1205][001E][SP]Now,[SP]what[SP]business\ndo[SP]you[SP]have[SP]with[SP]us[SP]today?\n[1208][0005]Spread[SP]rumors\nCheck[SP]rumors\nTalk[SP]with[SP]the[SP]Chief\nCancel\n[1210][0159]Leave[SP]the[SP]detective[SP]agency",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Le Cercle masqué et le Bataillon...[1205][001E]\nÇa pourrait être un problème.[1205][001E] Alors,\nquelle affaire vous amène?\n[1208][0005]Répandre rumeurs\nVérifier rumeurs\nParler au Chef\nAnnuler\n[1210][0159]Quitter l'agence",
+    "texte_fr": "Le Cercle masqué et le Bataillon...[001E][1205]\nÇa pourrait être un problème.[001E][1205] Alors,\nquelle affaire vous amène?\n[1208][0005]Répandre rumeurs\nVérifier rumeurs\nParler au Chef\nAnnuler\n[1210][0159]Quitter l'agence",
     "question_orig": "The[SP]Masked[SP]Circle[SP]and[SP]the[SP]Last[SP]Battalion...[1205][001E]\nThis[SP]could[SP]be[SP]a[SP]problem.[1205][001E][SP]Now,[SP]what[SP]business\ndo[SP]you[SP]have[SP]with[SP]us[SP]today?",
     "choix_orig": [
       "Spread[SP]rumors",
@@ -1984,7 +1984,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "The[SP]former[SP]inhabitant[SP]of[SP]this[SP]body...[1205][001E]\nSeems[SP]he[SP]did[SP]some[SP]digging[SP]into[SP]Kashihara.\nIt's[SP]on[SP]the[SP]desk,[SP]if[SP]you're[SP]interested.",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "L'ancien habitant de ce corps...[1205][001E] On dirait\nqu'il a fouillé sur Kashihara. C'est sur\nle bureau, si ça vous intéresse."
+    "texte_fr": "L'ancien habitant de ce corps...[001E][1205] On dirait\nqu'il a fouillé sur Kashihara. C'est sur\nle bureau, si ça vous intéresse."
   },
   {
     "id": 124,
@@ -2069,7 +2069,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "Oh,[SP]you're[SP]broke,[SP]meow[1432][NULL][NULL][0007]\nShow[SP]me[SP]a[SP]liar[SP]and[SP]I'll[SP]show[SP]you[SP]a[SP]thief,[SP]meow[1432][NULL][NULL][0007]\nGet[SP]out[SP]of[SP]here,[SP]hiss[1432][NULL][NULL][0007]",
     "nom_fr": "Statue de chat",
-    "texte_fr": "T'es fauché, miaou[1432][NULL][NULL][0007]\nMontre-moi un menteur, je\nte montrerai un voleur,\nmiaou[1432][NULL][NULL][0007] Sors d'ici, fsh[1432][NULL][NULL][0007]"
+    "texte_fr": "T'es fauché, miaou[1432][NULL][NULL][0007]\nMontre-moi un menteur, je\nte montrerai un voleur, miaou[1432][NULL][NULL][0007] Sors d'ici, fsh[1432][NULL][NULL][0007]"
   },
   {
     "id": 129,
@@ -2099,7 +2099,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "Meowvelous![1432][NULL][NULL][0007][1205][000F]\nI[SP]can't[SP]believe[SP]you[SP]fed[SP]me[SP]50[SP]times,[SP]purrrr[1432][NULL][NULL][0007][1205][000F]\nYou're[SP]so[SP]generous,[SP]Misterrr[1432][NULL][NULL][0007]",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Miaourveilleux![1205][000F][1205][000F][1432][NULL][NULL][0007] Tu m'as nourri 50 fois,\nronron[1432][NULL][NULL][0007] Tu es si généreux, ronrrrron[1432][NULL][NULL][0007]"
+    "texte_fr": "Miaourveilleux![000F][1205][000F][1205][1432][NULL][NULL][0007] Tu m'as nourri 50 fois,\nronron[1432][NULL][NULL][0007] Tu es si généreux, ronrrrron[1432][NULL][NULL][0007]"
   },
   {
     "id": 131,
@@ -2114,7 +2114,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "Amazing,[SP]meow![1205][000F]\nYou've[SP]fed[SP]me[SP]80[SP]times[SP]now,[SP]meow[1432][NULL][NULL][0007][1205][000F]\nDo[SP]you[SP]have[SP]a[SP]kitten[SP]agenda,[SP]meow?",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Super, miaou! [1205][000F][1205][000F]Tu m'as nourri 80 fois,\nmiaou[1432][NULL][NULL][0007] Tu caches quelque chose, miaou?"
+    "texte_fr": "Super, miaou! [000F][1205][000F][1205]Tu m'as nourri 80 fois,\nmiaou[1432][NULL][NULL][0007] Tu caches quelque chose, miaou?"
   },
   {
     "id": 132,

--- a/traduction/event_scripts/script_090.json
+++ b/traduction/event_scripts/script_090.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "There[SP]was[SP]a[SP]fire[SP]at[SP]this[SP]shrine[SP]once...[1205][001E][SP]It's\nrumored[SP]you[SP]can[SP]see[SP]the[SP]ghost[SP]of[SP]the[SP]girl[SP]who\ndied[SP]here.[1205][001E][SP]You[SP]know[SP]about[SP]that,[SP]right?",
     "nom_fr": "Ginko",
-    "texte_fr": "Un jour, ce sanctuaire a pris feu...[001E][1205][1205][001E] On\nraconte qu'on peut y voir l'esprit de la\nfille morte ici. Tu le savais déjà, hein?"
+    "texte_fr": "Un jour, ce sanctuaire a pris feu...[001E][1205][001E][1205] On\nraconte qu'on peut y voir l'esprit de la\nfille morte ici. Tu le savais déjà, hein?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Haha...[SP]Yeah,[SP]what[SP]about[SP]it?[1205][001E][SP]It's[SP]a[SP]famous\nrumor.[SP]Everyone[SP]knows[SP]that[SP]one--",
     "nom_fr": "Eikichi",
-    "texte_fr": "Haha... Ouais, et?[1205][001E] Cette rumeur est\nrépandue. Tout le monde la connaît--"
+    "texte_fr": "Haha... Ouais, et?[001E][1205] Cette rumeur est\nrépandue. Tout le monde la connaît--"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We[SP]can't[SP]hide[SP]from[SP]it[SP]anymore,[SP]Eikichi!\nWe[SP]know[SP]who[SP]that[SP]girl[SP]is...[1205][001E][SP]We[SP]know[SP]about\n[1432][NULL][NULL][0014]Big[SP]Sis[1432][NULL][NULL][0014]!",
     "nom_fr": "Ginko",
-    "texte_fr": "On ne peut plus se cacher, Eikichi! On sait\nqui est cette\nfille...[1205][001E] C'est [1432][NULL][NULL][0014]notre Sœurette[1432][NULL][NULL][0014]!"
+    "texte_fr": "On ne peut plus se cacher, Eikichi! On sait\nqui est cette\nfille...[001E][1205] C'est [1432][NULL][NULL][0014]notre Sœurette[1432][NULL][NULL][0014]!"
   },
   {
     "id": 3,

--- a/traduction/event_scripts/script_091.json
+++ b/traduction/event_scripts/script_091.json
@@ -27,7 +27,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "You[SP]have[SP]begun[SP]to[SP]recover[SP]your[SP]forgotten\npast...[1205][001E][SP]If[SP]you[SP]wish[SP]to[SP]learn[SP]the[SP]truth,\ngo[SP]to[SP]the[SP]Alaya[SP]Cavern[SP]behind[SP]this[SP]shrine.",
     "nom_fr": "Philémon",
-    "texte_fr": "Tu commences à te\nrappeler ton passé oublié.[1205].[001E].\nSi tu souhaites connaître\nla vérité, va à la\ncaverne Alaya derrière le temple."
+    "texte_fr": "Tu commences à te\nrappeler ton passé oublié.[1205].[001E].\nSi tu souhaites connaître\nla vérité, va à la caverne Alaya derrière le temple."
   },
   {
     "id": 2,

--- a/traduction/event_scripts/script_092.json
+++ b/traduction/event_scripts/script_092.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Do[SP]you[SP]still[SP]not[SP]remember?[SP][1113]...[1205][001E]\nOur[SP]summer[SP]vacation[SP]10[SP]years[SP]ago...[1205][001E]\nThis[SP]cavern[SP]was[SP]our[SP]secret[SP]hideout...",
     "nom_fr": "Ginko",
-    "texte_fr": "Tu ne te souviens toujours pas? [001E][1205][001E][1205][1113]...\nTes vacances d'été il y a 10 ans... Cette\ngrotte était notre cachette..."
+    "texte_fr": "Tu ne te souviens toujours pas? [001E][001E][1205][1205][1113]...\nTes vacances d'été il y a 10 ans... Cette\ngrotte était notre cachette..."
   },
   {
     "id": 1,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Why...[1205][001E][SP]Why[SP]did[SP]that[SP]happen...?[1205][001E][SP]Why...",
     "nom_fr": "Ginko",
-    "texte_fr": "Pourquoi.[001E][1205][001E][1205].. Pourquoi c'est réel...?"
+    "texte_fr": "Pourquoi.[001E][001E][1205][1205].. Pourquoi c'est réel...?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "[1113]...[1205][001E][SP]I,[SP]uh...[1205][001E][SP]I[SP]really[SP]don't[SP]want\nto[SP]go[SP]on...[1205][001E]",
     "nom_fr": "Eikichi",
-    "texte_fr": "[1113].[1205].[001E]. Je, euh... Je ne\nveux vraiment pas y aller...[1205][001E][1205][001E]"
+    "texte_fr": "[1113].[1205].[001E]. Je, euh... Je ne\nveux vraiment pas y aller...[001E][1205][001E][1205]"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "But...[1205][001E][SP]if[SP]that[SP]really[SP]happened...[1205][001E][SP]I've[SP]got\nno[SP]choice[SP]but[SP]to[SP]go...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mais.[001E][1205][001E][1205].. si c'est réel... je n'ai\nplus le choix, je dois y aller..."
+    "texte_fr": "Mais.[001E][001E][1205][1205].. si c'est réel... je n'ai\nplus le choix, je dois y aller..."
   },
   {
     "id": 9,

--- a/traduction/event_scripts/script_096.json
+++ b/traduction/event_scripts/script_096.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "This...[1205][001E][SP]is[SP]where[SP]I[SP]hid[SP]my[SP]mask...",
     "nom_fr": "Ginko",
-    "texte_fr": "J'ai...[1205][001E] caché mon masque ici..."
+    "texte_fr": "J'ai...[001E][1205] caché mon masque ici..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Back[SP]then...[1205][001E][SP]Hiding[SP]my[SP]face[SP]made[SP]me[SP]feel[SP]like\na[SP]different[SP]person.[SP]I[SP]didn't[SP]have[SP]to[SP]worry\nabout[SP]the[SP]color[SP]of[SP]my[SP]hair[SP]or[SP]eyes...",
     "nom_fr": "Ginko",
-    "texte_fr": "Avant...[1205][001E] couvrir mon visage me faisait\nsentir différente. J'avais pas à me soucier\nde la couleur de mes yeux ou cheveux..."
+    "texte_fr": "Avant...[001E][1205] couvrir mon visage me faisait\nsentir différente. J'avais pas à me soucier\nde la couleur de mes yeux ou cheveux..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That's[SP]right...[1205][001E][SP]We[SP]came[SP]here[SP]afterwards[SP]and\nhid[SP]our[SP]masks...[1205][001E][SP]And[SP]forgot[SP]all[SP]about[SP]it\never[SP]since...",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est ça...[1205][001E] On est ensuite venu\nici et on a caché nos masques...[1205][001E]\nEt depuis, on a tout oublié..."
+    "texte_fr": "C'est ça...[001E][1205] On est ensuite venu\nici et on a caché nos masques...[001E][1205]\nEt depuis, on a tout oublié..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "A[SP]secret[SP]hideout[SP]and[SP]masks[SP]as[SP]treasure?[1205][001E]\nHonestly,[SP]it's[SP]like[SP]something[SP]a[SP]child[SP]would\ncome[SP]up[SP]with.",
     "nom_fr": "Maya",
-    "texte_fr": "Une planque secrète et des masques\nen guise de trésor?[1205][001E] Franchement,\non dirait une idée de gosse."
+    "texte_fr": "Une planque secrète et des masques\nen guise de trésor?[001E][1205] Franchement,\non dirait une idée de gosse."
   },
   {
     "id": 4,
@@ -72,6 +72,6 @@
     "nom_orig": "Yukino",
     "texte_orig": "Another[SP]sad[SP]story[SP]about[SP]masks,[SP]huh?[1205][001E][SP]Humans\nseem[SP]doomed[SP]to[SP]suffer[SP]the[SP]same[SP]things[SP]over\nand[SP]over...",
     "nom_fr": "",
-    "texte_fr": "Encore une histoire triste\nde masques, hein ?[1205][001E]\nCes gens souffrent tous."
+    "texte_fr": "Encore une histoire triste\nde masques, hein ?[001E][1205]\nCes gens souffrent tous."
   }
 ]

--- a/traduction/event_scripts/script_097.json
+++ b/traduction/event_scripts/script_097.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Secret[SP]friends[SP]who[SP]would[SP]never[SP]reveal[SP]their\ntrue[SP]selves...[1205][001E][SP]And[SP]yet...[1205][001E][SP]We[SP]understood[SP]each\nother[SP]better[SP]than[SP]anyone[SP]else...",
     "nom_fr": "Ginko",
-    "texte_fr": "Des amis secrets qui ne se livraient\njamais...[1205][001E] Et pourtant...[1205][001E] on se\ncomprenait mieux que quiconque."
+    "texte_fr": "Des amis secrets qui ne se livraient\njamais...[001E][1205] Et pourtant...[001E][1205] on se\ncomprenait mieux que quiconque."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Here...[1205][001E][SP]This[SP]was[SP]where[SP]I[SP]hid[SP]my[SP]mask...[1205][001E]",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ici...[1205][001E] Je cachais mon masque là...[1205][001E]"
+    "texte_fr": "Ici...[001E][1205] Je cachais mon masque là...[001E][1205]"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "With[SP]the[SP]mask[SP]on,[SP]I[SP]could[SP]be[SP]someone[SP]else.[1205][001E]\nInstead[SP]of[SP]some[SP]wussy[SP]kid[SP]who[SP]wasn't[SP]good[SP]at\nanything[SP]except[SP]drawing...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je pouvais être quelqu'un d'autre en\nportant ce masque.[1205][001E] Et pas un froussard\nqui est bon à rien sauf en dessin..."
+    "texte_fr": "Je pouvais être quelqu'un d'autre en\nportant ce masque.[001E][1205] Et pas un froussard\nqui est bon à rien sauf en dessin..."
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Everyone[SP]has[SP]memories[SP]they'd[SP]rather[SP]forget,\nor[SP]sad[SP]things[SP]they[SP]don't[SP]want[SP]to[SP]remember...[1205][001E]",
     "nom_fr": "Yukino",
-    "texte_fr": "Chacun a ses secrets\nà oublier ou des moments\ntriste qu'on veut plus se rappeler...[1205][001E]"
+    "texte_fr": "Chacun a ses secrets\nà oublier ou des moments\ntriste qu'on veut plus se rappeler...[001E][1205]"
   },
   {
     "id": 5,

--- a/traduction/event_scripts/script_098.json
+++ b/traduction/event_scripts/script_098.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "That's[SP]right...[SP]This[SP]was[SP]where[SP]you[SP]hid[SP]yours,\n[1113]...[1205][001E]",
     "nom_fr": "Ginko",
-    "texte_fr": "Oui... C'est là où tu l'as caché, [1113]...[1205][001E]"
+    "texte_fr": "Oui... C'est là où tu l'as caché, [1113]...[001E][1205]"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We[SP]must've[SP]sealed[SP]everything[SP]so[SP]that[SP]our\nsins[SP]wouldn't[SP]catch[SP]up[SP]to[SP]us...[1205][001E][SP]Including\nour[SP]memories...[1205][001E][SP]I'm[SP]sorry,[SP][1113]...",
     "nom_fr": "Ginko",
-    "texte_fr": "On devait tout sceller afin que nos pécher\nnous rattrapent pas...[1205][001E] Incluant nos\nsouvenirs...[1205][001E] Je suis désolé, [1113]..."
+    "texte_fr": "On devait tout sceller afin que nos pécher\nnous rattrapent pas...[001E][1205] Incluant nos\nsouvenirs...[001E][1205] Je suis désolé, [1113]..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP][1114][SP]I[SP]knew[SP]then[SP]was[SP]a[SP]lot[SP]more\nenergetic...[1205][001E][SP]It's[SP]probably[SP]our[SP]fault[SP]that\nyou[SP]became[SP]so[SP]distant.[1205][001E]",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le [1114] que j'ai connu était plus\nénergique...[1205][001E] C'est sûrement notre\nfaute si tu es devenu si froid.[1205][001E]"
+    "texte_fr": "Le [1114] que j'ai connu était plus\nénergique...[001E][1205] C'est sûrement notre\nfaute si tu es devenu si froid.[001E][1205]"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]know[SP]that[SP]words[SP]can[SP]never[SP]be[SP]enough...[1205][001E]\nBut[SP]there's[SP]nothing[SP]else[SP]I[SP]can[SP]do[SP]now\nbesides[SP]apologize.[1205][001E][SP]I'm[SP]so[SP]sorry...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je sais que les mots ne font pas\ntous...[1205][001E] Mais je n'ai aucun autre choix\nque de m'excuser.[1205][001E] Je suis désolé..."
+    "texte_fr": "Je sais que les mots ne font pas\ntous...[001E][1205] Mais je n'ai aucun autre choix\nque de m'excuser.[001E][1205] Je suis désolé..."
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP][1432][NULL][NULL][0014]I'm[SP]sorry.[1432][NULL][NULL][0014][1205][001E][SP]Anyone[SP]who[SP]hears[SP]that[SP]is\nobligated[SP]to[SP]forgive,[SP]no[SP]matter[SP]how[SP]hurt[SP]or\nangry[SP]they[SP]may[SP]be...",
     "nom_fr": "Maya",
-    "texte_fr": "C'est [1432][NULL][NULL][0014]Je suis désolé.[1432][NULL][NULL][0014][1205][001E] Quiconque qui\nentend ça, qu'il soit blessé ou en\ncolère, se doit de pardonner..."
+    "texte_fr": "C'est [1432][NULL][NULL][0014]Je suis désolé.[1432][NULL][NULL][0014][001E][1205] Quiconque qui\nentend ça, qu'il soit blessé ou en\ncolère, se doit de pardonner..."
   },
   {
     "id": 6,

--- a/traduction/event_scripts/script_099.json
+++ b/traduction/event_scripts/script_099.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "This[SP]is...[1205][001E][SP]where[SP]we[SP]hid[SP]Big[SP]Sis'[SP]mask...",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est...[1205][001E] ici qu'est caché le masque."
+    "texte_fr": "C'est...[001E][1205] ici qu'est caché le masque."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yeah,[SP]you're[SP]right...[1205][001E][SP]I[SP]felt[SP]like[SP]this[SP]ten\nyears[SP]ago,[SP]too...",
     "nom_fr": "Eikichi",
-    "texte_fr": "T'as raison... [1205][001E]Je me sentais\npareil il y a 10 ans aussi"
+    "texte_fr": "T'as raison... [001E][1205]Je me sentais\npareil il y a 10 ans aussi"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "A[SP]sense[SP]of[SP]regret[SP]and[SP]awareness[SP]of[SP]the[SP]sin\nwe[SP]committed...[1205][001E][SP]utter[SP]terror...[1205][001E][SP]And[SP]sorrow\nas[SP]if[SP]my[SP]heart[SP]was[SP]being[SP]torn[SP]apart...",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'ai du regret envers les péchés qu'on a\ncommis...[1205][001E] une terreur infinie...[1205][001E] Et une\npeine comme si mon cœur se déchirait.."
+    "texte_fr": "J'ai du regret envers les péchés qu'on a\ncommis...[001E][1205] une terreur infinie...[001E][1205] Et une\npeine comme si mon cœur se déchirait.."
   },
   {
     "id": 3,

--- a/traduction/event_scripts/script_101.json
+++ b/traduction/event_scripts/script_101.json
@@ -12,7 +12,7 @@
     "nom_orig": "Katsuya",
     "texte_orig": "*sigh*[1205][001E][SP]I[SP]can't[SP]enjoy[SP]the[SP]festival[SP]at[SP]my[SP]own\npace[SP]with[SP]you[SP]around.[SP]My[SP]allowance[SP]is\ndraining[SP]fast,[SP]too...",
     "nom_fr": "Katsuya",
-    "texte_fr": "*soupir*[1205][001E] J'peux pas profiter du\nfestival à mon rythme avec toi.\nMon argent part vite lui aussi..."
+    "texte_fr": "*soupir*[001E][1205] J'peux pas profiter du\nfestival à mon rythme avec toi.\nMon argent part vite lui aussi..."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Black-masked[SP]boy",
     "texte_orig": "Um...[1205][001E][SP]Whatcha[SP]doing?",
     "nom_fr": "Garçon masqué",
-    "texte_fr": "Euh...[1205][001E] Tu fais quoi?"
+    "texte_fr": "Euh...[001E][1205] Tu fais quoi?"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Black-masked[SP]boy",
     "texte_orig": "Oh...[1205][001E][SP]You're[SP]by[SP]yourself[SP]too...[1205][001E][SP]That[SP]makes\ntwo[SP]of[SP]us.",
     "nom_fr": "Garçon masqué",
-    "texte_fr": "Oh...[1205][001E] T'es tout seul aussi...[1205][001E] On est deux."
+    "texte_fr": "Oh...[001E][1205] T'es tout seul aussi...[001E][1205] On est deux."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Black-masked[SP]boy",
     "texte_orig": "Papa[SP]and[SP]Mama[SP]were[SP]fighting[SP]today,[SP]too...[1205][001E]\nAnd[SP]they[SP]promised[SP]they'd[SP]go[SP]to[SP]the[SP]festival\nwith[SP]me.[1205][001E][SP]Why[SP]are[SP]grown-ups[SP]always[SP]so[SP]mad?",
     "nom_fr": "Garçon masqué",
-    "texte_fr": "Papa et Maman se disputaient encore...[1205][001E]\nIls avaient promis de venir au festival\navec moi.[1205][001E] Pourquoi ils s'énervent autant?"
+    "texte_fr": "Papa et Maman se disputaient encore...[001E][1205]\nIls avaient promis de venir au festival\navec moi.[001E][1205] Pourquoi ils s'énervent autant?"
   },
   {
     "id": 5,
@@ -147,7 +147,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "*sniffle*[1205][001E][SP]*sob*[1205][001E][SP]Y-Yeah...",
     "nom_fr": "Eikichi",
-    "texte_fr": "*snif*[1205][001E] O-Ouais.[001E][1205].."
+    "texte_fr": "*snif*[001E][1205] O-Ouais.[001E][1205].."
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Black-masked[SP]boy",
     "texte_orig": "Umm...[1205][001E][SP]I'm[SP]Black[SP]Falcon.",
     "nom_fr": "Garçon masqué",
-    "texte_fr": "Euh...[1205][001E] Faucon Noir."
+    "texte_fr": "Euh...[001E][1205] Faucon Noir."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Black-masked[SP]boy",
     "texte_orig": "And[SP]this[SP]is...[1205][001E][SP]Red[SP]Eagle,[SP]I[SP]guess?",
     "nom_fr": "Garçon masqué",
-    "texte_fr": "Et voici...[1205][001E] Aigle Rouge, non?"
+    "texte_fr": "Et voici...[001E][1205] Aigle Rouge, non?"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "*sniffle*[1205][001E][SP]Th-Then[SP]I'm[SP]Y-Yellow[SP]Owl.",
     "nom_fr": "Eikichi",
-    "texte_fr": "*snif*[1205][001E] Moi c'est Hibou Jaune."
+    "texte_fr": "*snif*[001E][1205] Moi c'est Hibou Jaune."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "M-My[SP]dad's[SP]r-really[SP]scary...[1205][001E][SP]H-He's[SP]like,\neighteenth[SP]rank[SP]in[SP]k-k-karate[SP]and[SP]judo...",
     "nom_fr": "Eikichi",
-    "texte_fr": "M-Mon père fait super peur...[1205][001E] I-Il\nest 18ème dan de k-karaté et judo..."
+    "texte_fr": "M-Mon père fait super peur...[001E][1205] I-Il\nest 18ème dan de k-karaté et judo..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Black-masked[SP]boy",
     "texte_orig": "My[SP]Papa's[SP]nice[SP]to[SP]me.[SP]He[SP]reads[SP]books[SP]to[SP]me\nand[SP]shows[SP]me[SP]the[SP]stars.[1205][001E][SP]But[SP]he[SP]doesn't[SP]get\nalong[SP]with[SP]Mama...",
     "nom_fr": "Garçon masqué",
-    "texte_fr": "Mon Papa est gentil. Il me lit des\nlivres et me montre les étoiles.[1205][001E]\nMais il s'entend pas avec Maman..."
+    "texte_fr": "Mon Papa est gentil. Il me lit des\nlivres et me montre les étoiles.[001E][1205]\nMais il s'entend pas avec Maman..."
   },
   {
     "id": 16,
@@ -297,7 +297,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "...[1205][001E]You[SP]really[SP]aren't[SP]gonna[SP]pick[SP]on[SP]me?",
     "nom_fr": "Ginko",
-    "texte_fr": "...[1205][001E] Vous n'allez pas m'embêter?"
+    "texte_fr": "...[001E][1205] Vous n'allez pas m'embêter?"
   },
   {
     "id": 20,
@@ -357,7 +357,7 @@
     "nom_orig": "Black-masked[SP]boy",
     "texte_orig": "Whew...[SP]I'm[SP]tired...[1205][001E][SP]I[SP]haven't[SP]laughed[SP]this\nmuch[SP]in[SP]a[SP]while...",
     "nom_fr": "Garçon masqué",
-    "texte_fr": "Ouf... J'suis fatigué...[1205][001E] J'avais\npas autant ri depuis un bail..."
+    "texte_fr": "Ouf... J'suis fatigué...[001E][1205] J'avais\npas autant ri depuis un bail..."
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP]um...[1205][001E][SP]Will[SP]you[SP]guys[SP]keep[SP]being\nmy[SP]friends?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, euh...[1205][001E] Vous voulez\nbien rester mes amis?"
+    "texte_fr": "Hé, euh...[001E][1205] Vous voulez\nbien rester mes amis?"
   },
   {
     "id": 25,

--- a/traduction/event_scripts/script_102.json
+++ b/traduction/event_scripts/script_102.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yeah...[1205][001E][SP]That's[SP]right,[SP][1113]...[1205][001E][SP]That[SP]was\nus[SP]back[SP]when[SP]we[SP]were[SP]kids...[1205][001E]",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ouais...[1205][001E] C'est exact, [1113]...[1205][001E]\nC'était nous quand on était gamins...[1205][001E]"
+    "texte_fr": "Ouais...[001E][1205] C'est exact, [1113]...[001E][1205]\nC'était nous quand on était gamins...[001E][1205]"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It[SP]wasn't[SP]just[SP]a[SP]dream...[1205][001E][SP]We[SP]met[SP]for[SP]the\nfirst[SP]time[SP]that[SP]night[SP]at[SP]the[SP]festival[SP]at\nthe[SP]Alaya[SP]Shrine!",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'était pas qu'un\nrêve...[1205][001E] On s'est rencontrés\nce soir-là à la fête du Sanctuaire d'Alaya!"
+    "texte_fr": "C'était pas qu'un\nrêve...[001E][1205] On s'est rencontrés\nce soir-là à la fête du Sanctuaire d'Alaya!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Now[SP]do[SP]you[SP]remember,[SP][1113]!?[1205][001E][SP]We[SP]all[SP]met\neach[SP]other[SP]a[SP]long[SP]time[SP]ago!",
     "nom_fr": "Ginko",
-    "texte_fr": "Tu t'en souviens, [1113]!?[1205][001E] On\ns'est tous connus il y a longtemps!"
+    "texte_fr": "Tu t'en souviens, [1113]!?[001E][1205] On\ns'est tous connus il y a longtemps!"
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Now[SP]this[SP]is[SP]a[SP]surprise...[1205][001E][SP]It[SP]was[SP]you[SP]who\ncreated[SP]the[SP]Masked[SP]Circle?[SP]What[SP]a[SP]terrible\nthing[SP]you've[SP]done...",
     "nom_fr": "Maya",
-    "texte_fr": "Quelle surprise...[1205][001E] C'est vous qui\navez créé le Cercle masqué? Quelle\nchose terrible vous avez faite..."
+    "texte_fr": "Quelle surprise...[001E][1205] C'est vous qui\navez créé le Cercle masqué? Quelle\nchose terrible vous avez faite..."
   },
   {
     "id": 5,
@@ -87,6 +87,6 @@
     "nom_orig": "Yukino",
     "texte_orig": "No...[1205][001E][SP]How[SP]could[SP]this[SP]be...?",
     "nom_fr": "",
-    "texte_fr": "Non...[1205][001E] Comment est-ce possible...?"
+    "texte_fr": "Non...[001E][1205] Comment est-ce possible...?"
   }
 ]

--- a/traduction/event_scripts/script_104.json
+++ b/traduction/event_scripts/script_104.json
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Okay,[SP]then[SP]today...[1205][001E][SP]We're[SP]gonna[SP]play[SP]house!",
     "nom_fr": "Ginko",
-    "texte_fr": "Ok, alors...[1205][001E] On joue au papa et à la maman!"
+    "texte_fr": "Ok, alors...[001E][1205] On joue au papa et à la maman!"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Black-masked[SP]boy",
     "texte_orig": "Sorry,[SP]Yellow.[SP]She's[SP]the[SP]boss,[SP]so[SP]we[SP]have[SP]to\nlisten[SP]to[SP]what[SP]she[SP]says[SP]no[SP]matter[SP]what.\nThat's[SP]the[SP]rule.",
     "nom_fr": "Garçon masqué",
-    "texte_fr": "Désolé, Jaune. C'est la\ncheffe, alors on doit\nl'écouter quoi qu'il\narrive. C'est la règle."
+    "texte_fr": "Désolé, Jaune. C'est la\ncheffe, alors on doit\nl'écouter quoi qu'il arrive. C'est la règle."
   },
   {
     "id": 7,
@@ -192,6 +192,6 @@
     "nom_orig": "Black-masked[SP]boy",
     "texte_orig": "Mama...?[1205][001E][SP]I[SP]didn't[SP]have[SP]supper[SP]yet...",
     "nom_fr": "",
-    "texte_fr": "Maman...?[1205][001E] J'ai pas encore\ndîné..."
+    "texte_fr": "Maman...?[001E][1205] J'ai pas encore\ndîné..."
   }
 ]

--- a/traduction/event_scripts/script_105.json
+++ b/traduction/event_scripts/script_105.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Oh[SP]yeah...[1205][001E][SP]We[SP]had[SP]that[SP]rule[SP]that[SP]you[SP]had[SP]to\nlisten[SP]to[SP]what[SP]the[SP]boss[SP]said...[1205][001E]",
     "nom_fr": "Eikichi",
-    "texte_fr": "Oh ouais...[1205][001E] On avait cette règle\nde devoir écouter le chef...[1205][001E]"
+    "texte_fr": "Oh ouais...[001E][1205] On avait cette règle\nde devoir écouter le chef...[001E][1205]"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]loved[SP]drawing,[SP]so[SP]I[SP]wanted[SP]to[SP]draw[SP]with\nyou[SP]all...[1205][001E][SP]But[SP]I[SP]always[SP]lost...[1205][001E][SP]I...",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'aurais adoré dessiner avec vous...[1205][001E]\nMais je perdais toujours...[1205][001E] Je..."
+    "texte_fr": "J'aurais adoré dessiner avec vous...[001E][1205]\nMais je perdais toujours...[001E][1205] Je..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I...[1205][001E][SP]I[SP]was[SP]bullied[SP]at[SP]school[SP]because[SP]my[SP]hair\nand[SP]eyes[SP]were[SP]different[SP]from[SP]everyone[SP]else...[1205][001E]",
     "nom_fr": "Ginko",
-    "texte_fr": "Je...[1205][001E] J'étais harcelée à l'école car mes\nyeux et cheveux étaient différents...[1205][001E]"
+    "texte_fr": "Je...[001E][1205] J'étais harcelée à l'école car mes\nyeux et cheveux étaient différents...[001E][1205]"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "The[SP]only[SP]time...[1205][001E][SP]The[SP]only[SP]time[SP]I[SP]got[SP]to[SP]play\nlike[SP]a[SP]normal[SP]kid[SP]was[SP]when[SP]we[SP]played[SP]the\nMasked[SP]Circle!",
     "nom_fr": "Ginko",
-    "texte_fr": "La seule fois...[1205][001E] Le seul moment où j'ai pu\njouer normalement, c'était avec le Cercle\nMasqué!"
+    "texte_fr": "La seule fois...[001E][1205] Le seul moment où j'ai pu\njouer normalement, c'était avec le Cercle\nMasqué!"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "It[SP]was[SP]only[SP]with[SP][1113][SP]and[SP]Eikichi[SP]that\nI[SP]could[SP]be[SP]myself...[1205][001E][SP]And...[1205]<[SP][1113]...\nYou[SP]were[SP]my[SP]first[SP]crush...",
     "nom_fr": "Ginko",
-    "texte_fr": "Je n'étais moi-même qu'avec [1113]\net Eikichi...[1205][001E] Et...[1205]< [1113]... Tu\nétais mon premier amour..."
+    "texte_fr": "Je n'étais moi-même qu'avec [1113]\net Eikichi...[001E][1205] Et...[1205]< [1113]... Tu\nétais mon premier amour..."
   },
   {
     "id": 5,

--- a/traduction/event_scripts/script_107.json
+++ b/traduction/event_scripts/script_107.json
@@ -72,7 +72,7 @@
     "nom_orig": "Sailor-suited[SP]girl",
     "texte_orig": "I'm[SP]visiting[SP]the[SP]shrine.[SP]I'm[SP]praying[SP]to[SP]become\nwhat[SP]I[SP]want[SP]in[SP]the[SP]future...[1205][001E][SP]Like[SP]that!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Je visite le sanctuaire.\nJe prie pour devenir\nce que je veux plus tard...[1205][001E] Comme ça!"
+    "texte_fr": "Je visite le sanctuaire.\nJe prie pour devenir\nce que je veux plus tard...[001E][1205] Comme ça!"
   },
   {
     "id": 5,
@@ -147,7 +147,7 @@
     "nom_orig": "Black-masked[SP]boy",
     "texte_orig": "Yeah...[1205][001E][SP]Are[SP]you[SP]okay[SP]with[SP]it,[SP]Red?",
     "nom_fr": "Garçon masqué",
-    "texte_fr": "Ouais...[1205][001E] T'es d'accord, Rouge?"
+    "texte_fr": "Ouais...[001E][1205] T'es d'accord, Rouge?"
   },
   {
     "id": 10,

--- a/traduction/event_scripts/script_108.json
+++ b/traduction/event_scripts/script_108.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "She[SP]was[SP]beautiful...[SP]energetic...[SP]kind...[1205][001E]\nShe[SP]taught[SP]us[SP]to[SP]follow[SP]our[SP]dreams...[1205][001E]\nAnd[SP]then...[SP]I...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Elle était belle... vive...\ndouce...[1205][001E] Elle nous disait de suivre\nnos rêves...[1205][001E] Et puis... j'ai..."
+    "texte_fr": "Elle était belle... vive...\ndouce...[001E][1205] Elle nous disait de suivre\nnos rêves...[001E][1205] Et puis... j'ai..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We[SP]played[SP]the[SP]Persona[SP]Game[SP]together.[1205][001E]\nBig[SP]Sis[SP]watched[SP]us[SP]with[SP]a[SP]huge[SP]smile[SP]on\nher[SP]face[SP]the[SP]whole[SP]time...",
     "nom_fr": "Ginko",
-    "texte_fr": "On jouait au Persona Game ensemble.[1205][001E]\nSœurette nous regardait avec un\ngrand sourire tout le temps..."
+    "texte_fr": "On jouait au Persona Game ensemble.[001E][1205]\nSœurette nous regardait avec un\ngrand sourire tout le temps..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "She[SP]told[SP]us[SP]that[SP]whether[SP]our[SP]dream[SP]comes\ntrue[SP]depends[SP]on[SP]us![1205][001E][SP]But[SP]then...[SP]I...[SP]I...!",
     "nom_fr": "Ginko",
-    "texte_fr": "Elle disait que nos rêves ne dépendaient\nque de nous![1205][001E] Mais après... je... je...!"
+    "texte_fr": "Elle disait que nos rêves ne dépendaient\nque de nous![001E][1205] Mais après... je... je...!"
   },
   {
     "id": 4,

--- a/traduction/event_scripts/script_110.json
+++ b/traduction/event_scripts/script_110.json
@@ -27,7 +27,7 @@
     "nom_orig": "Sailor-suited[SP]girl",
     "texte_orig": "I'm[SP]sorry[SP]I[SP]forgot[SP]to[SP]tell[SP]you...[1205][001E][SP]We[SP]were\nplanning[SP]on[SP]moving[SP]before[SP]summer[SP]vacation\nends...",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Désolée de ne pas vous avoir\nprévenus...[1205][001E] On prévoyait de déménager\navant la fin des vacances d'été..."
+    "texte_fr": "Désolée de ne pas vous avoir\nprévenus...[001E][1205] On prévoyait de déménager\navant la fin des vacances d'été..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Sailor-suited[SP]girl",
     "texte_orig": "I[SP]had[SP]so[SP]much[SP]fun[SP]playing[SP]with[SP]you[SP]kids\nthat...[1205][001E][SP]I[SP]just[SP]couldn't[SP]bring[SP]it[SP]up...[1205][001E]",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Je m'amusais tellement à jouer avec vous...[1205][001E]\nJe n'arrivais pas à vous le dire...[1205][001E]"
+    "texte_fr": "Je m'amusais tellement à jouer avec vous...[001E][1205]\nJe n'arrivais pas à vous le dire...[001E][1205]"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "But...[SP]Members[SP]of[SP]the[SP]Masked[SP]Circle[SP]will\nalways[SP]be[SP]together...[1205][001E][SP]That's[SP]our[SP]rule...[1205][001E]\nYou[SP]promised[SP]us!",
     "nom_fr": "Ginko",
-    "texte_fr": "Mais... les membres du Cercle\nmasqué restent ensemble...[1205][001E] C'est\nnotre règle... tu l'avais promis![1205][001E]"
+    "texte_fr": "Mais... les membres du Cercle\nmasqué restent ensemble...[001E][1205] C'est\nnotre règle... tu l'avais promis![001E][1205]"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Sailor-suited[SP]girl",
     "texte_orig": "I[SP]know[SP]I[SP]wasn't[SP]fair[SP]to[SP]you...[1205][001E][SP]I[SP]know[SP]this\nis[SP]cruel...",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Je sais que ce n'était pas juste...[1205][001E]\nje sais que c'est cruel..."
+    "texte_fr": "Je sais que ce n'était pas juste...[001E][1205]\nje sais que c'est cruel..."
   },
   {
     "id": 6,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]won't[SP]let[SP]you...[1205][001E][SP]I[SP]won't[SP]let[SP]you[SP]go!",
     "nom_fr": "Ginko",
-    "texte_fr": "Je ne te laisse pas...[1205][001E] Pas question!"
+    "texte_fr": "Je ne te laisse pas...[001E][1205] Pas question!"
   },
   {
     "id": 10,
@@ -177,6 +177,6 @@
     "nom_orig": "Ginko's[SP]voice",
     "texte_orig": "Don't...[1205][001E][SP]Please[SP]stop...!",
     "nom_fr": "",
-    "texte_fr": "Arrêtez...[1205][001E] Je vous en supplie,\narrêtez...!"
+    "texte_fr": "Arrêtez...[001E][1205] Je vous en supplie,\narrêtez...!"
   }
 ]

--- a/traduction/event_scripts/script_111.json
+++ b/traduction/event_scripts/script_111.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]get[SP]it...[1205][001E][SP]I[SP]didn't[SP]forget...[1205][001E][SP]So[SP]please,\nno[SP]more...",
     "nom_fr": "Ginko",
-    "texte_fr": "Je comprends...[1205][001E] Je\nn'ai pas oublié...[1205][001E] Assez..."
+    "texte_fr": "Je comprends...[001E][1205] Je\nn'ai pas oublié...[001E][1205] Assez..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Do[SP]you[SP]remember[SP]now...[1205][001E][SP][1113]...?[1205][001E]",
     "nom_fr": "Ginko",
-    "texte_fr": "Tu t'en souviens...[1205][001E] [1113]...?[1205][001E]"
+    "texte_fr": "Tu t'en souviens...[001E][1205] [1113]...?[001E][1205]"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I...[1205][001E][SP]I...[1205][001E][SP]I[SP]killed[SP]our[SP]Big[SP]Sis!",
     "nom_fr": "Ginko",
-    "texte_fr": "Je...[1205][001E] Je...[1205][001E] J'ai tuée sœurette!"
+    "texte_fr": "Je...[001E][1205] Je...[001E][1205] J'ai tuée sœurette!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It[SP]wasn't[SP]you...[1205][001E][SP]This[SP]is[SP]all[SP]my[SP]fault...[1205][001E]",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'était pas toi...[1205][001E] C'est ma faute...[1205][001E]"
+    "texte_fr": "C'était pas toi...[001E][1205] C'est ma faute...[001E][1205]"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]knew.[1205][001E][SP]Ever[SP]since[SP]I[SP]heard[SP]the[SP]name[SP][1432][NULL][NULL][0014]Masked\nCircle[1432][NULL][NULL][0014]...[1205][001E][SP]I[SP]started[SP]to[SP]remember[SP]that[SP]what\nhappened[SP]was[SP]real...",
     "nom_fr": "Ginko",
-    "texte_fr": "Je savais.[1205][001E] Depuis que j'ai entendu\n[1432][NULL][NULL][0014]Cercle masqué[1432][NULL][NULL][0014]...[1205][001E] J'ai commencé à\nme souvenir que c'était réel..."
+    "texte_fr": "Je savais.[001E][1205] Depuis que j'ai entendu\n[1432][NULL][NULL][0014]Cercle masqué[1432][NULL][NULL][0014]...[001E][1205] J'ai commencé à\nme souvenir que c'était réel..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "The[SP]last[SP]ten[SP]years...[1205][001E][SP]I[SP]had[SP]hoped[SP]it[SP]was[SP]all\njust[SP]a[SP]bad[SP]dream...[1205][001E]",
     "nom_fr": "Ginko",
-    "texte_fr": "Ces dix ans...[1205][001E] J'espérais que\nc'était un mauvais rêve...[1205][001E]"
+    "texte_fr": "Ces dix ans...[001E][1205] J'espérais que\nc'était un mauvais rêve...[001E][1205]"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Eventually,[SP]I[SP]couldn't[SP]tell[SP]what[SP]was[SP]real\nanymore.[1205][001E][SP]I[SP]began[SP]to[SP]think[SP]it[SP]had[SP]all[SP]been\nin[SP]my[SP]head...",
     "nom_fr": "Ginko",
-    "texte_fr": "Au bout d'un moment, je ne savais\nplus ce qui était réel.[1205][001E] J'ai cru\nque j'avais tout imaginé..."
+    "texte_fr": "Au bout d'un moment, je ne savais\nplus ce qui était réel.[001E][1205] J'ai cru\nque j'avais tout imaginé..."
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We[SP]locked[SP]Big[SP]Sis[SP]in[SP]the[SP]shrine...[1205][001E][SP][1113]\nwas[SP]against[SP]it[SP]to[SP]the[SP]very[SP]end...[1205][001E][SP]That's\nwhy...[SP]we[SP]put[SP]him[SP]in[SP]too...",
     "nom_fr": "Ginko",
-    "texte_fr": "On a enfermé sœurette...[1205][001E] [1113]\ns'y opposa jusqu'au bout...[1205][001E] C'est\npourquoi on l'enferma aussi..."
+    "texte_fr": "On a enfermé sœurette...[001E][1205] [1113]\ns'y opposa jusqu'au bout...[001E][1205] C'est\npourquoi on l'enferma aussi..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We[SP]thought[SP]if[SP]she[SP]spent[SP]one[SP]night[SP]there,[SP]she\nwouldn't[SP]be[SP]able[SP]to[SP]move[SP]away...[1205][001E][SP]We[SP]were[SP]such\ndumb[SP]kids.[SP]It[SP]didn't[SP]make[SP]much[SP]sense...",
     "nom_fr": "Eikichi",
-    "texte_fr": "On pensait que si elle passait une nuit là,\nelle ne pourrait pas déménager...[1205][001E] On était\nde vrais gamins. C'était pas malin..."
+    "texte_fr": "On pensait que si elle passait une nuit là,\nelle ne pourrait pas déménager...[001E][1205] On était\nde vrais gamins. C'était pas malin..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "When[SP]we[SP]came[SP]back[SP]the[SP]next[SP]day,[SP]the[SP]shrine\nhad[SP]been[SP]burned[SP]to[SP]the[SP]ground...[1205][001E]",
     "nom_fr": "Ginko",
-    "texte_fr": "Quand on est revenus le lendemain,\nle sanctuaire avait brûlé...[1205][001E]"
+    "texte_fr": "Quand on est revenus le lendemain,\nle sanctuaire avait brûlé...[001E][1205]"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]was[SP]scared...[1205][001E][SP]I[SP]thought[SP]I[SP]had[SP]killed\nBig[SP]Sis[SP]and[SP][1113]...",
     "nom_fr": "Ginko",
-    "texte_fr": "J'avais peur...[1205][001E] Je croyais avoir\ntué sœurette et [1113]..."
+    "texte_fr": "J'avais peur...[001E][1205] Je croyais avoir\ntué sœurette et [1113]..."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Jun,[SP]Ginko,[SP]and[SP]me...[1205][001E][SP]We[SP]hid[SP]our[SP]masks[SP]in\nthis[SP]secret[SP]hideout,[SP]crying[SP]our[SP]eyes[SP]out,\nand[SP]made[SP]one[SP]last[SP]rule[SP]never[SP]to[SP]meet[SP]again...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Jun, Ginko et moi...[1205][001E] On a caché nos\nmasques ici en pleurant, et juré de\nne plus jamais se revoir..."
+    "texte_fr": "Jun, Ginko et moi...[001E][1205] On a caché nos\nmasques ici en pleurant, et juré de\nne plus jamais se revoir..."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Way[SP]later,[SP]I[SP]heard[SP]a[SP]rumor[SP]that[SP][1113][SP]had\nbeen[SP]stabbed[SP]by[SP]the[SP]arsonist,[SP]but[SP]lived...[1205][001E]\nStill,[SP]I[SP]didn't[SP]dare[SP]show[SP]my[SP]face...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Bien plus tard, j'ai appris que [1113]\navait été poignardé mais avait survécu...[1205][001E]\nMais je n'ai pas osé me montrer..."
+    "texte_fr": "Bien plus tard, j'ai appris que [1113]\navait été poignardé mais avait survécu...[001E][1205]\nMais je n'ai pas osé me montrer..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]tried[SP]to[SP]protect[SP]our[SP]Big[SP]Sis[SP]to[SP]the\nvery[SP]end...[1205][001E][SP]But[SP]I...[SP]killed[SP]her...!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tu as protégé sœurette jusqu'au bout...[1205][001E]\nMais moi... je l'ai... tuée...!"
+    "texte_fr": "Tu as protégé sœurette jusqu'au bout...[001E][1205]\nMais moi... je l'ai... tuée...!"
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What...!?[1205][001E][SP]B-But[SP]you[SP]just[SP]said[SP]we[SP]killed\nBig[SP]Sis...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Quoi...!?[1205][001E] M-Mais tu disais\nqu'on l'avait tuée..."
+    "texte_fr": "Quoi...!?[001E][1205] M-Mais tu disais\nqu'on l'avait tuée..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "When[SP]the[SP]shrine[SP]burned[SP]down[SP]and[SP]it[SP]became[SP]a\nhuge[SP]deal...[1205][001E][SP]I[SP]had[SP]my[SP]dad[SP]call[SP]the[SP]police.[1205][001E]\nBut[SP]they[SP]said[SP]there[SP]were[SP]no[SP]bodies[SP]found...",
     "nom_fr": "Ginko",
-    "texte_fr": "Quand le sanctuaire a brûlé...[1205][001E] J'ai\ndemandé à mon père d'appeler la\npolice.[1205][001E] Mais pas de corps retrouvé..."
+    "texte_fr": "Quand le sanctuaire a brûlé...[001E][1205] J'ai\ndemandé à mon père d'appeler la\npolice.[001E][1205] Mais pas de corps retrouvé..."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "So[SP]that's[SP]why[SP]you[SP]were[SP]so[SP]confused...[1205][001E]\nYou[SP]were[SP]just[SP]a[SP]kid.",
     "nom_fr": "Yukino",
-    "texte_fr": "Voilà pourquoi tu étais si\nperdue...[1205][001E] T'étais une gamine."
+    "texte_fr": "Voilà pourquoi tu étais si\nperdue...[001E][1205] T'étais une gamine."
   },
   {
     "id": 20,
@@ -327,7 +327,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "No,[SP]it[SP]isn't![1205][001E][SP]Don't[SP]you[SP]see...?\nBig[SP]Sis[SP]is[SP]Joker!",
     "nom_fr": "Ginko",
-    "texte_fr": "Non![1205][001E] Vous voyez pas? C'est Joker, sœurette!"
+    "texte_fr": "Non![001E][1205] Vous voyez pas? C'est Joker, sœurette!"
   },
   {
     "id": 22,
@@ -387,7 +387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That's[SP]right,[SP]I'm[SP]alive.[1205][001E][SP]I[SP]posed[SP]as[SP]one[SP]of\nyour[SP]team[SP]to[SP]get[SP]my[SP]revenge...[SP]I[SP]was[SP]only\nwaiting[SP]for[SP]you[SP]to[SP]remember[SP]everything!",
     "nom_fr": "Maya",
-    "texte_fr": "C'est exact, je suis vivante.[1205][001E] Je me suis\nfait passer pour l'une de vous...\nJ'attendais que vous\nvous souveniez de tout!"
+    "texte_fr": "C'est exact, je suis vivante.[001E][1205] Je me suis\nfait passer pour l'une de vous...\nJ'attendais que vous vous souveniez de tout!"
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "F...[SP]Forgive[SP]us...[1205][001E][SP]Big...[SP]Sis...",
     "nom_fr": "Ginko",
-    "texte_fr": "Pa-Pardon...[1205][001E] Sœ-Sœurette..."
+    "texte_fr": "Pa-Pardon...[001E][1205] Sœ-Sœurette..."
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Maya",
     "texte_orig": "No.[1205][001E][SP]You'll[SP]suffer[SP]through[SP]the[SP]same[SP]terror\nthat[SP]I[SP]had[SP]to!",
     "nom_fr": "Maya",
-    "texte_fr": "Non.[1205][001E] Vous allez souffrir\nla même terreur que moi!"
+    "texte_fr": "Non.[001E][1205] Vous allez souffrir\nla même terreur que moi!"
   },
   {
     "id": 29,
@@ -492,7 +492,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Two[SP]Mayas...!?[1205][001E][SP]Wh-What[SP]in[SP]the[SP]world--!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Deux Mayas...!?[1205][001E] Q-Qu'est-ce que...!?"
+    "texte_fr": "Deux Mayas...!?[001E][1205] Q-Qu'est-ce que...!?"
   },
   {
     "id": 33,
@@ -522,7 +522,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]Maya's[SP]an[SP]impostor,[SP]probably[SP]caused[SP]by\nthose[SP]terrorist[SP]rumors...[1205][001E][SP]She's[SP]a[SP]spy[SP]from\nthe[SP]Masked[SP]Circle!",
     "nom_fr": "Maya",
-    "texte_fr": "Cette Maya est une impostrice causée\npar les rumeurs terroristes...[1205][001E] C'est\nune espionne du Cercle masqué!"
+    "texte_fr": "Cette Maya est une impostrice causée\npar les rumeurs terroristes...[001E][1205] C'est\nune espionne du Cercle masqué!"
   },
   {
     "id": 35,
@@ -537,7 +537,7 @@
     "nom_orig": "Maya",
     "texte_orig": "You...[1205][001E][SP]And[SP]just[SP]when[SP]everything[SP]was[SP]starting\nto[SP]go[SP]so[SP]smoothly...!",
     "nom_fr": "Maya",
-    "texte_fr": "Toi...[1205][001E] Et juste quand tout\ncommençait à aller si bien...!"
+    "texte_fr": "Toi...[001E][1205] Et juste quand tout\ncommençait à aller si bien...!"
   },
   {
     "id": 36,
@@ -552,7 +552,7 @@
     "nom_orig": "???",
     "texte_orig": "Indeed...[1205][001E][SP]You[SP]won't[SP]get[SP]in[SP]my[SP]way\nany[SP]longer...",
     "nom_fr": "???",
-    "texte_fr": "En effet...[1205][001E] Vous ne\nserez plus un obstacle..."
+    "texte_fr": "En effet...[001E][1205] Vous ne\nserez plus un obstacle..."
   },
   {
     "id": 37,
@@ -597,7 +597,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Leave[SP]now.[1205][001E][SP]That[SP]is,[SP]if[SP]you[SP]value[SP]your[SP]life.",
     "nom_fr": "Joker",
-    "texte_fr": "Partez.[1205][001E] Si vous tenez à votre vie."
+    "texte_fr": "Partez.[001E][1205] Si vous tenez à votre vie."
   },
   {
     "id": 40,
@@ -642,7 +642,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I'm[SP]alive...[1205][001E][SP]You[SP]don't[SP]have[SP]to[SP]suffer\nanymore...",
     "nom_fr": "Maya",
-    "texte_fr": "Je suis vivante...[1205][001E] Vous\nn'avez plus à souffrir."
+    "texte_fr": "Je suis vivante...[001E][1205] Vous\nn'avez plus à souffrir."
   },
   {
     "id": 43,
@@ -657,7 +657,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Stop...[1205][001E][SP]That's[SP]impossible...[1205][001E][SP][1113]\nkilled[SP]you...!",
     "nom_fr": "Joker",
-    "texte_fr": "Arrête...[1205][001E] C'est impossible...[1205][001E]\n[1113]t'a tuée...!"
+    "texte_fr": "Arrête...[001E][1205] C'est impossible...[001E][1205]\n[1113]t'a tuée...!"
   },
   {
     "id": 44,
@@ -672,7 +672,7 @@
     "nom_orig": "Maya",
     "texte_orig": "There's[SP]no[SP]reason[SP]why[SP]you[SP]and[SP][1113]-kun\nshould[SP]fight...[1205][001E][SP]Remember[SP]that[SP]night[SP]at[SP]the\npark?[SP]It[SP]was[SP]as[SP]if[SP]you[SP]two[SP]were--",
     "nom_fr": "Maya",
-    "texte_fr": "Aucune raison de vous battre, toi et\n[1113]...[1205][001E] Souviens-toi de cette nuit\ndans le parc! Vous étiez presque--"
+    "texte_fr": "Aucune raison de vous battre, toi et\n[1113]...[001E][1205] Souviens-toi de cette nuit\ndans le parc! Vous étiez presque--"
   },
   {
     "id": 45,

--- a/traduction/event_scripts/script_112.json
+++ b/traduction/event_scripts/script_112.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Are...[1205][001E][SP]Are[SP]you[SP]really...[SP]Big[SP]Sis?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est...[1205][001E] Vraiment toi, sœurette?"
+    "texte_fr": "C'est...[001E][1205] Vraiment toi, sœurette?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]saw[SP]the[SP]spring[SP]on[SP]my[SP]way[SP]here...[1205][001E]\nI[SP]remembered[SP]everything.",
     "nom_fr": "Maya",
-    "texte_fr": "J'ai vu la source en venant...[1205][001E]\nJe me suis souvenue de tout."
+    "texte_fr": "J'ai vu la source en venant...[001E][1205]\nJe me suis souvenue de tout."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I'm[SP]sorry...[1205][001E][SP]that[SP]I[SP]forgot[SP]about[SP]you[SP]all...[1205][001E]\nI'm[SP]so[SP]sorry...",
     "nom_fr": "Maya",
-    "texte_fr": "Pardon...[1205][001E] de vous avoir\noubliés...[1205][001E] Vraiment désolée..."
+    "texte_fr": "Pardon...[001E][1205] de vous avoir\noubliés...[001E][1205] Vraiment désolée..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "How...[1205][001E][SP]How[SP]did[SP]I[SP]not[SP]notice...?[1205][001E]",
     "nom_fr": "Ginko",
-    "texte_fr": "Comment...[1205][001E] Comment j'ai pas vu?[1205][001E]"
+    "texte_fr": "Comment...[001E][1205] Comment j'ai pas vu?[001E][1205]"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I'm[SP]sorry...[1205][001E][SP]I...![SP]*sob*",
     "nom_fr": "Ginko",
-    "texte_fr": "Pardon...[1205][001E] Je... *pleurs*"
+    "texte_fr": "Pardon...[001E][1205] Je... *pleurs*"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I...[1205][001E][SP]I[SP]did[SP]something[SP]so[SP]terrible...[1205][001E][SP]I'll\nunderstand[SP]if[SP]you[SP]hold[SP]a[SP]grudge[SP]over[SP]it...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je...[1205][001E] J'ai fait\nquelque chose de terrible...[1205][001E]\nJe comprendrais si tu m'en voulais..."
+    "texte_fr": "Je...[001E][1205] J'ai fait\nquelque chose de terrible...[001E][1205]\nJe comprendrais si tu m'en voulais..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "No...[1205][001E][SP]This[SP]is[SP]all[SP]because[SP]of[SP]an[SP]unfortunate\nmisunderstanding[SP]that[SP]started[SP]that[SP]day...",
     "nom_fr": "Maya",
-    "texte_fr": "Non...[1205][001E] Tout ça part d'un malheureux\nmalentendu de ce jour-là..."
+    "texte_fr": "Non...[001E][1205] Tout ça part d'un malheureux\nmalentendu de ce jour-là..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "If[SP]anything,[SP]I'm[SP]glad[SP]to[SP]be[SP]able[SP]to[SP]see[SP]you\nall[SP]again.[SP]I'd[SP]never[SP]resent[SP]you![SP]On[SP]the\ncontrary,[SP]it's[SP]you[SP]who[SP]should...[1205][001E]",
     "nom_fr": "Maya",
-    "texte_fr": "Au contraire, je suis heureuse de\nvous revoir. Je ne vous en veux pas!\nC'est plutôt vous qui devriez...[1205][001E]"
+    "texte_fr": "Au contraire, je suis heureuse de\nvous revoir. Je ne vous en veux pas!\nC'est plutôt vous qui devriez...[001E][1205]"
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "You're...[1205][001E][SP]also[SP]a[SP]false[SP]me[SP]born[SP]from[SP]a[SP]rumor...[1205][001E]",
     "nom_fr": "Maya",
-    "texte_fr": "Tu es...[1205][001E] un faux\nmoi né d'une rumeur aussi...[1205][001E]"
+    "texte_fr": "Tu es...[001E][1205] un faux\nmoi né d'une rumeur aussi...[001E][1205]"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Illusory[SP]Maya",
     "texte_orig": "I...[1205][001E][SP]I[SP]just[SP]wanted[SP]to[SP]tell[SP]you[SP]about[SP]Jun-kun\nin[SP]your[SP]place,[SP]since[SP]you[SP]forgot[SP]everyone\nbecause[SP]of[SP]how[SP]awful[SP]that[SP]fire[SP]was...",
     "nom_fr": "Maya illusoire",
-    "texte_fr": "Je...[1205][001E] Je voulais juste te parler de Jun\nà ta place, puisque tu avais oublié tout\nle monde à cause de cet incendie..."
+    "texte_fr": "Je...[001E][1205] Je voulais juste te parler de Jun\nà ta place, puisque tu avais oublié tout\nle monde à cause de cet incendie..."
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Illusory[SP]Maya",
     "texte_orig": "Jun-kun[SP]is[SP]also[SP]suffering[SP]from[SP]false[SP]memories...[1205][001E]\nI...[SP]could[SP]only[SP]watch[SP]as[SP]he[SP]changed...",
     "nom_fr": "Maya illusoire",
-    "texte_fr": "Jun-kun souffre aussi de faux souvenirs...[1205][001E]\nJe... n'ai pu que le voir changer..."
+    "texte_fr": "Jun-kun souffre aussi de faux souvenirs...[001E][1205]\nJe... n'ai pu que le voir changer..."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Illusory[SP]Maya",
     "texte_orig": "Please...[1205][001E][SP]Save[SP]him...",
     "nom_fr": "Maya illusoire",
-    "texte_fr": "Pitié...[1205][001E] Sauvez-le."
+    "texte_fr": "Pitié...[001E][1205] Sauvez-le."
   },
   {
     "id": 15,
@@ -237,6 +237,6 @@
     "nom_orig": "Illusory[SP]Maya",
     "texte_orig": "Grazie...[1205][001E][SP]My...[1205][001E][SP]hero...",
     "nom_fr": "",
-    "texte_fr": "Grazie...[1205][001E] Mon...[1205][001E] héros..."
+    "texte_fr": "Grazie...[001E][1205] Mon...[001E][1205] héros..."
   }
 ]

--- a/traduction/event_scripts/script_113.json
+++ b/traduction/event_scripts/script_113.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya",
     "texte_orig": "You're...[SP]Philemon?[1205][001E][SP]That's[SP]right...[SP]Now[SP]I\nremember.[1205][001E][SP]I[SP]met[SP]you[SP]ten[SP]years[SP]ago...",
     "nom_fr": "Maya",
-    "texte_fr": "Vous êtes Philémon?[1205][001E] C'est exact...\nJe me souviens.[1205][001E] Il y a dix ans..."
+    "texte_fr": "Vous êtes Philémon?[001E][1205] C'est exact...\nJe me souviens.[001E][1205] Il y a dix ans..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "I[SP]am[SP]honored[SP]that[SP]you[SP]remember.[1205][001E][SP]You[SP]have[SP]all\ngrown[SP]splendidly,[SP]yet[SP]you[SP]have[SP]not[SP]lost[SP]the\nshine[SP]in[SP]your[SP]eyes[SP]from[SP]those[SP]days.",
     "nom_fr": "Philémon",
-    "texte_fr": "Je suis honoré que vous vous souveniez.[1205][001E]\nVous avez bien grandi, sans pour autant\nperdre la lumière dans vos yeux d'alors."
+    "texte_fr": "Je suis honoré que vous vous souveniez.[001E][1205]\nVous avez bien grandi, sans pour autant\nperdre la lumière dans vos yeux d'alors."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "I[SP]am[SP]honored[SP]that[SP]you[SP]remember.[1205][001E][SP]You[SP]have[SP]all\ngrown[SP]splendidly,[SP]yet[SP]you[SP]have[SP]not[SP]lost[SP]the\nshine[SP]in[SP]your[SP]eyes[SP]from[SP]those[SP]days.",
     "nom_fr": "Philémon",
-    "texte_fr": "Je suis honoré que vous vous souveniez.[1205][001E]\nVous avez bien grandi, sans pour autant\nperdre la lumière dans vos yeux d'alors."
+    "texte_fr": "Je suis honoré que vous vous souveniez.[001E][1205]\nVous avez bien grandi, sans pour autant\nperdre la lumière dans vos yeux d'alors."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "In[SP]homage[SP]to[SP]your[SP]strong[SP]will,[SP]I[SP]grant[SP]you\npower...[1205][001E][SP]The[SP]strength[SP]of[SP]your[SP]hearts[SP]and\nkindness[SP]has[SP]awakened[SP]your[SP]true[SP]Personas.",
     "nom_fr": "Philémon",
-    "texte_fr": "En hommage à votre volonté, je vous\naccorde ce pouvoir...[1205][001E] La force de vos\ncœurs a éveillé vos vraies Personae."
+    "texte_fr": "En hommage à votre volonté, je vous\naccorde ce pouvoir...[001E][1205] La force de vos\ncœurs a éveillé vos vraies Personae."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Rhadamanthus[SP]Prime",
     "texte_orig": "Thou[SP]hast[SP]realized[SP]thine[SP]sin[SP]and[SP]frailty...[1205][001E]\nUnderstanding[SP]the[SP]meaning[SP]of[SP]power[SP]hath\ngiven[SP]I,[SP][E4][NULL][NULL][0005]Rhadamanthus[E4][NULL][NULL][0002],[SP]true[SP]strength...",
     "nom_fr": "Rhadamanthus Prime",
-    "texte_fr": "Tu as reconnu ta faute et ta fragilité...[1205][001E]\nComprendre le sens du pouvoir a donné à\nmoi, [E4][NULL][NULL][0005]Rhadamanthus[E4][NULL][NULL][0002], une vraie force..."
+    "texte_fr": "Tu as reconnu ta faute et ta fragilité...[001E][1205]\nComprendre le sens du pouvoir a donné à\nmoi, [E4][NULL][NULL][0005]Rhadamanthus[E4][NULL][NULL][0002], une vraie force..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Eros[SP]Prime",
     "texte_orig": "I[SP]am[SP]the[SP]awakened[SP][E4][NULL][NULL][0005]Eros[E4][NULL][NULL][0002]...[1205][001E][SP]You[SP]who[SP]are[SP]in[SP]love,\ntake[SP]to[SP]heart[SP]the[SP]knowledge[SP]that[SP]your\naffections[SP]fuel[SP]your[SP]strength...",
     "nom_fr": "Eros Prime",
-    "texte_fr": "Je suis l'éveillé [E4][NULL][NULL][0005]Eros[E4][NULL][NULL][0002]...[1205][001E] Toi qui\naimes, garde à l'esprit que tes\naffections alimentent ta force..."
+    "texte_fr": "Je suis l'éveillé [E4][NULL][NULL][0005]Eros[E4][NULL][NULL][0002]...[001E][1205] Toi qui\naimes, garde à l'esprit que tes\naffections alimentent ta force..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Maia[SP]Prime",
     "texte_orig": "I[SP]am[SP][E4][NULL][NULL][0005]Maia[E4][NULL][NULL][0002]...[SP]Awakened[SP]messenger[SP]of[SP]the[SP]Pleaides:[1205][001E]\nFlowers[SP]to[SP]the[SP]past;[SP]fertility[SP]to[SP]your[SP]heart.\nThe[SP]sixteenth[SP]night's[SP]moon[SP]now[SP]shines...",
     "nom_fr": "Maia Prime",
-    "texte_fr": "Je suis [E4][NULL][NULL][0005]Maia[E4][NULL][NULL][0002]... messagère éveillée des\nPléiades:[1205][001E] Fleurs au passé; fertilité à ton\ncœur. La lune\ndu seizième soir brilledésormais..."
+    "texte_fr": "Je suis [E4][NULL][NULL][0005]Maia[E4][NULL][NULL][0002]... messagère éveillée des\nPléiades:[001E][1205] Fleurs au passé; fertilité à ton\ncœur. La lune\ndu seizième soir brilledésormais..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Vulcanus[SP]Prime",
     "texte_orig": "Thy[SP]heart[SP]that[SP]beats[SP]for[SP]thy[SP]friends[SP]lights\nmine[SP]holy[SP]flame...[1205][001E][SP]I[SP]am[SP]thou...[SP]Thou[SP]art[SP]I...[1205][001E]\nI[SP]am[SP][E4][NULL][NULL][0005]Vulcanus[E4][NULL][NULL][0002],[SP]awakened[SP]to[SP]the[SP]ancient[SP]fire...",
     "nom_fr": "Vulcanus Prime",
-    "texte_fr": "Ton cœur qui bat pour tes amis attise ma\nflamme sacrée...[1205][001E] Je suis\ntoi... Tu es moi...[1205][001E]\nJe suis [E4][NULL][NULL][0005]Vulcanus[E4][NULL][NULL][0002],\néveillé au feu ancestral..."
+    "texte_fr": "Ton cœur qui bat pour tes amis attise ma\nflamme sacrée...[001E][1205] Je suis\ntoi... Tu es moi...[001E][1205]\nJe suis [E4][NULL][NULL][0005]Vulcanus[E4][NULL][NULL][0002],\néveillé au feu ancestral..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "Now...[1205][001E][SP]As[SP]you[SP]have[SP]seen,[SP]your[SP]old[SP]friend[SP]is\ntormented[SP]by[SP]false[SP]memories.",
     "nom_fr": "Philémon",
-    "texte_fr": "À présent...[1205][001E] Votre vieil ami est\ntourmenté par de faux souvenirs."
+    "texte_fr": "À présent...[001E][1205] Votre vieil ami est\ntourmenté par de faux souvenirs."
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "Such[SP]was[SP]not[SP]Jun[SP]Kurosu's[SP]original[SP]desire...[1205][001E]\nHis[SP]mind[SP]is[SP]snared[SP]in[SP]rumors[SP]and[SP]is[SP]slowly\nbecoming[SP]something[SP]inhuman.",
     "nom_fr": "Philémon",
-    "texte_fr": "Ce n'était pas le désir de Jun\nKurosu...[1205][001E] Son esprit est piégé dans les\nrumeurs et lentement devient inhumain."
+    "texte_fr": "Ce n'était pas le désir de Jun\nKurosu...[001E][1205] Son esprit est piégé dans les\nrumeurs et lentement devient inhumain."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "The[SP][1432][NULL][NULL][0014]holy[SP]cross[1432][NULL][NULL][0014][SP]is[SP]the[SP]Grand[SP]Cross,[SP]and\nNahui-Ollin[SP]is[SP]the[SP]world[SP]of[SP]the[SP]fifth[SP]sun...\nThere[SP]is[SP]no[SP]time[SP]to[SP]lose[SP]before[SP]it[SP]perishes.",
     "nom_fr": "Philémon",
-    "texte_fr": "La [1432][NULL][NULL][0014]croix sacrée[1432][NULL][NULL][0014] est la Croix Cosmique, et\nNahui-Ollin est le monde du cinquième\nsoleil... Il n'y a plus\nde temps avant sa fin."
+    "texte_fr": "La [1432][NULL][NULL][0014]croix sacrée[1432][NULL][NULL][0014] est la Croix Cosmique, et\nNahui-Ollin est le monde du cinquième\nsoleil... Il n'y a plus de temps avant sa fin."
   },
   {
     "id": 12,

--- a/traduction/event_scripts/script_114.json
+++ b/traduction/event_scripts/script_114.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]is[SP]where[SP]I[SP]spent[SP]that[SP]night[SP]with\n[1113]-kun...[1205][001E][SP]Where[SP]I[SP]played[SP]with[SP]you\nall...[1205][001E][SP]So[SP]many[SP]great[SP]memories[SP]here...",
     "nom_fr": "Maya",
-    "texte_fr": "C'est ici que j'ai passé la nuit avec\n[1205][1113]-kun.[001E][1205][001E].. Où j'ai joué avec vous\ntous... Tant de bons souvenirs ici..."
+    "texte_fr": "C'est ici que j'ai passé la nuit avec\n[1205][1113]-kun.[001E][001E][1205].. Où j'ai joué avec vous\ntous... Tant de bons souvenirs ici..."
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Is[SP]this[SP]Tamaki?[SP]Good[SP]timing.[SP]We[SP]need[SP]to[SP]ask\nMs.[SP]Okamura[SP]something.[SP]Could[SP]you[SP]get[SP]her\non[SP]the--",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est Tamaki? On doit\ndemander quelque chose à\nMme Okamura. Tu peux\nme mettre en relation--"
+    "texte_fr": "C'est Tamaki? On doit\ndemander quelque chose à\nMme Okamura. Tu peux me mettre en relation--"
   },
   {
     "id": 4,
@@ -72,6 +72,6 @@
     "nom_orig": "Tamaki's[SP]voice",
     "texte_orig": "Forget[SP]that![SP]Look[SP]up[SP]at[SP]the[SP]sky!",
     "nom_fr": "",
-    "texte_fr": "Une fleur, certes, mais c'est une\nfleur très précieuse...[1205][001E] Il est temps\nde rendre le crâne de cristal de vent !"
+    "texte_fr": "Une fleur, certes, mais c'est une\nfleur très précieuse...[001E][1205] Il est temps\nde rendre le crâne de cristal de vent !"
   }
 ]

--- a/traduction/event_scripts/script_115.json
+++ b/traduction/event_scripts/script_115.json
@@ -132,7 +132,7 @@
     "nom_orig": "Ms.[SP]Ideal's[SP]voice",
     "texte_orig": "If[SP]the[SP]Rings[SP]of[SP]Time[SP]are[SP]set[SP]in[SP]motion,\nthe[SP]world...[1205][001E][SP]You[SP]must[SP]get[SP]to[SP]the[SP]Caracol\nat[SP]once![SP]Don't[SP]let[SP]them[SP]near[SP]the[SP]Rings!",
     "nom_fr": "Voix de Mme Idéale",
-    "texte_fr": "Si les Anneaux du Temps s'activent,\nle monde...[1205][001E] File au Caracol, vite! Ne\nles laisse pas approcher des Anneaux!"
+    "texte_fr": "Si les Anneaux du Temps s'activent,\nle monde...[001E][1205] File au Caracol, vite! Ne\nles laisse pas approcher des Anneaux!"
   },
   {
     "id": 9,

--- a/traduction/event_scripts/script_116.json
+++ b/traduction/event_scripts/script_116.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]doubt[SP]they'll[SP]hold[SP]back[SP]if[SP]they[SP]see[SP]anyone\ncoming.[1205][001E][SP]Our[SP]choices[SP]are[SP]the[SP]frontal[SP]route...[1205][001E]\nOr[SP]the[SP]mountain[SP]path[SP]over[SP]here...",
     "nom_fr": "Eikichi",
-    "texte_fr": "S'ils nous voient, ils ne se retiendront\npas.[1205][001E] On peut y aller de front...[1205][001E] Ou\nprendre le chemin de montagne par ici..."
+    "texte_fr": "S'ils nous voient, ils ne se retiendront\npas.[001E][1205] On peut y aller de front...[001E][1205] Ou\nprendre le chemin de montagne par ici..."
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]direct[SP]route[SP]would[SP]be[SP]a[SP]shorter[SP]distance...[1205][001E]\nBut[SP]I[SP]don't[SP]think[SP]it'll[SP]be[SP]easy,[SP]necessarily.",
     "nom_fr": "Maya",
-    "texte_fr": "La route directe serait plus courte...[1205][001E] Mais\nje ne pense pas\nque ce sera forcément facile."
+    "texte_fr": "La route directe serait plus courte...[001E][1205] Mais\nje ne pense pas\nque ce sera forcément facile."
   },
   {
     "id": 4,
@@ -143,7 +143,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]decided,[SP]then.[1205][001E][SP]Let's[SP]take[SP]the[SP]mountain\npath[SP]next[SP]to[SP]that[SP]brush[SP]and[SP]make[SP]sure[SP]they\ndon't[SP]see[SP]us!",
     "nom_fr": "Maya",
-    "texte_fr": "C'est décidé, alors.[1205][001E] Prenons le\nchemin de montagne près des buissons\net évitons qu'ils nous voient!"
+    "texte_fr": "C'est décidé, alors.[001E][1205] Prenons le\nchemin de montagne près des buissons\net évitons qu'ils nous voient!"
   },
   {
     "id": 9,
@@ -158,7 +158,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "This[SP]is[SP]all[SP]getting[SP]too[SP]complicated[SP]for\nme...[1205][001E][SP]But[SP]in[SP]the[SP]end,[SP]it[SP]was[SP]us[SP]humans\nwho[SP]called[SP]them[SP]here,[SP]huh?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ça devient trop dur pour moi...[1205][001E] Mais\nau final, c'est nous, les humains,\nqui les avons appelés, hein?"
+    "texte_fr": "Ça devient trop dur pour moi...[001E][1205] Mais\nau final, c'est nous, les humains,\nqui les avons appelés, hein?"
   },
   {
     "id": 10,
@@ -173,7 +173,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "These[SP]guys[SP]are[SP]ruthless[SP]killers,[SP]right...?\nI[SP]know[SP]they're[SP]here[SP]because[SP]of[SP]the[SP]rumor,[SP]but\nall[SP]this[SP]killing...[SP]I[SP]feel[SP]a[SP]little[SP]sick...",
     "nom_fr": "Ginko",
-    "texte_fr": "Ces types sont des tueurs impitoyables,\nnon...? Je sais qu'ils sont\nlà à cause de la\nrumeur, mais ces tueries... Ça m'écœure..."
+    "texte_fr": "Ces types sont des tueurs impitoyables,\nnon...? Je sais qu'ils sont\nlà à cause de la rumeur, mais ces tueries... Ça m'écœure..."
   },
   {
     "id": 11,
@@ -188,7 +188,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]returning[SP]Fuhrer,[SP]rumored[SP]to[SP]be[SP]alive[SP]for\nover[SP]50[SP]years...[1205][001E][SP]It's[SP]a[SP]sorry[SP]reminder[SP]of\nmankind's[SP]karma...[E1][E2]\n[E3][E4][NULL][NULL]\"Yukino\nI'm[SP]sorry...[1205][001E][SP]I[SP]know[SP]you[SP]guys[SP]must[SP]be[SP]worried\nabout[SP]Jun,[SP]but...",
     "nom_fr": "Maya",
-    "texte_fr": "Le Führer aurait survécu plus de 50\nans...[1205][001E] Triste rappel du karma humain...[E1][E2]\n[E3][E4][NULL][NULL]\"Yukino Désolée...\n[1205][001E] Je sais que vous\nvous inquiétez pour Jun, mais..."
+    "texte_fr": "Le Führer aurait survécu plus de 50\nans...[001E][1205] Triste rappel du karma humain...[E1][E2]\n[E3][E4][NULL][NULL]\"Yukino Désolée...\n[001E][1205] Je sais que vous\nvous inquiétez pour Jun, mais..."
   },
   {
     "id": 12,
@@ -203,7 +203,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I'm[SP]going[SP]crazy[SP]with[SP]worry.[1205][001E][SP]I[SP]feel[SP]like[SP]I\ncan't[SP]stand[SP]still...",
     "nom_fr": "Yukino",
-    "texte_fr": "Je suis folle d'inquiétude.[1205][001E]\nJe ne tiens plus en place..."
+    "texte_fr": "Je suis folle d'inquiétude.[001E][1205]\nJe ne tiens plus en place..."
   },
   {
     "id": 13,

--- a/traduction/event_scripts/script_117.json
+++ b/traduction/event_scripts/script_117.json
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Focused[SP]manpower[SP]and[SP]speed[SP]is[SP]essential[SP]when\nbreaking[SP]through![SP]Then[SP]again,[SP]there's[SP]only\nfive[SP]of[SP]us...[1205][001E][SP]But[SP]we[SP]still[SP]need[SP]to[SP]hurry!",
     "nom_fr": "Maya",
-    "texte_fr": "Vitesse et force sont\nvitales pour forcer le\npassage! Même à cinq...[1205][001E] Faut se dépêcher!"
+    "texte_fr": "Vitesse et force sont\nvitales pour forcer le\npassage! Même à cinq...[001E][1205] Faut se dépêcher!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I've[SP]come[SP]here[SP]lots[SP]of[SP]times[SP]with[SP]Fujii-san...[1205][001E]\nWe'd[SP]talk[SP]about[SP]Zen[SP]with[SP]the[SP]monks,[SP]photograph\nthe[SP]night[SP]sky...[1205][001E][SP]I[SP]loved[SP]it[SP]here.",
     "nom_fr": "Yukino",
-    "texte_fr": "Je venais souvent avec Fujii...[1205][001E] Parler\ndu Zen avec les moines, photographier\nle ciel...[1205][001E] J'adorais cet endroit."
+    "texte_fr": "Je venais souvent avec Fujii...[001E][1205] Parler\ndu Zen avec les moines, photographier\nle ciel...[001E][1205] J'adorais cet endroit."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Shit...[1205][001E][SP]They've[SP]crossed[SP]a[SP]line[SP]now...",
     "nom_fr": "Yukino",
-    "texte_fr": "Merde...[1205][001E] Ils sont allés trop loin..."
+    "texte_fr": "Merde...[001E][1205] Ils sont allés trop loin..."
   },
   {
     "id": 5,

--- a/traduction/event_scripts/script_120.json
+++ b/traduction/event_scripts/script_120.json
@@ -12,7 +12,7 @@
     "nom_orig": "Young[SP]monk",
     "texte_orig": "Oh[SP]gods...[1205][001E][SP]W-We're[SP]dead!",
     "nom_fr": "Novice",
-    "texte_fr": "Dieux...[1205][001E] O-On est morts!"
+    "texte_fr": "Dieux...[001E][1205] O-On est morts!"
   },
   {
     "id": 1,
@@ -72,6 +72,6 @@
     "nom_orig": "Eikichi's[SP]voice",
     "texte_orig": "Rock[SP]and[SP]rooooooooooll!",
     "nom_fr": "",
-    "texte_fr": "Au fait, Jun...[1205][001E] Qu'est-ce que\ntu regardes comme ça ?"
+    "texte_fr": "Au fait, Jun...[001E][1205] Qu'est-ce que\ntu regardes comme ça ?"
   }
 ]

--- a/traduction/event_scripts/script_121.json
+++ b/traduction/event_scripts/script_121.json
@@ -12,7 +12,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Excuse[SP]me![SP]Um...[1205][001E][SP]Where[SP]is[SP]Shunsuke-san!?",
     "nom_fr": "Yukino",
-    "texte_fr": "Excusez-moi! Hum...[1205][001E] Où est Shunsuke!?"
+    "texte_fr": "Excusez-moi! Hum...[001E][1205] Où est Shunsuke!?"
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "No...[1205][001E][SP]Why'd[SP]he[SP]let[SP]his[SP]photographer's[SP]instinct\ntake[SP]over[SP]NOW!?",
     "nom_fr": "Yukino",
-    "texte_fr": "Non...[1205][001E] Pourquoi son instinct de\nphotographe agit MAINTENANT!?"
+    "texte_fr": "Non...[001E][1205] Pourquoi son instinct de\nphotographe agit MAINTENANT!?"
   },
   {
     "id": 3,
@@ -162,7 +162,7 @@
     "nom_orig": "Head[SP]monk",
     "texte_orig": "He[SP]inherited[SP]it[SP]from[SP]his[SP]father.[1205][001E]\nQuite[SP]often[SP]did[SP]he[SP]tell[SP]me...",
     "nom_fr": "Maître",
-    "texte_fr": "Il l'a hérité de son père.[1205][001E]\nBien souvent, il m'a dit..."
+    "texte_fr": "Il l'a hérité de son père.[001E][1205]\nBien souvent, il m'a dit..."
   },
   {
     "id": 11,
@@ -237,6 +237,6 @@
     "nom_orig": "Young[SP]monk",
     "texte_orig": "Sir![SP]Look...[1205][001E][SP]The[SP]sky!",
     "nom_fr": "",
-    "texte_fr": "Là là...[1205][001E] C'est grâce à Eikichi-kun\nqu'on a repéré le piège. Allez, traînons pas\ntrop par ici..."
+    "texte_fr": "Là là...[001E][1205] C'est grâce à Eikichi-kun\nqu'on a repéré le piège. Allez, traînons pas\ntrop par ici..."
   }
 ]

--- a/traduction/event_scripts/script_122.json
+++ b/traduction/event_scripts/script_122.json
@@ -12,7 +12,7 @@
     "nom_orig": "Head[SP]monk",
     "texte_orig": "Is[SP]that[SP]the[SP]rumored[SP]Leonids...?[1205][001E][SP]Indeed,[SP]it\nlooks[SP]as[SP]if[SP]a[SP]lion[SP]is[SP]roaring.",
     "nom_fr": "Maître",
-    "texte_fr": "Est-ce les Léonides...?[1205][001E] On\ndirait le rugissement d'un lion."
+    "texte_fr": "Est-ce les Léonides...?[001E][1205] On\ndirait le rugissement d'un lion."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Head[SP]monk",
     "texte_orig": "The[SP]sky[SP]is[SP]streaked[SP]with[SP]stars[SP]that[SP]should[SP]not\nbe[SP]falling[SP]now...[1205][001E][SP]What[SP]a[SP]terrible[SP]omen...",
     "nom_fr": "Maître",
-    "texte_fr": "Le ciel est rayé d'étoiles qui ne devraient\npas tomber...[1205][001E] Quel terrible présage..."
+    "texte_fr": "Le ciel est rayé d'étoiles qui ne devraient\npas tomber...[001E][1205] Quel terrible présage..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1432][NULL][NULL][0014]The[SP]lion's[SP]roar[SP]echoes[SP]far[SP]and[SP]wide[1432][NULL][NULL][0014]...[1205][001E]\nThe[SP]Grand[SP]Cross[SP]will[SP]be[SP]starting[SP]soon!\nThe[SP]Caracol[SP]must[SP]be[SP]at[SP]the[SP]summit![SP]Hurry!\n[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\n[1113]-kun...[1205][001E][SP]What[SP]can[SP]I[SP]do[SP]for[SP]Jun-kun?\nI[SP]don't[SP]want[SP]anyone[SP]else[SP]to[SP]suffer[SP]because\nof[SP]me...",
     "nom_fr": "Maya",
-    "texte_fr": "[1432][NULL][NULL][0014]Le cri du lion résonne au loin[1432][NULL][NULL][0014]...[1205][001E] La Grande\nCroix va vite commencer! Le Caracol doit\nêtre au sommet! Vite! [E1][E2] [E3][E4][NULL][NULL]\"Maya\n[1113]-kun...[1205][001E]\nQue faire pour Jun-kun? Je ne\nveux pas qued'autres souffrent par ma faute..."
+    "texte_fr": "[1432][NULL][NULL][0014]Le cri du lion résonne au loin[1432][NULL][NULL][0014]...[001E][1205] La Grande\nCroix va vite commencer! Le Caracol doit\nêtre au sommet! Vite! [E1][E2] [E3][E4][NULL][NULL]\"Maya\n[1113]-kun...[001E][1205]\nQue faire pour Jun-kun? Je ne\nveux pas qued'autres souffrent par ma faute..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Putting[SP]yourself[SP]in[SP]harm's[SP]way[SP]for[SP]the[SP]sake\nof[SP]your[SP]dream...[1205][001E][SP]Hell[SP]yeah![SP]That's[SP]what[SP]all\nreal[SP]men[SP]yearn[SP]for!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Se mettre en danger pour son\nrêve...[1205][001E] Carrément! C'est ce à quoi\naspirent tous les vrais hommes!"
+    "texte_fr": "Se mettre en danger pour son\nrêve...[001E][1205] Carrément! C'est ce à quoi\naspirent tous les vrais hommes!"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Though[SP]on[SP]the[SP]other[SP]hand...[SP]You[SP]have[SP]to[SP]think\nof[SP]how[SP]the[SP]people[SP]you[SP]leave[SP]behind[SP]feel,[SP]huh?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mais d'un autre côté...\nFaut penser à ce que\nressentent ceux qu'on\nlaisse derrière, hein?"
+    "texte_fr": "Mais d'un autre côté...\nFaut penser à ce que\nressentent ceux qu'on laisse derrière, hein?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "The[SP]line[SP]from[SP]the[SP]Oracle[SP]of[SP]Maia[SP]after[SP]this\nwas,[SP][1432][NULL][NULL][0014]Five[SP]skulls[SP]glow[SP]in[SP]the[SP]depths[SP]of[SP]the\nearth.[1432][NULL][NULL][0014][1205][001E][SP]They're[SP]steadily[SP]getting[SP]closer...",
     "nom_fr": "Ginko",
-    "texte_fr": "La ligne suivante de l'Oracle était: [1432][NULL][NULL][0014]Cinq\ncrânes brillent dans les profondeurs de\nla terre.[1432][NULL][NULL][0014][1205][001E] Ils se rapprochent..."
+    "texte_fr": "La ligne suivante de l'Oracle était: [1432][NULL][NULL][0014]Cinq\ncrânes brillent dans les profondeurs de\nla terre.[1432][NULL][NULL][0014][001E][1205] Ils se rapprochent..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Is[SP]Jun[SP]really[SP]trying[SP]to[SP]destroy[SP]the[SP]world?\nWhy[SP]did[SP]he[SP]become[SP]Joker?[SP][1113]...[1205][001E][SP]I[SP]don't\nget[SP]it[SP]at[SP]all!",
     "nom_fr": "Ginko",
-    "texte_fr": "Jun veut vraiment détruire le monde?\nPourquoi est-il devenu Joker?\n[1113]...[1205][001E] Je pige pas du tout!"
+    "texte_fr": "Jun veut vraiment détruire le monde?\nPourquoi est-il devenu Joker?\n[1113]...[001E][1205] Je pige pas du tout!"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Sorry[SP]I[SP]lost[SP]my[SP]cool,[SP][1113]...[1205][001E]\nShunsuke-san...[1205][001E][SP]Please[SP]be[SP]okay...",
     "nom_fr": "Yukino",
-    "texte_fr": "Pardon, [1113]...[1205][001E]\nShunsuke-san...[1205][001E] Sois prudent..."
+    "texte_fr": "Pardon, [1113]...[001E][1205]\nShunsuke-san...[001E][1205] Sois prudent..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Head[SP]monk",
     "texte_orig": "Leonid[SP]is[SP]an[SP]phenomenon[SP]where,[SP]when[SP]the[SP]rings\nof[SP]dust[SP]around[SP]the[SP]sun[SP]overlap[SP]with[SP]Earth's\nrotation,[SP]look[SP]like[SP]they're[SP]pouring[SP]from[SP]Leo.",
     "nom_fr": "Maître",
-    "texte_fr": "Les Léonides surviennent si la poussière\nautour du soleil croise\nl'orbite de la Terre,\ndonnant l'impression de jaillir du Lion."
+    "texte_fr": "Les Léonides surviennent si la poussière\nautour du soleil croise\nl'orbite de la Terre, donnant l'impression de jaillir du Lion."
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Head[SP]monk",
     "texte_orig": "Speak[SP]of[SP]the[SP]devil[SP]and[SP]he[SP]doth[SP]appear...[1205][001E]\nThe[SP]rumors[SP]circulating[SP]are[SP]what[SP]brought[SP]about\nthis[SP]strange[SP]phenomenon.",
     "nom_fr": "Maître",
-    "texte_fr": "Quand on parle du loup, on en voit la\nqueue...[1205][001E] Les rumeurs qui circulent\nont provoqué cet étrange phénomène."
+    "texte_fr": "Quand on parle du loup, on en voit la\nqueue...[001E][1205] Les rumeurs qui circulent\nont provoqué cet étrange phénomène."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Young[SP]monk",
     "texte_orig": "Oh[SP]no...[SP]Oh[SP]no...[1205][001E][SP]F-First[SP]soldiers[SP]and[SP]now\nstars...?[SP]M-My[SP]knees[SP]are[SP]shaking[SP]so[SP]much[SP]that\nI[SP]can't[SP]move!",
     "nom_fr": "Novice",
-    "texte_fr": "Oh non... Oh non...[1205][001E] D'abord les\nsoldats, puis les étoiles...? M-Mes\ngenoux tremblent trop pour bouger!"
+    "texte_fr": "Oh non... Oh non...[001E][1205] D'abord les\nsoldats, puis les étoiles...? M-Mes\ngenoux tremblent trop pour bouger!"
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Young[SP]monk",
     "texte_orig": "I-I[SP]didn't[SP]know[SP]Yukino-san[SP]could[SP]be[SP]so\nscary...[1205][001E][SP]I[SP]mean,[SP]she[SP]was[SP]hard[SP]as[SP]nails...\nShe's[SP]so[SP]modest[SP]when[SP]she's[SP]with[SP]Fujii-san!",
     "nom_fr": "Novice",
-    "texte_fr": "J-J'ignorais que Yukino pouvait être si\neffrayante...[1205][001E] Dure comme la pierre...\nElle est si modeste avec Fujii-san!"
+    "texte_fr": "J-J'ignorais que Yukino pouvait être si\neffrayante...[001E][1205] Dure comme la pierre...\nElle est si modeste avec Fujii-san!"
   },
   {
     "id": 14,

--- a/traduction/event_scripts/script_123.json
+++ b/traduction/event_scripts/script_123.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]must[SP]be[SP]the[SP]Caracol...[1205][001E][SP]It[SP]does[SP]look[SP]like\nthe[SP]photos[SP]I've[SP]seen[SP]of[SP]Mayan[SP]ruins.[1205][001E][SP]They\nsaid[SP]it[SP]was[SP]an[SP]astronomical[SP]observatory...",
     "nom_fr": "Maya",
-    "texte_fr": "Ça doit être le Caracol...[1205][001E] Ça ressemble aux\nphotos de ruines mayas.[1205][001E] Ils disaient que\nc'était un observatoire astronomique..."
+    "texte_fr": "Ça doit être le Caracol...[001E][1205] Ça ressemble aux\nphotos de ruines mayas.[001E][1205] Ils disaient que\nc'était un observatoire astronomique..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "It[SP]wasn't[SP]here[SP]last[SP]time[SP]I[SP]came...[1205][001E][SP]You[SP]think\nShunsuke-san's[SP]in[SP]there!?",
     "nom_fr": "Yukino",
-    "texte_fr": "J'étais absente à ma dernière\nvisite...[1205][001E] Shunsuke y est!?"
+    "texte_fr": "J'étais absente à ma dernière\nvisite...[001E][1205] Shunsuke y est!?"
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "???",
     "texte_orig": "Hold[SP]it,[SP]Elf.[1205][001E][SP]My[SP]sonar[SP]picked[SP]up[SP]on[SP]something.",
     "nom_fr": "???",
-    "texte_fr": "Attends, Elf.[1205][001E] Mon sonar a repéré un truc. \nOrdre de la Sainte Lance Unité anti-Persona\ndu Dernier Bataillon, 13 chevaliers\npilotantles Marionette Jaeger [NULL][NULL]Himmel Feurer.[NULL][NULL][E4][NULL][NULL]"
+    "texte_fr": "Attends, Elf.[001E][1205] Mon sonar a repéré un truc. \nOrdre de la Sainte Lance Unité anti-Persona\ndu Dernier Bataillon, 13 chevaliers pilotantles Marionette Jaeger [NULL][NULL]Himmel Feurer.[NULL][NULL][E4][NULL][NULL]"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Longinus[SP]#11",
     "texte_orig": "Hmph.[SP]We[SP]have[SP]vermin[SP]to[SP]deal[SP]with...[1205][001E]\nVery[SP]well.[SP]I[SP]was[SP]growing[SP]bored[SP]of[SP]dealing\nwith[SP]weaklings.",
     "nom_fr": "Longinus #11",
-    "texte_fr": "Hmph. On a de la\nvermine à gérer...[1205][001E] Très bien.\nJe commençais à\nm'ennuyer avec les faiblards."
+    "texte_fr": "Hmph. On a de la\nvermine à gérer...[001E][1205] Très bien.\nJe commençais à\nm'ennuyer avec les faiblards."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Longinus[SP]#11",
     "texte_orig": "Let's[SP]have[SP]them[SP]show[SP]us[SP]what[SP]strength[SP]the\nPersona-users[SP]of[SP]this[SP]country[SP]hold...[1205][001E]\nZwolf![SP]Dreizehn![SP]To[SP]me!",
     "nom_fr": "Longinus #11",
-    "texte_fr": "Qu'ils nous montrent la\nforce des manieurs de\nPersona de ce pays...[1205][001E]\nZwölf! Dreizehn! À moi!"
+    "texte_fr": "Qu'ils nous montrent la\nforce des manieurs de\nPersona de ce pays...[001E][1205]\nZwölf! Dreizehn! À moi!"
   },
   {
     "id": 7,
@@ -147,7 +147,7 @@
     "nom_orig": "Longinus[SP]#11",
     "texte_orig": "I[SP]expect[SP]to[SP]face[SP]skilled[SP]warriors,[SP]and[SP]yet\nI[SP]see[SP]women[SP]and[SP]children...[1205][001E][SP]How[SP]unfortunate\nthat[SP]you[SP]found[SP]the[SP]Order[SP]of[SP]the[SP]Holy[SP]Lance!",
     "nom_fr": "Longinus #11",
-    "texte_fr": "J'espérais de vrais guerriers, pas des\nfemmes et enfants...[1205][001E] Malheur à vous\nd'avoir trouvé l'Ordre de la Sainte Lance!"
+    "texte_fr": "J'espérais de vrais guerriers, pas des\nfemmes et enfants...[001E][1205] Malheur à vous\nd'avoir trouvé l'Ordre de la Sainte Lance!"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "We're[SP]surrounded...![1205][001E][SP]Form[SP]groups[SP]of[SP]two[SP]to\ntake[SP]them[SP]out![SP]The[SP]third[SP]one's[SP]mine!",
     "nom_fr": "Yukino",
-    "texte_fr": "On est cernés...![1205][001E] Mettez-vous par\ndeux! Le troisième est pour moi!"
+    "texte_fr": "On est cernés...![001E][1205] Mettez-vous par\ndeux! Le troisième est pour moi!"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What[SP]kind[SP]of[SP]a[SP]gentleman[SP]would[SP]I[SP]be[SP]if[SP]I[SP]let\na[SP]lady[SP]do[SP]the[SP]hard[SP]work!?[SP]Leave[SP]the[SP]solo\nto[SP]the[SP]great[SP]Michel!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Quel gentleman laisserait une dame s'en\ncharger!? Laisse le\ngrand Michel s'occuper du\nsolo!"
+    "texte_fr": "Quel gentleman laisserait une dame s'en\ncharger!? Laisse le\ngrand Michel s'occuper du solo!"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Leave[SP]the[SP]solo[SP]to[SP]the[SP]great[SP]Michel!\n[1208][0005][1432][NULL][NULL][0014]I'll[SP]go[SP]it[SP]alone.[1432][NULL][NULL][0014]\nTeam[SP]up[SP]with[SP]Maya\nTeam[SP]up[SP]with[SP]Ginko\nTeam[SP]up[SP]with[SP]Eikichi\nTeam[SP]up[SP]with[SP]Yukino",
     "nom_fr": "",
-    "texte_fr": "Mon Papa...[1205][001E] Il est...[1205][001E]\nC'est pas un bon à rien !",
+    "texte_fr": "Mon Papa...[001E][1205] Il est...[001E][1205]\nC'est pas un bon à rien !",
     "question_orig": "Leave[SP]the[SP]solo[SP]to[SP]the[SP]great[SP]Michel!",
     "choix_orig": [
       "[0005]",

--- a/traduction/event_scripts/script_124.json
+++ b/traduction/event_scripts/script_124.json
@@ -12,7 +12,7 @@
     "nom_orig": "Fujii's[SP]voice",
     "texte_orig": "Yo...[1205][001E][SP]Wh-What's[SP]with[SP]the[SP]long[SP]face...?[1205][001E]\nDoesn't[SP]suit...[SP]a[SP]pretty[SP]girl[SP]like[SP]you...",
     "nom_fr": "Voix de Fujii",
-    "texte_fr": "Yo...[1205][001E] P-Pourquoi cette tête...?[1205][001E] Ça ne va\npas... à une jolie fille comme toi..."
+    "texte_fr": "Yo...[001E][1205] P-Pourquoi cette tête...?[001E][1205] Ça ne va\npas... à une jolie fille comme toi..."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Fujii",
     "texte_orig": "I[SP]made...[SP]a[SP]little[SP]error[SP]in[SP]judgement,[SP]but...[1205][001E]\nI[SP]got[SP]the[SP]battle...[1205][001E][SP]all[SP]captured[SP]on[SP]film...",
     "nom_fr": "Fujii",
-    "texte_fr": "Petite... erreur de jugement...[1205][001E]\nMais j'ai tout...[1205][001E] tout filmé..."
+    "texte_fr": "Petite... erreur de jugement...[001E][1205]\nMais j'ai tout...[001E][1205] tout filmé..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Why...[1205][001E][SP]Why[SP]did[SP]you...!?",
     "nom_fr": "Yukino",
-    "texte_fr": "Pourquoi...[1205][001E] Pourquoi!?"
+    "texte_fr": "Pourquoi...[001E][1205] Pourquoi!?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Fujii",
     "texte_orig": "Our[SP]job...[SP]is[SP]to[SP]show[SP]people...[1205][001E][SP]the[SP]bright...\nand[SP]the[SP]dirty[SP]things...[SP]without[SP]covering[SP]any\nof[SP]it[SP]up...[1205][001E][SP]Right,[SP]Makki...?",
     "nom_fr": "Fujii",
-    "texte_fr": "Notre métier... c'est de montrer...[1205][001E] la\nbeauté... et la laideur... sans rien\ndissimuler...[1205][001E] Pas vrai, Makki...?"
+    "texte_fr": "Notre métier... c'est de montrer...[001E][1205] la\nbeauté... et la laideur... sans rien\ndissimuler...[001E][1205] Pas vrai, Makki...?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Fujii",
     "texte_orig": "That's[SP]why...[1205][001E][SP]It's[SP]because...[SP]that's...\nwhat[SP]makes[SP]us[SP]proud...",
     "nom_fr": "Fujii",
-    "texte_fr": "C'est pour ça...[1205][001E] Car c'est...\nnotre grande fierté..."
+    "texte_fr": "C'est pour ça...[001E][1205] Car c'est...\nnotre grande fierté..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Fujii",
     "texte_orig": "Did[SP]you...[1205][001E][SP]get[SP]my[SP]camera?[SP]From[SP]the\nhead[SP]monk...?",
     "nom_fr": "Fujii",
-    "texte_fr": "As-tu...[1205][001E] reçu mon appareil? Du maître...?"
+    "texte_fr": "As-tu...[001E][1205] reçu mon appareil? Du maître...?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Yeah...[1205][001E][SP]See?[SP]I[SP]have[SP]it[SP]right[SP]here...",
     "nom_fr": "Yukino",
-    "texte_fr": "Oui...[1205][001E] Tu vois? Je l'ai juste ici..."
+    "texte_fr": "Oui...[001E][1205] Tu vois? Je l'ai juste ici..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Fujii",
     "texte_orig": "So[SP]you[SP]do...[1205][001E][SP]*cough*[1205][001E][SP]*wheeze*",
     "nom_fr": "Fujii",
-    "texte_fr": "Bien...[1205][001E] *tousse*[1205][001E] *halète*"
+    "texte_fr": "Bien...[001E][1205] *tousse*[001E][1205] *halète*"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Fujii",
     "texte_orig": "How[SP]many[SP]times...[SP]have[SP]I[SP]come[SP]here...[1205][001E][SP]snapping\npics...[SP]while[SP]wondering...[SP]if[SP]I[SP]could[SP]capture\nthose[SP]stars?[1205][001E][SP]Yukki...[1205][001E][SP]capture...[1205][001E][SP]your[SP]star...",
     "nom_fr": "Fujii",
-    "texte_fr": "Tant de fois... venu ici...[1205][001E] prendre des\nphotos... espérant... capturer ces\nétoiles?[1205][001E] Yukki...[1205][001E] capture...[1205][001E] ton étoile..."
+    "texte_fr": "Tant de fois... venu ici...[001E][1205] prendre des\nphotos... espérant... capturer ces\nétoiles?[001E][1205] Yukki...[001E][1205] capture...[001E][1205] ton étoile..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yukki...[1205][001E][SP]We...[SP]don't[SP]have[SP]much[SP]time...",
     "nom_fr": "Maya",
-    "texte_fr": "Yukki...[1205][001E] On a... peu de temps..."
+    "texte_fr": "Yukki...[001E][1205] On a... peu de temps..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I'm[SP]NOT[SP]leaving[SP]him![1205][001E][SP]I'm...[SP]staying[SP]here...\nI...[SP]I[SP]can't[SP]fight[SP]anymore...[1205][001E][SP]I[SP]don't[SP]want\nto[SP]fight...!",
     "nom_fr": "Yukino",
-    "texte_fr": "Je le quitte PAS![1205][001E] Je reste là... Je ne peux\nplus lutter...[1205][001E] Je refuse de me battre...!"
+    "texte_fr": "Je le quitte PAS![001E][1205] Je reste là... Je ne peux\nplus lutter...[001E][1205] Je refuse de me battre...!"
   },
   {
     "id": 12,
@@ -218,7 +218,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "That's...![SP]Chinyan...[1205][001E][SP]You're[SP]being[SP]too\nhard[SP]on[SP]her...",
     "nom_fr": "Ginko",
-    "texte_fr": "Mais...! Chinyan...[1205][001E] Tu\nes trop dur avec elle..."
+    "texte_fr": "Mais...! Chinyan...[001E][1205] Tu\nes trop dur avec elle..."
   },
   {
     "id": 14,
@@ -233,7 +233,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun's[SP]right...[1205][001E][SP]Fujii-san[SP]wanted[SP]you\nto[SP]achieve[SP]your[SP]dream,[SP]Yukki...",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]a raison...[1205][001E] Fujii voulait\nque tu atteignes ton rêve, Yukki..."
+    "texte_fr": "[1113]a raison...[001E][1205] Fujii voulait\nque tu atteignes ton rêve, Yukki..."
   },
   {
     "id": 15,
@@ -248,7 +248,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]world[SP]is[SP]on[SP]the[SP]verge[SP]of[SP]being[SP]swallowed\nby[SP]rumors.[1205][001E][SP]If[SP]that[SP]happens,[SP]Fujii-san's[SP]last\nwish[SP]and[SP]your[SP]dream[SP]will[SP]never[SP]come[SP]true...",
     "nom_fr": "Maya",
-    "texte_fr": "Les rumeurs vont engloutir le monde.[1205][001E]\nSi ça arrive, le souhait de Fujii et\nton rêve ne se réaliseront jamais..."
+    "texte_fr": "Les rumeurs vont engloutir le monde.[001E][1205]\nSi ça arrive, le souhait de Fujii et\nton rêve ne se réaliseront jamais..."
   },
   {
     "id": 16,
@@ -263,7 +263,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Let's[SP]go...[1205][001E][SP]There's...[SP]still[SP]something[SP]I[SP]need\nto[SP]do.[1205][001E][SP]I[SP]haven't[SP]kept[SP]my[SP]promise[SP]to[SP]save\nAnna[SP]yet...",
     "nom_fr": "Yukino",
-    "texte_fr": "Allons-y...[1205][001E] Je dois...\nfaire encore une chose.[1205][001E]\nJe n'ai pas tenue\nma promesse envers Anna..."
+    "texte_fr": "Allons-y...[001E][1205] Je dois...\nfaire encore une chose.[001E][1205]\nJe n'ai pas tenue\nma promesse envers Anna..."
   },
   {
     "id": 17,
@@ -278,7 +278,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "Strong[SP]emotions[SP]and[SP]warm[SP]feelings[SP]are[SP]passed\nfrom[SP]person[SP]to[SP]person...[1205][001E][SP]That[SP]camera[SP]is[SP]your\nlover's[SP]heart[SP]and[SP]soul...",
     "nom_fr": "Philémon",
-    "texte_fr": "Émotions et chaleur se transmettent...[1205][001E]\nCet appareil est l'âme de votre amant..."
+    "texte_fr": "Émotions et chaleur se transmettent...[001E][1205]\nCet appareil est l'âme de votre amant..."
   },
   {
     "id": 18,
@@ -308,7 +308,7 @@
     "nom_orig": "Durga",
     "texte_orig": "I[SP]am[SP][E4][NULL][NULL][0005]Durga[E4][NULL][NULL][0002].[1205][001E][SP]My[SP]duty[SP]is[SP]to[SP]rend[SP]asunder[SP]the\nevil[SP]that[SP]threatens[SP]the[SP]world...[1205][001E][SP]Know[SP]that\nyour[SP]destiny[SP]is[SP]nothing[SP]less[SP]than[SP]this.",
     "nom_fr": "Durga",
-    "texte_fr": "Je suis [E4][NULL][NULL][0005]Durga[E4][NULL][NULL][0002].[1205][001E] Mon devoir est de\npourfendre le mal qui menace ce monde...[1205][001E]\nSache que ton destin n'est rien de moinsque\ncela.  Le stock de Personae est\nplein. Veuillez libérer un emplacement.[E4][NULL][NULL]"
+    "texte_fr": "Je suis [E4][NULL][NULL][0005]Durga[E4][NULL][NULL][0002].[001E][1205] Mon devoir est de\npourfendre le mal qui menace ce monde...[001E][1205]\nSache que ton destin n'est rien de moinsque\ncela.  Le stock de Personae est plein. Veuillez libérer un emplacement.[E4][NULL][NULL]"
   },
   {
     "id": 20,
@@ -323,7 +323,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Huh...[1205][001E][SP]Thanks,[SP]Philemon.[1205][001E][SP]C'mon,[SP]let's[SP]go...",
     "nom_fr": "Yukino",
-    "texte_fr": "Hein...[1205][001E] Merci, Philémon.[1205][001E] Allez, on y va..."
+    "texte_fr": "Hein...[001E][1205] Merci, Philémon.[001E][1205] Allez, on y va..."
   },
   {
     "id": 21,
@@ -338,7 +338,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yeah...[1205][001E][SP]Yukki?[1205][001E][SP]We'll[SP]come[SP]back[SP]for[SP]you[SP]later,\nso[SP]wait[SP]for[SP]us[SP]here...",
     "nom_fr": "Maya",
-    "texte_fr": "Oui...[1205][001E] Yukki?[1205][001E] On reviendra\nte chercher, attends-nous..."
+    "texte_fr": "Oui...[001E][1205] Yukki?[001E][1205] On reviendra\nte chercher, attends-nous..."
   },
   {
     "id": 22,
@@ -353,7 +353,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Come[SP]on,[SP]guys...[1205][001E][SP]Let's[SP]go...",
     "nom_fr": "Maya",
-    "texte_fr": "Allez...[1205][001E] On y va..."
+    "texte_fr": "Allez...[001E][1205] On y va..."
   },
   {
     "id": 23,
@@ -368,7 +368,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Holeen...[1205][001E][SP]Poor[SP]Yukino-san...",
     "nom_fr": "Ginko",
-    "texte_fr": "Ho lian...[1205][001E] Pauvre Yukino..."
+    "texte_fr": "Ho lian...[001E][1205] Pauvre Yukino..."
   },
   {
     "id": 24,
@@ -383,7 +383,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]know[SP]it's[SP]not[SP]Fujii-san's[SP]fault,[SP]but...[1205][001E]\nThis[SP]is[SP]just...![1205][001E][SP]It's[SP]not[SP]fair[SP]to[SP]the[SP]ones\nwho[SP]get[SP]left[SP]behind...!",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est pas la faute de Fujii, mais...[1205][001E]\nC'est juste...![1205][001E] C'est injuste pour\nceux qui restent derrière...!"
+    "texte_fr": "C'est pas la faute de Fujii, mais...[001E][1205]\nC'est juste...![001E][1205] C'est injuste pour\nceux qui restent derrière...!"
   },
   {
     "id": 25,
@@ -398,7 +398,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Someone[SP]who's[SP]so[SP]passionate[SP]about[SP]a[SP]dream\nthey'd[SP]die[SP]for[SP]it...[1205][001E][SP]You[SP]can't[SP]stop[SP]people\nlike[SP]that.[1205][001E][SP]I[SP]know[SP]you[SP]can't,[SP]but...",
     "nom_fr": "Maya",
-    "texte_fr": "Quelqu'un prêt à mourir pour son\nrêve...[1205][001E] On ne peut pas l'en\nempêcher.[1205][001E] Je le sais bien, mais..."
+    "texte_fr": "Quelqu'un prêt à mourir pour son\nrêve...[001E][1205] On ne peut pas l'en\nempêcher.[001E][1205] Je le sais bien, mais..."
   },
   {
     "id": 26,
@@ -413,7 +413,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]is[SP]too[SP]horrible...[SP]I[SP]feel[SP]so[SP]bad[SP]for\nYukki.[1205][001E][SP]Things[SP]like[SP]this[SP]are[SP]just...[1205][001E][SP]Dad...",
     "nom_fr": "Maya",
-    "texte_fr": "C'est trop horrible... Pauvre Yukki.[1205][001E]\nDe telles choses sont...[1205][001E] Papa..."
+    "texte_fr": "C'est trop horrible... Pauvre Yukki.[001E][1205]\nDe telles choses sont...[001E][1205] Papa..."
   },
   {
     "id": 27,
@@ -428,7 +428,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Look,[SP][1114]...[1205][001E][SP]You[SP]can[SP]see[SP]the[SP]pride[SP]on\nthe[SP]guy's[SP]face.[1205][001E][SP]I[SP]hope[SP]one[SP]day[SP]I[SP]can[SP]find[SP]it\nin[SP]me[SP]to[SP]smile[SP]like[SP]that...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Regarde, [1114]...[1205][001E] Tu peux voir la fierté\nsur son visage.[1205][001E] J'espère qu'un jour\nje pourrai sourire comme ça..."
+    "texte_fr": "Regarde, [1114]...[001E][1205] Tu peux voir la fierté\nsur son visage.[001E][1205] J'espère qu'un jour\nje pourrai sourire comme ça..."
   },
   {
     "id": 28,
@@ -443,7 +443,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Why...[SP]Why!?[1205][001E][SP]I[SP]still[SP]hadn't...[1205][001E][SP]I[SP]never[SP]got\nto[SP]tell[SP]him...[SP]that[SP]I[SP]liked[SP]him...[SP]that[SP]I\nloved[SP]him...!",
     "nom_fr": "Yukino",
-    "texte_fr": "Pourquoi... Pourquoi!?[1205][001E] J'ai jamais\npu...[1205][001E] lui dire... que je l'aimais...\nque je l'aimais tant...!"
+    "texte_fr": "Pourquoi... Pourquoi!?[001E][1205] J'ai jamais\npu...[001E][1205] lui dire... que je l'aimais...\nque je l'aimais tant...!"
   },
   {
     "id": 29,
@@ -458,7 +458,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Shunsuke-san...[1205][001E][SP]It[SP]wasn't[SP]a[SP]mistake...[1205][001E]\nfalling[SP]in[SP]love[SP]with[SP]you,[SP]right...?",
     "nom_fr": "Yukino",
-    "texte_fr": "Shunsuke...[1205][001E] Ce n'était pas une\nerreur...[1205][001E] de t'aimer, pas vrai...?"
+    "texte_fr": "Shunsuke...[001E][1205] Ce n'était pas une\nerreur...[001E][1205] de t'aimer, pas vrai...?"
   },
   {
     "id": 30,
@@ -473,7 +473,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]know[SP]it's[SP]cold[SP]here...[1205][001E][SP]But[SP]wait[SP]for[SP]me...[1205][001E]\nI'll[SP]be[SP]back[SP]for[SP]you[SP]real[SP]soon...",
     "nom_fr": "Yukino",
-    "texte_fr": "Il fait froid ici...[1205][001E] Mais attends-moi...[1205][001E] Je\nreviendrai vite te chercher...\n Le corps de\nFujii. Son visage est paisible et fier. Le\nvisage d'un homme\nayant accompli ses rêves..."
+    "texte_fr": "Il fait froid ici...[001E][1205] Mais attends-moi...[001E][1205] Je\nreviendrai vite te chercher...\nLe corps de Fujii. Son visage est paisible et fier. Le visage d'un homme ayant accompli ses rêves..."
   },
   {
     "id": 31,
@@ -488,6 +488,6 @@
     "nom_orig": "Maya",
     "texte_orig": "Where[SP]are[SP]you[SP]going,[SP][1113]-kun?[1205][001E]\nThere's[SP]nothing[SP]we[SP]need[SP]to[SP]do[SP]down[SP]there...",
     "nom_fr": "",
-    "texte_fr": "Je suppose que c'est inévitable...[1205][001E]\nOn va devoir affronter cet homme bientôt,\naprès tout..."
+    "texte_fr": "Je suppose que c'est inévitable...[001E][1205]\nOn va devoir affronter cet homme bientôt,\naprès tout..."
   }
 ]

--- a/traduction/event_scripts/script_128.json
+++ b/traduction/event_scripts/script_128.json
@@ -12,7 +12,7 @@
     "nom_orig": "Longinus[SP]#8",
     "texte_orig": "Is[SP]that[SP]all?[SP]What[SP]a[SP]waste...[1205][001E][SP]Is[SP]this[SP]the\nextent[SP]of[SP]your[SP]hunger[SP]for[SP]destruction?",
     "nom_fr": "Longinus #8",
-    "texte_fr": "C'est tout? Quel gâchis...[1205][001E] Est-ce là\nl'étendue de ta soif de destruction?"
+    "texte_fr": "C'est tout? Quel gâchis...[001E][1205] Est-ce là\nl'étendue de ta soif de destruction?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Anna",
     "texte_orig": "Ngh...[1205][001E][SP]How[SP]do[SP]you[SP]know[SP]about[SP]that...?",
     "nom_fr": "Anna",
-    "texte_fr": "Argh...[1205][001E] Comment savez-vous cela...?"
+    "texte_fr": "Argh...[001E][1205] Comment savez-vous cela...?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Longinus[SP]#9",
     "texte_orig": "There[SP]is[SP]nothing[SP]we[SP]do[SP]not[SP]know.[1205][001E][SP]Hahaha...\nAfter[SP]so[SP]long,[SP]you[SP]cling[SP]to[SP]life[SP]now?[1205][001E][SP]Even[SP]a\nnothing[SP]like[SP]you[SP]can't[SP]abandon[SP]your[SP]dreams...",
     "nom_fr": "Longinus #9",
-    "texte_fr": "Nous savons tout.[1205][001E] Ahaha... Après tout ce\ntemps, tu tiens à la vie à présent?[1205][001E] Même un\nrien comme toi ne\npeut abandonner ses rêves..."
+    "texte_fr": "Nous savons tout.[001E][1205] Ahaha... Après tout ce\ntemps, tu tiens à la vie à présent?[001E][1205] Même un\nrien comme toi ne\npeut abandonner ses rêves..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Longinus[SP]#10",
     "texte_orig": "You[SP]still[SP]have[SP]attachments.[SP]We[SP]have[SP]no[SP]need\nof[SP]a[SP]broken[SP]marionette.[1205][001E][SP]Auf[SP]Wiedersehen...[1205][001E]\nReturn[SP]to[SP]the[SP]abyss[SP]of[SP]unconsciousness.",
     "nom_fr": "Longinus #10",
-    "texte_fr": "Tu as encore des attaches. On n'a\nque faire d'un pantin brisé.[1205][001E] Auf\nWiedersehen...[1205][001E] Retourne au néant."
+    "texte_fr": "Tu as encore des attaches. On n'a\nque faire d'un pantin brisé.[001E][1205] Auf\nWiedersehen...[001E][1205] Retourne au néant."
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Right[SP]now...[1205][001E][SP]we're[SP]this[SP]close[SP]to[SP]bursting\nsome[SP]blood[SP]vessels...[1205][001E][SP]I[SP]ain't[SP]gonna[SP]tell[SP]you\nto[SP]get[SP]lost![SP]Come[SP]get[SP]us!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Là, tout de suite...[1205][001E]\non va péter un câble...[1205][001E]\nJe vous dirai pas de dégager! Amenez-vous!"
+    "texte_fr": "Là, tout de suite...[001E][1205]\non va péter un câble...[001E][1205]\nJe vous dirai pas de dégager! Amenez-vous!"
   },
   {
     "id": 6,

--- a/traduction/event_scripts/script_129.json
+++ b/traduction/event_scripts/script_129.json
@@ -12,7 +12,7 @@
     "nom_orig": "Anna",
     "texte_orig": "You[SP]really[SP]are[SP]a[SP]handful...[1205][001E][SP]What[SP]do[SP]you[SP]care\nabout[SP]me[SP]anyway...?",
     "nom_fr": "Anna",
-    "texte_fr": "T'es compliquée...[1205][001E] Pourquoi te\nsoucier de moi, d'ailleurs...?"
+    "texte_fr": "T'es compliquée...[001E][1205] Pourquoi te\nsoucier de moi, d'ailleurs...?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Because[SP]you[SP]remind[SP]me[SP]of[SP]how[SP]I[SP]was[SP]once.[1205][001E][SP]I[SP]had\nno[SP]idea[SP]what[SP]I[SP]wanted[SP]or[SP]why[SP]I[SP]should[SP]go[SP]on\nliving.[SP]I[SP]wished[SP]everything[SP]would[SP]disappear.",
     "nom_fr": "Yukino",
-    "texte_fr": "Car tu me rappelles comment j'étais.[1205][001E]\nJ'ignorais ce que je voulais et pourquoi\nvivre. Je voulais que tout disparaisse."
+    "texte_fr": "Car tu me rappelles comment j'étais.[001E][1205]\nJ'ignorais ce que je voulais et pourquoi\nvivre. Je voulais que tout disparaisse."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]was[SP]being[SP]a[SP]baby.[1205][001E][SP]You[SP]can't[SP]figure[SP]stuff\nlike[SP]that[SP]out[SP]when[SP]you[SP]want[SP]it[SP]too[SP]bad.[1205][001E]\nYou[SP]have[SP]to[SP]calm[SP]down[SP]and[SP]take[SP]your[SP]time...",
     "nom_fr": "Yukino",
-    "texte_fr": "J'étais un bébé.[1205][001E] Tu ne peux pas résoudre\nça quand tu le veux trop fort.[1205][001E] Il faut\nse calmer et prendre son temps..."
+    "texte_fr": "J'étais un bébé.[001E][1205] Tu ne peux pas résoudre\nça quand tu le veux trop fort.[001E][1205] Il faut\nse calmer et prendre son temps..."
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Yukino's[SP]voice",
     "texte_orig": "Ugh,[SP]what[SP]a[SP]load[SP]of[SP]shit.[1205][001E][SP]Like[SP]you're[SP]not\nstill[SP]agonizing[SP]over[SP]whether[SP]or[SP]not[SP]you[SP]took\nthe[SP]wrong[SP]path.\n[E1][E2]\n[E3][E4][NULL][NULL]\"Shadow[SP]Yukino\nYou[SP]had[SP]two[SP]dreams,[SP]didn't[SP]you?[1205][001E][SP]One[SP]was[SP]to[SP]be\na[SP]photographer[SP]like[SP]you[SP]are[SP]now.[1205][001E][SP]The[SP]other[SP]was\nto[SP]be[SP]a[SP]teacher[SP]like[SP]your[SP]dear[SP]Ms.[SP]Saeko...",
     "nom_fr": "Voix de Yukino",
-    "texte_fr": "Ugh, quelles conneries.[1205][001E] Comme si tu ne\ncraignais pas d'avoir pris\nle mauvais chemin. [E1][E2]\n[E3][E4][NULL][NULL]\"Ombre de Yukino\nTu avais deux rêves, non?[1205][001E]\nL'un était d'être photographe comme\naujourd'hui.[1205][001E] L'autre, être prof\ncomme ta chèreMme Saeko..."
+    "texte_fr": "Ugh, quelles conneries.[001E][1205] Comme si tu ne\ncraignais pas d'avoir pris\nle mauvais chemin. [E1][E2]\n[E3][E4][NULL][NULL]\"Ombre de Yukino\nTu avais deux rêves, non?[001E][1205]\nL'un était d'être photographe comme\naujourd'hui.[001E][1205] L'autre, être prof\ncomme ta chèreMme Saeko..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Shadow[SP]Yukino",
     "texte_orig": "But[SP]you[SP]didn't[SP]have[SP]the[SP]brains[SP]to[SP]teach[SP]and[SP]you\ndon't[SP]have[SP]the[SP]eye[SP]to[SP]be[SP]a[SP]photographer.[SP]You're\nin[SP]hell,[SP]caught[SP]between[SP]ideals[SP]and[SP]reality.\n[E1][E2]\n[E3][E4][NULL][NULL]\"Shadow[SP]Yukino\nSo[SP]tell[SP]the[SP]girl[SP]here...[1205][001E][SP]That[SP]it's[SP]easier[SP]to\ntake[SP]it[SP]out[SP]on[SP]everyone,[SP]like[SP]you[SP]used[SP]to.[1205][001E]\nThat[SP]it's[SP]easier[SP]to[SP]sleep[SP]around.\n[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nYou[SP]bastard...[1205][001E][SP]You're[SP]just[SP]a[SP]frickin'[SP]fake--",
     "nom_fr": "Ombre de Yukino",
-    "texte_fr": "Tu n'as ni le\ncerveau pour enseigner, ni l'œil\npour la photo. Tu es en enfer, prise entre\nidéaux et réalité. [E1][E2] [E3][E4][NULL][NULL]\"Ombre de Yukino\n Alors dis\nà la fille ici...[1205][001E] Qu'il est plus facile\ndes'en prendre à tout le monde, comme avant.[1205][001E]\nQu'il est plus facile de coucher partout.[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi Enfoirée...\n[1205][001E] Tu n'es qu'une foutue\nimposteu--"
+    "texte_fr": "Tu n'as ni le\ncerveau pour enseigner, ni l'œil\npour la photo. Tu es en enfer, prise entre\nidéaux et réalité. [E1][E2] [E3][E4][NULL][NULL]\"Ombre de Yukino\n Alors dis\nà la fille ici...[001E][1205] Qu'il est plus facile\ndes'en prendre à tout le monde, comme avant.[001E][1205]\nQu'il est plus facile de coucher partout.[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi Enfoirée...\n[001E][1205] Tu n'es qu'une foutue\nimposteu--"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Sure...[1205][001E][SP]I[SP]had[SP]a[SP]nasty[SP]side[SP]lurking[SP]in[SP]me.[1205][001E]\nThat's[SP]why[SP]I[SP]tried[SP]to[SP]lean[SP]on[SP]Shunsuke-san...",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est vrai...[1205][001E] Un côté vil rôdait en moi.[1205][001E]\nAlors je m'appuyais sur Shunsuke..."
+    "texte_fr": "C'est vrai...[001E][1205] Un côté vil rôdait en moi.[001E][1205]\nAlors je m'appuyais sur Shunsuke..."
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Shunsuke-san...[SP]All[SP]my[SP]friends[SP]taught[SP]me[SP]that.[1205][001E]\nI[SP]can[SP]accept[SP]myself[SP]for[SP]what[SP]I[SP]am[SP]now...[1205][001E][SP]If[SP]I\ncouldn't,[SP]I'd[SP]never[SP]be[SP]able[SP]to[SP]follow[SP]my[SP]dream.",
     "nom_fr": "Yukino",
-    "texte_fr": "Shunsuke... Tous mes amis\nme l'ont appris.[1205][001E] Je\npeux m'accepter telle que je suis...[1205][001E] Sinon,\nje ne pourrais jamais poursuivre mon rêve."
+    "texte_fr": "Shunsuke... Tous mes amis\nme l'ont appris.[001E][1205] Je\npeux m'accepter telle que je suis...[001E][1205] Sinon,\nje ne pourrais jamais poursuivre mon rêve."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Shadow[SP]Yukino",
     "texte_orig": "Tch...![1205][001E][SP]You're[SP]pissing[SP]me[SP]off![SP]This[SP]world\ndoesn't[SP]need[SP]two[SP]of[SP]me!",
     "nom_fr": "Ombre de Yukino",
-    "texte_fr": "Tch...![1205][001E] Tu m'énerves! Le monde\nn'a pas besoin de deux moi!"
+    "texte_fr": "Tch...![001E][1205] Tu m'énerves! Le monde\nn'a pas besoin de deux moi!"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "[1113],[SP]get[SP]going[SP]already![SP]You[SP]had[SP]something\nto[SP]take[SP]care[SP]of[SP]too,[SP]right?[1205][001E][SP]Make[SP]sure[SP]you\nsnap[SP]Jun[SP]out[SP]of[SP]it!",
     "nom_fr": "Yukino",
-    "texte_fr": "[1113], allez-y vite! Tu avais\naussi un truc à régler, non?[1205][001E] Fais en\nsorte de ramener Jun à la raison!"
+    "texte_fr": "[1113], allez-y vite! Tu avais\naussi un truc à régler, non?[001E][1205] Fais en\nsorte de ramener Jun à la raison!"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yukki...[1205][001E][SP]C'mon,[SP]everyone!",
     "nom_fr": "Maya",
-    "texte_fr": "Yukki...[1205][001E] Venez, tous!"
+    "texte_fr": "Yukki...[001E][1205] Venez, tous!"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Anna",
     "texte_orig": "You're[SP]so...[1205][001E][SP]so[SP]confident[SP]that[SP]you[SP]must[SP]be\nan[SP]idiot.[1205][001E][SP]But[SP]I[SP]like[SP]seeing[SP]you[SP]like[SP]that...",
     "nom_fr": "Anna",
-    "texte_fr": "Tu es si...[1205][001E] si confiante que tu dois être\nidiote.[1205][001E] Mais j'aime te voir comme ça..."
+    "texte_fr": "Tu es si...[001E][1205] si confiante que tu dois être\nidiote.[001E][1205] Mais j'aime te voir comme ça..."
   },
   {
     "id": 13,

--- a/traduction/event_scripts/script_130.json
+++ b/traduction/event_scripts/script_130.json
@@ -12,7 +12,7 @@
     "nom_orig": "Shadow[SP]Yukino",
     "texte_orig": "Look,[SP]Anna...[1205][001E][SP]More[SP]toys.",
     "nom_fr": "Ombre de Yukino",
-    "texte_fr": "Anna...[1205][001E] Des jouets!"
+    "texte_fr": "Anna...[001E][1205] Des jouets!"
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Shadow[SP]Yukino",
     "texte_orig": "Doesn't[SP]it[SP]hurt[SP]when[SP]your[SP]dreams[SP]are[SP]shattered?[1205][001E]\nWhen[SP]you[SP]don't[SP]know[SP]what[SP]you're[SP]living[SP]for?[1205][001E]\nThen[SP]all[SP]you[SP]have[SP]to[SP]do[SP]is[SP]destroy[SP]everything.",
     "nom_fr": "Ombre de Yukino",
-    "texte_fr": "Ça fait mal quand tes rêves sont brisés,\nnon?[1205][001E] Quand tu ne sais plus pourquoi tu\nvis?[1205][001E] Alors tu n'as qu'à tout détruire."
+    "texte_fr": "Ça fait mal quand tes rêves sont brisés,\nnon?[001E][1205] Quand tu ne sais plus pourquoi tu\nvis?[001E][1205] Alors tu n'as qu'à tout détruire."
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Shadow[SP]Yukino",
     "texte_orig": "I[SP]am[SP]the[SP]real[SP]Yukino,[SP]idiot.[1205][001E][SP]And[SP]reaching[SP]for\na[SP]star[SP]that's[SP]forever[SP]out[SP]of[SP]your[SP]grasp[SP]is\njust[SP]painful.",
     "nom_fr": "Ombre de Yukino",
-    "texte_fr": "Je suis la vraie Yukino, idiote.[1205][001E]\nViser une étoile à jamais hors de\nportée, c'est juste douloureux."
+    "texte_fr": "Je suis la vraie Yukino, idiote.[001E][1205]\nViser une étoile à jamais hors de\nportée, c'est juste douloureux."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Shadow[SP]Yukino",
     "texte_orig": "I'm[SP]not[SP]going[SP]to[SP]live[SP]like[SP]Fujii[SP]did.[1205][001E]\nI'll[SP]have[SP]all[SP]the[SP]fun[SP]I[SP]want,[SP]and[SP]damn[SP]the\nconsequences!",
     "nom_fr": "Ombre de Yukino",
-    "texte_fr": "Je ne vivrai pas comme Fujii.[1205][001E] Je\nm'amuserai, au diable les conséquences!"
+    "texte_fr": "Je ne vivrai pas comme Fujii.[001E][1205] Je\nm'amuserai, au diable les conséquences!"
   },
   {
     "id": 6,
@@ -147,6 +147,6 @@
     "nom_orig": "Shadow[SP]Yukino",
     "texte_orig": "Aaaahahaha![1205][001E][SP]Jealous[SP]of[SP]my[SP]cute[SP]little[SP]doll?\nTake[SP]it[SP]from[SP]me[SP]if[SP]you[SP]can!",
     "nom_fr": "",
-    "texte_fr": "Ahahaha ![1205][001E] Tu es jaloux de ma petite\npoupée adorable ? Prends-la si tu peux !"
+    "texte_fr": "Ahahaha ![001E][1205] Tu es jaloux de ma petite\npoupée adorable ? Prends-la si tu peux !"
   }
 ]

--- a/traduction/event_scripts/script_131.json
+++ b/traduction/event_scripts/script_131.json
@@ -12,7 +12,7 @@
     "nom_orig": "Shadow[SP]Yukino",
     "texte_orig": "Heh...[1205][001E][SP]You're[SP]such[SP]idiots...[1205][001E][SP]I[SP]told[SP]you\nI'm[SP]Yukino...",
     "nom_fr": "Ombre de Yukino",
-    "texte_fr": "Ha...[1205][001E] Vous êtes idiots...[1205][001E] Je SUIS Yukino..."
+    "texte_fr": "Ha...[001E][1205] Vous êtes idiots...[001E][1205] Je SUIS Yukino..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Shadow[SP]Yukino",
     "texte_orig": "I'm[SP]taking[SP]this[SP]girl's[SP]ego[SP]to[SP]the[SP]abyss[SP]of\nthe[SP]collective[SP]unconsciousness![1205][001E][SP]Rue[SP]your[SP]own\nstupidity!",
     "nom_fr": "Ombre de Yukino",
-    "texte_fr": "Je vais plonger son égo dans l'inconscient\ncollectif![1205][001E] À vous\nd'assumer les conséquences!"
+    "texte_fr": "Je vais plonger son égo dans l'inconscient\ncollectif![001E][1205] À vous\nd'assumer les conséquences!"
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That[SP]wasn't[SP]really...[1205][001E][SP]the[SP]real[SP]Yukino-san,\nwas[SP]it...?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ce n'était pas...[1205][001E] la vraie Yukino, hein...?"
+    "texte_fr": "Ce n'était pas...[001E][1205] la vraie Yukino, hein...?"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]do[SP]have[SP]a[SP]really[SP]bad[SP]feeling[SP]about[SP]this...[1205][001E]\nBut[SP]we[SP]need[SP]to[SP]hurry[SP]on[SP]ahead[SP]for[SP]now.",
     "nom_fr": "Maya",
-    "texte_fr": "J'ai un mauvais pressentiment...[1205][001E]\nDépechôns-nous maintenant."
+    "texte_fr": "J'ai un mauvais pressentiment...[001E][1205]\nDépechôns-nous maintenant."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "But[SP]Eikichi...[1205][001E][SP]We[SP]didn't[SP]save[SP]Anna...[1205][001E]\nYukino-san's[SP]going[SP]to[SP]be[SP]devastated...",
     "nom_fr": "Ginko",
-    "texte_fr": "Mais Eikichi...[1205][001E] On a pas sauvé\nAnna... [1205][001E] Yukino va être dévastée..."
+    "texte_fr": "Mais Eikichi...[001E][1205] On a pas sauvé\nAnna... [001E][1205] Yukino va être dévastée..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]hope...[SP]Yukki[SP]isn't...[1205][001E][SP]But[SP]then...[SP]the[SP]real\nYukki[SP]would[SP]never[SP]say[SP]those[SP]things...",
     "nom_fr": "Maya",
-    "texte_fr": "J'espère qu'elle n'est pas...[1205][001E]\nMais... Yukki ne dirait jamais ca..."
+    "texte_fr": "J'espère qu'elle n'est pas...[001E][1205]\nMais... Yukki ne dirait jamais ca..."
   },
   {
     "id": 8,
@@ -132,6 +132,6 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Y-You're[SP]right...[1205][001E][SP]The[SP]real[SP]one's[SP]outside...[1205][001E]\nThat[SP]was[SP]an[SP]impostor,[SP]like[SP]the[SP]fake[SP]Big[SP]Maya\nfrom[SP]before...",
     "nom_fr": "",
-    "texte_fr": "T-Tu as raison...[1205][001E] La vraie est dehors...[1205][001E]\nC'était une impostrice, comme la fausse\nGrande Maya de tout à l'heure..."
+    "texte_fr": "T-Tu as raison...[001E][1205] La vraie est dehors...[001E][1205]\nC'était une impostrice, comme la fausse\nGrande Maya de tout à l'heure..."
   }
 ]

--- a/traduction/event_scripts/script_133.json
+++ b/traduction/event_scripts/script_133.json
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]won't[SP]let[SP]you...[1205][001E][SP]I[SP]won't[SP]let[SP]you[SP]go!",
     "nom_fr": "Ginko",
-    "texte_fr": "Je...[1205][001E] Je ne te laisserai pas partir!"
+    "texte_fr": "Je...[001E][1205] Je ne te laisserai pas partir!"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Jun",
     "texte_orig": "We[SP]can't,[SP]guys![SP]We...[1205][001E][SP]We[SP]have[SP]to[SP]let\nBig[SP]Sis[SP]go!",
     "nom_fr": "Jun",
-    "texte_fr": "On ne peut pas! On...[1205][001E] On\ndoit la laisser partir!"
+    "texte_fr": "On ne peut pas! On...[001E][1205] On\ndoit la laisser partir!"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We're[SP]gonna...[1205][001E][SP]kill[SP]Big[SP]Sis,[SP]right?",
     "nom_fr": "Eikichi",
-    "texte_fr": "On va...[1205][001E] tuer soeurette, pas vrai?"
+    "texte_fr": "On va...[001E][1205] tuer soeurette, pas vrai?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Please[SP]let[SP]me[SP]out![1205][001E][SP]Please...[1205][001E][SP]Help[SP]me,[SP]Jun-kun!",
     "nom_fr": "Maya",
-    "texte_fr": "Pitié, laissez moi! [1205][001E]S'il-vous-plaît...[1205][001E] Jun!"
+    "texte_fr": "Pitié, laissez moi! [001E][1205]S'il-vous-plaît...[001E][1205] Jun!"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "To[SP]make[SP]sure[SP]she[SP]can't[SP]go[SP]anywhere...[1205][001E]\nWe're[SP]gonna[SP]kill[SP]Big[SP]Sis,[SP]right?",
     "nom_fr": "Ginko",
-    "texte_fr": "Pour qu'elle n'aille nulle part...[1205][001E]\nOn va tuer soeurette, pas vrai?"
+    "texte_fr": "Pour qu'elle n'aille nulle part...[001E][1205]\nOn va tuer soeurette, pas vrai?"
   },
   {
     "id": 9,

--- a/traduction/event_scripts/script_134.json
+++ b/traduction/event_scripts/script_134.json
@@ -12,7 +12,7 @@
     "nom_orig": "Jun",
     "texte_orig": "*sob*[SP]Big[SP]Sis...[1205][001E][SP]I'm[SP]sorry...[SP]I'm[SP]sorry![1205][001E]\nI...[SP]I[SP]couldn't[SP]save[SP]you...",
     "nom_fr": "Jun",
-    "texte_fr": "*Snif* Soeurette.[001E][1205]..[1205][001E] Pardon... Pardon!\nJe... n'ai pas pu te sauver..."
+    "texte_fr": "*Snif* Soeurette.[001E][1205]..[001E][1205] Pardon... Pardon!\nJe... n'ai pas pu te sauver..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "No...![1205][001E][SP]That[SP]wasn't[SP]it,[SP]Jun...[1205][001E][SP]What[SP]we[SP]just\nsaw[SP]wasn't[SP]what[SP]happened[SP]at[SP]all!",
     "nom_fr": "Ginko",
-    "texte_fr": "Non...![1205][001E] C'est faux, Jun...[1205][001E] Ce que nous\nvenons de voir n'est jamais arrivé!"
+    "texte_fr": "Non...![001E][1205] C'est faux, Jun...[001E][1205] Ce que nous\nvenons de voir n'est jamais arrivé!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That's[SP]right...[1205][001E][SP][1114][SP]tried[SP]to[SP]save\nBig[SP]Maya...[1205][001E][SP]We're[SP]to[SP]blame[SP]here![SP]You[SP]gotta\nremember!",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est vrai... [1205][001E][1114] a essayé de sauver Maya...\n[1205][001E]Ce n'était pas notre faute! Souviens toi!"
+    "texte_fr": "C'est vrai... [001E][1205][1114] a essayé de sauver Maya...\n[001E][1205]Ce n'était pas notre faute! Souviens toi!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Jun-kun![1205][001E][SP]I'm[SP]alive,[SP]see?[SP]Please,[SP]you[SP]have\nto[SP]snap[SP]out[SP]of[SP]it...",
     "nom_fr": "Maya",
-    "texte_fr": "Jun! [1205][001E]Je suis en vie, tu vois?\nS'il-te-plaît, ressaisis-toi..."
+    "texte_fr": "Jun! [001E][1205]Je suis en vie, tu vois?\nS'il-te-plaît, ressaisis-toi..."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Jun",
     "texte_orig": "That's[SP]a[SP]lie...[1205][001E][SP]There's[SP]no[SP]way[SP]you[SP]could[SP]be\nBig[SP]Sis![SP][1113][SP]killed[SP]her!",
     "nom_fr": "Jun",
-    "texte_fr": "C'est faux...[1205][001E] C'est impossible que\ntu sois soeurette![1113] l'a tuée!"
+    "texte_fr": "C'est faux...[001E][1205] C'est impossible que\ntu sois soeurette![1113] l'a tuée!"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "A[SP][E4][NULL][NULL][0006]Raspberry[SP]flower[E4][NULL][NULL][0002]...[1205][001E][SP][1432][NULL][NULL][0014]Regret[1432][NULL][NULL][0014]...[1205][001E][SP]Deep[SP]down,\nJun-kun[SP]knows[SP]all[SP]this[SP]already...",
     "nom_fr": "Maya",
-    "texte_fr": "Une [E4][NULL][NULL][0006]fleur de framboisier[E4][NULL][NULL][0002]...[1205][001E] [1432][NULL][NULL][0014]Le regret[1432][NULL][NULL][0014]...[1205][001E]\nAu fond, Jun sait déjà tout ça..."
+    "texte_fr": "Une [E4][NULL][NULL][0006]fleur de framboisier[E4][NULL][NULL][0002]...[001E][1205] [1432][NULL][NULL][0014]Le regret[1432][NULL][NULL][0014]...[001E][1205]\nAu fond, Jun sait déjà tout ça..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "But[SP]something[SP]is[SP]stopping[SP]him[SP]from[SP]realizing\nthe[SP]truth...[1205][001E][SP]Or[SP]someone...[1205][001E][SP]Someone[SP]who's\nmaking[SP]rumors[SP]become[SP]reality...",
     "nom_fr": "Maya",
-    "texte_fr": "Mais quelque chose l'empêche de voir\nla vérité...[1205][001E] Ou quelqu'un...[1205][001E] Quelqu'un\nqui rend les rumeurs réalité..."
+    "texte_fr": "Mais quelque chose l'empêche de voir\nla vérité...[001E][1205] Ou quelqu'un...[001E][1205] Quelqu'un\nqui rend les rumeurs réalité..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "[1432][NULL][NULL][0014]Regret[1432][NULL][NULL][0014]...[1205][001E][SP]Jun[SP]hasn't[SP]changed[SP]at[SP]all...[1205][001E]\nThe[SP]real[SP]Jun[SP]is[SP]still[SP]in[SP]there!",
     "nom_fr": "Ginko",
-    "texte_fr": "[1432][NULL][NULL][0014]Le regret...[001E][1205][001E][1205][1432][NULL][NULL][0014]... Jun n'a pas changé du\ntout... Le vrai Jun est toujours là!"
+    "texte_fr": "[1432][NULL][NULL][0014]Le regret...[001E][001E][1205][1205][1432][NULL][NULL][0014]... Jun n'a pas changé du\ntout... Le vrai Jun est toujours là!"
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]remember[SP]Philemon[SP]telling[SP]us...[1205][001E][SP]we[SP]had\nto[SP]save[SP]Jun-kun[SP]from[SP]the[SP]clutches[SP]of[SP]the\n[1432][NULL][NULL][0014]Crawling[SP]Chaos[1432][NULL][NULL][0014]...",
     "nom_fr": "Maya",
-    "texte_fr": "Je me souviens, Philémon nous a\ndit...[1205][001E] Nous devons sauver Jun des\ngriffes du [1432][NULL][NULL][0014] Chaos Rampant [1432][NULL][NULL][0014]..."
+    "texte_fr": "Je me souviens, Philémon nous a\ndit...[001E][1205] Nous devons sauver Jun des\ngriffes du [1432][NULL][NULL][0014] Chaos Rampant [1432][NULL][NULL][0014]..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What[SP]in[SP]the[SP]world[SP]is[SP]that?[1205][001E][SP]I[SP]bet[SP]it's[SP]what's\nmaking[SP]rumors[SP]into[SP]reality...[1205][001E][SP]And[SP]controlling\nJun-kun[SP]too...",
     "nom_fr": "Maya",
-    "texte_fr": "Qu'est-ce que c'est que ça?[001E][1205][1205][001E] Je parie\nque c'est ce qui réalise les\nrumeurs... Et ce qui contrôle Jun..."
+    "texte_fr": "Qu'est-ce que c'est que ça?[001E][1205][001E][1205] Je parie\nque c'est ce qui réalise les\nrumeurs... Et ce qui contrôle Jun..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]haven't[SP]forgotten[SP]that[SP]Jun[SP]turned[SP]Ken[SP]and\nthe[SP]guys[SP]into[SP]shadowmen...[1205][001E][SP]But[SP]he's[SP]my[SP]good\nfriend[SP]all[SP]the[SP]same.",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'ai pas oublié que Jun a changé Ken et les\nautres en Ombres...[1205][001E] Mais ça reste mon ami."
+    "texte_fr": "J'ai pas oublié que Jun a changé Ken et les\nautres en Ombres...[001E][1205] Mais ça reste mon ami."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]memories[SP]from[SP]that[SP]summer[SP]are[SP]important\nto[SP]me...[1205][001E][SP]For[SP]Ginko[SP]and[SP]Big[SP]Maya,[SP]too.[SP]For[SP]all\nof[SP]us,[SP]really...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Les souvenirs de cet été là me\nsont chers...[1205][001E] À Ginko et Maya\naussi. Pour nous tous, en fait..."
+    "texte_fr": "Les souvenirs de cet été là me\nsont chers...[001E][1205] À Ginko et Maya\naussi. Pour nous tous, en fait..."
   },
   {
     "id": 13,
@@ -207,6 +207,6 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That's[SP]why[SP]I[SP]won't[SP]let[SP]anyone[SP]violate[SP]them![1205][001E]\nThey[SP]shouldn't[SP]be[SP]messed[SP]with!",
     "nom_fr": "",
-    "texte_fr": "C'est pour ça que je ne laisserai personne\nles violer ![1205][001E] On ne touche pas à ça !"
+    "texte_fr": "C'est pour ça que je ne laisserai personne\nles violer ![001E][1205] On ne touche pas à ça !"
   }
 ]

--- a/traduction/event_scripts/script_136.json
+++ b/traduction/event_scripts/script_136.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]is...[1205][001E][SP]the[SP]park[SP]in[SP]the[SP]neighborhood[SP]where\nI[SP]lived[SP]ten[SP]years[SP]ago...[1205][001E]",
     "nom_fr": "Maya",
-    "texte_fr": "C'est le...[1205][001E] park du quartier\noù je vivais il y a dix ans...[1205][001E]"
+    "texte_fr": "C'est le...[001E][1205] park du quartier\noù je vivais il y a dix ans...[001E][1205]"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I'm[SP]surprised[SP]you[SP]figured[SP]out[SP]which[SP]house[SP]was\nmine.[1205][001E][SP]When[SP]I[SP]opened[SP]the[SP]window,[SP]I[SP]thought[SP]I\nwas[SP]seeing[SP]double!",
     "nom_fr": "Maya",
-    "texte_fr": "Je suis surprise que\ntu aies trouvé ma maison.[1205][001E]\nEn ouvrant la fenêtre,\nj'ai cru voir double!"
+    "texte_fr": "Je suis surprise que\ntu aies trouvé ma maison.[001E][1205]\nEn ouvrant la fenêtre,\nj'ai cru voir double!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Jun",
     "texte_orig": "W-Well,[SP]it[SP]was[SP]dark[SP]out...[1205][001E][SP]I'm[SP]not[SP]that\nsurprised[SP]you'd[SP]think[SP]so...",
     "nom_fr": "Jun",
-    "texte_fr": "E-Eh bien, avec la nuit...[1205][001E] C'est\nnormal que tu aies cru ça..."
+    "texte_fr": "E-Eh bien, avec la nuit...[001E][1205] C'est\nnormal que tu aies cru ça..."
   },
   {
     "id": 3,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Jun-kun[SP]and[SP][1113]-kun...[1205][001E][SP]Your[SP]personalities\nare[SP]different,[SP]but[SP]maybe[SP]that's[SP]why[SP]you[SP]two\ndraw[SP]each[SP]other[SP]together[SP]like[SP]shadows...",
     "nom_fr": "Maya",
-    "texte_fr": "Jun et [1113]...[1205][001E] Vous êtes si\ndifférents, pourtant vous vous attirez\nl'un l'autre comme des ombres..."
+    "texte_fr": "Jun et [1113]...[001E][1205] Vous êtes si\ndifférents, pourtant vous vous attirez\nl'un l'autre comme des ombres..."
   },
   {
     "id": 11,
@@ -192,6 +192,6 @@
     "nom_orig": "Jun",
     "texte_orig": "We[SP]both[SP]loved[SP]Big[SP]Sis...[1205][001E][SP]We[SP]promised[SP]to\nprotect[SP]our[SP][1432][NULL][NULL][0014]Mama[1432][NULL][NULL][0014][SP]whatever[SP]happened...[1205][001E]\nAnd[SP]you[SP]broke[SP]that[SP]promise[SP]and[SP]killed[SP]her!",
     "nom_fr": "",
-    "texte_fr": "On aimait tous les deux Grande Sœur...[1205][001E]\nOn avait promis de protéger notre\n[1432][NULL][NULL][0014]Maman[1432][NULL][NULL][0014] quoi qu'il arrive...[1205][001E]\nEt toi tu as brisé cette promesse et tu l'as tuée !"
+    "texte_fr": "On aimait tous les deux Grande Sœur...[001E][1205]\nOn avait promis de protéger notre\n[1432][NULL][NULL][0014]Maman[1432][NULL][NULL][0014] quoi qu'il arrive...[001E][1205]\nEt toi tu as brisé cette promesse et tu l'as tuée !"
   }
 ]

--- a/traduction/event_scripts/script_137.json
+++ b/traduction/event_scripts/script_137.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]one[SP]seems[SP]to[SP]be[SP]for[SP]you,[SP][1113]-kun...[1205][001E]\nAn[SP][E4][NULL][NULL][0006]Aster[SP]Tataricus[E4][NULL][NULL][0002]...[1205][001E][SP][1432][NULL][NULL][0014]I[SP]won't[SP]forget[SP]you[1432][NULL][NULL][0014]...",
     "nom_fr": "Maya",
-    "texte_fr": "Celle-là est pour toi, [1113]...[1205][001E] Une [E4][NULL][NULL][0006]Aster\nde Tartarie[E4][NULL][NULL][0002]...[1205][001E] [1432][NULL][NULL][0014]Je ne t'oublierai jamais[1432][NULL][NULL][0014]..."
+    "texte_fr": "Celle-là est pour toi, [1113]...[001E][1205] Une [E4][NULL][NULL][0006]Aster\nde Tartarie[E4][NULL][NULL][0002]...[001E][1205] [1432][NULL][NULL][0014]Je ne t'oublierai jamais[1432][NULL][NULL][0014]..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Maya",
     "texte_orig": "There's[SP]no[SP]denying[SP]that[SP]Jun-kun[SP]wants[SP]your\nhelp[SP]more[SP]than[SP]anyone[SP]else's...[1205][001E][SP]You[SP]two[SP]were\nsuch[SP]close[SP]friends,[SP]after[SP]all...",
     "nom_fr": "Maya",
-    "texte_fr": "Ca ne fait aucun doute que Jun veut ton\naide plus que celle de quiconque...[1205][001E]\nAprès tout, vous étiez si proches."
+    "texte_fr": "Ca ne fait aucun doute que Jun veut ton\naide plus que celle de quiconque...[001E][1205]\nAprès tout, vous étiez si proches."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Jun-kun[SP]is[SP]tormented[SP]by[SP]false[SP]memories...[1205][001E]\nIn[SP]the[SP]depths[SP]of[SP]his[SP]heart,[SP]he's[SP]crying[SP]out\nfor[SP]help...[1205][001E][SP]Wait[SP]for[SP]us...[SP]We'll[SP]be[SP]there...",
     "nom_fr": "Maya",
-    "texte_fr": "Jun est tourmenté par de faux souvenirs...[1205][001E]\nAu plus profond de son cœur, il crie à\nl'aide... [1205][001E] Attends-nous... On sera là..."
+    "texte_fr": "Jun est tourmenté par de faux souvenirs...[001E][1205]\nAu plus profond de son cœur, il crie à\nl'aide... [001E][1205] Attends-nous... On sera là..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Jun...[1205][001E][SP]Why,[SP]man...?[1205][001E][SP]Why[SP]did[SP]things[SP]have[SP]to\nturn[SP]out[SP]like[SP]this...?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Jun.[1205].[001E].[1205][001E] Pourquoi...? Pourquoi les\nchoses ont tournées ainsi...?"
+    "texte_fr": "Jun.[1205].[001E].[001E][1205] Pourquoi...? Pourquoi les\nchoses ont tournées ainsi...?"
   },
   {
     "id": 4,
@@ -72,6 +72,6 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]see...[SP]I[SP]never[SP]knew[SP]about[SP]this[SP]part...[1205][001E]\nEveryone[SP]loved[SP]Big[SP]Sis.[1205][001E][SP]So[SP]why...?",
     "nom_fr": "",
-    "texte_fr": "Je vois... Je ne savais pas ça...[1205][001E]\nTout le monde aimait Grande Sœur.[1205][001E]\nAlors pourquoi...?"
+    "texte_fr": "Je vois... Je ne savais pas ça...[001E][1205]\nTout le monde aimait Grande Sœur.[001E][1205]\nAlors pourquoi...?"
   }
 ]

--- a/traduction/event_scripts/script_138.json
+++ b/traduction/event_scripts/script_138.json
@@ -42,7 +42,7 @@
     "nom_orig": "Joker",
     "texte_orig": "It[SP]seems[SP]all[SP]the[SP]players[SP]have[SP]taken[SP]the[SP]stage.[1205][001E]\nThe[SP]three[SP]factions[SP]here[SP]are[SP]qualified[SP]to[SP]raise\nXibalba[SP]and[SP]have[SP]their[SP]desires[SP]granted.",
     "nom_fr": "Joker",
-    "texte_fr": "On dirait que tous\nles joueurs sont présents.[1205][001E]\nLes trois factions\nprésentes peuvent invoquer\nXibalba et voir leurs souhaits exaucés."
+    "texte_fr": "On dirait que tous\nles joueurs sont présents.[001E][1205]\nLes trois factions\nprésentes peuvent invoquer Xibalba et voir leurs souhaits exaucés."
   },
   {
     "id": 3,
@@ -102,7 +102,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Ha...[1205][001E][SP]And[SP]what[SP]would[SP]a[SP]ghost[SP]from[SP]the[SP]past,\nresurrected[SP]by[SP]rumors,[SP]wish[SP]for?",
     "nom_fr": "Joker",
-    "texte_fr": "Ha...[1205][001E] Et que désire donc un fantôme\ndu passé réanimé par les rumeurs?"
+    "texte_fr": "Ha...[001E][1205] Et que désire donc un fantôme\ndu passé réanimé par les rumeurs?"
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Fuhrer",
     "texte_orig": "Destruction[SP]and[SP]progress...[1205][001E][SP]These[SP]contradictory\nimpulses[SP]are[SP]constantly[SP]at[SP]war[SP]within[SP]man.",
     "nom_fr": "Führer",
-    "texte_fr": "Destruction et progrès...[1205][001E] Chez l'homme, ces\npulsions contraires sont\ntoujours en guerre."
+    "texte_fr": "Destruction et progrès...[001E][1205] Chez l'homme, ces\npulsions contraires sont\ntoujours en guerre."
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Joker",
     "texte_orig": "True...[SP]But[SP]that's[SP]my[SP]duty.[SP]I[SP]wish[SP]you'd\nleave,[SP]old[SP]man...[1205][001E][SP]Along[SP]with[SP]that[SP]trash\nover[SP]there...",
     "nom_fr": "Joker",
-    "texte_fr": "C'est vrai... Mais c'est mon devoir. Je\nvoudrais que tu\npartes...[1205][001E] Avec tes déchets..."
+    "texte_fr": "C'est vrai... Mais c'est mon devoir. Je\nvoudrais que tu\npartes...[001E][1205] Avec tes déchets..."
   },
   {
     "id": 11,
@@ -207,7 +207,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Foolish[SP]girl...[1205][001E][SP]Do[SP]you[SP]believe[SP]that[SP]all[SP]humans\nhave[SP]such[SP]a[SP]sugarcoated[SP]view[SP]of[SP]the[SP]world?",
     "nom_fr": "Joker",
-    "texte_fr": "Idiote...[1205][001E] Tu crois vraiment que tous les\nhumains ont une vision\nsi édulcorée du monde?"
+    "texte_fr": "Idiote...[001E][1205] Tu crois vraiment que tous les\nhumains ont une vision\nsi édulcorée du monde?"
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Fuhrer",
     "texte_orig": "The[SP]masses[SP]will[SP]always[SP]desire[SP]a[SP]leader[SP]who\ndecides[SP]everything[SP]for[SP]them...[1205][001E][SP]Anxiety[SP]over\nthe[SP]future[SP]only[SP]causes[SP]them[SP]pain!",
     "nom_fr": "Führer",
-    "texte_fr": "Les masses voudront toujours un chef qui\ndécide à leur place...[1205][001E] L'inquiétude du\nfutur provoque uniquement leur douleur!"
+    "texte_fr": "Les masses voudront toujours un chef qui\ndécide à leur place...[001E][1205] L'inquiétude du\nfutur provoque uniquement leur douleur!"
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Behold[SP]the[SP]wings[SP]of[SP]death[SP]and[SP]rebirth![1205][001E]\nXibalba!",
     "nom_fr": "Joker",
-    "texte_fr": "Les ailes de la mort renaissante![1205][001E] Xibalba!"
+    "texte_fr": "Les ailes de la mort renaissante![001E][1205] Xibalba!"
   },
   {
     "id": 18,

--- a/traduction/event_scripts/script_139.json
+++ b/traduction/event_scripts/script_139.json
@@ -27,7 +27,7 @@
     "nom_orig": "Fuhrer",
     "texte_orig": "Wunderbar...![SP]Such[SP]a[SP]dignified[SP]appearance[SP]is\nworthy[SP]of[SP]the[SP]true[SP]city[SP]for[SP]a[SP]Fuhrer...[1205][001E]\nThe[SP]Fuhrer[SP]Staat!",
     "nom_fr": "Führer",
-    "texte_fr": "Wunderbar...! Une apparence si\nmajestueuse est digne de la vraie\nville du Führer...[1205][001E] Der Führer Staat!"
+    "texte_fr": "Wunderbar...! Une apparence si\nmajestueuse est digne de la vraie\nville du Führer...[001E][1205] Der Führer Staat!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Hahaha....[SP]Aaaahahahahaha![1205][001E][SP]Look![SP]What\nFather[SP]said[SP]was[SP]true!",
     "nom_fr": "Joker",
-    "texte_fr": "Hahaha... Aaaahahahahaha![1205][001E]\nRegarde! Père avait raison!"
+    "texte_fr": "Hahaha... Aaaahahahahaha![001E][1205]\nRegarde! Père avait raison!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "???",
     "texte_orig": "I-It[SP]can't[SP]be...[1205][001E][SP]It[SP]was[SP]true...?",
     "nom_fr": "???",
-    "texte_fr": "Ç-Ça peut pas...[1205][001E] C'était vrai?"
+    "texte_fr": "Ç-Ça peut pas...[001E][1205] C'était vrai?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Ngh...!?[1205][001E][SP]No...[SP]What...[SP]I[SP]wanted...[1205][001E][SP]wasn't...\nthis[SP]horrible...[SP]thing...!",
     "nom_fr": "Joker",
-    "texte_fr": "Urgh...!?[1205][001E] Non... Ce que je voulais...[1205][001E]\npas... cette chose horrible...!"
+    "texte_fr": "Urgh...!?[001E][1205] Non... Ce que je voulais...[001E][1205]\npas... cette chose horrible...!"
   },
   {
     "id": 5,
@@ -132,7 +132,7 @@
     "nom_orig": "Fuhrer",
     "texte_orig": "Hahahaha![1205][001E][SP]Since[SP]that's[SP]risen,[SP]there's[SP]no\nmore[SP]use[SP]for[SP]this[SP]place!",
     "nom_fr": "Führer",
-    "texte_fr": "Hahahaha![1205][001E] Puisque ça s'est élevé,\ncet endroit ne sert à rien!"
+    "texte_fr": "Hahahaha![001E][1205] Puisque ça s'est élevé,\ncet endroit ne sert à rien!"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Fuhrer",
     "texte_orig": "This[SP]place[SP]will[SP]collapse[SP]soon![1205][001E][SP]If[SP]you[SP]don't\nhurry[SP]and[SP]get[SP]on[SP]with[SP]it,[SP]you'll[SP]be[SP]another\ncasualty[SP]of[SP]the[SP]world's[SP]destruction!",
     "nom_fr": "Führer",
-    "texte_fr": "Cet endroit va s'effondrer bientôt![1205][001E] Si\nvous ne vous dépêchez pas, vous serez une\nautre victime de la destruction du monde!"
+    "texte_fr": "Cet endroit va s'effondrer bientôt![001E][1205] Si\nvous ne vous dépêchez pas, vous serez une\nautre victime de la destruction du monde!"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Tch...![1205][001E][SP]Take[SP]the[SP]remaining[SP]skulls[SP]and[SP]go\nafter[SP]him!",
     "nom_fr": "Joker",
-    "texte_fr": "Tch...![1205][001E] Prenez les autres\ncrânes et poursuivez-le!"
+    "texte_fr": "Tch...![001E][1205] Prenez les autres\ncrânes et poursuivez-le!"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Shadows",
     "texte_orig": "As[SP]you[SP]wish...[1205][001E][SP]Glory[SP]to[SP]the[SP]Mask...",
     "nom_fr": "Ombres",
-    "texte_fr": "À vos ordres...[1205][001E] Gloire au Masque..."
+    "texte_fr": "À vos ordres...[001E][1205] Gloire au Masque..."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Ngh...[SP]It[SP]was[SP][1113]...[1205][001E][SP]who[SP]killed[SP]Big[SP]Sis...[1205][001E]\nwho[SP]killed[SP]our[SP]Mama...[1205][001E][SP]right,[SP]Papa...?",
     "nom_fr": "Joker",
-    "texte_fr": "Urgh... C'est [1113]...[1205][001E] qui a tué\nsœurette...[1205][001E] qui a\ntué maman...[1205][001E] hein, papa...?"
+    "texte_fr": "Urgh... C'est [1113]...[001E][1205] qui a tué\nsœurette...[001E][1205] qui a\ntué maman...[001E][1205] hein, papa...?"
   },
   {
     "id": 13,
@@ -222,7 +222,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Jun...?[1205][001E][SP]Who...[SP]am[SP]I...?[1205][001E][SP]I'm...[SP]I'm...",
     "nom_fr": "Joker",
-    "texte_fr": "Jun...?[1205][001E] Qui suis-je?[1205][001E] je suis... je..."
+    "texte_fr": "Jun...?[001E][1205] Qui suis-je?[001E][1205] je suis... je..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Unknown[SP]voice",
     "texte_orig": "Don't[SP]forget...[1205][001E][SP]You[SP]are[SP]Joker...[1205][001E]\nKill...[SP]Kill...[SP]Kill...",
     "nom_fr": "Voix inconnue",
-    "texte_fr": "N'oublie pas...[1205][001E] Tu es\nJoker...[1205][001E] Tue... Tue... Tue..."
+    "texte_fr": "N'oublie pas...[001E][1205] Tu es\nJoker...[001E][1205] Tue... Tue... Tue..."
   },
   {
     "id": 16,
@@ -252,6 +252,6 @@
     "nom_orig": "Joker",
     "texte_orig": "That's[SP]right...[1205][001E][SP]I'm...[SP]Joker!",
     "nom_fr": "",
-    "texte_fr": "C'est vrai...[1205][001E] Je suis... le Joker !"
+    "texte_fr": "C'est vrai...[001E][1205] Je suis... le Joker !"
   }
 ]

--- a/traduction/event_scripts/script_140.json
+++ b/traduction/event_scripts/script_140.json
@@ -27,7 +27,7 @@
     "nom_orig": "Joker",
     "texte_orig": "I-Impossible...[1205][001E][SP]This...[SP]can't[SP]be...![1205][001E]\nI...[SP]I[SP]refuse[SP]to[SP]accept[SP]this!",
     "nom_fr": "Joker",
-    "texte_fr": "C-c'est...[1205][001E] impossible...[1205][001E]\nJamais je n'accepterais... ça!"
+    "texte_fr": "C-c'est...[001E][1205] impossible...[001E][1205]\nJamais je n'accepterais... ça!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Unknown[SP]voice",
     "texte_orig": "You[SP]want[SP]power...?[1205][001E][SP]Then[SP]wish[SP]for[SP]it...\nHate...[1205][001E][SP]Immolate[SP]yourself[SP]in[SP]the[SP]flames\nof[SP]abhorrence...",
     "nom_fr": "Voix inconnue",
-    "texte_fr": "Tu veux le pouvoir.[001E][1205][001E][1205]..? Alors\ndemande-le. Déteste-toi, immole-toi\ndans les flammes de l'aversion..."
+    "texte_fr": "Tu veux le pouvoir.[001E][001E][1205][1205]..? Alors\ndemande-le. Déteste-toi, immole-toi\ndans les flammes de l'aversion..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Joker",
     "texte_orig": "I...[SP]want[SP]power...![1205][001E][SP]Power[SP]enough[SP]to[SP]yield[SP]to\nno[SP]one...!",
     "nom_fr": "Joker",
-    "texte_fr": "Oui, du pouvoir...[1205][001E] Assez pour\nne plus jamais flancher!"
+    "texte_fr": "Oui, du pouvoir...[001E][1205] Assez pour\nne plus jamais flancher!"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Nyarlathotep",
     "texte_orig": "Your[SP]wish[SP]has[SP]been[SP]heard...[1205][001E][SP]The[SP]sacrifice[SP]on\noffer[SP]is[SP]yourself.[1205][001E][SP]Since[SP]you[SP]were[SP]shunned[SP]as\na[SP]demon,[SP]I[SP]give[SP]you[SP]a[SP]demon[SP]king's[SP]power...",
     "nom_fr": "Nyarlathotep",
-    "texte_fr": "Ton souhait a été\nentendu. [001E][1205][001E][1205]Pour ce sacrifice,\ntu sera le dû. Craint\ntel un démon, c'est le \npouvoir d'un roi démon\nqui te sera offert..."
+    "texte_fr": "Ton souhait a été\nentendu. [001E][001E][1205][1205]Pour ce sacrifice,\ntu sera le dû. Craint\ntel un démon, c'est le pouvoir d'un roi démon qui te sera offert..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Aaaaaaaaagh...!?[1205][001E][SP]S-Stop...!",
     "nom_fr": "Joker",
-    "texte_fr": "Aaaaargh...!?[1205][001E] S-Stop...!"
+    "texte_fr": "Aaaaargh...!?[001E][1205] S-Stop...!"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Nyarlathotep",
     "texte_orig": "Your[SP]wish[SP]has[SP]been[SP]heard...[1205][001E][SP]The[SP]sacrifice[SP]on\noffer[SP]is[SP]yourself.[1205][001E][SP]Since[SP]you[SP]were[SP]praised[SP]as\nan[SP]angel,[SP]I[SP]grant[SP]you[SP]heavenly[SP]strength...",
     "nom_fr": "Nyarlathotep",
-    "texte_fr": "Ton souhait a été\nentendu. [001E][1205][001E][1205]Pour ce sacrifice,\ntu sera le dû. Loué\ntel un ange, c'est depuis\nles cieux que ton pouvoir te sera offert."
+    "texte_fr": "Ton souhait a été\nentendu. [001E][001E][1205][1205]Pour ce sacrifice,\ntu sera le dû. Loué\ntel un ange, c'est depuis les cieux que ton pouvoir te sera offert."
   },
   {
     "id": 8,
@@ -132,6 +132,6 @@
     "nom_orig": "Joker",
     "texte_orig": "Aaaaaaaaagh...!?[1205][001E][SP]S-Stop...!",
     "nom_fr": "Joker",
-    "texte_fr": "Aaaaargh...!?[1205][001E] S-Stop...!"
+    "texte_fr": "Aaaaargh...!?[001E][1205] S-Stop...!"
   }
 ]

--- a/traduction/event_scripts/script_141.json
+++ b/traduction/event_scripts/script_141.json
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Oh,[SP]thank[SP]goodness...[1205][001E][SP]I'm...[1205][001E][SP]I'm[SP]so[SP]glad...!",
     "nom_fr": "Ginko",
-    "texte_fr": "Bon sang...[1205][001E] Je suis...[1205][001E] tellement soulagée!"
+    "texte_fr": "Bon sang...[001E][1205] Je suis...[001E][1205] tellement soulagée!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Damn,[SP]dude...[1205][001E][SP]You[SP]had[SP]us[SP]so[SP]worried...[1205][001E]",
     "nom_fr": "Eikichi",
-    "texte_fr": "'tain, mec...[1205][001E] On était si inquiets...[1205][001E]"
+    "texte_fr": "'tain, mec...[001E][1205] On était si inquiets...[001E][1205]"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Jun",
     "texte_orig": "[1113]...[1205][001E][SP]You[SP]had[SP]that...[1205][001E][SP]all[SP]this[SP]time...?",
     "nom_fr": "Jun",
-    "texte_fr": "[1113]...[1205][001E] Tu l'as gardé...[1205][001E] tout ce temps?"
+    "texte_fr": "[1113]...[001E][1205] Tu l'as gardé...[001E][1205] tout ce temps?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Jun",
     "texte_orig": "It's[SP]ticking...[1205][001E][SP]It[SP]had[SP]been[SP]stopped...[1205][001E]\nEver[SP]since[SP]that[SP]day...[1205][001E]",
     "nom_fr": "Jun",
-    "texte_fr": "L'aiguille bouge...[1205][001E] Elle s'était\narrêtée...[1205][001E] depuis ce jour...[1205][001E]"
+    "texte_fr": "L'aiguille bouge...[001E][1205] Elle s'était\narrêtée...[001E][1205] depuis ce jour...[001E][1205]"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Jun",
     "texte_orig": "That's[SP]right...[1205][001E][SP]We[SP]promised[SP]to[SP]protect[SP]Big\nSis[SP]together...[SP]forever...[1205][001E][SP]And[SP]I...[SP]I...![1205][001E]",
     "nom_fr": "Jun",
-    "texte_fr": "C'est ça...[1205][001E] On s'était jurés de protéger\nSœurette ensemble...[1205][001E] Et je... j'ai...![1205][001E]"
+    "texte_fr": "C'est ça...[001E][1205] On s'était jurés de protéger\nSœurette ensemble...[001E][1205] Et je... j'ai...![001E][1205]"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Jun-kun...[1205][001E][SP]This[SP]is[SP]how[SP]I[SP]feel...[1205][001E]\nI[SP]promise[SP]you...",
     "nom_fr": "Maya",
-    "texte_fr": "Jun...[1205][001E] Voici ce que je\nressens...[1205][001E] Je te jure..."
+    "texte_fr": "Jun...[001E][1205] Voici ce que je\nressens...[001E][1205] Je te jure..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "No[SP]matter[SP]who[SP]stands[SP]against[SP]you...[1205][001E][SP]Even[SP]if\nthe[SP]whole[SP]world[SP]becomes[SP]my[SP]enemy...[1205][001E][SP]I'll[SP]keep\nmy[SP]promise...",
     "nom_fr": "Maya",
-    "texte_fr": "Que peu importe tes ennemis...[1205][001E]\nMême si je me met le monde à\ndos...[1205][001E] Je tiendrai ma promesse..."
+    "texte_fr": "Que peu importe tes ennemis...[001E][1205]\nMême si je me met le monde à\ndos...[001E][1205] Je tiendrai ma promesse..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Jun",
     "texte_orig": "A[SP][E4][NULL][NULL][0006]Nemophilia[E4][NULL][NULL][0002][SP]flower...[1205]<[SP]I'm[SP]sorry...[SP]Big[SP]Sis...[1205][001E]\nI'm[SP]so[SP]sorry...[SP][1113]...",
     "nom_fr": "Jun",
-    "texte_fr": "Une [E4][NULL][NULL][0006]Némophile...[E4][NULL][NULL][0002] Je...[1205]< suis désolé,\nSœurette...[1205][001E] Si désolé... [1113]..."
+    "texte_fr": "Une [E4][NULL][NULL][0006]Némophile...[E4][NULL][NULL][0002] Je...[1205]< suis désolé,\nSœurette...[001E][1205] Si désolé... [1113]..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I...[SP]I...[1205][001E][SP]*sob*",
     "nom_fr": "Jun",
-    "texte_fr": "Je...[1205][001E] *pleurs*"
+    "texte_fr": "Je...[001E][1205] *pleurs*"
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "???",
     "texte_orig": "Shame[SP]on[SP]you.[1205][001E][SP]The[SP]head[SP]of[SP]the[SP]Masked[SP]Circle\ndares[SP]to[SP]allow[SP]his[SP]enemies[SP]to[SP]pity[SP]him?",
     "nom_fr": "???",
-    "texte_fr": "Quelle honte.[1205][001E] Le chef du Cercle Masqué\nlaisse ses ennemis le prendre en pitié?"
+    "texte_fr": "Quelle honte.[001E][1205] Le chef du Cercle Masqué\nlaisse ses ennemis le prendre en pitié?"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "???",
     "texte_orig": "Come,[SP]Jun...[1205][001E][SP]Claim[SP]your[SP]revenge[SP]and[SP]open[SP]the\nway[SP]to[SP]Idealian.",
     "nom_fr": "???",
-    "texte_fr": "Viens, Jun.[1205][001E] Venge-toi et\nouvre la voie de l'Idéalien."
+    "texte_fr": "Viens, Jun.[001E][1205] Venge-toi et\nouvre la voie de l'Idéalien."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Father...[SP]We[SP]need[SP]to[SP]stop[SP]this...[1205][001E][SP]I...[SP]I[SP]just\nwanted[SP]to[SP]be[SP]like[SP]Big[SP]Sis[SP]and[SP]lead[SP]everyone\nto[SP]their[SP]dreams!",
     "nom_fr": "Jun",
-    "texte_fr": "Père... Arrêtons tout ça...[1205][001E] Je...\nsouhaitais juste aider les gens à\natteindre leurs rêves, comme Sœurette!"
+    "texte_fr": "Père... Arrêtons tout ça...[001E][1205] Je...\nsouhaitais juste aider les gens à\natteindre leurs rêves, comme Sœurette!"
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Jun's[SP]father",
     "texte_orig": "It's[SP]your[SP]turn[SP]now[SP]to[SP]grant[SP]MY[SP]dream...[1205][001E]\nAnd[SP]as[SP]your[SP]father,[SP]I[SP]will[SP]eliminate[SP]anyone\nwho[SP]tries[SP]to[SP]deceive[SP]you.[SP]Now,[SP]come.",
     "nom_fr": "Père de Jun",
-    "texte_fr": "C'est désormais à toi de réaliser MON\nrêve...[1205][001E] En tant que père, j'écraserais\ntout ceux qui te manipulent. Alors viens."
+    "texte_fr": "C'est désormais à toi de réaliser MON\nrêve...[001E][1205] En tant que père, j'écraserais\ntout ceux qui te manipulent. Alors viens."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]won't[SP]let[SP]anyone[SP]hurt[SP]Big[SP]Maya...[1205][001E]\nNot[SP]even[SP]you,[SP]Father...!",
     "nom_fr": "Jun",
-    "texte_fr": "Père! Je ne laisserai ni toi...[1205][001E]\nni personne blesser Maya!"
+    "texte_fr": "Père! Je ne laisserai ni toi...[001E][1205]\nni personne blesser Maya!"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Jun's[SP]father",
     "texte_orig": "...[1205]<Ha.[SP]Very[SP]well.[1205][001E][SP]Jun...[SP]You[SP]have[SP]been\nremoved[SP]from[SP]the[SP]wheel[SP]of[SP]fortune.",
     "nom_fr": "Père de Jun",
-    "texte_fr": "...[1205]<Bien. Très bien.[1205][001E] Jun... Te voilà\nécarté de la roue de la fortune."
+    "texte_fr": "...[1205]<Bien. Très bien.[001E][1205] Jun... Te voilà\nécarté de la roue de la fortune."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Jun's[SP]father",
     "texte_orig": "I[SP]will[SP]lead[SP]the[SP]Masked[SP]Circle[SP]in[SP]your[SP]stead.\nFarewell,[SP]my[SP]son.[1205][001E][SP]You[SP]will[SP]become[SP]part[SP]of[SP]the\nfoundation[SP]for[SP]the[SP]new[SP]world...",
     "nom_fr": "Père de Jun",
-    "texte_fr": "Je prendrais la tête du Cercle Masqué.\nAdieu, mon fils.[1205][001E] Tu vas faire partie\ndes fondations de ce nouveau monde..."
+    "texte_fr": "Je prendrais la tête du Cercle Masqué.\nAdieu, mon fils.[001E][1205] Tu vas faire partie\ndes fondations de ce nouveau monde..."
   },
   {
     "id": 19,
@@ -312,7 +312,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Oh,[SP]thank[SP]goodness...[1205][001E][SP]I'm...[1205][001E][SP]I'm[SP]so[SP]glad...!",
     "nom_fr": "Ginko",
-    "texte_fr": "Bon sang...[1205][001E] Je suis...[1205][001E] tellement soulagée!"
+    "texte_fr": "Bon sang...[001E][1205] Je suis...[001E][1205] tellement soulagée!"
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Damn,[SP]dude...[1205][001E][SP]You[SP]had[SP]us[SP]so[SP]worried...[1205][001E]",
     "nom_fr": "Eikichi",
-    "texte_fr": "'tain, mec...[1205][001E] On était si inquiets...[1205][001E]"
+    "texte_fr": "'tain, mec...[001E][1205] On était si inquiets...[001E][1205]"
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Jun",
     "texte_orig": "[1113]...[1205][001E][SP]You[SP]had[SP]that...[1205][001E][SP]all[SP]this[SP]time...?",
     "nom_fr": "Jun",
-    "texte_fr": "[1113]...[1205][001E] Tu l'as gardé...[1205][001E] tout ce temps?"
+    "texte_fr": "[1113]...[001E][1205] Tu l'as gardé...[001E][1205] tout ce temps?"
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Jun",
     "texte_orig": "It's[SP]ticking...[1205][001E][SP]It[SP]had[SP]been[SP]stopped...[1205][001E]\nEver[SP]since[SP]that[SP]day...[1205][001E]",
     "nom_fr": "Jun",
-    "texte_fr": "L'aiguille bouge...[1205][001E] Elle s'était\narrêtée...[1205][001E] depuis ce jour...[1205][001E]"
+    "texte_fr": "L'aiguille bouge...[001E][1205] Elle s'était\narrêtée...[001E][1205] depuis ce jour...[001E][1205]"
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Jun",
     "texte_orig": "That's[SP]right...[1205][001E][SP]We[SP]promised[SP]to[SP]protect[SP]Big\nSis[SP]together...[SP]forever...[1205][001E][SP]And[SP]I...[SP]I...![1205][001E]",
     "nom_fr": "Jun",
-    "texte_fr": "C'est ça...[1205][001E] On s'était jurés de protéger\nSœurette ensemble...[1205][001E] Et je... j'ai...![1205][001E]"
+    "texte_fr": "C'est ça...[001E][1205] On s'était jurés de protéger\nSœurette ensemble...[001E][1205] Et je... j'ai...![001E][1205]"
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Jun-kun...[1205][001E][SP]This[SP]is[SP]how[SP]I[SP]feel...[1205][001E]\nI[SP]promise[SP]you...",
     "nom_fr": "Maya",
-    "texte_fr": "Jun...[1205][001E] Voici ce que je\nressens...[1205][001E] Je te jure..."
+    "texte_fr": "Jun...[001E][1205] Voici ce que je\nressens...[001E][1205] Je te jure..."
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Maya",
     "texte_orig": "No[SP]matter[SP]who[SP]stands[SP]against[SP]you...[1205][001E][SP]Even[SP]if\nthe[SP]whole[SP]world[SP]becomes[SP]my[SP]enemy...[1205][001E][SP]I'll[SP]keep\nmy[SP]promise...",
     "nom_fr": "Maya",
-    "texte_fr": "Que peu importe tes ennemis...[1205][001E]\nMême si je me met le monde à\ndos...[1205][001E] Je tiendrai ma promesse..."
+    "texte_fr": "Que peu importe tes ennemis...[001E][1205]\nMême si je me met le monde à\ndos...[001E][1205] Je tiendrai ma promesse..."
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Jun",
     "texte_orig": "A[SP][E4][NULL][NULL][0006]Nemophilia[E4][NULL][NULL][0002][SP]flower...[1205]<[SP]I'm[SP]sorry...[SP]Big[SP]Sis...[1205][001E]\nI'm[SP]so[SP]sorry...[SP][1113]...",
     "nom_fr": "Jun",
-    "texte_fr": "Une [E4][NULL][NULL][0006]Némophile...[E4][NULL][NULL][0002] Je...[1205]< suis désolé,\nSœurette...[1205][001E] Si désolé... [1113]..."
+    "texte_fr": "Une [E4][NULL][NULL][0006]Némophile...[E4][NULL][NULL][0002] Je...[1205]< suis désolé,\nSœurette...[001E][1205] Si désolé... [1113]..."
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I...[SP]I...[1205][001E][SP]*sob*",
     "nom_fr": "Jun",
-    "texte_fr": "Je...[1205][001E] *pleurs*"
+    "texte_fr": "Je...[001E][1205] *pleurs*"
   },
   {
     "id": 29,
@@ -462,7 +462,7 @@
     "nom_orig": "???",
     "texte_orig": "Shame[SP]on[SP]you.[1205][001E][SP]The[SP]head[SP]of[SP]the[SP]Masked[SP]Circle\ndares[SP]to[SP]allow[SP]his[SP]enemies[SP]to[SP]pity[SP]him?",
     "nom_fr": "???",
-    "texte_fr": "Quelle honte.[1205][001E] Le chef du Cercle Masqué\nlaisse ses ennemis le prendre en pitié?"
+    "texte_fr": "Quelle honte.[001E][1205] Le chef du Cercle Masqué\nlaisse ses ennemis le prendre en pitié?"
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "???",
     "texte_orig": "Come,[SP]Jun...[1205][001E][SP]Claim[SP]your[SP]revenge[SP]and[SP]open[SP]the\nway[SP]to[SP]Idealian.",
     "nom_fr": "???",
-    "texte_fr": "Viens, Jun.[1205][001E] Venge-toi et\nouvre la voie de l'Idéalien."
+    "texte_fr": "Viens, Jun.[001E][1205] Venge-toi et\nouvre la voie de l'Idéalien."
   },
   {
     "id": 32,
@@ -492,7 +492,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Father...[SP]We[SP]need[SP]to[SP]stop[SP]this...[1205][001E][SP]I...[SP]I[SP]just\nwanted[SP]to[SP]be[SP]like[SP]Big[SP]Sis[SP]and[SP]lead[SP]everyone\nto[SP]their[SP]dreams!",
     "nom_fr": "Jun",
-    "texte_fr": "Père... Arrêtons tout ça...[1205][001E] Je...\nsouhaitais juste aider les gens à\natteindre leurs rêves, comme Sœurette!"
+    "texte_fr": "Père... Arrêtons tout ça...[001E][1205] Je...\nsouhaitais juste aider les gens à\natteindre leurs rêves, comme Sœurette!"
   },
   {
     "id": 33,
@@ -522,7 +522,7 @@
     "nom_orig": "Jun's[SP]father",
     "texte_orig": "It's[SP]your[SP]turn[SP]now[SP]to[SP]grant[SP]MY[SP]dream...[1205][001E]\nAnd[SP]as[SP]your[SP]father,[SP]I[SP]will[SP]eliminate[SP]anyone\nwho[SP]tries[SP]to[SP]deceive[SP]you.[SP]Now,[SP]come.",
     "nom_fr": "Père de Jun",
-    "texte_fr": "C'est désormais à toi de réaliser MON\nrêve...[1205][001E] En tant que père, j'écraserais\ntout ceux qui te manipulent. Alors viens."
+    "texte_fr": "C'est désormais à toi de réaliser MON\nrêve...[001E][1205] En tant que père, j'écraserais\ntout ceux qui te manipulent. Alors viens."
   },
   {
     "id": 35,
@@ -537,7 +537,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]won't[SP]let[SP]anyone[SP]hurt[SP]Big[SP]Maya...[1205][001E]\nNot[SP]even[SP]you,[SP]Father...!",
     "nom_fr": "Jun",
-    "texte_fr": "Père! Je ne laisserai ni toi...[1205][001E]\nni personne blesser Maya!"
+    "texte_fr": "Père! Je ne laisserai ni toi...[001E][1205]\nni personne blesser Maya!"
   },
   {
     "id": 36,
@@ -552,7 +552,7 @@
     "nom_orig": "Jun's[SP]father",
     "texte_orig": "...[1205]<Ha.[SP]Very[SP]well.[1205][001E][SP]Jun...[SP]You[SP]have[SP]been\nremoved[SP]from[SP]the[SP]wheel[SP]of[SP]fortune.",
     "nom_fr": "Père de Jun",
-    "texte_fr": "...[1205]<Bien. Très bien.[1205][001E] Jun... Te voilà\nécarté de la roue de la fortune."
+    "texte_fr": "...[1205]<Bien. Très bien.[001E][1205] Jun... Te voilà\nécarté de la roue de la fortune."
   },
   {
     "id": 37,
@@ -567,6 +567,6 @@
     "nom_orig": "Jun's[SP]father",
     "texte_orig": "I[SP]will[SP]lead[SP]the[SP]Masked[SP]Circle[SP]in[SP]your[SP]stead.\nFarewell,[SP]my[SP]son.[1205][001E][SP]You[SP]will[SP]become[SP]part[SP]of[SP]the\nfoundation[SP]for[SP]the[SP]new[SP]world...",
     "nom_fr": "Père de Jun",
-    "texte_fr": "Je prendrais la tête du Cercle Masqué.\nAdieu, mon fils.[1205][001E] Tu vas faire partie\ndes fondations de ce nouveau monde..."
+    "texte_fr": "Je prendrais la tête du Cercle Masqué.\nAdieu, mon fils.[001E][1205] Tu vas faire partie\ndes fondations de ce nouveau monde..."
   }
 ]

--- a/traduction/event_scripts/script_142.json
+++ b/traduction/event_scripts/script_142.json
@@ -27,7 +27,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "To[SP]escape[SP]the[SP]eternal[SP]suffering[SP]that[SP]comes[SP]with\nunderstanding[SP]one's[SP]existence,[SP]man[SP]has[SP]summoned\nfrom[SP]the[SP]abyss[SP]that[SP]which[SP]should[SP]not[SP]exist.",
     "nom_fr": "Philémon",
-    "texte_fr": "Fuyant la douleur infinie que s'inflige\nquiconque réalise son\nexistence, l'humanité a \nappelée depuis l'abysse\nce qui ne doitexister."
+    "texte_fr": "Fuyant la douleur infinie que s'inflige\nquiconque réalise son\nexistence, l'humanité a appelée depuis l'abysse ce qui ne doitexister."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP][1432][NULL][NULL][0014]Crawling[SP]Chaos[1432][NULL][NULL][0014][SP]again...[1205][001E][SP]What[SP]exactly\nare[SP]you[SP]talking[SP]about?[1205][001E]",
     "nom_fr": "Maya",
-    "texte_fr": "Le [1432][NULL][NULL][0014]Chaos Rampant[1432][NULL][NULL][0014]...[1205][001E] De quoi\nvous parlez exactement?[1205][001E]"
+    "texte_fr": "Le [1432][NULL][NULL][0014]Chaos Rampant[1432][NULL][NULL][0014]...[001E][1205] De quoi\nvous parlez exactement?[001E][1205]"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "There's[SP]still[SP]too[SP]much[SP]we[SP]don't[SP]know.[1205][001E][SP]About\nJun-kun's[SP]father,[SP]and[SP]that[SP]Persona...[1205][001E][SP]Or[SP]why\nrumors[SP]started[SP]to[SP]come[SP]true...",
     "nom_fr": "Maya",
-    "texte_fr": "Encore tant de choses nous échappent.[1205][001E] Le\npère de Jun, cette Persona...[1205][001E] Et pourquoi\nles rumeurs deviennent réalité..."
+    "texte_fr": "Encore tant de choses nous échappent.[001E][1205] Le\npère de Jun, cette Persona...[001E][1205] Et pourquoi\nles rumeurs deviennent réalité..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "Eventually,[SP]the[SP]time[SP]will[SP]be[SP]right[SP]for[SP]you[SP]to\nlearn[SP]everything.[1205][001E][SP]If[SP]anyone[SP]can[SP]stop[SP]him...\nthe[SP]darkness[SP]from[SP]thriving,[SP]it[SP]is[SP]you.",
     "nom_fr": "Philémon",
-    "texte_fr": "Vous le saurez le moment venu.[1205][001E] Si il\nexiste des gens capables d'empêcher les\nténébres de prospérer, c'est vous."
+    "texte_fr": "Vous le saurez le moment venu.[001E][1205] Si il\nexiste des gens capables d'empêcher les\nténébres de prospérer, c'est vous."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "The[SP]power[SP]amassed[SP]by[SP]the[SP]feelings[SP]which[SP]have\nbeen[SP]fostered[SP]over[SP]ten[SP]years...[1205][001E][SP]Show[SP]him[SP]the\npotential[SP]that[SP]lies[SP]within[SP]you.",
     "nom_fr": "Philémon",
-    "texte_fr": "Le pouvoir que vos émotions ont cultivé\ndurant ces dix années...[1205][001E] Montrez-lui\ntout le potentiel qui someille en vous."
+    "texte_fr": "Le pouvoir que vos émotions ont cultivé\ndurant ces dix années...[001E][1205] Montrez-lui\ntout le potentiel qui someille en vous."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Philemon...[1205][001E][SP]my[SP]Persona-summoning[SP]ability...[1205][001E]\nWould[SP]you[SP]mind[SP]giving[SP]it[SP]to[SP]Jun?",
     "nom_fr": "Yukino",
-    "texte_fr": "Philémon,[1205][001E] ma capacité à invoquer des\nPersonae...[1205][001E] Jun pourrait-il l'avoir?"
+    "texte_fr": "Philémon,[001E][1205] ma capacité à invoquer des\nPersonae...[001E][1205] Jun pourrait-il l'avoir?"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What...?[1205][001E][SP]But[SP]then...[1205][001E][SP]What[SP]will[SP]you[SP]do,[SP]Yukki?",
     "nom_fr": "Maya",
-    "texte_fr": "Mais?[1205][001E] Et toi Yukki?[1205][001E] Si tu fais ça tu..."
+    "texte_fr": "Mais?[001E][1205] Et toi Yukki?[001E][1205] Si tu fais ça tu..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]don't[SP]need[SP]Personas[SP]anymore.[1205][001E][SP]I[SP]can[SP]keep[SP]my\nhead[SP]high[SP]and[SP]walk[SP]on[SP]my[SP]own[SP]now...[1205][001E][SP]It's[SP]time\nI[SP]passed[SP]these[SP]feelings[SP]on[SP]to[SP]someone[SP]else.",
     "nom_fr": "Yukino",
-    "texte_fr": "Je n'ai plus besoin de Personae.[1205][001E] Je peux\navancer moi-même maintenant...[1205][001E]\nIl est temps de\ntransmettre ces émotions\nà quelqu'un d'autre."
+    "texte_fr": "Je n'ai plus besoin de Personae.[001E][1205] Je peux\navancer moi-même maintenant...[001E][1205]\nIl est temps de\ntransmettre ces émotions à quelqu'un d'autre."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "Understood...[1205][001E][SP]But[SP]there[SP]aren't[SP]many[SP]who[SP]can\nremember[SP]their[SP]identity[SP]when[SP]in[SP]this[SP]domain.\nCan[SP]you[SP]state[SP]your[SP]name?",
     "nom_fr": "Philémon",
-    "texte_fr": "Bien...[1205][001E] Mais en ce lieu, tous ne\nsont pas capables de se rappeler qui\nils sont. Peux-tu donner ton nom?"
+    "texte_fr": "Bien...[001E][1205] Mais en ce lieu, tous ne\nsont pas capables de se rappeler qui\nils sont. Peux-tu donner ton nom?"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Jun",
     "texte_orig": "My[SP]name...[1205][001E][SP]is[SP]Jun...[SP]Jun[SP]Kurosu!\nThat's...[SP]all[SP]I[SP]am[SP]now!",
     "nom_fr": "Jun",
-    "texte_fr": "Mon nom...[1205][001E] est Jun... Jun\nKurosu! C'est... qui je suis!"
+    "texte_fr": "Mon nom...[001E][1205] est Jun... Jun\nKurosu! C'est... qui je suis!"
   },
   {
     "id": 12,
@@ -222,7 +222,7 @@
     "nom_orig": "Hermes",
     "texte_orig": "I[SP]am[SP][E4][NULL][NULL][0005]Hermes[E4][NULL][NULL][0002]...[1205][001E][SP]Giver[SP]of[SP]fortune[SP]and[SP]fame,[SP]and\nherald[SP]of[SP]souls...[1205][001E][SP]To[SP]my[SP]alter[SP]ego:[SP]Love[SP]thy\nneighbor[SP]with[SP]a[SP]selflessness[SP]like[SP]the[SP]wind's...",
     "nom_fr": "Hermès",
-    "texte_fr": "Je suis [E4][NULL][NULL][0005]Hermès[E4][NULL][NULL][0002]...[1205][001E] Donneur de fortune et\nde gloire, héraut des âmes...[1205][001E] À mon alter\négo: Aime ton voisin, incarne le\nvent ded'altruisme...  Le stock de Personae est\nplein. Libérez un emplacement.[E4][NULL][NULL]"
+    "texte_fr": "Je suis [E4][NULL][NULL][0005]Hermès[E4][NULL][NULL][0002]...[001E][1205] Donneur de fortune et\nde gloire, héraut des âmes...[001E][1205] À mon alter\négo: Aime ton voisin, incarne le\nvent ded'altruisme...  Le stock de Personae est plein. Libérez un emplacement.[E4][NULL][NULL]"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Jun",
     "texte_orig": "It's[SP]so[SP]warm...[1205][001E][SP]Thank[SP]you,[SP]Mayuzumi-san...[1205][001E]\nI[SP]won't[SP]waste[SP]your[SP]feelings.",
     "nom_fr": "Jun",
-    "texte_fr": "C'est si doux...[1205][001E] Merci, Mayuzumi...[1205][001E]\nJe ne gâcherai pas ces émotions."
+    "texte_fr": "C'est si doux...[001E][1205] Merci, Mayuzumi...[001E][1205]\nJe ne gâcherai pas ces émotions."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "It[SP]seems[SP]the[SP]others[SP]have[SP]also[SP]found[SP]their[SP]true\nPersonas[SP]that[SP]caused[SP]such[SP]changes[SP]in[SP]them[SP]when\nthey[SP]were[SP]young...[1205][001E][SP]These[SP]will[SP]grant[SP]you[SP]power.",
     "nom_fr": "Philémon",
-    "texte_fr": "Les autres semblent,\neux aussi, avoir révélé\nles Personae qui ont tant impacté leur \njeunesse... [1205]Elles\n[001E]augmenteront votre pouvoir."
+    "texte_fr": "Les autres semblent,\neux aussi, avoir révélé\nles Personae qui ont tant impacté leur jeunesse... [1205]Elles[001E]augmenteront votre pouvoir."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Apollo",
     "texte_orig": "I[SP]am[SP]thou...[SP]Thou[SP]art[SP]I...[1205][001E][SP]From[SP]the[SP]sea[SP]of\nthy[SP]soul[SP]I[SP]cometh...[1205][001E][SP]Ruler[SP]of[SP]the[SP]blazing[SP]sun\nand[SP]blue[SP]skies,[SP][E4][NULL][NULL][0005]Apollo[E4][NULL][NULL][0002]...",
     "nom_fr": "",
-    "texte_fr": "Je suis toi... Tu es moi...[1205][001E] Arrivé depuis\nl'océan de ton âme...[1205][001E] Souverain du soleil\nembrasé, des cieux azurés, [E4][NULL][NULL][0005]Apollo[E4][NULL][NULL][0002]..."
+    "texte_fr": "Je suis toi... Tu es moi...[001E][1205] Arrivé depuis\nl'océan de ton âme...[001E][1205] Souverain du soleil\nembrasé, des cieux azurés, [E4][NULL][NULL][0005]Apollo[E4][NULL][NULL][0002]..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Artemis",
     "texte_orig": "I[SP]am[SP][E4][NULL][NULL][0005]Artemis[E4][NULL][NULL][0002]...[1205][001E][SP]The[SP]moon[SP]goddess[SP]who\nilluminates[SP]your[SP]twilight[SP]virtue...[1205][001E][SP]My[SP]purer\nhalf,[SP]do[SP]not[SP]be[SP]bashful[SP]of[SP]your[SP]destiny.",
     "nom_fr": "Artémis",
-    "texte_fr": "Je suis [E4][NULL][NULL][0005]Artémis[E4][NULL][NULL][0002]...[1205][001E] Déesse sélène illuminant\nta vertu crépusculaire...[1205][001E] Toi, ma pure \nmoitié, ne craint pas ta destinée."
+    "texte_fr": "Je suis [E4][NULL][NULL][0005]Artémis[E4][NULL][NULL][0002]...[001E][1205] Déesse sélène illuminant\nta vertu crépusculaire...[001E][1205] Toi, ma pure \nmoitié, ne craint pas ta destinée."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Venus",
     "texte_orig": "I[SP]am[SP][E4][NULL][NULL][0005]Venus[E4][NULL][NULL][0002]...[1205][001E][SP]Goddess[SP]of[SP]fertility[SP]about\nwhom[SP]beauty[SP]and[SP]love[SP]dance...[1205][001E][SP]I[SP]am[SP]you...\nYou[SP]are[SP]me...[SP]Let[SP]us[SP]become[SP]one...",
     "nom_fr": "Vénus",
-    "texte_fr": "Je suis [E4][NULL][NULL][0005]Vénus[E4][NULL][NULL][0002]...[1205][001E] Déesse de la fertilité,\namour et beauté dansent avec moi.[1205][001E] Je\nsuis toi... tu es moi... Devenons un..."
+    "texte_fr": "Je suis [E4][NULL][NULL][0005]Vénus[E4][NULL][NULL][0002]...[001E][1205] Déesse de la fertilité,\namour et beauté dansent avec moi.[001E][1205] Je\nsuis toi... tu es moi... Devenons un..."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Hades",
     "texte_orig": "I[SP]am[SP][E4][NULL][NULL][0005]Hades[E4][NULL][NULL][0002]...[1205][001E][SP]King[SP]of[SP]the[SP]underworld[SP]who[SP]judges\nthe[SP]evil[SP]and[SP]the[SP]righteous[SP]alike.[1205][001E][SP]I[SP]am[SP]thou...\nThou[SP]art[SP]I...[SP]Let[SP]us[SP]walk[SP]this[SP]path[SP]together...",
     "nom_fr": "Hadès",
-    "texte_fr": "Je suis [E4][NULL][NULL][0005]Hadès[E4][NULL][NULL][0002]...[1205][001E] Roi des enfers, jugeant\nles vils comme les vertueux.[1205][001E] Je suis toi...\nTu es moi... Marchons côte à côte..."
+    "texte_fr": "Je suis [E4][NULL][NULL][0005]Hadès[E4][NULL][NULL][0002]...[001E][1205] Roi des enfers, jugeant\nles vils comme les vertueux.[001E][1205] Je suis toi...\nTu es moi... Marchons côte à côte..."
   },
   {
     "id": 21,
@@ -342,7 +342,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "If[SP]you[SP]have[SP]the[SP]faintest[SP]strength[SP]to[SP]reach[SP]for\nyour[SP]dreams,[SP]the[SP]stars[SP]will[SP]shine[SP]even[SP]in[SP]the\ndarkness.[SP]Take[SP]control[SP]of[SP]your[SP]destiny...",
     "nom_fr": "Philémon",
-    "texte_fr": "La force d'atteindre son rêve... Un rien\nsuffira pour que les étoiles brillent même\ndans les ténébres.\nPrenez votre destin enmain..."
+    "texte_fr": "La force d'atteindre son rêve... Un rien\nsuffira pour que les étoiles brillent même\ndans les ténébres. Prenez votre destin enmain..."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yukki...[1205][001E][SP]Thank[SP]you...[1205][001E][SP]I'll[SP]never[SP]forget[SP]you...",
     "nom_fr": "Maya",
-    "texte_fr": "Yukki...[1205][001E] Merci.[1205][001E] Je ne t'oublierai jamais..."
+    "texte_fr": "Yukki...[001E][1205] Merci.[001E][1205] Je ne t'oublierai jamais..."
   },
   {
     "id": 24,
@@ -387,7 +387,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "To[SP]escape[SP]the[SP]eternal[SP]suffering[SP]that[SP]comes[SP]with\nunderstanding[SP]one's[SP]existence,[SP]man[SP]has[SP]summoned\nfrom[SP]the[SP]abyss[SP]that[SP]which[SP]should[SP]not[SP]exist.",
     "nom_fr": "Philémon",
-    "texte_fr": "Fuyant la douleur infinie que s'inflige\nquiconque réalise son\nexistence, l'humanité a \nappelée depuis l'abysse\nce qui ne doitexister."
+    "texte_fr": "Fuyant la douleur infinie que s'inflige\nquiconque réalise son\nexistence, l'humanité a appelée depuis l'abysse ce qui ne doitexister."
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP][1432][NULL][NULL][0014]Crawling[SP]Chaos[1432][NULL][NULL][0014][SP]again...[1205][001E][SP]What[SP]exactly\nare[SP]you[SP]talking[SP]about?[1205][001E]",
     "nom_fr": "Maya",
-    "texte_fr": "Le [1432][NULL][NULL][0014]Chaos Rampant[1432][NULL][NULL][0014]...[1205][001E] De quoi\nvous parlez exactement?[1205][001E]"
+    "texte_fr": "Le [1432][NULL][NULL][0014]Chaos Rampant[1432][NULL][NULL][0014]...[001E][1205] De quoi\nvous parlez exactement?[001E][1205]"
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Maya",
     "texte_orig": "There's[SP]still[SP]too[SP]much[SP]we[SP]don't[SP]know.[1205][001E][SP]About\nJun-kun's[SP]father,[SP]and[SP]that[SP]Persona...[1205][001E][SP]Or[SP]why\nrumors[SP]started[SP]to[SP]come[SP]true...",
     "nom_fr": "Maya",
-    "texte_fr": "Encore tant de choses nous échappent.[1205][001E] Le\npère de Jun, cette Persona...[1205][001E] Et pourquoi\nles rumeurs deviennent réalité..."
+    "texte_fr": "Encore tant de choses nous échappent.[001E][1205] Le\npère de Jun, cette Persona...[001E][1205] Et pourquoi\nles rumeurs deviennent réalité..."
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "Eventually,[SP]the[SP]time[SP]will[SP]be[SP]right[SP]for[SP]you[SP]to\nlearn[SP]everything.[1205][001E][SP]If[SP]anyone[SP]can[SP]stop[SP]him...\nthe[SP]darkness[SP]from[SP]thriving,[SP]it[SP]is[SP]you.",
     "nom_fr": "Philémon",
-    "texte_fr": "Vous le saurez le moment venu.[1205][001E] Si il\nexiste des gens capables d'empêcher les\nténébres de prospérer, c'est vous."
+    "texte_fr": "Vous le saurez le moment venu.[001E][1205] Si il\nexiste des gens capables d'empêcher les\nténébres de prospérer, c'est vous."
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "The[SP]power[SP]amassed[SP]by[SP]the[SP]feelings[SP]which[SP]have\nbeen[SP]fostered[SP]over[SP]ten[SP]years...[1205][001E][SP]Show[SP]him[SP]the\npotential[SP]that[SP]lies[SP]within[SP]you.",
     "nom_fr": "Philémon",
-    "texte_fr": "Le pouvoir que vos émotions ont cultivé\ndurant ces dix années...[1205][001E] Montrez-lui\ntout le potentiel qui someille en vous."
+    "texte_fr": "Le pouvoir que vos émotions ont cultivé\ndurant ces dix années...[001E][1205] Montrez-lui\ntout le potentiel qui someille en vous."
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Philemon,[SP]wait![1205][001E][SP]What...[1205][001E][SP]What's[SP]wrong\nwith[SP]Yukki?",
     "nom_fr": "Maya",
-    "texte_fr": "Attendez![1205][001E] Yukki...[1205][001E] Que lui arrive-t-il?"
+    "texte_fr": "Attendez![001E][1205] Yukki...[001E][1205] Que lui arrive-t-il?"
   },
   {
     "id": 32,
@@ -492,7 +492,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "The[SP]Crawling[SP]Chaos[SP]lured[SP]her[SP]ego[SP]into[SP]being\nswallowed[SP]into[SP]the[SP]abyss[SP]of[SP]the[SP]collective\nunconsciousness...[1205][001E][SP]You[SP]can[SP]do[SP]nothing[SP]for[SP]her.",
     "nom_fr": "Philémon",
-    "texte_fr": "Le Chaos Rampant a\nmanipulé son égo pour qu'il\nfinisse englouti par\nl'abysse de l'inconscient\ncollectif...[1205][001E] Il est déjà trop tard."
+    "texte_fr": "Le Chaos Rampant a\nmanipulé son égo pour qu'il\nfinisse englouti par l'abysse de l'inconscient collectif...[001E][1205] Il est déjà trop tard."
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What...!?[SP]Yukki![1205][001E][SP]Answer[SP]me,[SP]please...!",
     "nom_fr": "Maya",
-    "texte_fr": "Yu-Yukki![1205][001E] Répond, je t'en prie...!"
+    "texte_fr": "Yu-Yukki![001E][1205] Répond, je t'en prie...!"
   },
   {
     "id": 34,
@@ -537,7 +537,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "This...[SP]No![1205][001E][SP]Jun's[SP]finally[SP]come[SP]back[SP]to[SP]us,\nbut...[1205][001E][SP]Now,[SP]Yukino-san's...",
     "nom_fr": "Ginko",
-    "texte_fr": "N-non![1205][001E] On a enfin retrouvé Jun,\nmais maintenant... [1205][001E] Yukino, elle..."
+    "texte_fr": "N-non![001E][1205] On a enfin retrouvé Jun,\nmais maintenant... [001E][1205] Yukino, elle..."
   },
   {
     "id": 36,
@@ -552,7 +552,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "However,[SP]the[SP]feelings[SP]that[SP]were[SP]once[SP]hers[SP]do\nremain.[1205][001E][SP]Emotions[SP]are[SP]passed[SP]from[SP]person[SP]to\nperson...[1205][001E][SP]Dreams[SP]go[SP]from[SP]one[SP]to[SP]another...",
     "nom_fr": "Philémon",
-    "texte_fr": "Cependant, les sentiments qui étaient siens\nsubsistent [1205][001E]Ces émotions voyagent d'individu\nen individu... [1205][001E]Tout comme les rêves..."
+    "texte_fr": "Cependant, les sentiments qui étaient siens\nsubsistent [001E][1205]Ces émotions voyagent d'individu\nen individu... [001E][1205]Tout comme les rêves..."
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "She[SP]said[SP]in[SP]the[SP]end[SP]that[SP]she[SP]would[SP]give[SP]her\npowers[SP]to[SP]you.[1205][001E][SP]Those[SP]feelings...[1205][001E][SP]Do[SP]you[SP]have\nthe[SP]right[SP]to[SP]claim[SP]them[SP]or[SP]not?[SP]Answer[SP]me.",
     "nom_fr": "Philémon",
-    "texte_fr": "Sa fin proche, elle a exprimé vouloir te\ndonner ses pouvoirs.[1205][001E] Ces émotions...[1205][001E] Es-tu\nen droit de les réclamer? Réponds-moi."
+    "texte_fr": "Sa fin proche, elle a exprimé vouloir te\ndonner ses pouvoirs.[001E][1205] Ces émotions...[001E][1205] Es-tu\nen droit de les réclamer? Réponds-moi."
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I...[1205][001E][SP]don't[SP]have[SP]the[SP]right...[1205][001E][SP]But[SP]I[SP]do[SP]have\nthe[SP]responsibility!",
     "nom_fr": "Jun",
-    "texte_fr": "Je...[1205][001E] n'en ai pas le droit...[1205][001E]\nMais j'en ai la responsabilité!"
+    "texte_fr": "Je...[001E][1205] n'en ai pas le droit...[001E][1205]\nMais j'en ai la responsabilité!"
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "That[SP]will[SP]suffice.[SP]It[SP]is[SP]not[SP]a[SP]question[SP]of\nhaving[SP]the[SP]right...[1205][001E][SP]It[SP]is[SP]a[SP]matter[SP]of[SP]having\nthe[SP]will.",
     "nom_fr": "Philémon",
-    "texte_fr": "Cela suffira. Il n'est pas question d'en\navoir le droit...[1205][001E] Mais\nd'en avoir la volonté."
+    "texte_fr": "Cela suffira. Il n'est pas question d'en\navoir le droit...[001E][1205] Mais\nd'en avoir la volonté."
   },
   {
     "id": 40,
@@ -627,7 +627,7 @@
     "nom_orig": "Hermes",
     "texte_orig": "I[SP]am[SP][E4][NULL][NULL][0005]Hermes[E4][NULL][NULL][0002]...[1205][001E][SP]Giver[SP]of[SP]fortune[SP]and[SP]fame,[SP]and\nherald[SP]of[SP]souls...[1205][001E][SP]To[SP]my[SP]alter[SP]ego:[SP]Love[SP]thy\nneighbor[SP]with[SP]a[SP]selflessness[SP]like[SP]the[SP]wind's...",
     "nom_fr": "Hermès",
-    "texte_fr": "Je suis [E4][NULL][NULL][0005]Hermès[E4][NULL][NULL][0002]...[1205][001E] Donneur de fortune et\nde gloire, héraut des âmes...[1205][001E] À mon alter\négo: Aime ton voisin, incarne le\nvent ded'altruisme...  Le stock de Personae est\nplein. Libérez un emplacement.[E4][NULL][NULL]"
+    "texte_fr": "Je suis [E4][NULL][NULL][0005]Hermès[E4][NULL][NULL][0002]...[001E][1205] Donneur de fortune et\nde gloire, héraut des âmes...[001E][1205] À mon alter\négo: Aime ton voisin, incarne le\nvent ded'altruisme...  Le stock de Personae est plein. Libérez un emplacement.[E4][NULL][NULL]"
   },
   {
     "id": 42,
@@ -642,7 +642,7 @@
     "nom_orig": "Jun",
     "texte_orig": "It's[SP]so[SP]warm...[1205][001E][SP]Thank[SP]you,[SP]Mayuzumi-san...[1205][001E]\nI[SP]won't[SP]waste[SP]your[SP]feelings.",
     "nom_fr": "Jun",
-    "texte_fr": "C'est si doux...[1205][001E] Merci, Mayuzumi...[1205][001E]\nJe ne gâcherais pas ces émotions."
+    "texte_fr": "C'est si doux...[001E][1205] Merci, Mayuzumi...[001E][1205]\nJe ne gâcherais pas ces émotions."
   },
   {
     "id": 43,
@@ -657,7 +657,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "It[SP]seems[SP]the[SP]others[SP]have[SP]also[SP]found[SP]their[SP]true\nPersonas[SP]that[SP]caused[SP]such[SP]changes[SP]in[SP]them[SP]when\nthey[SP]were[SP]young...[1205][001E][SP]These[SP]will[SP]grant[SP]you[SP]power.",
     "nom_fr": "Philémon",
-    "texte_fr": "Les autres semblent,\neux aussi, avoir révélé\nles Personae qui ont tant impacté leur \njeunesse... [1205]Elles\n[001E]augmenteront votre pouvoir."
+    "texte_fr": "Les autres semblent,\neux aussi, avoir révélé\nles Personae qui ont tant impacté leur jeunesse... [1205]Elles[001E]augmenteront votre pouvoir."
   },
   {
     "id": 44,
@@ -672,7 +672,7 @@
     "nom_orig": "Apollo",
     "texte_orig": "I[SP]am[SP]thou...[SP]Thou[SP]art[SP]I...[1205][001E][SP]From[SP]the[SP]sea[SP]of\nthy[SP]soul[SP]I[SP]cometh...[1205][001E][SP]Ruler[SP]of[SP]the[SP]blazing[SP]sun\nand[SP]blue[SP]skies,[SP][E4][NULL][NULL][0005]Apollo[E4][NULL][NULL][0002]...",
     "nom_fr": "Apollo",
-    "texte_fr": "Je suis toi... Tu es moi...[1205][001E] Venu depuis\nl'océan de ton âme...[1205][001E] Souverain du\nsoleil ardent, du ciel azure, [E4][NULL][NULL][0005]Apollo[E4][NULL][NULL][0002]..."
+    "texte_fr": "Je suis toi... Tu es moi...[001E][1205] Venu depuis\nl'océan de ton âme...[001E][1205] Souverain du\nsoleil ardent, du ciel azure, [E4][NULL][NULL][0005]Apollo[E4][NULL][NULL][0002]..."
   },
   {
     "id": 45,
@@ -687,7 +687,7 @@
     "nom_orig": "Artemis",
     "texte_orig": "I[SP]am[SP][E4][NULL][NULL][0005]Artemis[E4][NULL][NULL][0002]...[1205][001E][SP]The[SP]moon[SP]goddess[SP]who\nilluminates[SP]your[SP]twilight[SP]virtue...[1205][001E][SP]My[SP]purer\nhalf,[SP]do[SP]not[SP]be[SP]bashful[SP]of[SP]your[SP]destiny.",
     "nom_fr": "Artémis",
-    "texte_fr": "Je suis [E4][NULL][NULL][0005]Artémis[E4][NULL][NULL][0002]...[1205][001E] Déesse sélène illuminant\nta vertu crépusculaire...[1205][001E] Toi, ma pure \nmoitié, ne craint pas ta destinée."
+    "texte_fr": "Je suis [E4][NULL][NULL][0005]Artémis[E4][NULL][NULL][0002]...[001E][1205] Déesse sélène illuminant\nta vertu crépusculaire...[001E][1205] Toi, ma pure \nmoitié, ne craint pas ta destinée."
   },
   {
     "id": 46,
@@ -702,7 +702,7 @@
     "nom_orig": "Venus",
     "texte_orig": "I[SP]am[SP][E4][NULL][NULL][0005]Venus[E4][NULL][NULL][0002]...[1205][001E][SP]Goddess[SP]of[SP]fertility[SP]about\nwhom[SP]beauty[SP]and[SP]love[SP]dance...[1205][001E][SP]I[SP]am[SP]you...\nYou[SP]are[SP]me...[SP]Let[SP]us[SP]become[SP]one...",
     "nom_fr": "Vénus",
-    "texte_fr": "Je suis [E4][NULL][NULL][0005]Vénus[E4][NULL][NULL][0002]...[1205][001E] Déesse de la fertilité,\namour et beauté dansent avec moi.[1205][001E] Je\nsuis toi... tu es moi... Devenons un..."
+    "texte_fr": "Je suis [E4][NULL][NULL][0005]Vénus[E4][NULL][NULL][0002]...[001E][1205] Déesse de la fertilité,\namour et beauté dansent avec moi.[001E][1205] Je\nsuis toi... tu es moi... Devenons un..."
   },
   {
     "id": 47,
@@ -717,6 +717,6 @@
     "nom_orig": "Hades",
     "texte_orig": "I[SP]am[SP][E4][NULL][NULL][0005]Hades[E4][NULL][NULL][0002]...[1205][001E][SP]King[SP]of[SP]the[SP]underworld[SP]who[SP]judges\nthe[SP]evil[SP]and[SP]the[SP]righteous[SP]alike.[1205][001E][SP]I[SP]am[SP]thou...\nThou[SP]art[SP]I...[SP]Let[SP]us[SP]walk[SP]this[SP]path[SP]together...",
     "nom_fr": "Hadès",
-    "texte_fr": "Je suis [E4][NULL][NULL][0005]Hadès[E4][NULL][NULL][0002]...[1205][001E] Roi des enfers, jugeant\nles vils comme les vertueux.[1205][001E] Je suis toi...\nTu es moi... Marchons côte à côte..."
+    "texte_fr": "Je suis [E4][NULL][NULL][0005]Hadès[E4][NULL][NULL][0002]...[001E][1205] Roi des enfers, jugeant\nles vils comme les vertueux.[001E][1205] Je suis toi...\nTu es moi... Marchons côte à côte..."
   }
 ]

--- a/traduction/event_scripts/script_143.json
+++ b/traduction/event_scripts/script_143.json
@@ -42,7 +42,7 @@
     "nom_orig": "Boy[SP]who[SP]resembles[SP]Jun",
     "texte_orig": "And...[1205][001E][SP]My[SP]Papa[SP]and[SP]Mama[SP]disappeared...",
     "nom_fr": "Sosie de Jun",
-    "texte_fr": "Et...[1205][001E] Mon papa et maman ont disparu..."
+    "texte_fr": "Et...[001E][1205] Mon papa et maman ont disparu..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Boy[SP]who[SP]resembles[SP]Jun",
     "texte_orig": "When[SP]I[SP]think[SP]hard,[SP]I[SP]know[SP]I[SP]had[SP]a[SP]Mama[SP]and\nPapa...[1205][001E][SP]But[SP]now[SP]when[SP]I[SP]go[SP]home,[SP]I'll[SP]be\nall[SP]alone...",
     "nom_fr": "Sosie de Jun",
-    "texte_fr": "Quand j'y pense, je sais que\nj'avais un papa et une maman...[1205][001E]\nMais si je rentre, je serai seul..."
+    "texte_fr": "Quand j'y pense, je sais que\nj'avais un papa et une maman...[001E][1205]\nMais si je rentre, je serai seul..."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Boy[SP]who[SP]resembles[SP]Jun",
     "texte_orig": "Papa[SP]and[SP]Mama[SP]were[SP]always[SP]fighting.\nBut...[1205][001E][SP]They[SP]were[SP]still[SP]my[SP]parents!",
     "nom_fr": "Sosie de Jun",
-    "texte_fr": "Papa et maman se disputaient toujours.\nMais...[1205][001E] C'était quand même mes parents!"
+    "texte_fr": "Papa et maman se disputaient toujours.\nMais...[001E][1205] C'était quand même mes parents!"
   },
   {
     "id": 5,
@@ -192,7 +192,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Um...[SP][1205][001E][SP]It's[SP]called[SP]the[SP]Persona[SP]Game...",
     "nom_fr": "Jun",
-    "texte_fr": "Hum... [1205][001E] C'est le Persona Game..."
+    "texte_fr": "Hum... [001E][1205] C'est le Persona Game..."
   },
   {
     "id": 13,
@@ -372,7 +372,7 @@
     "nom_orig": "Jun",
     "texte_orig": "My[SP]father...[1205][001E][SP]should[SP]be[SP]chasing[SP]the[SP]Heaven[SP]Skull\nand[SP]the[SP]Fuhrer[SP]to[SP]the[SP]center[SP]of[SP]Xibalba...",
     "nom_fr": "Jun",
-    "texte_fr": "Mon père...[1205][001E] devrait poursuivre le Crâne\nCéleste et le Führer jusqu'au centre de\nXibalba..."
+    "texte_fr": "Mon père...[001E][1205] devrait poursuivre le Crâne\nCéleste et le Führer jusqu'au centre de\nXibalba..."
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Sorry[SP]to[SP]spring[SP]this[SP]on[SP]you,[SP]guys...[1205][001E][SP]But[SP]I'm\ngonna[SP]part[SP]ways[SP]here.[SP]I've[SP]been[SP]thinking[SP]of\nstaying[SP]in[SP]the[SP]city.",
     "nom_fr": "Yukino",
-    "texte_fr": "Désolée de vous surprendre comme\nça...[1205][001E] Mais je vais vous quitter\nici. J'ai pensé rester en ville."
+    "texte_fr": "Désolée de vous surprendre comme\nça...[001E][1205] Mais je vais vous quitter\nici. J'ai pensé rester en ville."
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "And[SP]I[SP]thought[SP]if[SP]that[SP]happens,[SP]it'd[SP]be[SP]best[SP]to\nhave[SP]someone[SP]who[SP]can[SP]fight[SP]there[SP]to[SP]handle[SP]it.\nI[SP]don't[SP]want[SP]anyone[SP]else[SP]to[SP]die...",
     "nom_fr": "Yukino",
-    "texte_fr": "J'ai pensé que si ça arrive, il vaudrait\nmieux avoir quelqu'un pouvant se battre\nlà-bas. Je ne veux\nplus personne qui meure..."
+    "texte_fr": "J'ai pensé que si ça arrive, il vaudrait\nmieux avoir quelqu'un pouvant se battre\nlà-bas. Je ne veux plus personne qui meure..."
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]see[SP]what[SP]you[SP]mean,[SP]but...[1205][001E][SP]It's[SP]crazy[SP]to[SP]try\nand[SP]fight[SP]them[SP]alone[SP]and[SP]without[SP]a[SP]Persona,\neven[SP]for[SP]you!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je vois ce que tu veux dire, mais...[1205][001E]\nC'est fou de les combattre seul et\nsans Persona, même pour toi!"
+    "texte_fr": "Je vois ce que tu veux dire, mais...[001E][1205]\nC'est fou de les combattre seul et\nsans Persona, même pour toi!"
   },
   {
     "id": 29,
@@ -537,7 +537,7 @@
     "nom_orig": "Boy[SP]who[SP]resembles[SP]Jun",
     "texte_orig": "And...[1205][001E][SP]My[SP]Papa[SP]and[SP]Mama[SP]disappeared...",
     "nom_fr": "Sosie de Jun",
-    "texte_fr": "Et...[1205][001E] Mon papa et maman ont disparu..."
+    "texte_fr": "Et...[001E][1205] Mon papa et maman ont disparu..."
   },
   {
     "id": 36,
@@ -552,7 +552,7 @@
     "nom_orig": "Boy[SP]who[SP]resembles[SP]Jun",
     "texte_orig": "When[SP]I[SP]think[SP]hard,[SP]I[SP]know[SP]I[SP]had[SP]a[SP]Mama[SP]and\nPapa...[1205][001E][SP]But[SP]now[SP]when[SP]I[SP]go[SP]home,[SP]I'll[SP]be\nall[SP]alone...",
     "nom_fr": "Sosie de Jun",
-    "texte_fr": "Quand j'y pense, je sais que\nj'avais un papa et une maman...[1205][001E]\nMais si je rentre, je serai seul..."
+    "texte_fr": "Quand j'y pense, je sais que\nj'avais un papa et une maman...[001E][1205]\nMais si je rentre, je serai seul..."
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Boy[SP]who[SP]resembles[SP]Jun",
     "texte_orig": "Papa[SP]and[SP]Mama[SP]were[SP]always[SP]fighting.\nBut...[1205][001E][SP]They[SP]were[SP]still[SP]my[SP]parents!",
     "nom_fr": "Sosie de Jun",
-    "texte_fr": "Papa et maman se disputaient toujours.\nMais...[1205][001E] C'était quand même mes parents!"
+    "texte_fr": "Papa et maman se disputaient toujours.\nMais...[001E][1205] C'était quand même mes parents!"
   },
   {
     "id": 38,
@@ -687,7 +687,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Um...[SP][1205][001E][SP]It's[SP]called[SP]the[SP]Persona[SP]Game...",
     "nom_fr": "Jun",
-    "texte_fr": "Hum... [1205][001E] C'est le Persona Game..."
+    "texte_fr": "Hum... [001E][1205] C'est le Persona Game..."
   },
   {
     "id": 46,
@@ -867,7 +867,7 @@
     "nom_orig": "Jun",
     "texte_orig": "My[SP]father...[1205][001E][SP]should[SP]be[SP]chasing[SP]the[SP]Heaven[SP]Skull\nand[SP]the[SP]Fuhrer[SP]to[SP]the[SP]center[SP]of[SP]Xibalba...",
     "nom_fr": "Jun",
-    "texte_fr": "Mon père...[1205][001E] devrait poursuivre le Crâne\nCéleste et le Führer jusqu'au centre de\nXibalba..."
+    "texte_fr": "Mon père...[001E][1205] devrait poursuivre le Crâne\nCéleste et le Führer jusqu'au centre de\nXibalba..."
   },
   {
     "id": 58,
@@ -927,7 +927,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We're[SP]going[SP]in[SP]there[SP]to[SP]avenge[SP]Yukino-san,\nso[SP]we[SP]can't[SP]lose![SP]I[SP]hope[SP]the[SP]Masked[SP]Circle\nand[SP]Last[SP]Battalion[SP]are[SP]ready[SP]to[SP]get[SP]creamed!",
     "nom_fr": "Ginko",
-    "texte_fr": "On entre là-dedans pour venger Yukino-san,\nalors on ne peut\npas perdre! J'espère que le\nCercle masqué et le Bataillon sont prêts!"
+    "texte_fr": "On entre là-dedans pour venger Yukino-san,\nalors on ne peut\npas perdre! J'espère que le Cercle masqué et le Bataillon sont prêts!"
   },
   {
     "id": 62,
@@ -942,7 +942,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We're[SP]finally[SP]reunited,[SP]all[SP]five[SP]of[SP]us...[1205][001E]\nI[SP]feel[SP]like[SP]nothing[SP]can[SP]stop[SP]me,[SP]Masked\nCircle[SP]or[SP]Last[SP]Battalion[SP]or[SP]whatever!",
     "nom_fr": "Eikichi",
-    "texte_fr": "On est enfin réunis, tous les cinq...[1205][001E]\nJe me sens invincible, que ce soit le\nCercle masqué ou le Bataillon!"
+    "texte_fr": "On est enfin réunis, tous les cinq...[001E][1205]\nJe me sens invincible, que ce soit le\nCercle masqué ou le Bataillon!"
   },
   {
     "id": 63,
@@ -957,7 +957,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We're[SP]finally[SP]reunited,[SP]all[SP]five[SP]of[SP]us...[1205][001E]\nI[SP]feel[SP]like[SP]nothing[SP]can[SP]stop[SP]me,[SP]Masked\nCircle[SP]or[SP]Last[SP]Battalion[SP]or[SP]whatever!",
     "nom_fr": "Eikichi",
-    "texte_fr": "On est enfin réunis, tous les cinq...[1205][001E]\nJe me sens invincible, que ce soit le\nCercle masqué ou le Bataillon!"
+    "texte_fr": "On est enfin réunis, tous les cinq...[001E][1205]\nJe me sens invincible, que ce soit le\nCercle masqué ou le Bataillon!"
   },
   {
     "id": 64,

--- a/traduction/event_scripts/script_145.json
+++ b/traduction/event_scripts/script_145.json
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "My[SP]Persona's[SP]telling[SP]me[SP]that[SP]it's[SP]him...[1205][001E]\nYour[SP]impostor[SP]is[SP]here,[SP][1113].[SP]I'm[SP]getting\nsome[SP]bad[SP]vibes...",
     "nom_fr": "Ginko",
-    "texte_fr": "Ma Persona m'indique que c'est\nlui...[1205][001E] Ton imposteur est droit\ndevant, [1113]. Je le sens pas..."
+    "texte_fr": "Ma Persona m'indique que c'est\nlui...[001E][1205] Ton imposteur est droit\ndevant, [1113]. Je le sens pas..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Looks[SP]like[SP]Mustache[SP]Man[SP]hasn't[SP]given[SP]up[SP]on\nthe[SP]skulls[SP]yet...[1205][001E][SP]Let's[SP]get[SP]them[SP]all[SP]first\nand[SP]give[SP]'em[SP]a[SP]good[SP]scare!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mac Moustache n'a pas l'air d'avoir\nabandonné les crânes...[1205][001E] Surprenons-les\nen les récupérant en premier!"
+    "texte_fr": "Mac Moustache n'a pas l'air d'avoir\nabandonné les crânes...[001E][1205] Surprenons-les\nen les récupérant en premier!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]relief...[1205][001E][SP]It's[SP]showing[SP]the[SP]four[SP]temples,\nright?[SP]But[SP]what[SP]is[SP]it?[SP]Order?[SP]Balance...?",
     "nom_fr": "Maya",
-    "texte_fr": "Ces reliefs...[1205][001E] C'est\nles quatre temples, non?\nMais ça? Une sorte d'ordre, d'équilibre?"
+    "texte_fr": "Ces reliefs...[001E][1205] C'est\nles quatre temples, non?\nMais ça? Une sorte d'ordre, d'équilibre?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Earth,[SP]water,[SP]fire,[SP]wind...[1205][001E][SP]Four[SP]elements.\nEarth[SP]is[SP]Taurus...[SP]Water[SP]is[SP]Scorpio...[SP]Fire[SP]is\nLeo...[SP]and[SP]Wind[SP]is[SP]Aquarius...",
     "nom_fr": "Maya",
-    "texte_fr": "Terre, eau, feu, air...[1205][001E] La Terre pour\nTaureau, l'Eau pour Scorpion, le Feu\npour Lion, et l'Air pour Verseau..."
+    "texte_fr": "Terre, eau, feu, air...[001E][1205] La Terre pour\nTaureau, l'Eau pour Scorpion, le Feu\npour Lion, et l'Air pour Verseau..."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Okay...[1205][001E][SP]I[SP]think[SP]I[SP]get[SP]it[SP]now.",
     "nom_fr": "Maya",
-    "texte_fr": "Oui...[1205][001E] Je pense avoir saisi."
+    "texte_fr": "Oui...[001E][1205] Je pense avoir saisi."
   },
   {
     "id": 7,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Alright...[1205][001E][SP]Like[SP]it[SP]or[SP]not,[SP]this[SP]is[SP]the[SP]last\none.[SP]Let's[SP]steel[SP]ourselves[SP]and[SP]do[SP]this!",
     "nom_fr": "Maya",
-    "texte_fr": "Bon...[1205][001E] Qu'on le veuille ou non, c'est le\ndernier. On reste concentrés et on y va!"
+    "texte_fr": "Bon...[001E][1205] Qu'on le veuille ou non, c'est le\ndernier. On reste concentrés et on y va!"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It'll[SP]be[SP]a[SP]battle[SP]against[SP]yourselves...[1205][001E]\nBut[SP]your[SP]hearts[SP]will[SP]overcome[SP]your[SP]other\nnature[SP]in[SP]the[SP]end!",
     "nom_fr": "Maya",
-    "texte_fr": "On va se retrouver\nface à nous-mêmes...[1205][001E] Mais\nnos coeurs surmonteront cette part de nous!"
+    "texte_fr": "On va se retrouver\nface à nous-mêmes...[001E][1205] Mais\nnos coeurs surmonteront cette part de nous!"
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Jun",
     "texte_orig": "These[SP]four[SP]elements[SP]maintain[SP]the[SP]balance[SP]of[SP]the\nworld,[SP]and[SP]each[SP]has[SP]strengths[SP]and[SP]weaknesses.[1205][001E]\nIt's[SP]a[SP]brand[SP]of[SP]mysticism[SP]Father[SP]told[SP]me[SP]about.",
     "nom_fr": "Jun",
-    "texte_fr": "Chaque élément, avec ses force et ses\nfaiblesses, contribue à l'équilibre du\nmonde.[1205][001E] Père m'a déjà parlé de ces mythes."
+    "texte_fr": "Chaque élément, avec ses force et ses\nfaiblesses, contribue à l'équilibre du\nmonde.[001E][1205] Père m'a déjà parlé de ces mythes."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Xibalba[SP]is,[SP]in[SP]other[SP]words,[SP]a[SP]model[SP]for[SP]the\nnew[SP]world...[1205][001E][SP]The[SP]balance[SP]of[SP]the[SP]temples\nsymbolizing[SP]the[SP]world[SP]may[SP]be[SP]important...",
     "nom_fr": "Jun",
-    "texte_fr": "Autrement dit, Xibalba est la maquette\nd'un monde nouveau...[1205][001E] L'équilibre du monde\net des temples doit être important..."
+    "texte_fr": "Autrement dit, Xibalba est la maquette\nd'un monde nouveau...[001E][1205] L'équilibre du monde\net des temples doit être important..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Even[SP]from[SP]here,[SP]I[SP]can[SP]sense[SP]Father's[SP]presence...[1205][001E]\nHis[SP]will[SP]is[SP]enveloping[SP]the[SP]city...",
     "nom_fr": "Jun",
-    "texte_fr": "Même ici, je ressens la présence de Père...[1205][001E]\nSon emprise enveloppe toute la ville..."
+    "texte_fr": "Même ici, je ressens la présence de Père...[001E][1205]\nSon emprise enveloppe toute la ville..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Father...?[SP]Yes...[1205][001E][SP]It's[SP]him.",
     "nom_fr": "Jun",
-    "texte_fr": "Père...? Oui...[1205][001E] C'est lui."
+    "texte_fr": "Père...? Oui...[001E][1205] C'est lui."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]need[SP]to[SP]stop[SP]Father[SP]for[SP]those[SP]children's\nsake[SP]as[SP]well...[1205][001E][SP]I[SP]won't[SP]end[SP]my[SP]life[SP]as[SP]a\npuppet!",
     "nom_fr": "Jun",
-    "texte_fr": "C'est aussi pour ces enfants que je dois\narrêter Père...[1205][001E] Assez\nd'être une marionnette!"
+    "texte_fr": "C'est aussi pour ces enfants que je dois\narrêter Père...[001E][1205] Assez\nd'être une marionnette!"
   },
   {
     "id": 18,
@@ -297,6 +297,6 @@
     "nom_orig": "Jun",
     "texte_orig": "After[SP]that...[1205][001E][SP]We[SP]only[SP]have[SP]to[SP]defeat[SP]Father.",
     "nom_fr": "Jun",
-    "texte_fr": "Après ça...[1205][001E] Il ne restera plus que Père.\n Quelque chose est écrit dans le relief."
+    "texte_fr": "Après ça...[001E][1205] Il ne restera plus que Père.\n Quelque chose est écrit dans le relief."
   }
 ]

--- a/traduction/event_scripts/script_147.json
+++ b/traduction/event_scripts/script_147.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Chinyan...[1205][001E][SP]It's[SP]still[SP]faint,[SP]but...[SP]I[SP]think\nwe're[SP]getting[SP]closer.",
     "nom_fr": "Ginko",
-    "texte_fr": "Chinyan...[1205][001E] C'est faible mais...\nJe crois qu'on s'en rapproche."
+    "texte_fr": "Chinyan...[001E][1205] C'est faible mais...\nJe crois qu'on s'en rapproche."
   },
   {
     "id": 1,
@@ -207,7 +207,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Owww...[1205][001E][SP]Every[SP]now[SP]and[SP]then,[SP]Ginko[SP]just[SP]loses\nit[SP]completely.[SP]She[SP]goes[SP]crazy[SP]at[SP]anything\nhaving[SP]to[SP]do[SP]with[SP][1114]...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ouch...[1205][001E] Parfois, Ginko pète complètement\nles plombs. Quand elle vire pas\nfoldingue dès que ça concerne [1114]..."
+    "texte_fr": "Ouch...[001E][1205] Parfois, Ginko pète complètement\nles plombs. Quand elle vire pas\nfoldingue dès que ça concerne [1114]..."
   },
   {
     "id": 14,
@@ -252,7 +252,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]time,[SP]we[SP]really[SP]are[SP]facing[SP]your[SP]shadow.[1205][001E]\nYou'll[SP]be[SP]fighting[SP]yourself...[1205][001E][SP]Hang[SP]in[SP]there,\n[1113]-kun!",
     "nom_fr": "Maya",
-    "texte_fr": "Cette fois, tu va réellement\n[001E][1205]affronter ton ombre, te confronter\nà toi-même...[1205][001E] Tiens bon, [1113]!"
+    "texte_fr": "Cette fois, tu va réellement\n[001E][1205]affronter ton ombre, te confronter\nà toi-même...[001E][1205] Tiens bon, [1113]!"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Leo...[1205][001E][SP]It[SP]embodies[SP]the[SP]element[SP]of[SP]fire[SP]and\nsymbolizes[SP]justice[SP]and[SP]leadership,[SP]as[SP]well\nas[SP]generosity[SP]and[SP]life...",
     "nom_fr": "Jun",
-    "texte_fr": "Le Lion...[1205][001E] Il incarne le feu et\nsymbolise justice, charisme, mais\naussi générosité et vitalité..."
+    "texte_fr": "Le Lion...[001E][1205] Il incarne le feu et\nsymbolise justice, charisme, mais\naussi générosité et vitalité..."
   },
   {
     "id": 18,
@@ -282,6 +282,6 @@
     "nom_orig": "Jun",
     "texte_orig": "[1113]...[1205][001E][SP]It's[SP]a[SP]constellation[SP]worthy[SP]of[SP]you.",
     "nom_fr": "Jun",
-    "texte_fr": "[1113]...[1205][001E] Ce signe est digne de toi. \nQuelque chose est inscrit dans le relief."
+    "texte_fr": "[1113]...[001E][1205] Ce signe est digne de toi. \nQuelque chose est inscrit dans le relief."
   }
 ]

--- a/traduction/event_scripts/script_149.json
+++ b/traduction/event_scripts/script_149.json
@@ -12,7 +12,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "Good[SP]job[SP]making[SP]it[SP]here,[SP][1113]...[1205][001E]\nI'm[SP]your[SP]shadow.[1205][001E][SP]I[SP]know[SP]full[SP]well[SP]what\ngoes[SP]on[SP]in[SP]your[SP]heart...",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Bravo [1113], tu es arrivé ici.[1205][001E]\nJe suis ton Ombre.[1205][001E] Je sais tout\nce qui se trâme dans ton cœur."
+    "texte_fr": "Bravo [1113], tu es arrivé ici.[001E][1205]\nJe suis ton Ombre.[001E][1205] Je sais tout\nce qui se trâme dans ton cœur."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "Your[SP]dream[SP]was[SP]to[SP]go[SP]to[SP]college...[1205][001E][SP]But[SP]not\nbecause[SP]there[SP]was[SP]anything[SP]you[SP]wanted\nto[SP]learn.",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Ton rêve c'était d'aller à la fac...[1205][001E] Mais\npas pour apprendre quoi que ce soit."
+    "texte_fr": "Ton rêve c'était d'aller à la fac...[001E][1205] Mais\npas pour apprendre quoi que ce soit."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "You[SP]were[SP]doing[SP]what[SP]society[SP]expected[SP]of[SP]you.[1205][001E]\nFollowing[SP]the[SP]path[SP]already[SP]laid[SP]out[SP]in[SP]front\nof[SP]you.",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Tu faisais juste ce\nque la société attendait\nde toi. [1205][001E] Tu suivait\nun chemin déjà tout tracé."
+    "texte_fr": "Tu faisais juste ce\nque la société attendait\nde toi. [001E][1205] Tu suivait\nun chemin déjà tout tracé."
   },
   {
     "id": 3,
@@ -113,7 +113,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "A[SP]man[SP]like[SP]you[SP]could[SP]never[SP]save[SP]even[SP]one\nperson,[SP]let[SP]alone[SP]the[SP]world.[1205][001E][SP]Why,[SP]I[SP]bet[SP]that\ndeep[SP]down[SP]inside,[SP]you[SP]actually[SP]hate[SP]Jun...",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[1205][001E] Je parie\nqu'au fond de toi, tu détestes Jun..."
+    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[001E][1205] Je parie\nqu'au fond de toi, tu détestes Jun..."
   },
   {
     "id": 7,
@@ -128,7 +128,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "Of[SP]course[SP]you[SP]can't.[1205][001E][SP]You[SP]never[SP]make[SP]any\ndecisions[SP]for[SP]yourself.",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Tu en es incapable.[1205][001E] Tu n'as\njamais pris une seule décision."
+    "texte_fr": "Tu en es incapable.[001E][1205] Tu n'as\njamais pris une seule décision."
   },
   {
     "id": 8,
@@ -143,7 +143,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "A[SP]man[SP]like[SP]you[SP]could[SP]never[SP]save[SP]even[SP]one\nperson,[SP]let[SP]alone[SP]the[SP]world.[1205][001E][SP]Why,[SP]I[SP]bet[SP]that\ndeep[SP]down[SP]inside,[SP]you[SP]actually[SP]hate[SP]Jun...",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[1205][001E] Je parie\nqu'au fond de toi, tu détestes Jun..."
+    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[001E][1205] Je parie\nqu'au fond de toi, tu détestes Jun..."
   },
   {
     "id": 9,
@@ -158,7 +158,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "You[SP]dream[SP]of[SP]a[SP]career...[1205][001E][SP]But[SP]you[SP]don't[SP]want\na[SP]job,[SP]because[SP]there's[SP]something[SP]else[SP]you\nwant[SP]to[SP]do.",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Tu rêves d'une carrière...[1205][001E] Mais tu ne veux\npas travailler, tu veux faire autre chose."
+    "texte_fr": "Tu rêves d'une carrière...[001E][1205] Mais tu ne veux\npas travailler, tu veux faire autre chose."
   },
   {
     "id": 10,
@@ -173,7 +173,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "Your[SP]circumstances[SP]won't[SP]allow[SP]it.[1205][001E][SP]You[SP]have\nno[SP]chance[SP]of[SP]going[SP]to[SP]college.[1205][001E][SP]Struggling\nnow[SP]won't[SP]change[SP]the[SP]facts.",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Ta situation ne le permet pas. [001E][1205]Tu n'as\naucune chance d'aller à la fac.[1205][001E] Se\nbattre maintenant n'y changera rien."
+    "texte_fr": "Ta situation ne le permet pas. [001E][1205]Tu n'as\naucune chance d'aller à la fac.[001E][1205] Se\nbattre maintenant n'y changera rien."
   },
   {
     "id": 11,
@@ -229,7 +229,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "When[SP]will[SP]you[SP]stop[SP]deluding[SP]yourself?\nThe[SP]real[SP]you[SP]gave[SP]up[SP]on[SP]his[SP]dreams...[1205][001E]\nGave[SP]up[SP]on[SP]his[SP]entire[SP]life.",
     "nom_fr": "",
-    "texte_fr": "Quand arrêtera-tu de te voiler la\nface? Le vrai toi a abandonné ses\nrêves..[1205][001E] .. abandonné sa vie entière."
+    "texte_fr": "Quand arrêtera-tu de te voiler la\nface? Le vrai toi a abandonné ses\nrêves..[001E][1205] .. abandonné sa vie entière."
   },
   {
     "id": 14,
@@ -244,7 +244,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "A[SP]man[SP]like[SP]you[SP]could[SP]never[SP]save[SP]even[SP]one\nperson,[SP]let[SP]alone[SP]the[SP]world.[1205][001E][SP]Why,[SP]I[SP]bet[SP]that\ndeep[SP]down[SP]inside,[SP]you[SP]actually[SP]hate[SP]Jun...",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[1205][001E] Je parie\nqu'au fond de toi, tu détestes Jun..."
+    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[001E][1205] Je parie\nqu'au fond de toi, tu détestes Jun..."
   },
   {
     "id": 15,
@@ -274,7 +274,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "A[SP]man[SP]like[SP]you[SP]could[SP]never[SP]save[SP]even[SP]one\nperson,[SP]let[SP]alone[SP]the[SP]world.[1205][001E][SP]Why,[SP]I[SP]bet[SP]that\ndeep[SP]down[SP]inside,[SP]you[SP]actually[SP]hate[SP]Jun...",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[1205][001E] Je parie\nqu'au fond de toi, tu détestes Jun..."
+    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[001E][1205] Je parie\nqu'au fond de toi, tu détestes Jun..."
   },
   {
     "id": 17,
@@ -304,7 +304,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "You[SP]must[SP]know[SP]already...[1205][001E][SP]It's[SP]much[SP]easier\nto[SP]walk[SP]a[SP]path[SP]that[SP]someone[SP]else[SP]decides\nfor[SP]you.[SP]Tell[SP]me[SP]I'm[SP]wrong.",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Tu le sais déjà...[1205][001E]\nC'est plus facile de suivre\nun chemin qu'on a\ntracé pour toi. J'ai tort?"
+    "texte_fr": "Tu le sais déjà...[001E][1205]\nC'est plus facile de suivre\nun chemin qu'on a tracé pour toi. J'ai tort?"
   },
   {
     "id": 19,
@@ -345,7 +345,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "When[SP]will[SP]you[SP]stop[SP]deluding[SP]yourself?[SP]So[SP]what\nsteps[SP]have[SP]you[SP]taken[SP]to[SP]achieve[SP]this[SP]dream?\nDon't[SP]tell[SP]me[SP]you're[SP]proud[SP]of[SP]your[SP]life...",
     "nom_fr": "",
-    "texte_fr": "Quand arrêtera-tu de te voiler la face?\nQu'as tu fait pour\nte rapprocher de ce rêve?\nNe me dit pas que\ntu es fier de cette vie..."
+    "texte_fr": "Quand arrêtera-tu de te voiler la face?\nQu'as tu fait pour\nte rapprocher de ce rêve? Ne me dit pas que tu es fier de cette vie..."
   },
   {
     "id": 21,
@@ -360,7 +360,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "A[SP]man[SP]like[SP]you[SP]could[SP]never[SP]save[SP]even[SP]one\nperson,[SP]let[SP]alone[SP]the[SP]world.[1205][001E][SP]Why,[SP]I[SP]bet[SP]that\ndeep[SP]down[SP]inside,[SP]you[SP]actually[SP]hate[SP]Jun...",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[1205][001E] Je parie\nqu'au fond de toi, tu détestes Jun..."
+    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[001E][1205] Je parie\nqu'au fond de toi, tu détestes Jun..."
   },
   {
     "id": 22,
@@ -375,7 +375,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "Of[SP]course[SP]you[SP]can't.[SP]You[SP]want[SP]more[SP]than\nanything[SP]for[SP]someone[SP]to[SP]pick[SP]a[SP]path[SP]for[SP]you...[1205][001E]\nYou[SP]can't[SP]make[SP]a[SP]single[SP]choice[SP]for[SP]yourself.",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Tu en es incapable. Tu veux juste\nqu'on choisisse pour toi...[1205][001E] Tu es\nimpuissant face à ta liberté."
+    "texte_fr": "Tu en es incapable. Tu veux juste\nqu'on choisisse pour toi...[001E][1205] Tu es\nimpuissant face à ta liberté."
   },
   {
     "id": 23,
@@ -390,7 +390,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "A[SP]man[SP]like[SP]you[SP]could[SP]never[SP]save[SP]even[SP]one\nperson,[SP]let[SP]alone[SP]the[SP]world.[1205][001E][SP]Why,[SP]I[SP]bet[SP]that\ndeep[SP]down[SP]inside,[SP]you[SP]actually[SP]hate[SP]Jun...",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[1205][001E] Je parie\nqu'au fond de toi, tu détestes Jun..."
+    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[001E][1205] Je parie\nqu'au fond de toi, tu détestes Jun..."
   },
   {
     "id": 24,
@@ -420,7 +420,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "Some[SP]life...[SP]Aimless[SP]and[SP]irritating...[1205][001E]\nYou[SP]must[SP]have[SP]figured[SP]out[SP]by[SP]now[SP]that[SP]your\nlife[SP]has[SP]no[SP]meaning[SP]whatsoever.",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Quelle vie... sans but et\nagaçante...[1205][001E] Tu dois l'avoir compris,\nton existence est dépourvue de sens."
+    "texte_fr": "Quelle vie... sans but et\nagaçante...[001E][1205] Tu dois l'avoir compris,\nton existence est dépourvue de sens."
   },
   {
     "id": 26,
@@ -435,7 +435,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "It's[SP]a[SP]scream[SP]to[SP]watch...[1205][001E][SP]You're[SP]nothing[SP]but\na[SP]puppet[SP]with[SP]tangled[SP]strings,[SP]writhing[SP]to\ntry[SP]and[SP]get[SP]free.[SP]Tell[SP]me[SP]I'm[SP]wrong.",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "C'est comique à voir...[1205][001E] Une marionnette\naux fils emmêlés, qui se tortille pour\nse libérer. Dis moi que j'ai tort."
+    "texte_fr": "C'est comique à voir...[001E][1205] Une marionnette\naux fils emmêlés, qui se tortille pour\nse libérer. Dis moi que j'ai tort."
   },
   {
     "id": 27,
@@ -491,7 +491,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "A[SP]man[SP]like[SP]you[SP]could[SP]never[SP]save[SP]even[SP]one\nperson,[SP]let[SP]alone[SP]the[SP]world.[1205][001E][SP]Why,[SP]I[SP]bet[SP]that\ndeep[SP]down[SP]inside,[SP]you[SP]actually[SP]hate[SP]Jun...",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[1205][001E] Je parie\nqu'au fond de toi, tu détestes Jun..."
+    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[001E][1205] Je parie\nqu'au fond de toi, tu détestes Jun..."
   },
   {
     "id": 30,
@@ -521,7 +521,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "A[SP]man[SP]like[SP]you[SP]could[SP]never[SP]save[SP]even[SP]one\nperson,[SP]let[SP]alone[SP]the[SP]world.[1205][001E][SP]Why,[SP]I[SP]bet[SP]that\ndeep[SP]down[SP]inside,[SP]you[SP]actually[SP]hate[SP]Jun...",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[1205][001E] Je parie\nqu'au fond de toi, tu détestes Jun..."
+    "texte_fr": "Tu ne pourrais même pas sauver une\nseule vie, alors le monde?[001E][1205] Je parie\nqu'au fond de toi, tu détestes Jun..."
   },
   {
     "id": 32,
@@ -565,7 +565,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "How[SP]self-righteous...[1205][001E][SP]Is[SP]your[SP]ego[SP]so\noverdeveloped[SP]that[SP]you[SP]can[SP]judge[SP]others\nlike[SP]that?",
     "nom_fr": "",
-    "texte_fr": "Quelle prétention...[1205][001E] À quel point\nton égo est-il grand pour que tu\njuges les autres comme ça?"
+    "texte_fr": "Quelle prétention...[001E][1205] À quel point\nton égo est-il grand pour que tu\njuges les autres comme ça?"
   },
   {
     "id": 34,
@@ -595,7 +595,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "Too[SP]bad...[1205][001E][SP]there's[SP]no[SP]meaning[SP]in[SP]an[SP]outlook\nlike[SP]that.[SP]Prepare[SP]to[SP]die[SP]here.",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Dommage...[1205][001E] une telle vision des choses\nn'a aucun sens. Tu vas mourir ici."
+    "texte_fr": "Dommage...[001E][1205] une telle vision des choses\nn'a aucun sens. Tu vas mourir ici."
   },
   {
     "id": 36,
@@ -610,7 +610,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "What[SP]a[SP]hypocrite![1205][001E][SP]Either[SP]that[SP]or[SP]you[SP]really\nare[SP]Mr.[SP]Perfect.",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Quel hypocrite![1205][001E] À moins\nque tu sois un petit ange?"
+    "texte_fr": "Quel hypocrite![001E][1205] À moins\nque tu sois un petit ange?"
   },
   {
     "id": 37,
@@ -640,7 +640,7 @@
     "nom_orig": "Shadow[SP][1113]",
     "texte_orig": "Too[SP]bad...[1205][001E][SP]there's[SP]no[SP]meaning[SP]in[SP]an[SP]outlook\nlike[SP]that.[SP]Prepare[SP]to[SP]die[SP]here.",
     "nom_fr": "Ombre de [1113]",
-    "texte_fr": "Dommage...[1205][001E] une telle vision des choses\nn'a aucun sens. Tu vas mourir ici."
+    "texte_fr": "Dommage...[001E][1205] une telle vision des choses\nn'a aucun sens. Tu vas mourir ici."
   },
   {
     "id": 39,

--- a/traduction/event_scripts/script_150.json
+++ b/traduction/event_scripts/script_150.json
@@ -12,7 +12,7 @@
     "nom_orig": "Jun",
     "texte_orig": "[1113]...[1205][001E][SP]I[SP]deserve[SP]your[SP]hatred...[1205][001E][SP]I[SP]don't\nmind[SP]if[SP]you[SP]hate[SP]me...",
     "nom_fr": "Jun",
-    "texte_fr": "[1113]...[1205][001E] Je mérite votre haine.[1205][001E]\nHaïssez-moi ça m'est égal."
+    "texte_fr": "[1113]...[001E][1205] Je mérite votre haine.[001E][1205]\nHaïssez-moi ça m'est égal."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]know[SP]I'm[SP]in[SP]no[SP]position[SP]to[SP]ask[SP]this...[1205][001E]\nBut[SP]please[SP]stand[SP]with[SP]me[SP]until[SP]this[SP]battle\nis[SP]over...[1205][001E][SP]I[SP]beg[SP]you...",
     "nom_fr": "Jun",
-    "texte_fr": "J'ai aucun droit de vous demander\nça...[1205][001E] Mais je vous en prie combattez\nà mes côtés... [1205][001E] Je vous en conjure."
+    "texte_fr": "J'ai aucun droit de vous demander\nça...[001E][1205] Mais je vous en prie combattez\nà mes côtés... [001E][1205] Je vous en conjure."
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "There's[SP]no[SP]need[SP]for[SP]that,[SP]Jun.[1205][001E][SP]We're[SP]friends.",
     "nom_fr": "Eikichi",
-    "texte_fr": "T'en fais pas, Jun.[1205][001E] On est amis."
+    "texte_fr": "T'en fais pas, Jun.[001E][1205] On est amis."
   },
   {
     "id": 5,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun...[1205][001E][SP]Let's[SP]get[SP]this[SP]done...",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]...[1205][001E] Finissons-en..."
+    "texte_fr": "[1113]...[001E][1205] Finissons-en..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Jun",
     "texte_orig": "[1113]...[1205][001E][SP]I[SP]deserve[SP]your[SP]hatred...[1205][001E][SP]I[SP]don't\nmind[SP]if[SP]you[SP]hate[SP]me...",
     "nom_fr": "Jun",
-    "texte_fr": "[1113]...[1205][001E] Je mérite votre haine.[1205][001E]\nHaïssez-moi ça m'est égal."
+    "texte_fr": "[1113]...[001E][1205] Je mérite votre haine.[001E][1205]\nHaïssez-moi ça m'est égal."
   },
   {
     "id": 9,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Jun-kun...[1205][001E][SP]You[SP]should[SP]have[SP]more[SP]trust[SP]in[SP]your\nfriends.[SP]True[SP]friends[SP]are[SP]those[SP]you[SP]can[SP]rely\non[SP]when[SP]you're[SP]suffering[SP]most.",
     "nom_fr": "Maya",
-    "texte_fr": "Jun...[1205][001E] Tu devrais te reposer plus sur\ntes amis. Les vrais amis, tu peux\ncompter sur eux même au fond du gouffre."
+    "texte_fr": "Jun...[001E][1205] Tu devrais te reposer plus sur\ntes amis. Les vrais amis, tu peux\ncompter sur eux même au fond du gouffre."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun...[1205][001E][SP]Let's[SP]get[SP]this[SP]done...",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]...[1205][001E] Finissons-en..."
+    "texte_fr": "[1113]...[001E][1205] Finissons-en..."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Jun",
     "texte_orig": "[1113]...[1205][001E][SP]I[SP]deserve[SP]your[SP]hatred...[1205][001E][SP]I[SP]don't\nmind[SP]if[SP]you[SP]hate[SP]me...",
     "nom_fr": "Jun",
-    "texte_fr": "[1113]...[1205][001E] Je mérite votre haine.[1205][001E]\nHaïssez-moi ça m'est égal."
+    "texte_fr": "[1113]...[001E][1205] Je mérite votre haine.[001E][1205]\nHaïssez-moi ça m'est égal."
   },
   {
     "id": 14,
@@ -252,7 +252,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Jun-kun...[1205][001E][SP]You[SP]should[SP]have[SP]more[SP]trust[SP]in[SP]your\nfriends.[SP]True[SP]friends[SP]are[SP]those[SP]you[SP]can[SP]rely\non[SP]when[SP]you're[SP]suffering[SP]most.",
     "nom_fr": "Maya",
-    "texte_fr": "Jun...[1205][001E] Tu devrais te reposer plus sur\ntes amis. Les vrais amis, tu peux\ncompter sur eux même au fond du gouffre."
+    "texte_fr": "Jun...[001E][1205] Tu devrais te reposer plus sur\ntes amis. Les vrais amis, tu peux\ncompter sur eux même au fond du gouffre."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun...[1205][001E][SP]Let's[SP]get[SP]this[SP]done...",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]...[1205][001E] Finissons-en..."
+    "texte_fr": "[1113]...[001E][1205] Finissons-en..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Fire[SP]crystal[SP]skull",
     "texte_orig": "I[SP]am[SP]the[SP]skull[SP]of[SP]raging[SP]fire...[1205][001E][SP]If[SP]my[SP]slumber\nis[SP]disturbed,[SP]wind[SP]will[SP]go[SP]unchecked[SP]and[SP]water\nwill[SP]lose[SP]its[SP]purpose...",
     "nom_fr": "Crâne de crystal ardent",
-    "texte_fr": "Je suis le crâne ardent.[1205][001E] Si ma torpeur\nest troublée, le vent se déchaînera et\nl'eau perdra toute raison d'être..."
+    "texte_fr": "Je suis le crâne ardent.[001E][1205] Si ma torpeur\nest troublée, le vent se déchaînera et\nl'eau perdra toute raison d'être..."
   },
   {
     "id": 19,
@@ -417,7 +417,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Of[SP]course...[SP]How[SP]careless[SP]of[SP]me.[1205][001E][SP]The[SP]woman[SP]who\nauthored[SP]the[SP]In[SP]Lak'ech[SP]with[SP]my[SP]father[SP]was\nnamed[SP]Maya[SP]Okamura...",
     "nom_fr": "Jun",
-    "texte_fr": "Bien sûr... J'ai été imprudent.[1205][001E] Celle\nqui a écrit le In Lak'ech avec mon\npère, elle s'appelait Maya Okumura..."
+    "texte_fr": "Bien sûr... J'ai été imprudent.[001E][1205] Celle\nqui a écrit le In Lak'ech avec mon\npère, elle s'appelait Maya Okumura..."
   },
   {
     "id": 28,
@@ -462,7 +462,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Their[SP]destination[SP]is[SP]no[SP]doubt[SP]Xibalba.[SP]We\nshould[SP]be[SP]able[SP]to[SP]follow[SP]them[SP]through[SP]Heaven's\nGate[SP]at[SP]Sevens...[1205][001E][SP]the[SP]Narurato[SP]Stone.",
     "nom_fr": "Jun",
-    "texte_fr": "Ils vont sûrement à Xibalba. On devrait\npouvoir les suivre en prenant les Portes\ndu Paradis du lycée...[1205][001E] La Pierre Narurato."
+    "texte_fr": "Ils vont sûrement à Xibalba. On devrait\npouvoir les suivre en prenant les Portes\ndu Paradis du lycée...[001E][1205] La Pierre Narurato."
   },
   {
     "id": 31,

--- a/traduction/event_scripts/script_152.json
+++ b/traduction/event_scripts/script_152.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "She's[SP]here...[1205][001E][SP]The[SP]fake[SP]me...[1205][001E]",
     "nom_fr": "Ginko",
-    "texte_fr": "La fausse moi...[1205][001E] est ici...[1205][001E]"
+    "texte_fr": "La fausse moi...[001E][1205] est ici...[001E][1205]"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]can[SP]feel[SP]her[SP]laughing[SP]at[SP]me...[1205][001E][SP]She[SP]knows\nI'm[SP]here[SP]too.",
     "nom_fr": "Ginko",
-    "texte_fr": "Elle se moque de moi...[1205][001E]\nElle sait que je suis là."
+    "texte_fr": "Elle se moque de moi...[001E][1205]\nElle sait que je suis là."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Rumors,[SP]rumors,[SP]rumors...[1205][001E][SP]Thinking[SP]back,\nthis[SP]all[SP]began[SP]with[SP]the[SP]emblem[SP]curse,[SP]and\nit's[SP]turned[SP]into[SP]this[SP]huge[SP]*thing*...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Rumeurs, rumeurs, rumeurs...[1205][001E] Regarde, tout\na commencé avec la malédiction de\nl'emblème et c'est devenu cette *merde*..."
+    "texte_fr": "Rumeurs, rumeurs, rumeurs...[001E][1205] Regarde, tout\na commencé avec la malédiction de\nl'emblème et c'est devenu cette *merde*..."
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]relief...[1205][001E][SP]It's[SP]showing[SP]the[SP]four[SP]temples,\nright?[SP]But[SP]what[SP]is[SP]it?[SP]Order?[SP]Balance...?",
     "nom_fr": "Maya",
-    "texte_fr": "Ce relief...[1205][001E] Il montre les quatre temples,\nc'est ça? C'est l'ordre? L'équilibre?"
+    "texte_fr": "Ce relief...[001E][1205] Il montre les quatre temples,\nc'est ça? C'est l'ordre? L'équilibre?"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Earth,[SP]water,[SP]fire,[SP]wind...[1205][001E][SP]Four[SP]elements.\nEarth[SP]is[SP]Taurus...[SP]Water[SP]is[SP]Scorpio...[SP]Fire[SP]is\nLeo...[SP]and[SP]Wind[SP]is[SP]Aquarius...",
     "nom_fr": "Maya",
-    "texte_fr": "Terre, eau, feu, air...[1205][001E] Quatre\néléments. Terre, Taureau... Eau,\nScorpion... Feu, Lion... Air, Verseau."
+    "texte_fr": "Terre, eau, feu, air...[001E][1205] Quatre\néléments. Terre, Taureau... Eau,\nScorpion... Feu, Lion... Air, Verseau."
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Okay...[1205][001E][SP]I[SP]think[SP]I[SP]get[SP]it[SP]now.",
     "nom_fr": "Maya",
-    "texte_fr": "Ok...[1205][001E] Je pense avoir compris."
+    "texte_fr": "Ok...[001E][1205] Je pense avoir compris."
   },
   {
     "id": 9,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Alright...[1205][001E][SP]Like[SP]it[SP]or[SP]not,[SP]this[SP]is[SP]the[SP]last\none.[SP]Let's[SP]steel[SP]ourselves[SP]and[SP]do[SP]this!",
     "nom_fr": "Maya",
-    "texte_fr": "Allez...[1205][001E] Peu importe, c'est le dernier.\nVolons-le de nos propres mains!"
+    "texte_fr": "Allez...[001E][1205] Peu importe, c'est le dernier.\nVolons-le de nos propres mains!"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It'll[SP]be[SP]a[SP]battle[SP]against[SP]yourselves...[1205][001E]\nBut[SP]your[SP]hearts[SP]will[SP]overcome[SP]your[SP]other\nnature[SP]in[SP]the[SP]end!",
     "nom_fr": "Maya",
-    "texte_fr": "Ça va être un combat contre\nvous-mêmes...[1205][001E] Mais vos cœurs finiront\npar surpasser vos autres vous!"
+    "texte_fr": "Ça va être un combat contre\nvous-mêmes...[001E][1205] Mais vos cœurs finiront\npar surpasser vos autres vous!"
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Jun",
     "texte_orig": "These[SP]four[SP]elements[SP]maintain[SP]the[SP]balance[SP]of[SP]the\nworld,[SP]and[SP]each[SP]has[SP]strengths[SP]and[SP]weaknesses.[1205][001E]\nIt's[SP]a[SP]brand[SP]of[SP]mysticism[SP]Father[SP]told[SP]me[SP]about.",
     "nom_fr": "Jun",
-    "texte_fr": "Ces éléments maintiennent l'équilibre du\nmonde, chacun a ses\nforces et ses faiblesses.[1205][001E]\nC'est un symbole du\nmysticisme dont Père m'aparlé."
+    "texte_fr": "Ces éléments maintiennent l'équilibre du\nmonde, chacun a ses\nforces et ses faiblesses.[001E][1205]\nC'est un symbole du\nmysticisme dont Père m'aparlé."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Xibalba[SP]is,[SP]in[SP]other[SP]words,[SP]a[SP]model[SP]for[SP]the\nnew[SP]world...[1205][001E][SP]The[SP]balance[SP]of[SP]the[SP]temples\nsymbolizing[SP]the[SP]world[SP]may[SP]be[SP]important...",
     "nom_fr": "Jun",
-    "texte_fr": "Donc, Xibalba est une maquette du nouveau\nmonde...[1205][001E] L'équilibre\ndes temples symbolisant\nle monde doit être important..."
+    "texte_fr": "Donc, Xibalba est une maquette du nouveau\nmonde...[001E][1205] L'équilibre\ndes temples symbolisant\nle monde doit être important..."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Even[SP]from[SP]here,[SP]I[SP]can[SP]sense[SP]Father's[SP]presence...[1205][001E]\nHis[SP]will[SP]is[SP]enveloping[SP]the[SP]city...",
     "nom_fr": "Jun",
-    "texte_fr": "Même d'ici, je ressens la présence de\nPère...[1205][001E] Sa volonté enveloppe la ville..."
+    "texte_fr": "Même d'ici, je ressens la présence de\nPère...[001E][1205] Sa volonté enveloppe la ville..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Father...?[SP]Yes...[1205][001E][SP]It's[SP]him.",
     "nom_fr": "Jun",
-    "texte_fr": "Père...? Oui...[1205][001E] C'est lui."
+    "texte_fr": "Père...? Oui...[001E][1205] C'est lui."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]need[SP]to[SP]stop[SP]Father[SP]for[SP]those[SP]children's\nsake[SP]as[SP]well...[1205][001E][SP]I[SP]won't[SP]end[SP]my[SP]life[SP]as[SP]a\npuppet!",
     "nom_fr": "Jun",
-    "texte_fr": "Je dois l'arrêter pour le bien de ces\nenfants...[1205][001E] Je ne mourrai pas en tant que\nmarionnette!"
+    "texte_fr": "Je dois l'arrêter pour le bien de ces\nenfants...[001E][1205] Je ne mourrai pas en tant que\nmarionnette!"
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Only[SP]one[SP]more...[1205][001E][SP]Just[SP]one[SP]last[SP]temple[SP]and\nwe'll[SP]have[SP]all[SP]the[SP]crystal[SP]skulls,[SP]other[SP]than\nthe[SP]Heaven[SP]Skull.",
     "nom_fr": "Jun",
-    "texte_fr": "Plus qu'un...[1205][001E] Juste un dernier temple\net nous aurons tous les crânes, autre\nque le Crâne du Paradis."
+    "texte_fr": "Plus qu'un...[001E][1205] Juste un dernier temple\net nous aurons tous les crânes, autre\nque le Crâne du Paradis."
   },
   {
     "id": 21,
@@ -327,6 +327,6 @@
     "nom_orig": "Jun",
     "texte_orig": "After[SP]that...[1205][001E][SP]We[SP]only[SP]have[SP]to[SP]defeat[SP]Father.",
     "nom_fr": "Jun",
-    "texte_fr": "Après ça...[1205][001E] On devra juste vaincre Père.\n Il y a une inscription sur ce relief."
+    "texte_fr": "Après ça...[001E][1205] On devra juste vaincre Père.\n Il y a une inscription sur ce relief."
   }
 ]

--- a/traduction/event_scripts/script_154.json
+++ b/traduction/event_scripts/script_154.json
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "For[SP]someone[SP]who's[SP]going[SP]to[SP]be[SP]fighting\nherself[SP]soon,[SP]Lisa[SP]seems[SP]pretty[SP]relaxed...[1205][001E]",
     "nom_fr": "Maya",
-    "texte_fr": "Lisa a l'air bien calme avant de\ndevoir s'affronter elle-même...[1205][001E]"
+    "texte_fr": "Lisa a l'air bien calme avant de\ndevoir s'affronter elle-même...[001E][1205]"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]is[SP]all[SP]thanks[SP]to[SP]Jun-kun,[SP]Eikichi-kun...[1205][001E]\nAnd[SP]you[SP]too,[SP]of[SP]course.[1205][001E][SP]I[SP]think[SP]you'll[SP]be[SP]fine\nno[SP]matter[SP]when[SP]I[SP]go.\n[E1][E2]\n\n\n[E3][E4][NULL][NULL]\"Jun\nTaurus...[1205][001E][SP]It's[SP]associated[SP]with[SP]earth[SP]and\nsymbolizes[SP]love[SP]and[SP]beauty,[SP]as[SP]well[SP]as\nwealth[SP]and[SP]fertility...",
     "nom_fr": "Maya",
-    "texte_fr": "C'est grâce à Jun, Eikichi...[1205][001E] Et toi aussi,\nbien sûr.[1205][001E] Vous irez bien, peu importe quand\nje partirai.[E1][E2]\n[E3][E4][NULL][NULL]\"Jun Le Taureau...\n[1205][001E] Lié à la\nterre, il symbolise l'amour et\nla beauté,ainsi que richesse et fertilité..."
+    "texte_fr": "C'est grâce à Jun, Eikichi...[001E][1205] Et toi aussi,\nbien sûr.[001E][1205] Vous irez bien, peu importe quand\nje partirai.[E1][E2]\n[E3][E4][NULL][NULL]\"Jun Le Taureau...\n[001E][1205] Lié à la\nterre, il symbolise l'amour et\nla beauté,ainsi que richesse et fertilité..."
   },
   {
     "id": 4,

--- a/traduction/event_scripts/script_156.json
+++ b/traduction/event_scripts/script_156.json
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Yeah,[SP]no[SP]thanks[SP]to[SP]you...[1205][001E]",
     "nom_fr": "Ginko",
-    "texte_fr": "Ouais, pas merci à toi...[1205][001E]"
+    "texte_fr": "Ouais, pas merci à toi...[001E][1205]"
   },
   {
     "id": 3,
@@ -132,7 +132,7 @@
     "nom_orig": "Shadow[SP]Ginko",
     "texte_orig": "You[SP]say[SP]you[SP]hate[SP]being[SP]different,[SP]but[SP]really,\nyou[SP]want[SP]to[SP]be[SP]noticed.[SP]That's[SP]why[SP]you[SP]went[SP]for\n[1113],[SP]the[SP]center[SP]of[SP]everyone's[SP]attention!",
     "nom_fr": "Ombre de Ginko",
-    "texte_fr": "Tu dis détester être différente, mais tu\nveux qu'on te remarque.\nC'est pour ça que tu\nvisais [1113], le centre de l'attention!"
+    "texte_fr": "Tu dis détester être différente, mais tu\nveux qu'on te remarque.\nC'est pour ça que tu visais [1113], le centre de l'attention!"
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "You're[SP]absolutely[SP]right...[1205][001E][SP]I[SP]was[SP]a[SP]pathetic\nlittle[SP]girl[SP]for[SP]a[SP]long[SP]time...",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est très vrai...[1205][001E] J'ai été une\ngamine pathétique longtemps..."
+    "texte_fr": "C'est très vrai...[001E][1205] J'ai été une\ngamine pathétique longtemps..."
   },
   {
     "id": 11,
@@ -207,7 +207,7 @@
     "nom_orig": "Shadow[SP]Ginko",
     "texte_orig": "Stop...![1205][001E][SP]The[SP][1113][SP]I[SP]loved[SP]died[SP]back[SP]then!\nSo[SP]he'll[SP]always[SP]be[SP]mine!",
     "nom_fr": "Ombre de Ginko",
-    "texte_fr": "Stop![1205][001E] Le [1113] que j'aimais\nest mort! Il restera mien!"
+    "texte_fr": "Stop![001E][1205] Le [1113] que j'aimais\nest mort! Il restera mien!"
   },
   {
     "id": 14,

--- a/traduction/event_scripts/script_157.json
+++ b/traduction/event_scripts/script_157.json
@@ -75,7 +75,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh...?[1205][001E][SP]Really...?[1205][001E][SP]I'm[SP]gonna[SP]hold[SP]you[SP]to\nthat,[SP]you[SP]know...",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein...?[1205][001E] Vraiment...?[1205][001E] Je te\nprends au mot, tu sais..."
+    "texte_fr": "Hein...?[001E][1205] Vraiment...?[001E][1205] Je te\nprends au mot, tu sais..."
   },
   {
     "id": 4,

--- a/traduction/event_scripts/script_159.json
+++ b/traduction/event_scripts/script_159.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "The[SP]Masked[SP]Circle[SP]is[SP]still[SP]kicking...[1205][001E]\nDo[SP]we[SP]really[SP]have[SP]no[SP]choice[SP]but[SP]to[SP]fight\nJun's[SP]dad?",
     "nom_fr": "Ginko",
-    "texte_fr": "Le Cercle Masqué tient bon...[1205][001E] Faut\nvraiment qu'on affronte le père de Jun?"
+    "texte_fr": "Le Cercle Masqué tient bon...[001E][1205] Faut\nvraiment qu'on affronte le père de Jun?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Heh...![1205][001E][SP]He's[SP]mocking[SP]us...[1205][001E][SP]Daring[SP]us[SP]to[SP]hurry\nup[SP]and[SP]reach[SP]him.",
     "nom_fr": "Michel",
-    "texte_fr": "[1205][001E]Il se moque de nous...[1205][001E] Il nous\ndéfie d'arriver jusqu'à lui."
+    "texte_fr": "[001E][1205]Il se moque de nous...[001E][1205] Il nous\ndéfie d'arriver jusqu'à lui."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]relief...[1205][001E][SP]It's[SP]showing[SP]the[SP]four[SP]temples,\nright?[SP]But[SP]what[SP]is[SP]it?[SP]Order?[SP]Balance...?",
     "nom_fr": "Maya",
-    "texte_fr": "Ce relief...[1205][001E] Il montre les quatre temples.\nC'est quoi? L'ordre? L'équilibre...?"
+    "texte_fr": "Ce relief...[001E][1205] Il montre les quatre temples.\nC'est quoi? L'ordre? L'équilibre...?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Earth,[SP]water,[SP]fire,[SP]wind...[1205][001E][SP]Four[SP]elements.\nEarth[SP]is[SP]Taurus...[SP]Water[SP]is[SP]Scorpio...[SP]Fire[SP]is\nLeo...[SP]and[SP]Wind[SP]is[SP]Aquarius...",
     "nom_fr": "Maya",
-    "texte_fr": "Terre, eau, feu, air...[1205][001E] Quatre\néléments. Terre = Taureau. Eau =\nScorpion. Feu = Lion. Air = Verseau..."
+    "texte_fr": "Terre, eau, feu, air...[001E][1205] Quatre\néléments. Terre = Taureau. Eau =\nScorpion. Feu = Lion. Air = Verseau..."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Okay...[1205][001E][SP]I[SP]think[SP]I[SP]get[SP]it[SP]now.",
     "nom_fr": "Maya",
-    "texte_fr": "Bon...[1205][001E] J'ai compris."
+    "texte_fr": "Bon...[001E][1205] J'ai compris."
   },
   {
     "id": 7,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Alright...[1205][001E][SP]Like[SP]it[SP]or[SP]not,[SP]this[SP]is[SP]the[SP]last\none.[SP]Let's[SP]steel[SP]ourselves[SP]and[SP]do[SP]this!",
     "nom_fr": "Maya",
-    "texte_fr": "Bon...[1205][001E] C'est le dernier.\nPréparez-vous, on y va!"
+    "texte_fr": "Bon...[001E][1205] C'est le dernier.\nPréparez-vous, on y va!"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It'll[SP]be[SP]a[SP]battle[SP]against[SP]yourselves...[1205][001E]\nBut[SP]your[SP]hearts[SP]will[SP]overcome[SP]your[SP]other\nnature[SP]in[SP]the[SP]end!",
     "nom_fr": "Maya",
-    "texte_fr": "Ce sera un combat contre vous-mêmes...[1205][001E] Mais\nvotre cœur triomphera\nde votre autre nature!"
+    "texte_fr": "Ce sera un combat contre vous-mêmes...[001E][1205] Mais\nvotre cœur triomphera\nde votre autre nature!"
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Jun",
     "texte_orig": "These[SP]four[SP]elements[SP]maintain[SP]the[SP]balance[SP]of[SP]the\nworld,[SP]and[SP]each[SP]has[SP]strengths[SP]and[SP]weaknesses.[1205][001E]\nIt's[SP]a[SP]brand[SP]of[SP]mysticism[SP]Father[SP]told[SP]me[SP]about.",
     "nom_fr": "Jun",
-    "texte_fr": "Ces quatre\néléments maintiennent l'équilibre\ndu monde, chacun a\nses forces et faiblesses.[1205][001E]\nC'est un mysticisme que\nmon père m'a enseigné."
+    "texte_fr": "Ces quatre\néléments maintiennent l'équilibre\ndu monde, chacun a ses forces et faiblesses.[001E][1205]\nC'est un mysticisme que\nmon père m'a enseigné."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Xibalba[SP]is,[SP]in[SP]other[SP]words,[SP]a[SP]model[SP]for[SP]the\nnew[SP]world...[1205][001E][SP]The[SP]balance[SP]of[SP]the[SP]temples\nsymbolizing[SP]the[SP]world[SP]may[SP]be[SP]important...",
     "nom_fr": "Jun",
-    "texte_fr": "Xibalba est un modèle du nouveau\nmonde...[1205][001E] L'équilibre des temples qui\nsymbolisent le monde est crucial..."
+    "texte_fr": "Xibalba est un modèle du nouveau\nmonde...[001E][1205] L'équilibre des temples qui\nsymbolisent le monde est crucial..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Even[SP]from[SP]here,[SP]I[SP]can[SP]sense[SP]Father's[SP]presence...[1205][001E]\nHis[SP]will[SP]is[SP]enveloping[SP]the[SP]city...",
     "nom_fr": "Jun",
-    "texte_fr": "Même d'ici, je sens mon père...[1205][001E]\nSa volonté enveloppe la ville..."
+    "texte_fr": "Même d'ici, je sens mon père...[001E][1205]\nSa volonté enveloppe la ville..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Father...?[SP]Yes...[1205][001E][SP]It's[SP]him.",
     "nom_fr": "Jun",
-    "texte_fr": "Père...? Oui...[1205][001E] C'est lui."
+    "texte_fr": "Père...? Oui...[001E][1205] C'est lui."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]need[SP]to[SP]stop[SP]Father[SP]for[SP]those[SP]children's\nsake[SP]as[SP]well...[1205][001E][SP]I[SP]won't[SP]end[SP]my[SP]life[SP]as[SP]a\npuppet!",
     "nom_fr": "Jun",
-    "texte_fr": "Je dois arrêter mon père, pour ces enfants\naussi...[1205][001E] Je ne finirai pas en pantin!"
+    "texte_fr": "Je dois arrêter mon père, pour ces enfants\naussi...[001E][1205] Je ne finirai pas en pantin!"
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Only[SP]one[SP]more...[1205][001E][SP]Just[SP]one[SP]last[SP]temple[SP]and\nwe'll[SP]have[SP]all[SP]the[SP]crystal[SP]skulls,[SP]other[SP]than\nthe[SP]Heaven[SP]Skull.",
     "nom_fr": "Jun",
-    "texte_fr": "Plus qu'un...[1205][001E] Un dernier temple et on aura\ntous les crânes, sauf le Crâne Céleste."
+    "texte_fr": "Plus qu'un...[001E][1205] Un dernier temple et on aura\ntous les crânes, sauf le Crâne Céleste."
   },
   {
     "id": 19,
@@ -297,6 +297,6 @@
     "nom_orig": "Jun",
     "texte_orig": "After[SP]that...[1205][001E][SP]We[SP]only[SP]have[SP]to[SP]defeat[SP]Father.",
     "nom_fr": "Jun",
-    "texte_fr": "Après...[1205][001E] Reste plus qu'à vaincre mon père.\n Il y a une inscription sur le relief."
+    "texte_fr": "Après...[001E][1205] Reste plus qu'à vaincre mon père.\n Il y a une inscription sur le relief."
   }
 ]

--- a/traduction/event_scripts/script_161.json
+++ b/traduction/event_scripts/script_161.json
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]dead[SP]will[SP]never[SP]return[SP]to[SP]life...[1205][001E]\nThere's[SP]no[SP]coming[SP]back[SP]from[SP]that...",
     "nom_fr": "Maya",
-    "texte_fr": "Les morts ne reviennent jamais à la\nvie...[1205][001E] On ne revient pas de là..."
+    "texte_fr": "Les morts ne reviennent jamais à la\nvie...[001E][1205] On ne revient pas de là..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Ah...!?[1205][001E][SP]A-Are[SP]we[SP]done[SP]chatting?[SP]Okay,[SP]then,\nlet's[SP]go!",
     "nom_fr": "Maya",
-    "texte_fr": "Ah...!?[1205][001E] On a fini de papoter?\nBon, alors, allons-y!"
+    "texte_fr": "Ah...!?[001E][1205] On a fini de papoter?\nBon, alors, allons-y!"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Scorpio...[1205][001E][SP]It's[SP]associated[SP]with[SP]the[SP]element\nof[SP]water[SP]and[SP]symbolizes[SP]death[SP]and[SP]rebirth,\nas[SP]well[SP]as[SP]sexual[SP]attraction[SP]and[SP]dominance...",
     "nom_fr": "Jun",
-    "texte_fr": "Scorpion...[1205][001E] Associé à l'eau, il symbolise\nmort et renaissance, ainsi que\nl'attirance sexuelle et la domination..."
+    "texte_fr": "Scorpion...[001E][1205] Associé à l'eau, il symbolise\nmort et renaissance, ainsi que\nl'attirance sexuelle et la domination..."
   },
   {
     "id": 7,
@@ -117,6 +117,6 @@
     "nom_orig": "Jun",
     "texte_orig": "They[SP]can[SP]also[SP]be[SP]quiet,[SP]cruel,[SP]and[SP]criminal,\nbut[SP]I[SP]think[SP]Michel[SP]has[SP]put[SP]those[SP]qualities\nbehind[SP]him...",
     "nom_fr": "Jun",
-    "texte_fr": "Ils peuvent être silencieux, cruels,\ncriminels, mais Michel a laissé ça\nderrière...  Une\ninscription sur le relief."
+    "texte_fr": "Ils peuvent être silencieux, cruels,\ncriminels, mais Michel a laissé ça\nderrière...  Une inscription sur le relief."
   }
 ]

--- a/traduction/event_scripts/script_163.json
+++ b/traduction/event_scripts/script_163.json
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "H...[SP]Hana...[1205][001E][SP]Hanakouji-san!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "H... Hana...[1205][001E] Hanakouji!?"
+    "texte_fr": "H... Hana...[001E][1205] Hanakouji!?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Miyabi",
     "texte_orig": "Wh-What...!?[1205][001E][SP]Two[SP]Eikichi-kuns...!?",
     "nom_fr": "Miyabi",
-    "texte_fr": "M-mais...!?[1205][001E] Deux Eikichi...!?"
+    "texte_fr": "M-mais...!?[001E][1205] Deux Eikichi...!?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What[SP]is[SP]this!?[SP]What's[SP]going[SP]on!?[SP]Why[SP]are[SP]you\nwith[SP]that[SP]fake...?[1205][001E][SP]A-And[SP]you've[SP]lost[SP]weight...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Il se passe quoi, bon sang?! Pourquoi t'es\navec mon ombre...?[1205][001E] T-t'as maigri,\nd'ailleurs..."
+    "texte_fr": "Il se passe quoi, bon sang?! Pourquoi t'es\navec mon ombre...?[001E][1205] T-t'as maigri,\nd'ailleurs..."
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I-I...[1205][001E][SP]drove[SP]Hanakouji-san[SP]to[SP]this...?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C-c'est...[1205][001E] de ma faute...?"
+    "texte_fr": "C-c'est...[001E][1205] de ma faute...?"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Miyabi",
     "texte_orig": "I'm[SP]sorry,[SP]Eikichi-kun...![1205][001E][SP]Ever[SP]since[SP]I[SP]was\nlittle,[SP]I...[1205][001E][SP]liked[SP]you...",
     "nom_fr": "Miyabi",
-    "texte_fr": "Je suis désolée, Eikichi![1205][001E] Depuis\ntoute petite, Je...[1205][001E] je t'aimais..."
+    "texte_fr": "Je suis désolée, Eikichi![001E][1205] Depuis\ntoute petite, Je...[001E][1205] je t'aimais..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Miyabi",
     "texte_orig": "But...[SP]in[SP]public...[SP]I[SP]was[SP]so[SP]embarrassed...[1205][001E]\nI[SP]said[SP]such[SP]cruel[SP]things...[1205][001E][SP]I[SP]hurt[SP]you...",
     "nom_fr": "Miyabi",
-    "texte_fr": "Mais en public, j'avais trop honte...[1205][001E] Je\nt'ai blessé...[1205][001E] et dit des choses atroces..."
+    "texte_fr": "Mais en public, j'avais trop honte...[001E][1205] Je\nt'ai blessé...[001E][1205] et dit des choses atroces..."
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Shadow[SP]Eikichi",
     "texte_orig": "No,[SP]no,[SP]no...[1205][001E][SP]You[SP]really[SP]don't[SP]understand\na[SP]lady's[SP]feelings,[SP]do[SP]you?",
     "nom_fr": "Ombre d'Eikichi",
-    "texte_fr": "Pff...[1205][001E] Tu ne comprend rien aux\nsentiments de cette dame, hein?"
+    "texte_fr": "Pff...[001E][1205] Tu ne comprend rien aux\nsentiments de cette dame, hein?"
   },
   {
     "id": 12,
@@ -237,7 +237,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Is[SP]that[SP]true...?[1205][001E][SP]You[SP]didn't[SP]want[SP]me[SP]to[SP]see\nyou...[1205][001E][SP]So[SP]you[SP]wouldn't[SP]tell[SP]me[SP]your[SP]name[SP]and\navoided[SP]me[SP]all[SP]the[SP]time...",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est vrai...?[1205][001E] Tu m'a évité, et tu\nn'a pas voulu me donner ton nom...[1205][001E]\nPour que je ne te reconnaisse pas..."
+    "texte_fr": "C'est vrai...?[001E][1205] Tu m'a évité, et tu\nn'a pas voulu me donner ton nom...[001E][1205]\nPour que je ne te reconnaisse pas..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Miyabi",
     "texte_orig": "I'm[SP]sorry...[1205][001E][SP]I[SP]knew[SP]that[SP]the[SP]Masked[SP]Circle\nwas[SP]against[SP]you,[SP]but...[1205][001E][SP]I[SP]still...",
     "nom_fr": "Miyabi",
-    "texte_fr": "Pardon...[1205][001E] Je savais que le Cercle Masqué\nétait ton ennemi. Ppourtant,[1205][001E] j'ai..."
+    "texte_fr": "Pardon...[001E][1205] Je savais que le Cercle Masqué\nétait ton ennemi. Ppourtant,[001E][1205] j'ai..."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Shadow[SP]Eikichi",
     "texte_orig": "And[SP]look[SP]how[SP]beautiful[SP]you've[SP]become!\nYou're[SP]my[SP]brown-eyed[SP]girl[SP]now![1205][001E]",
     "nom_fr": "Ombre d'Eikichi",
-    "texte_fr": "Regarde-toi! Tu es devenue ma\njolie copine aux yeux marrons![1205][001E]"
+    "texte_fr": "Regarde-toi! Tu es devenue ma\njolie copine aux yeux marrons![001E][1205]"
   },
   {
     "id": 18,
@@ -297,7 +297,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Get[SP]your[SP]filthy[SP]paws[SP]off[SP]her,[SP]you[SP]goddamned\nfake...[1205][001E][SP]Miyabi's...[1205][001E][SP]She's[SP]MY[SP]girl!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Bas les pattes, la contrefaçon...[1205][001E]\nMiyabi...[1205][001E] Sa place est à MES côtés!"
+    "texte_fr": "Bas les pattes, la contrefaçon...[001E][1205]\nMiyabi...[001E][1205] Sa place est à MES côtés!"
   },
   {
     "id": 20,

--- a/traduction/event_scripts/script_164.json
+++ b/traduction/event_scripts/script_164.json
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]didn't[SP]care[SP]what[SP]you[SP]looked[SP]like...[1205][001E]\nIt[SP]was[SP]your[SP]big[SP]heart[SP]that[SP]I...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je m'en fichais de ton physique...[1205][001E]\nC'est ta gentillesse qui m'a..."
+    "texte_fr": "Je m'en fichais de ton physique...[001E][1205]\nC'est ta gentillesse qui m'a..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]were[SP]nice[SP]when[SP]everyone[SP]else[SP]made[SP]fun[SP]of\nme...[SP]I[SP]fell[SP]in[SP]love[SP]with[SP]the[SP]girl[SP]who[SP]didn't\ntreat[SP]me[SP]different[SP]from[SP]anyone[SP]else...[1205][001E]",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est de cette fille si gentille, qui me\ntraitait comme les autres même quand on\nm'humiliait que je suis tombé amoureux...[1205][001E]"
+    "texte_fr": "C'est de cette fille si gentille, qui me\ntraitait comme les autres même quand on\nm'humiliait que je suis tombé amoureux...[001E][1205]"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Miyabi",
     "texte_orig": "Thank[SP]you...[1205][001E][SP]Thank[SP]you...",
     "nom_fr": "Miyabi",
-    "texte_fr": "Merci, Eikichi...[1205][001E] Merci..."
+    "texte_fr": "Merci, Eikichi...[001E][1205] Merci..."
   },
   {
     "id": 5,
@@ -147,7 +147,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Now...[1205][001E][SP]Shall[SP]we...?",
     "nom_fr": "Jun",
-    "texte_fr": "Bon...[1205][001E] On y va...?"
+    "texte_fr": "Bon...[001E][1205] On y va...?"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yeah...[1205][001E][SP]I[SP]know.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Oui,[1205][001E] je sais."
+    "texte_fr": "Oui,[001E][1205] je sais."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Sorry,[SP]Miyabi...[1205][001E][SP]There's[SP]still[SP]some[SP]stuff\nI[SP]need[SP]to[SP]take[SP]care[SP]of.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pardon, Miyabi...[1205][001E] Il me reste\nencore des trucs à gérer."
+    "texte_fr": "Pardon, Miyabi...[001E][1205] Il me reste\nencore des trucs à gérer."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Miyabi",
     "texte_orig": "That's[SP]okay...[1205][001E][SP]I'll[SP]wait[SP]for[SP]you.",
     "nom_fr": "Miyabi",
-    "texte_fr": "C'est bon...[1205][001E] Je t'attendrais."
+    "texte_fr": "C'est bon...[001E][1205] Je t'attendrais."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Water[SP]crystal[SP]skull",
     "texte_orig": "I[SP]am[SP]the[SP]skull[SP]of[SP]the[SP]still[SP]waters...[1205][001E][SP]If[SP]my\nslumber[SP]is[SP]disturbed,[SP]fire's[SP]wrath[SP]will[SP]grow\nstronger[SP]and[SP]the[SP]earth[SP]will[SP]be[SP]parched...",
     "nom_fr": "Crâne de crystal d'eau",
-    "texte_fr": "Je suis le crâne des eaux dormantes...[1205][001E]\nTroubler mon sommeil libérera le feu,\ntandis que la terre finira assêchée..."
+    "texte_fr": "Je suis le crâne des eaux dormantes...[001E][1205]\nTroubler mon sommeil libérera le feu,\ntandis que la terre finira assêchée..."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We've[SP]got[SP]four[SP]skulls[SP]now...[1205][001E][SP]There's[SP]only\none[SP]left[SP]for[SP]us[SP]to--",
     "nom_fr": "Eikichi",
-    "texte_fr": "On a les quatre crânes...[1205][001E]\nPlus qu'un à récupérer pour--"
+    "texte_fr": "On a les quatre crânes...[001E][1205]\nPlus qu'un à récupérer pour--"
   },
   {
     "id": 15,
@@ -342,7 +342,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Of[SP]course...[SP]How[SP]careless[SP]of[SP]me.[1205][001E][SP]The[SP]woman[SP]who\nauthored[SP]the[SP]In[SP]Lak'ech[SP]with[SP]my[SP]father[SP]was\nnamed[SP]Maya[SP]Okamura...",
     "nom_fr": "Jun",
-    "texte_fr": "Mais oui... Celle qui a co-écrit l'In\nLak'ech avec Père...[1205][001E] s'appelait Maya\nOkamura! J'ai manqué de vigilance..."
+    "texte_fr": "Mais oui... Celle qui a co-écrit l'In\nLak'ech avec Père...[001E][1205] s'appelait Maya\nOkamura! J'ai manqué de vigilance..."
   },
   {
     "id": 23,
@@ -387,7 +387,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Their[SP]destination[SP]is[SP]no[SP]doubt[SP]Xibalba.[SP]We\nshould[SP]be[SP]able[SP]to[SP]follow[SP]them[SP]through[SP]Heaven's\nGate[SP]at[SP]Sevens...[1205][001E][SP]the[SP]Narurato[SP]Stone.",
     "nom_fr": "Jun",
-    "texte_fr": "Ils doivent se diriger vers Xibalba. On\ndoit pouvoir les suivre grâce à la Porte\ndu Paradis à Seven...[1205][001E] La Pierre Narurato."
+    "texte_fr": "Ils doivent se diriger vers Xibalba. On\ndoit pouvoir les suivre grâce à la Porte\ndu Paradis à Seven...[001E][1205] La Pierre Narurato."
   },
   {
     "id": 26,

--- a/traduction/event_scripts/script_166.json
+++ b/traduction/event_scripts/script_166.json
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "It[SP]was[SP]everyone's[SP]rumors[SP]that[SP]gave[SP]Joker\nthe[SP]power[SP]to[SP]grant[SP]dreams...[1205][001E][SP]And[SP]Xibalba\ntook[SP]flight[SP]because[SP]of[SP]rumors[SP]too,[SP]right?",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est les rumeurs qui ont permis à\nJoker de réaliser les rêves...[1205][001E] Xibalba\ns'est envolée de la même façon, non?"
+    "texte_fr": "C'est les rumeurs qui ont permis à\nJoker de réaliser les rêves...[001E][1205] Xibalba\ns'est envolée de la même façon, non?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Philemon[SP]said[SP][1432][NULL][NULL][0014]someone[1432][NULL][NULL][0014][SP]is[SP]making[SP]rumors\ncome[SP]true...[1205][001E][SP]But[SP]did[SP]he[SP]mean[SP]Jun's[SP]father?",
     "nom_fr": "Ginko",
-    "texte_fr": "D'après Philémon, [1432][NULL][NULL][0014]quelqu'un[1432][NULL][NULL][0014]\nrend les rumeurs\nréelles...[1205][001E] Ce serait le père de Jun?"
+    "texte_fr": "D'après Philémon, [1432][NULL][NULL][0014]quelqu'un[1432][NULL][NULL][0014]\nrend les rumeurs\nréelles...[001E][1205] Ce serait le père de Jun?"
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Not[SP]everyone[SP]thinks[SP]it's[SP]a[SP]good[SP]thing.[1205][001E]\nBut[SP]once[SP]they[SP]know[SP]the[SP]option[SP]is[SP]out[SP]there,\nit's[SP]too[SP]tempting[SP]to[SP]pass[SP]up...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Même en sachant que c'est une mauvaise\nidée,[1205][001E] une fois l'option à portée de\nmain, c'est facile de succomber..."
+    "texte_fr": "Même en sachant que c'est une mauvaise\nidée,[001E][1205] une fois l'option à portée de\nmain, c'est facile de succomber..."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]relief...[1205][001E][SP]It's[SP]showing[SP]the[SP]four[SP]temples,\nright?[SP]But[SP]what[SP]is[SP]it?[SP]Order?[SP]Balance...?",
     "nom_fr": "Maya",
-    "texte_fr": "Ces reliefs...[1205][001E] C'est\nles quatre temples, non?\nMais ça? Une sorte d'ordre, d'équilibre?"
+    "texte_fr": "Ces reliefs...[001E][1205] C'est\nles quatre temples, non?\nMais ça? Une sorte d'ordre, d'équilibre?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Earth,[SP]water,[SP]fire,[SP]wind...[1205][001E][SP]Four[SP]elements.\nEarth[SP]is[SP]Taurus...[SP]Water[SP]is[SP]Scorpio...[SP]Fire[SP]is\nLeo...[SP]and[SP]Wind[SP]is[SP]Aquarius...",
     "nom_fr": "Maya",
-    "texte_fr": "Terre, eau, feu, air...[1205][001E] La Terre pour\nTaureau, l'Eau pour Scorpion, le Feu\npour Lion, et l'Air pour Verseau..."
+    "texte_fr": "Terre, eau, feu, air...[001E][1205] La Terre pour\nTaureau, l'Eau pour Scorpion, le Feu\npour Lion, et l'Air pour Verseau..."
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Okay...[1205][001E][SP]I[SP]think[SP]I[SP]get[SP]it[SP]now.",
     "nom_fr": "Maya",
-    "texte_fr": "Oui...[1205][001E] Je pense avoir saisi."
+    "texte_fr": "Oui...[001E][1205] Je pense avoir saisi."
   },
   {
     "id": 10,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Alright...[1205][001E][SP]Like[SP]it[SP]or[SP]not,[SP]this[SP]is[SP]the[SP]last\none.[SP]Let's[SP]steel[SP]ourselves[SP]and[SP]do[SP]this!",
     "nom_fr": "Maya",
-    "texte_fr": "Bon...[1205][001E] Qu'on le veuille ou non, c'est le\ndernier. On reste concentrés et on y va!"
+    "texte_fr": "Bon...[001E][1205] Qu'on le veuille ou non, c'est le\ndernier. On reste concentrés et on y va!"
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It'll[SP]be[SP]a[SP]battle[SP]against[SP]yourselves...[1205][001E]\nBut[SP]your[SP]hearts[SP]will[SP]overcome[SP]your[SP]other\nnature[SP]in[SP]the[SP]end!",
     "nom_fr": "Maya",
-    "texte_fr": "On va se retrouver\nface à nous-mêmes...[1205][001E] Mais\nnos coeurs surmonteront cette part de nous!"
+    "texte_fr": "On va se retrouver\nface à nous-mêmes...[001E][1205] Mais\nnos coeurs surmonteront cette part de nous!"
   },
   {
     "id": 15,
@@ -252,7 +252,7 @@
     "nom_orig": "Jun",
     "texte_orig": "These[SP]four[SP]elements[SP]maintain[SP]the[SP]balance[SP]of[SP]the\nworld,[SP]and[SP]each[SP]has[SP]strengths[SP]and[SP]weaknesses.[1205][001E]\nIt's[SP]a[SP]brand[SP]of[SP]mysticism[SP]Father[SP]told[SP]me[SP]about.",
     "nom_fr": "Jun",
-    "texte_fr": "Chaque élément, avec ses force et ses\nfaiblesses, contribue à l'équilibre du\nmonde.[1205][001E] Père m'a déjà parlé de ces mythes."
+    "texte_fr": "Chaque élément, avec ses force et ses\nfaiblesses, contribue à l'équilibre du\nmonde.[001E][1205] Père m'a déjà parlé de ces mythes."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Xibalba[SP]is,[SP]in[SP]other[SP]words,[SP]a[SP]model[SP]for[SP]the\nnew[SP]world...[1205][001E][SP]The[SP]balance[SP]of[SP]the[SP]temples\nsymbolizing[SP]the[SP]world[SP]may[SP]be[SP]important...",
     "nom_fr": "Jun",
-    "texte_fr": "Autrement dit, Xibalba est la maquette\nd'un monde nouveau...[1205][001E] L'équilibre du monde\net des temples doit être important..."
+    "texte_fr": "Autrement dit, Xibalba est la maquette\nd'un monde nouveau...[001E][1205] L'équilibre du monde\net des temples doit être important..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Even[SP]from[SP]here,[SP]I[SP]can[SP]sense[SP]Father's[SP]presence...[1205][001E]\nHis[SP]will[SP]is[SP]enveloping[SP]the[SP]city...",
     "nom_fr": "Jun",
-    "texte_fr": "Même ici, je ressens la présence de Père...[1205][001E]\nSon emprise enveloppe toute la ville..."
+    "texte_fr": "Même ici, je ressens la présence de Père...[001E][1205]\nSon emprise enveloppe toute la ville..."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Father...?[SP]Yes...[1205][001E][SP]It's[SP]him.",
     "nom_fr": "Jun",
-    "texte_fr": "Père...? Oui...[1205][001E] C'est lui."
+    "texte_fr": "Père...? Oui...[001E][1205] C'est lui."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]need[SP]to[SP]stop[SP]Father[SP]for[SP]those[SP]children's\nsake[SP]as[SP]well...[1205][001E][SP]I[SP]won't[SP]end[SP]my[SP]life[SP]as[SP]a\npuppet!",
     "nom_fr": "Jun",
-    "texte_fr": "C'est aussi pour ces enfants que je dois\narrêter Père...[1205][001E] Assez\nd'être une marionnette!"
+    "texte_fr": "C'est aussi pour ces enfants que je dois\narrêter Père...[001E][1205] Assez\nd'être une marionnette!"
   },
   {
     "id": 21,
@@ -342,6 +342,6 @@
     "nom_orig": "Jun",
     "texte_orig": "After[SP]that...[1205][001E][SP]We[SP]only[SP]have[SP]to[SP]defeat[SP]Father.",
     "nom_fr": "Jun",
-    "texte_fr": "Après ça...[1205][001E] Il ne restera plus que Père.\n Quelque chose est écrit dans le relief."
+    "texte_fr": "Après ça...[001E][1205] Il ne restera plus que Père.\n Quelque chose est écrit dans le relief."
   }
 ]

--- a/traduction/event_scripts/script_168.json
+++ b/traduction/event_scripts/script_168.json
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ahahah...[1205][001E][SP]If[SP]it's[SP]a[SP][1432][NULL][NULL][0014]Hou[1432][NULL][NULL][0014][SP]you[SP]want,[SP]watch[SP]and\nlearn[SP]from[SP]the[SP]great[SP]Michel!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Héhé...[1205][001E] Vous voulez un [1432][NULL][NULL][0014]Wouhou,[1432][NULL][NULL][0014]\nhein? Laissez faire Great Michel!"
+    "texte_fr": "Héhé...[001E][1205] Vous voulez un [1432][NULL][NULL][0014]Wouhou,[1432][NULL][NULL][0014]\nhein? Laissez faire Great Michel!"
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That's[SP]not[SP]true,[SP]Jun-kun![1205][001E][SP]You[SP]said[SP]when[SP]you\nwere[SP]little[SP]that[SP]you[SP]wanted[SP]to[SP]be[SP]a[SP]teacher,\ndidn't[SP]you?",
     "nom_fr": "Maya",
-    "texte_fr": "Tu te trompes, Jun![1205][001E] À l'époque tu disais\nvouloir devenir professeur, n'est-ce pas?"
+    "texte_fr": "Tu te trompes, Jun![001E][1205] À l'époque tu disais\nvouloir devenir professeur, n'est-ce pas?"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Aquarius...[1205][001E][SP]It's[SP]associated[SP]with[SP]the[SP]element\nof[SP]wind,[SP]symbolizing[SP]upheaval[SP]and[SP]destruction,\nas[SP]well[SP]as[SP]evolution[SP]and[SP]philanthropy...",
     "nom_fr": "Jun",
-    "texte_fr": "Le Verseau...[1205][001E] Associé\nà l'air, il représente\nle bouleversement et la destruction, mais\naussi l'évolution et la philanthropie..."
+    "texte_fr": "Le Verseau...[001E][1205] Associé\nà l'air, il représente\nle bouleversement et la destruction, mais aussi l'évolution et la philanthropie..."
   },
   {
     "id": 7,
@@ -117,6 +117,6 @@
     "nom_orig": "Jun",
     "texte_orig": "But[SP]those[SP]are[SP]only[SP]words...[1205][001E][SP]In[SP]reality,\nI[SP]symbolize[SP]an[SP]arrogant[SP]fool.[SP]There's[SP]no[SP]way\nI[SP]can[SP]lead[SP]people[SP]to[SP]their[SP]ideals...",
     "nom_fr": "Jun",
-    "texte_fr": "Mais ces mots ne valent rien...[1205][001E] Je\nreprésente l'arrogance, comment pourrais-je\naider quiconque à atteindre ses idéaux? \nQuelque chose est écrit dans le relief."
+    "texte_fr": "Mais ces mots ne valent rien...[001E][1205] Je\nreprésente l'arrogance, comment pourrais-je\naider quiconque à atteindre ses idéaux? Quelque chose est écrit dans le relief."
   }
 ]

--- a/traduction/event_scripts/script_170.json
+++ b/traduction/event_scripts/script_170.json
@@ -12,7 +12,7 @@
     "nom_orig": "Longinus[SP]#7",
     "texte_orig": "Pathetic...[1205][001E][SP]The[SP]marionette[SP]that[SP]danced[SP]in\nignorance[SP]has[SP]arrived.",
     "nom_fr": "Longinus #7",
-    "texte_fr": "Pathétique...[1205][001E] Le pantin qui dansait\ndans l'ignorance est arrivé."
+    "texte_fr": "Pathétique...[001E][1205] Le pantin qui dansait\ndans l'ignorance est arrivé."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Longinus[SP]#5",
     "texte_orig": "Flowers[SP]inevitably[SP]wilt...[1205][001E][SP]Can[SP]something[SP]so\ntransient[SP]be[SP]compared[SP]to[SP]the[SP]stars?",
     "nom_fr": "Longinus #5",
-    "texte_fr": "Toute fleur flétrit...[1205][001E] Peut-on comparer\nune chose aussi éphémère aux étoiles?"
+    "texte_fr": "Toute fleur flétrit...[001E][1205] Peut-on comparer\nune chose aussi éphémère aux étoiles?"
   },
   {
     "id": 2,
@@ -42,6 +42,6 @@
     "nom_orig": "Jun",
     "texte_orig": "A[SP]flower[SP]it[SP]may[SP]be,[SP]but[SP]it's[SP]still[SP]a[SP]very\nprecious[SP]blossom...[1205][001E][SP]Time[SP]for[SP]you[SP]to[SP]give\nback[SP]the[SP]wind[SP]crystal[SP]skull!",
     "nom_fr": "",
-    "texte_fr": "Une fleur, certes, mais c'est une\nfleur très précieuse...[1205][001E] Il est temps\nde rendre le crâne de cristal de vent !"
+    "texte_fr": "Une fleur, certes, mais c'est une\nfleur très précieuse...[001E][1205] Il est temps\nde rendre le crâne de cristal de vent !"
   }
 ]

--- a/traduction/event_scripts/script_171.json
+++ b/traduction/event_scripts/script_171.json
@@ -12,7 +12,7 @@
     "nom_orig": "Longinus[SP]#6",
     "texte_orig": "Hoh[SP]hoh...[SP]You[SP]pitiful[SP]fool...[1205][001E][SP]You[SP]don't[SP]even\nknow[SP]who[SP]was[SP]meant[SP]to[SP]be[SP]seated[SP]here...",
     "nom_fr": "Longinus #6",
-    "texte_fr": "Huh huh... Pitoyable idiot...[1205][001E] Tu ne sais\nrien de qui était censé se trouver ici..."
+    "texte_fr": "Huh huh... Pitoyable idiot...[001E][1205] Tu ne sais\nrien de qui était censé se trouver ici..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Jun",
     "texte_orig": "What...?[1205][001E][SP]Ngh...!",
     "nom_fr": "Jun",
-    "texte_fr": "Hein...?[1205][001E] Ngh...!"
+    "texte_fr": "Hein...?[001E][1205] Ngh...!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Ungh...[1205][001E][SP]Ma...ma...?",
     "nom_fr": "Jun",
-    "texte_fr": "Agh...[1205][001E] Ma... mère...?"
+    "texte_fr": "Agh...[001E][1205] Ma... mère...?"
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Y-Yes...[1205][001E][SP]I'm[SP]all[SP]right...[1205][001E][SP]I[SP]just[SP]need[SP]to\nhurry[SP]and[SP]get[SP]the[SP]skull...",
     "nom_fr": "Jun",
-    "texte_fr": "J-je...[1205][001E] Oui, ça va...[1205][001E] Je dois\nvite récupérer le crâne..."
+    "texte_fr": "J-je...[001E][1205] Oui, ça va...[001E][1205] Je dois\nvite récupérer le crâne..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Wind[SP]crystal[SP]skull",
     "texte_orig": "I[SP]am[SP]the[SP]skull[SP]of[SP]howling[SP]winds...[1205][001E][SP]If[SP]my\nslumber[SP]is[SP]disturbed,[SP]earth[SP]will[SP]become\nconceited[SP]and[SP]fire[SP]will[SP]lose[SP]its[SP]wrath...",
     "nom_fr": "Crâne de cristal d'air",
-    "texte_fr": "Je suis le crâne de l'air turbulent...[1205][001E]\nTroubler mon sommeil rendra la terre\nvaniteuse et calmera la colère du feu..."
+    "texte_fr": "Je suis le crâne de l'air turbulent...[001E][1205]\nTroubler mon sommeil rendra la terre\nvaniteuse et calmera la colère du feu..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Jun",
     "texte_orig": "We[SP]now[SP]have[SP]the[SP]four[SP]skulls[SP]of[SP]earth,[SP]water,\nfire,[SP]and[SP]wind...[1205][001E][SP]All[SP]that's[SP]left[SP]is--",
     "nom_fr": "Jun",
-    "texte_fr": "Les quatre crânes élémentaires sont\nentre nos mains...[1205][001E] Il ne reste plus que-"
+    "texte_fr": "Les quatre crânes élémentaires sont\nentre nos mains...[001E][1205] Il ne reste plus que-"
   },
   {
     "id": 7,
@@ -222,7 +222,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Of[SP]course...[SP]How[SP]careless[SP]of[SP]me.[1205][001E][SP]The[SP]woman[SP]who\nauthored[SP]the[SP]In[SP]Lak'ech[SP]with[SP]my[SP]father[SP]was\nnamed[SP]Maya[SP]Okamura...",
     "nom_fr": "Jun",
-    "texte_fr": "Mais oui... Celle qui a co-écrit l'In\nLak'ech avec Père...[1205][001E] s'appelait Maya\nOkamura! J'ai manqué de vigilance..."
+    "texte_fr": "Mais oui... Celle qui a co-écrit l'In\nLak'ech avec Père...[001E][1205] s'appelait Maya\nOkamura! J'ai manqué de vigilance..."
   },
   {
     "id": 15,
@@ -267,7 +267,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Their[SP]destination[SP]is[SP]no[SP]doubt[SP]Xibalba.[SP]We\nshould[SP]be[SP]able[SP]to[SP]follow[SP]them[SP]through[SP]Heaven's\nGate[SP]at[SP]Sevens...[1205][001E][SP]the[SP]Narurato[SP]Stone.",
     "nom_fr": "Jun",
-    "texte_fr": "Ils doivent se diriger vers Xibalba. On\ndoit pouvoir les suivre grâce à la Porte\ndu Paradis à Seven...[1205][001E] La Pierre Narurato."
+    "texte_fr": "Ils doivent se diriger vers Xibalba. On\ndoit pouvoir les suivre grâce à la Porte\ndu Paradis à Seven...[001E][1205] La Pierre Narurato."
   },
   {
     "id": 18,

--- a/traduction/event_scripts/script_172.json
+++ b/traduction/event_scripts/script_172.json
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah...[1205][001E][SP]I[SP]can't[SP]believe[SP]the[SP]Narurato[SP]Stone\nwas[SP]that[SP]important...",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiyah...[1205][001E] J'y crois pas, la Pierre\nNarurato était si cruciale..."
+    "texte_fr": "Aiyah...[001E][1205] J'y crois pas, la Pierre\nNarurato était si cruciale..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Then[SP]again...[1205][001E][SP]I[SP]guess[SP]that's[SP]why[SP]you[SP]could\nalways[SP]find[SP]Ms.[SP]Ideal[SP]nearby.",
     "nom_fr": "Ginko",
-    "texte_fr": "Enfin...[1205][001E] C'est pourquoi Mme Ideal\ntraînait toujours autour, j'imagine."
+    "texte_fr": "Enfin...[001E][1205] C'est pourquoi Mme Ideal\ntraînait toujours autour, j'imagine."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Jun",
     "texte_orig": "This[SP]is[SP]Heaven's[SP]Gate.[1205][001E][SP]Father[SP]believed[SP]that\nthe[SP]Silver[SP]River[SP]was[SP]the[SP]path[SP]to[SP]Xibalba...",
     "nom_fr": "Jun",
-    "texte_fr": "Voici la Porte du Paradis.[1205][001E] D'après Père,\nla Rivière d'Argent menait à Xibalba..."
+    "texte_fr": "Voici la Porte du Paradis.[001E][1205] D'après Père,\nla Rivière d'Argent menait à Xibalba..."
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Jun",
     "texte_orig": "And[SP]that[SP]the[SP]Heaven's[SP]Gate[SP]that[SP]led[SP]to[SP]the\nunderground[SP]Silver[SP]River...[1205][001E][SP]It[SP]was[SP]supposed\nto[SP]be[SP]this[SP]Narurato[SP]Stone.",
     "nom_fr": "Jun",
-    "texte_fr": "Et que la Porte du Paradis menant à\nla Rivière d'Argent sous terre...[1205][001E]\nétait censée être la Pierre Narurato."
+    "texte_fr": "Et que la Porte du Paradis menant à\nla Rivière d'Argent sous terre...[001E][1205]\nétait censée être la Pierre Narurato."
   },
   {
     "id": 6,
@@ -102,6 +102,6 @@
     "nom_orig": "Maya",
     "texte_orig": "Once[SP]we[SP]go[SP]in,[SP]there's[SP]no[SP]telling[SP]if[SP]we'll\nbe[SP]able[SP]to[SP]come[SP]back...[1205][001E][SP][1113]-kun,\nare[SP]we[SP]all[SP]set?",
     "nom_fr": "",
-    "texte_fr": "Une fois qu'on entre, on sait pas\nsi on peut revenir...[1205][001E] [1113]-kun,\non est tous prêts ?"
+    "texte_fr": "Une fois qu'on entre, on sait pas\nsi on peut revenir...[001E][1205] [1113]-kun,\non est tous prêts ?"
   }
 ]

--- a/traduction/event_scripts/script_174.json
+++ b/traduction/event_scripts/script_174.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah...[1205][001E][SP]There[SP]really[SP]is[SP]a[SP]river[SP]here!",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiyah...[1205][001E] Y'a vraiment une rivière ici!"
+    "texte_fr": "Aiyah...[001E][1205] Y'a vraiment une rivière ici!"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]walls[SP]are[SP]shining...[1205][001E][SP]The[SP]Silver[SP]River[SP]is\na[SP]pretty[SP]appropriate[SP]name[SP]for[SP]it.",
     "nom_fr": "Maya",
-    "texte_fr": "Les parois brillent...[1205][001E] La Rivière\nd'Argent porte très bien son nom."
+    "texte_fr": "Les parois brillent...[001E][1205] La Rivière\nd'Argent porte très bien son nom."
   },
   {
     "id": 2,

--- a/traduction/event_scripts/script_176.json
+++ b/traduction/event_scripts/script_176.json
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Uggggh...[1205][001E][SP][1113]...?",
     "nom_fr": "Ginko",
-    "texte_fr": "Uggggh...[1205][001E] [1113]...?"
+    "texte_fr": "Uggggh...[001E][1205] [1113]...?"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Ngh...[SP][1113]-kun...?[SP]Where's...[1205][001E][SP]the[SP]others?",
     "nom_fr": "Maya",
-    "texte_fr": "Ngh... [1113]? Où sont...[1205][001E] les autres?"
+    "texte_fr": "Ngh... [1113]? Où sont...[001E][1205] les autres?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Owww...[1205][001E][SP]That[SP]was[SP]horrible...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ouïlle...[1205][001E] C'était atroce..."
+    "texte_fr": "Ouïlle...[001E][1205] C'était atroce..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Whew...[1205][001E][SP]At[SP]least[SP]everyone's[SP]okay.",
     "nom_fr": "Maya",
-    "texte_fr": "Fiou...[1205][001E] Personne n'est blessé."
+    "texte_fr": "Fiou...[001E][1205] Personne n'est blessé."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "There's[SP]no[SP]way[SP]we[SP]can[SP]get[SP]all[SP]the[SP]way[SP]back\nup[SP]there...[1205][001E][SP]Let's[SP]take[SP]a[SP]minute[SP]to[SP]think\nabout[SP]what[SP]to[SP]do.",
     "nom_fr": "Maya",
-    "texte_fr": "Par contre, aucune\nchance de remonter d'ici...[1205][001E]\nPrenons une minute pour\nréfléchir à la suite."
+    "texte_fr": "Par contre, aucune\nchance de remonter d'ici...[001E][1205]\nPrenons une minute pour\nréfléchir à la suite."
   },
   {
     "id": 7,
@@ -117,6 +117,6 @@
     "nom_orig": "Eikichi",
     "texte_orig": "By[SP]the[SP]way,[SP]Jun...[1205][001E][SP]What're[SP]you[SP]staring[SP]at?",
     "nom_fr": "",
-    "texte_fr": "Au fait, Jun...[1205][001E] Qu'est-ce que\ntu regardes comme ça ?"
+    "texte_fr": "Au fait, Jun...[001E][1205] Qu'est-ce que\ntu regardes comme ça ?"
   }
 ]

--- a/traduction/event_scripts/script_177.json
+++ b/traduction/event_scripts/script_177.json
@@ -87,6 +87,6 @@
     "nom_orig": "Maya",
     "texte_orig": "There,[SP]there...[1205][001E][SP]It[SP]was[SP]thanks[SP]to[SP]Eikichi-kun\nthat[SP]we[SP]noticed[SP]the[SP]trap.[SP]Come[SP]on,[SP]let's[SP]not\nstay[SP]too[SP]long[SP]around[SP]here...",
     "nom_fr": "",
-    "texte_fr": "Là là...[1205][001E] C'est grâce à Eikichi-kun\nqu'on a repéré le piège. Allez, traînons\npas trop par ici..."
+    "texte_fr": "Là là...[001E][1205] C'est grâce à Eikichi-kun\nqu'on a repéré le piège. Allez, traînons\npas trop par ici..."
   }
 ]

--- a/traduction/event_scripts/script_184.json
+++ b/traduction/event_scripts/script_184.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Y-You're[SP]s-so[SP]lucky,[SP]Jun...[1205][001E][SP]I[SP]c-can't[SP]believe\nyour[SP]d-d-dad[SP]buys[SP]you[SP]s-stuff[SP]like[SP]this...",
     "nom_fr": "Eikichi",
-    "texte_fr": "L-La chance Jun...[1205][001E] j-je n'arrive pas à\nc-croire que ton p-père t'offre ça..."
+    "texte_fr": "L-La chance Jun...[001E][1205] j-je n'arrive pas à\nc-croire que ton p-père t'offre ça..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Eheheh...[1205][001E][SP]I'll[SP]show[SP]you[SP]some[SP]stars,[SP]too.\nPapa[SP]knows[SP]lots[SP]about[SP]the[SP]stars!",
     "nom_fr": "Jun",
-    "texte_fr": "Eheh...[1205][001E] Je te montrerai quelques\nétoiles. Père en connaît un paquet!"
+    "texte_fr": "Eheh...[001E][1205] Je te montrerai quelques\nétoiles. Père en connaît un paquet!"
   },
   {
     "id": 2,
@@ -72,7 +72,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Huh?[1205][001E][SP]Um...[1205][001E][SP]Well...",
     "nom_fr": "Jun",
-    "texte_fr": "Euhh...[1205][001E]...[1205][001E] Bahh..."
+    "texte_fr": "Euhh...[001E][1205]...[001E][1205] Bahh..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Jun",
     "texte_orig": "H-He's[SP]really[SP]cool[SP]and[SP]strong[SP]and[SP]great...[1205][001E]\nReally!",
     "nom_fr": "Jun",
-    "texte_fr": "Il est... trop fort et...\nIncroyable...[1205][001E] Vraiment!"
+    "texte_fr": "Il est... trop fort et...\nIncroyable...[001E][1205] Vraiment!"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Seriously...?[1205][001E][SP]I[SP]don't[SP]have[SP]a[SP]dad,[SP]so[SP]I'm\nkinda[SP]jealous...[1205][001E][SP]You're[SP]so[SP]lucky,[SP]Jun-kun!",
     "nom_fr": "Maya",
-    "texte_fr": "Sérieux...?[1205][001E] J'ai pas de père, je suis un\npeu jalouse...[1205][001E] Tu as de la chance Jun-kun!"
+    "texte_fr": "Sérieux...?[001E][1205] J'ai pas de père, je suis un\npeu jalouse...[001E][1205] Tu as de la chance Jun-kun!"
   },
   {
     "id": 7,
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "D-Don't[SP]worry[SP]about[SP]those[SP]k-kids...[1205][001E][SP]They\nsay[SP]even[SP]m-meaner[SP]s-stuff[SP]to[SP]m-me...",
     "nom_fr": "Eikichi",
-    "texte_fr": "N-Ne fais p-pas attention...[1205][001E] Elles\nm'ont d-déja dit p-p-pire..."
+    "texte_fr": "N-Ne fais p-pas attention...[001E][1205] Elles\nm'ont d-déja dit p-p-pire..."
   },
   {
     "id": 11,
@@ -177,6 +177,6 @@
     "nom_orig": "Jun",
     "texte_orig": "My[SP]Papa...[1205][001E][SP]He's...[1205][001E][SP]He's[SP]not[SP]a[SP]deadbeat!",
     "nom_fr": "",
-    "texte_fr": "Mon Papa...[1205][001E] Il est...[1205][001E]\nC'est pas un bon à rien !"
+    "texte_fr": "Mon Papa...[001E][1205] Il est...[001E][1205]\nC'est pas un bon à rien !"
   }
 ]

--- a/traduction/event_scripts/script_185.json
+++ b/traduction/event_scripts/script_185.json
@@ -12,7 +12,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Wh-Why[SP]are[SP]we[SP]seeing[SP]this...!?[1205][001E][SP]My[SP]head...",
     "nom_fr": "Jun",
-    "texte_fr": "C-C'était quoi...!?[1205][001E] Ma tête..."
+    "texte_fr": "C-C'était quoi...!?[001E][1205] Ma tête..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Jun-kun!?[SP]Are[SP]you[SP]okay...?[1205][001E][SP]Hang[SP]in[SP]there!",
     "nom_fr": "Maya",
-    "texte_fr": "Tout va bien Jun-kun!?[1205][001E] Tient le coup!"
+    "texte_fr": "Tout va bien Jun-kun!?[001E][1205] Tient le coup!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I'm...[SP]I'm[SP]all[SP]right...[1205][001E][SP]Sorry,[SP]everyone...[1205][001E]\nLet's...[SP]keep[SP]going...",
     "nom_fr": "Jun",
-    "texte_fr": "Je... Vais bien...[1205][001E] Désolé tout\nle monde...[1205][001E] Continuons..."
+    "texte_fr": "Je... Vais bien...[001E][1205] Désolé tout\nle monde...[001E][1205] Continuons..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Jun",
     "texte_orig": "That's[SP]right...[SP]Father[SP]was[SP]my[SP]pride[SP]and[SP]joy...[1205][001E]\nI[SP]need[SP]to[SP]stop[SP]him...",
     "nom_fr": "Jun",
-    "texte_fr": "C'est vrai... Père fut ma plus grande\nfierté...[1205][001E] Je dois l'arrêter..."
+    "texte_fr": "C'est vrai... Père fut ma plus grande\nfierté...[001E][1205] Je dois l'arrêter..."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Dads,[SP]huh...?[1205][001E][SP]It's[SP]such[SP]a[SP]complicated\nthing,[SP]for[SP]some[SP]reason...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Les pères hein...?[1205][001E] c'est\nun sujet si compliqué..."
+    "texte_fr": "Les pères hein...?[001E][1205] c'est\nun sujet si compliqué..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Our[SP]dads[SP]make[SP]us[SP]who[SP]we[SP]are,[SP]and[SP]they're[SP]also\nthe[SP]first[SP]big[SP]obstacle[SP]we[SP]face...[1205][001E][SP]Maybe[SP]that's\njust[SP]how[SP]it[SP]has[SP]to[SP]be[SP]for[SP]kids.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Nos pères font de nous ce que l'on est,\net sont nos premiers obstacles...[1205][001E] C'est\npeut-être ainsi pour les enfants."
+    "texte_fr": "Nos pères font de nous ce que l'on est,\net sont nos premiers obstacles...[001E][1205] C'est\npeut-être ainsi pour les enfants."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Oh[SP]yeah...[SP]I[SP]remember[SP]that.[1205][001E][SP]Jun[SP]was[SP]so\nproud[SP]of[SP]his[SP]dad.",
     "nom_fr": "Ginko",
-    "texte_fr": "Je m'en souviens...[1205][001E] Jun\nétait si fier de son père."
+    "texte_fr": "Je m'en souviens...[001E][1205] Jun\nétait si fier de son père."
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What[SP]we[SP]saw[SP]just[SP]now...[1205][001E][SP]Was[SP]that[SP]what[SP]Jun-kun's\nheart[SP]showed[SP]us...?",
     "nom_fr": "Maya",
-    "texte_fr": "Ce qu'on vient de voir...[1205][001E]\nEtait-ce le coeur de Jun-kun...?"
+    "texte_fr": "Ce qu'on vient de voir...[001E][1205]\nEtait-ce le coeur de Jun-kun...?"
   },
   {
     "id": 9,
@@ -147,6 +147,6 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]guess[SP]it's[SP]to[SP]be[SP]expected...[1205][001E][SP]We're[SP]going[SP]to\nhave[SP]to[SP]fight[SP]the[SP]man[SP]soon,[SP]after[SP]all...",
     "nom_fr": "",
-    "texte_fr": "Je suppose que c'est inévitable...[1205][001E]\nOn va devoir affronter cet homme bientôt,\naprès tout..."
+    "texte_fr": "Je suppose que c'est inévitable...[001E][1205]\nOn va devoir affronter cet homme bientôt,\naprès tout..."
   }
 ]

--- a/traduction/event_scripts/script_186.json
+++ b/traduction/event_scripts/script_186.json
@@ -267,6 +267,6 @@
     "nom_orig": "Jun",
     "texte_orig": "Dreams...[SP]Ideals...[1205][001E][SP]People[SP]are[SP]frequently\nwilling[SP]to[SP]risk[SP]their[SP]lives[SP]for[SP]them.\nThen[SP]is[SP]it[SP]better[SP]if[SP]they[SP]don't[SP]dream...?",
     "nom_fr": "",
-    "texte_fr": "Les rêves... Les idéaux...[1205][001E] Les gens sont\nsouvent prêts à risquer leur vie pour eux.\nAlors vaut-il mieux ne pas en avoir...?"
+    "texte_fr": "Les rêves... Les idéaux...[001E][1205] Les gens sont\nsouvent prêts à risquer leur vie pour eux.\nAlors vaut-il mieux ne pas en avoir...?"
   }
 ]

--- a/traduction/event_scripts/script_187.json
+++ b/traduction/event_scripts/script_187.json
@@ -27,7 +27,7 @@
     "nom_orig": "Maya's[SP]father",
     "texte_orig": "Listen[SP]to[SP]me,[SP]Maya...[1205][001E][SP]If[SP]you[SP]pray[SP]at[SP]this\nshrine,[SP]your[SP]dreams[SP]will[SP]come[SP]true.[SP]Try[SP]it!",
     "nom_fr": "Père de Maya",
-    "texte_fr": "Ecoute-moi, Maya...[1205][001E] Si tu pries ici,\ntes rêves se réaliseront. Essaie!"
+    "texte_fr": "Ecoute-moi, Maya...[001E][1205] Si tu pries ici,\ntes rêves se réaliseront. Essaie!"
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]Daddy...[1205][001E][SP]would[SP]stay[SP]home[SP]forever...[1205][001E]",
     "nom_fr": "Maya",
-    "texte_fr": "Que Papa...[1205][001E] reste ici pour toujours...[1205][001E]"
+    "texte_fr": "Que Papa...[001E][1205] reste ici pour toujours...[001E][1205]"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Is[SP]your[SP]job...[1205][001E][SP]that[SP]important...?",
     "nom_fr": "Maya",
-    "texte_fr": "Ton travail...[1205][001E] si important...?"
+    "texte_fr": "Ton travail...[001E][1205] si important...?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya's[SP]father",
     "texte_orig": "I'll[SP]be[SP]back[SP]home[SP]as[SP]soon[SP]as[SP]I[SP]can,[SP]sweetie...[1205][001E]\nBut[SP]this[SP]job[SP]has[SP]been[SP]Daddy's[SP]dream[SP]ever[SP]since\nhe[SP]was[SP]a[SP]little[SP]boy.",
     "nom_fr": "Père de Maya",
-    "texte_fr": "Je rentrerai dès que possible, ma\nchérie...[1205][001E] Mais ce travail est le\nrêve de Papa depuis qu'il est petit."
+    "texte_fr": "Je rentrerai dès que possible, ma\nchérie...[001E][1205] Mais ce travail est le\nrêve de Papa depuis qu'il est petit."
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Liar![1205][001E][SP]You[SP]promised...[1205][001E][SP]You[SP]promised[SP]you'd\ncome[SP]home...",
     "nom_fr": "Maya",
-    "texte_fr": "Menteur![1205][001E] Tu l'avais\ndit...[1205][001E] Tu avais promis..."
+    "texte_fr": "Menteur![001E][1205] Tu l'avais\ndit...[001E][1205] Tu avais promis..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "When[SP]you[SP]were[SP]assigned[SP]to[SP]the[SP]war[SP]zone...[1205][001E]\nDo[SP]you[SP]know[SP]how[SP]scared[SP]I[SP]was!?[1205][001E][SP]That[SP]Daddy\nmight[SP]have[SP]forgotten[SP]about[SP]me...!?",
     "nom_fr": "Maya",
-    "texte_fr": "Quand tu as été envoyé au front...[1205][001E]\nTu sais à quel point j'avais\npeur!?[1205][001E] Que Papa m'ait oubliée...!?"
+    "texte_fr": "Quand tu as été envoyé au front...[001E][1205]\nTu sais à quel point j'avais\npeur!?[001E][1205] Que Papa m'ait oubliée...!?"
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Here,[SP]Daddy...[1205][001E][SP]It's[SP]a[SP]good[SP]luck[SP]charm[SP]I[SP]made...[1205][001E]",
     "nom_fr": "Maya",
-    "texte_fr": "Tiens, Papa...[1205][001E] Un\nporte-bonheur fait par moi...[1205][001E]"
+    "texte_fr": "Tiens, Papa...[001E][1205] Un\nporte-bonheur fait par moi...[001E][1205]"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya's[SP]father",
     "texte_orig": "Aww,[SP]thanks...[1205][001E][SP]C'mon.[SP]If[SP]you[SP]keep[SP]crying,\nMr.[SP]Bunbun's[SP]gonna[SP]laugh[SP]at[SP]you!",
     "nom_fr": "Père de Maya",
-    "texte_fr": "Oh, merci...[1205][001E] Allez. Si tu pleures\nencore, M. Lapin va se moquer de toi!"
+    "texte_fr": "Oh, merci...[001E][1205] Allez. Si tu pleures\nencore, M. Lapin va se moquer de toi!"
   },
   {
     "id": 12,
@@ -192,6 +192,6 @@
     "nom_orig": "Maya",
     "texte_orig": "No![1205][001E][SP]I'm[SP]not[SP]the[SP]good[SP]girl[SP]you[SP]think[SP]I[SP]am!\nPlease[SP]don't[SP]go!",
     "nom_fr": "",
-    "texte_fr": "Non ![1205][001E] Je ne suis pas la fille bien\nque tu crois que je suis !\nNe pars pas !"
+    "texte_fr": "Non ![001E][1205] Je ne suis pas la fille bien\nque tu crois que je suis !\nNe pars pas !"
   }
 ]

--- a/traduction/event_scripts/script_188.json
+++ b/traduction/event_scripts/script_188.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya's[SP]father's[SP]voice",
     "texte_orig": "Listen[SP]closely,[SP]Maya...[1205][001E][SP]Journalism[SP]is[SP]a[SP]job\nyou[SP]can[SP]be[SP]proud[SP]of.[SP]Society[SP]needs[SP]us...",
     "nom_fr": "Voix du père de Maya",
-    "texte_fr": "Ecoute, Maya...[1205][001E] Le journalisme est un\nmétier noble. On a besoin de nous..."
+    "texte_fr": "Ecoute, Maya...[001E][1205] Le journalisme est un\nmétier noble. On a besoin de nous..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That's[SP]why...[1205][001E][SP]I'm[SP]gonna[SP]be[SP]a[SP]reporter[SP]who\npasses[SP]down[SP]dreams[SP]to[SP]everyone...",
     "nom_fr": "Maya",
-    "texte_fr": "C'est pour ça...[1205][001E] Je veux être reporter\net transmettre des rêves à tous..."
+    "texte_fr": "C'est pour ça...[001E][1205] Je veux être reporter\net transmettre des rêves à tous..."
   },
   {
     "id": 2,
@@ -98,7 +98,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]know...[1205][001E][SP]I...[SP]know...",
     "nom_fr": "Maya",
-    "texte_fr": "Je sais...[1205][001E] Je sais..."
+    "texte_fr": "Je sais...[001E][1205] Je sais..."
   },
   {
     "id": 6,
@@ -113,7 +113,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]went[SP]into[SP]the[SP]same[SP]line[SP]of[SP]work[SP]as[SP]my[SP]dad...[1205][001E]\nMaybe[SP]I[SP]was[SP]trying[SP]to[SP]outdo[SP]him...",
     "nom_fr": "Maya",
-    "texte_fr": "J'ai suivi le métier de mon père...[1205][001E]\nPeut-être pour le dépasser..."
+    "texte_fr": "J'ai suivi le métier de mon père...[001E][1205]\nPeut-être pour le dépasser..."
   },
   {
     "id": 7,
@@ -128,7 +128,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Dad[SP]died[SP]pursuing[SP]his[SP]dream.[1205][001E][SP]All[SP]he[SP]left[SP]me\nwas[SP]this...",
     "nom_fr": "Maya",
-    "texte_fr": "Papa est mort pour son rêve.[1205][001E]\nIl ne m'a laissé que ça..."
+    "texte_fr": "Papa est mort pour son rêve.[001E][1205]\nIl ne m'a laissé que ça..."
   },
   {
     "id": 8,
@@ -158,7 +158,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Have[SP]you...[1205][001E][SP]ever[SP]heard[SP]this[SP]poem[SP]before?",
     "nom_fr": "Maya",
-    "texte_fr": "Tu as...[1205][001E] déjà entendu ce poème?"
+    "texte_fr": "Tu as...[001E][1205] déjà entendu ce poème?"
   },
   {
     "id": 10,
@@ -173,7 +173,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Worse[SP]than[SP]alone[SP]/[SP]Exiled.[1205][001E]\nWorse[SP]than[SP]exiled[SP]/[SP]Dead.[1205][001E]\nWorse[SP]than[SP]dead[SP]/[SP]Forgotten.",
     "nom_fr": "Maya",
-    "texte_fr": "Pire que seul / Exilé.[1205][001E] Pire qu'exilé\n/ Mort.[1205][001E] Pire que mort / Oublié."
+    "texte_fr": "Pire que seul / Exilé.[001E][1205] Pire qu'exilé\n/ Mort.[001E][1205] Pire que mort / Oublié."
   },
   {
     "id": 11,
@@ -188,7 +188,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What[SP]does[SP]it[SP]take[SP]to[SP]prove[SP]you[SP]were[SP]ever\nalive...?[1205][001E][SP]Even[SP]if[SP]you[SP]die,[SP]as[SP]long[SP]as[SP]you're\nremembered,[SP]you'll[SP]live[SP]on[SP]as[SP]a[SP]memory...",
     "nom_fr": "Ginko",
-    "texte_fr": "Que faut-il pour prouver qu'on a\nvécu...?[1205][001E] Même mort, si on est souvenu,\non continue comme souvenir..."
+    "texte_fr": "Que faut-il pour prouver qu'on a\nvécu...?[001E][1205] Même mort, si on est souvenu,\non continue comme souvenir..."
   },
   {
     "id": 12,
@@ -203,7 +203,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "But[SP]then,[SP]if[SP]you're[SP]forgotten...[1205][001E][SP]That's[SP]really\nno[SP]different[SP]from[SP]being[SP]dead...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mais si on est oublié...[1205][001E] Ce n'est\npas si différent d'être mort..."
+    "texte_fr": "Mais si on est oublié...[001E][1205] Ce n'est\npas si différent d'être mort..."
   },
   {
     "id": 13,
@@ -218,7 +218,7 @@
     "nom_orig": "Jun",
     "texte_orig": "No[SP]man[SP]is[SP]an[SP]island...[1205][001E][SP]So[SP]we[SP]try[SP]to[SP]imprint\nour[SP]existence[SP]in[SP]others...[1205][001E][SP]Following[SP]one's\ndream[SP]may[SP]be[SP]one[SP]way[SP]of[SP]doing[SP]so.",
     "nom_fr": "Jun",
-    "texte_fr": "Nul n'est une île...[1205][001E] On cherche\nà laisser une trace en autrui...[1205][001E]\nSuivre ses rêves peut y aider."
+    "texte_fr": "Nul n'est une île...[001E][1205] On cherche\nà laisser une trace en autrui...[001E][1205]\nSuivre ses rêves peut y aider."
   },
   {
     "id": 14,
@@ -233,7 +233,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That's[SP]how[SP]it[SP]was[SP]with[SP]me.[1205][001E][SP]If[SP]you[SP]guys[SP]had\nreally[SP]forgotten[SP]about[SP]me...[1205][001E][SP]I[SP]might[SP]not[SP]be\nhere[SP]right[SP]now...",
     "nom_fr": "Maya",
-    "texte_fr": "C'était pareil pour moi.[1205][001E] Si vous\nm'aviez vraiment oubliée...[1205][001E] Je\nne serais peut-être pas là..."
+    "texte_fr": "C'était pareil pour moi.[001E][1205] Si vous\nm'aviez vraiment oubliée...[001E][1205] Je\nne serais peut-être pas là..."
   },
   {
     "id": 15,
@@ -248,7 +248,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]won't[SP]forget...![1205][001E][SP]I[SP]won't[SP]ever[SP]forget[SP]my\nBig[SP]Maya,[SP]or[SP]anyone[SP]here,[SP]ever[SP]again!",
     "nom_fr": "Jun",
-    "texte_fr": "Je n'oublierai pas![1205][001E] Jamais je n'oublierai\nma grande Maya, ni personne ici!"
+    "texte_fr": "Je n'oublierai pas![001E][1205] Jamais je n'oublierai\nma grande Maya, ni personne ici!"
   },
   {
     "id": 16,
@@ -263,7 +263,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Thank[SP]you...[1205][001E][SP]I'm[SP]sorry[SP]for[SP]whatever[SP]trouble\nI've[SP]caused.[1205][001E][SP]Let's[SP]go...",
     "nom_fr": "Maya",
-    "texte_fr": "Merci...[1205][001E] Désolée pour les\nproblèmes causés.[1205][001E] Allons-y..."
+    "texte_fr": "Merci...[001E][1205] Désolée pour les\nproblèmes causés.[001E][1205] Allons-y..."
   },
   {
     "id": 17,
@@ -278,7 +278,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]like...[SP]I've[SP]finally[SP]found[SP]where[SP]I[SP]belong.[1205][001E]\nThis[SP]is[SP]where[SP]my[SP]Persona[SP]has[SP]been[SP]guiding[SP]me\nfor[SP]the[SP]last[SP]ten[SP]years...",
     "nom_fr": "Maya",
-    "texte_fr": "C'est comme si j'avais enfin\ntrouvé ma place.[1205][001E] C'est là que ma\nPersona me guide depuis dix ans..."
+    "texte_fr": "C'est comme si j'avais enfin\ntrouvé ma place.[001E][1205] C'est là que ma\nPersona me guide depuis dix ans..."
   },
   {
     "id": 18,
@@ -293,7 +293,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]don't[SP]want[SP]anyone[SP]else[SP]to[SP]suffer...[1205][001E]\nWe[SP]need[SP]to[SP]hurry[SP]and[SP]put[SP]an[SP]end[SP]to[SP]this.",
     "nom_fr": "Maya",
-    "texte_fr": "Je ne veux plus que quelqu'un\nsouffre...[1205][001E] On doit vite en finir."
+    "texte_fr": "Je ne veux plus que quelqu'un\nsouffre...[001E][1205] On doit vite en finir."
   },
   {
     "id": 19,
@@ -323,7 +323,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Wearing[SP]trendy[SP]clothes[SP]and[SP]chasing[SP]after[SP]the\nlatest[SP]fashion[SP]is[SP]the[SP]same[SP]thing...[1205][001E][SP]Everyone's\ndesperate[SP]to[SP]carve[SP]out[SP]their[SP]own[SP]niche.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Suivre la mode et porter des\nvêtements branchés, c'est pareil...[1205][001E]\nChacun veut se faire une place."
+    "texte_fr": "Suivre la mode et porter des\nvêtements branchés, c'est pareil...[001E][1205]\nChacun veut se faire une place."
   },
   {
     "id": 21,
@@ -353,7 +353,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "But[SP]that's[SP]not[SP]so[SP]bad,[SP]is[SP]it?[1205][001E][SP]There's[SP]nothing\nwrong[SP]with[SP]thinking[SP]that[SP]way...[SP]is[SP]there...?[1205][001E]\nMaybe[SP]I'm[SP]not[SP]that[SP]strong[SP]after[SP]all..",
     "nom_fr": "Ginko",
-    "texte_fr": "Mais ce n'est pas si mal, non?[1205][001E] Penser\nainsi n'a rien de mauvais...[1205][001E] Peut-être\nque je ne suis pas si forte..."
+    "texte_fr": "Mais ce n'est pas si mal, non?[001E][1205] Penser\nainsi n'a rien de mauvais...[001E][1205] Peut-être\nque je ne suis pas si forte..."
   },
   {
     "id": 23,
@@ -368,6 +368,6 @@
     "nom_orig": "Jun",
     "texte_orig": "That[SP]might[SP]have[SP]been[SP]the[SP]case[SP]with[SP]my[SP]father's\ndream...[1205][001E][SP]But[SP]if[SP]it's[SP]going[SP]to[SP]bring[SP]suffering\nto[SP]the[SP]world,[SP]then[SP]even[SP]if[SP]I[SP]die,[SP]I'll...",
     "nom_fr": "",
-    "texte_fr": "C'était peut-être le rêve de mon père...[1205][001E]\nMais si ça doit apporter de la souffrance\nau monde, même si je dois mourir, je..."
+    "texte_fr": "C'était peut-être le rêve de mon père...[001E][1205]\nMais si ça doit apporter de la souffrance\nau monde, même si je dois mourir, je..."
   }
 ]

--- a/traduction/event_scripts/script_189.json
+++ b/traduction/event_scripts/script_189.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP][1113]...[1205][001E][SP]Haven't[SP]we[SP]been[SP]walking[SP]for\na[SP]long[SP]time?[SP]I'm[SP]tired...",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé,[1113]...[1205][001E] On marche depuis\nlongtemps, non? Je suis crevée..."
+    "texte_fr": "Hé,[1113]...[001E][1205] On marche depuis\nlongtemps, non? Je suis crevée..."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You've[SP]got[SP]a[SP]point...[1205][001E][SP]We[SP]haven't[SP]seen[SP]Igor's\nface[SP]in[SP]a[SP]while,[SP]either.",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est vrai...[1205][001E] On n'a pas\nvu Igor depuis un moment."
+    "texte_fr": "C'est vrai...[001E][1205] On n'a pas\nvu Igor depuis un moment."
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We're[SP]in[SP]a[SP]real[SP]fix...[1205][001E][SP]There's[SP]no[SP]time[SP]to[SP]go\nback[SP]to[SP]the[SP]city[SP]and[SP]no[SP]way[SP]to[SP]get[SP]there[SP]if\nwe[SP]could.[SP]Just[SP]hang[SP]in[SP]there,[SP]guys.",
     "nom_fr": "Maya",
-    "texte_fr": "On est mal...[1205][001E] Pas le temps de retourner en\nville, et même si on pouvait... Tenez bon."
+    "texte_fr": "On est mal...[001E][1205] Pas le temps de retourner en\nville, et même si on pouvait... Tenez bon."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "They're[SP]proud[SP]of[SP]all[SP]their[SP]high-tech[SP]gizmos,\naren't[SP]they?[SP]I[SP]wonder[SP]if[SP]they[SP]brought[SP]anything\nthey[SP]can[SP]use[SP]to[SP]get[SP]in[SP]and[SP]out[SP]of[SP]here.",
     "nom_fr": "Ginko",
-    "texte_fr": "Ils sont fiers de\nleur matos high-tech, non?\nIls ont peut-être un\nmoyen d'entrer et sortir."
+    "texte_fr": "Ils sont fiers de\nleur matos high-tech, non?\nIls ont peut-être un moyen d'entrer et sortir."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "No[SP]use[SP]hoping[SP]for[SP]a[SP]miracle...[1205][001E][SP]Let's[SP]just[SP]go.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Inutile d'espérer un miracle...[1205][001E] Avançons."
+    "texte_fr": "Inutile d'espérer un miracle...[001E][1205] Avançons."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Wait,[SP]look...[1205][001E][SP]This[SP]door[SP]says[SP][1432][NULL][NULL][0014]Velvet[SP]Room[1432][NULL][NULL][0014]...[1205][001E]\nAnd[SP]the[SP]one[SP]over[SP]here[SP]says[SP][1432][NULL][NULL][0014]Trish's[SP]Spring.[1432][NULL][NULL][0014]",
     "nom_fr": "Jun",
-    "texte_fr": "Attends, regarde...[1205][001E] Cette porte dit [1432][NULL][NULL][0014]Velvet\nRoom[1432][NULL][NULL][0014]...[1205][001E] Et l'autre, [1432][NULL][NULL][0014]Source de Trish[1432][NULL][NULL][0014]."
+    "texte_fr": "Attends, regarde...[001E][1205] Cette porte dit [1432][NULL][NULL][0014]Velvet\nRoom[1432][NULL][NULL][0014]...[001E][1205] Et l'autre, [1432][NULL][NULL][0014]Source de Trish[1432][NULL][NULL][0014]."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Eikichi,[SP]Maya[SP]&[SP]Ginko",
     "texte_orig": "Huh...?[1205][001E][SP]Seriously!?",
     "nom_fr": "Eikichi, Maya & Ginko",
-    "texte_fr": "Hein...?[1205][001E] Sérieux!?"
+    "texte_fr": "Hein...?[001E][1205] Sérieux!?"
   },
   {
     "id": 10,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Y-Yikes...[1205][001E]",
     "nom_fr": "Maya",
-    "texte_fr": "A-Ah...[1205][001E]"
+    "texte_fr": "A-Ah...[001E][1205]"
   },
   {
     "id": 13,

--- a/traduction/event_scripts/script_190.json
+++ b/traduction/event_scripts/script_190.json
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "*pant*[SP]*pant*[1205][001E][SP]Th-That[SP]wasn't[SP]funny...![1205][001E]\nI[SP]nearly[SP]got[SP]pressed[SP]like[SP]a[SP]new[SP]suit!\nI[SP]could[SP]have[SP]died[SP]in[SP]there!",
     "nom_fr": "Maya",
-    "texte_fr": "*pam* *pam* C-C'est pas drôle.[001E][1205][001E][1205]..!\nJ'ai failli me faire écraser comme un\ncostume neuf! J'aurais pu y rester!"
+    "texte_fr": "*pam* *pam* C-C'est pas drôle.[001E][001E][1205][1205]..!\nJ'ai failli me faire écraser comme un\ncostume neuf! J'aurais pu y rester!"
   },
   {
     "id": 7,

--- a/traduction/event_scripts/script_191.json
+++ b/traduction/event_scripts/script_191.json
@@ -12,7 +12,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Lisa...![1205][001E][SP]Huh!?",
     "nom_fr": "Jun",
-    "texte_fr": "Lisa![1205][001E] Hein!?"
+    "texte_fr": "Lisa![001E][1205] Hein!?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Jun",
     "texte_orig": "It's[SP]not[SP]opening...[1205][000F][SP]It[SP]was[SP]a[SP]trap[SP]after[SP]all![1205][001E]\nDamn[SP]it!",
     "nom_fr": "Jun",
-    "texte_fr": "Ça s'ouvre pas.[1205].[000F]. C'était\nvraiment un piège![1205][001E] Putain!"
+    "texte_fr": "Ça s'ouvre pas.[1205].[000F]. C'était\nvraiment un piège![001E][1205] Putain!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]can't[SP]die[SP]here[SP]like[SP]this![SP]I[SP]promised[SP]those\nkids...[1205][001E][SP]Stop![SP]Pull[SP]back![E1][E2]\n[E3][E4][NULL][NULL]\"Jun\n...Huh!?[SP]H-How...?",
     "nom_fr": "Jun",
-    "texte_fr": "Je peux pas mourir ici! J'ai promis aux\ngamins...[1205][001E] Stop! Reculez![E1][E2] [E3][E4][NULL][NULL]\"Jun\n ... Hein!?\nQue...?"
+    "texte_fr": "Je peux pas mourir ici! J'ai promis aux\ngamins...[001E][1205] Stop! Reculez![E1][E2] [E3][E4][NULL][NULL]\"Jun\n ... Hein!?\nQue...?"
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Wh...[SP]What[SP]does[SP]this[SP]mean...?[1205][001E][SP]Lisa's[SP]not\nhere...[SP]Let's[SP]go[SP]back[SP]to[SP]the[SP]other[SP]room\nfor[SP]now,[SP][1113]...",
     "nom_fr": "Jun",
-    "texte_fr": "Qu.. Qu'est-ce que ça veut dire?[1205][001E] Lisa\nn'est pas là, rebroussons chemin, [1113]."
+    "texte_fr": "Qu.. Qu'est-ce que ça veut dire?[001E][1205] Lisa\nn'est pas là, rebroussons chemin, [1113]."
   },
   {
     "id": 5,
@@ -87,6 +87,6 @@
     "nom_orig": "Jun",
     "texte_orig": "Hmm...[1205][001E][SP]I'm[SP]worried[SP]about[SP]Michel[SP]and[SP]Big[SP]Maya.\nWe[SP]should[SP]go[SP]back,[SP][1113].",
     "nom_fr": "",
-    "texte_fr": "Hmm...[1205][001E] Je m'inquiète pour Michel\net Grande Maya.\nOn devrait retourner, [1113]."
+    "texte_fr": "Hmm...[001E][1205] Je m'inquiète pour Michel\net Grande Maya.\nOn devrait retourner, [1113]."
   }
 ]

--- a/traduction/event_scripts/script_192.json
+++ b/traduction/event_scripts/script_192.json
@@ -42,7 +42,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Ngh...[SP]Again...?[1205][001E][SP]Why?[SP]Why[SP]are[SP]we[SP]seeing\nthese[SP]things...?",
     "nom_fr": "Jun",
-    "texte_fr": "Heu... Encore?[1205][001E] Pourquoi?\nPourquoi on voit ces choses?"
+    "texte_fr": "Heu... Encore?[001E][1205] Pourquoi?\nPourquoi on voit ces choses?"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Isn't[SP]your[SP]mom[SP]gonna[SP]come[SP]pick[SP]you[SP]up,[SP]Jun-kun?\n[E1][E2]\n[E3][E4][NULL][NULL]\"Jun\n...[1205][001E]I[SP]wish...[1205][001E][SP]I[SP]wish[SP]you[SP]were[SP]my[SP]Mama,\nBig[SP]Sis...\n[E1][E2]\n[E3][E4][NULL][NULL]\"Jun\nMama...[SP]She[SP]hates[SP]me...[1205][001E][SP]But[SP]Papa's[SP]really\ngreat![SP]I[SP]swear!",
     "nom_fr": "Maya",
-    "texte_fr": "Ta maman vient pas te chercher, Jun-kun? [E1][E2]\n[E3][E4][NULL][NULL]\"Jun\n ...[1205][001E] J'aimerais...[1205][001E] que tu sois ma\nmaman, Sœurette...[E1][E2]\n[E3][E4][NULL][NULL]\"Jun Maman me\ndéteste...[1205][001E] Mais papa est super! Je le jure!"
+    "texte_fr": "Ta maman vient pas te chercher, Jun-kun? [E1][E2]\n[E3][E4][NULL][NULL]\"Jun\n ...[001E][1205] J'aimerais...[001E][1205] que tu sois ma\nmaman, Sœurette...[E1][E2]\n[E3][E4][NULL][NULL]\"Jun Maman me\ndéteste...[001E][1205] Mais papa est super! Je le jure!"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Oh...[1205][001E][SP]Then[SP]I'll[SP]walk[SP]you[SP]home!",
     "nom_fr": "Maya",
-    "texte_fr": "Oh...[1205][001E] Je t'accompagne!"
+    "texte_fr": "Oh...[001E][1205] Je t'accompagne!"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Grrk...![1205][001E][SP]Th-That's...[1205][001E][SP]Who[SP]is[SP]that...?",
     "nom_fr": "Jun",
-    "texte_fr": "Rrr..[1205].!1205][001E]C'est...[1205][001E] C'est qui...?"
+    "texte_fr": "Rrr..[1205].!1205][001E]C'est...[001E][1205] C'est qui...?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hello.[1205][001E][SP]Um...[SP]Are[SP]you[SP]Jun-kun's[SP]father?\n[E1][E2]\n[E3][E4][NULL][NULL]\"Jun\nN-No...![1205][001E][SP]He's...[1205][001E][SP]He's[SP]my[SP]uncle!\n[E1][E2]\n[E3][E4][NULL][NULL]\"Jun's[SP]uncle\n...[1205][001E]Come[SP]on...[SP]Let's[SP]go[SP]home.[SP]Jun...?",
     "nom_fr": "Maya",
-    "texte_fr": "Bonjour.[1205][001E] Euh, vous êtes le père de Jun?[E1][E2]\n[E3][E4][NULL][NULL]\"Jun N-Non...!\n[1205][001E] C'est...[1205][001E] mon oncle![E1][E2]\n[E3][E4][NULL][NULL]\"Oncle\nde Jun ...[1205][001E] Allez, rentrons. Jun?"
+    "texte_fr": "Bonjour.[001E][1205] Euh, vous êtes le père de Jun?[E1][E2]\n[E3][E4][NULL][NULL]\"Jun N-Non...!\n[001E][1205] C'est...[001E][1205] mon oncle![E1][E2]\n[E3][E4][NULL][NULL]\"Oncle\nde Jun ...[001E][1205] Allez, rentrons. Jun?"
   },
   {
     "id": 8,
@@ -132,6 +132,6 @@
     "nom_orig": "Jun",
     "texte_orig": "N-No...[1205][001E][SP]Wait...[SP]Th-That's[SP]right...[1205][001E]\nS-Stop...[SP]STOP!",
     "nom_fr": "",
-    "texte_fr": "N-Non...[1205][001E] Attends... C'est ça...[1205][001E]\nA-Arrête... ARRÊTE !"
+    "texte_fr": "N-Non...[001E][1205] Attends... C'est ça...[001E][1205]\nA-Arrête... ARRÊTE !"
   }
 ]

--- a/traduction/event_scripts/script_193.json
+++ b/traduction/event_scripts/script_193.json
@@ -12,7 +12,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Ngh...[1205][001E][SP]That's...[SP]not...",
     "nom_fr": "Jun",
-    "texte_fr": "Ngh...[1205][001E] C'est... pas..."
+    "texte_fr": "Ngh...[001E][1205] C'est... pas..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Dude...[1205][001E][SP]Are[SP]you[SP]okay,[SP]Jun?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mec...[1205][001E] Ça va, Jun?"
+    "texte_fr": "Mec...[001E][1205] Ça va, Jun?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Jun",
     "texte_orig": "That's[SP]right...[1205][001E][SP]My[SP]mother[SP]is[SP]someone[SP]else...",
     "nom_fr": "Jun",
-    "texte_fr": "C'est vrai...[1205][001E] Ma\nmère est quelqu'un d'autre."
+    "texte_fr": "C'est vrai...[001E][1205] Ma\nmère est quelqu'un d'autre."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I'm[SP]all[SP]right[SP]now.[1205][001E][SP]Come[SP]on...[SP]Let's[SP]go...",
     "nom_fr": "Jun",
-    "texte_fr": "Je vais bien.[1205][001E] Allons-y..."
+    "texte_fr": "Je vais bien.[001E][1205] Allons-y..."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "That[SP]guy...[1205][001E][SP]Didn't[SP]he[SP]look[SP]exactly[SP]like[SP]the\nghost[SP]from[SP]the[SP]clock[SP]tower!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Ce gars...[1205][001E] Il ne ressemble pas\nexactement au fantôme du clocher!?"
+    "texte_fr": "Ce gars...[001E][1205] Il ne ressemble pas\nexactement au fantôme du clocher!?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh...?[SP]Wait...[1205][001E][SP]Jun's[SP]dad[SP]wrote[SP]the[SP]In[SP]Lak'ech,\nright?[SP]And[SP]the[SP]one[SP]who[SP]died[SP]at[SP]the[SP]clock[SP]tower\nis[SP]supposedly[SP]In[SP]Lak'ech's[SP]author...",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein...? Attends...[1205][001E] Le père de Jun a écrit\nle In Lak'ech, non? Et celui qui est mort\ndans le clocher est\ncensé être son auteur..."
+    "texte_fr": "Hein...? Attends...[001E][1205] Le père de Jun a écrit\nle In Lak'ech, non? Et celui qui est mort\ndans le clocher est censé être son auteur..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Then[SP]Jun's[SP]dad[SP]is...[1205][001E][SP]No[SP]way![1205][001E][SP]The[SP]man[SP]we[SP]knew\nas[SP]Jun's[SP]dad[SP]was...",
     "nom_fr": "Ginko",
-    "texte_fr": "Son père...[1205][001E] Non![1205][001E] L'homme qu'on\nprenait pour son père était..."
+    "texte_fr": "Son père...[001E][1205] Non![001E][1205] L'homme qu'on\nprenait pour son père était..."
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "But[SP]the[SP]author[SP]of[SP]the[SP]In[SP]Lak'ech[SP]was[SP]the\nghost[SP]we[SP]saw[SP]at[SP]the[SP]clock[SP]tower![1205][001E][SP]Does[SP]that\nmean...[SP]they're[SP]both[SP]Jun's[SP]dad...?",
     "nom_fr": "Ginko",
-    "texte_fr": "L'auteur du In Lak'ech, c'était le\nfantôme du clocher![1205][001E] Ça veut dire\nqu'ils sont tous les deux son père...?"
+    "texte_fr": "L'auteur du In Lak'ech, c'était le\nfantôme du clocher![001E][1205] Ça veut dire\nqu'ils sont tous les deux son père...?"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "If[SP]our[SP]rumors[SP]really[SP]did[SP]create[SP]an[SP]impostor[SP]of\nJun's[SP]dad...[1205][001E][SP]Then[SP]we've[SP]been[SP]making[SP]Jun[SP]suffer\nall[SP]these[SP]years...",
     "nom_fr": "Ginko",
-    "texte_fr": "Si nos rumeurs ont créé un\nimposteur du père de Jun...[1205][001E] On l'a\nfait souffrir toutes ces années..."
+    "texte_fr": "Si nos rumeurs ont créé un\nimposteur du père de Jun...[001E][1205] On l'a\nfait souffrir toutes ces années..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "...[1205][001E]I[SP]need[SP]some[SP]time[SP]to[SP]think,[SP][1113]-kun.",
     "nom_fr": "Maya",
-    "texte_fr": "...[1205][001E] J'ai besoin de réfléchir, [1113]."
+    "texte_fr": "...[001E][1205] J'ai besoin de réfléchir, [1113]."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "A[SP]false[SP]accusation...[1205][001E][SP]Even[SP]if[SP]it[SP]wasn't\nintentional,[SP]man[SP]can't[SP]help[SP]unwittingly\nhurting[SP]others...",
     "nom_fr": "Maya",
-    "texte_fr": "Une fausse accusation...[1205][001E]\nMême sans intention,\non peut blesser les\nautres sans le vouloir..."
+    "texte_fr": "Une fausse accusation...[001E][1205]\nMême sans intention,\non peut blesser les autres sans le vouloir..."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Jun's[SP]uncle,[SP]huh?[1205][001E][SP]He[SP]looks[SP]a[SP]lot[SP]like[SP]Jun's\ndad.[SP]Definitely[SP]different[SP]personality-wise,\nthough.",
     "nom_fr": "Eikichi",
-    "texte_fr": "L'oncle de Jun, hein?[1205][001E]\nIl ressemble à son père.\nPersonnalité très différente, par contre."
+    "texte_fr": "L'oncle de Jun, hein?[001E][1205]\nIl ressemble à son père.\nPersonnalité très différente, par contre."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Okay,[SP]so[SP]the[SP]guy[SP]we[SP]saw[SP]here[SP]was[SP]Jun's[SP]uncle,\nand[SP]the[SP]dude[SP]on[SP]B9F[SP]was[SP]Jun's[SP]dad,[SP]right?[1205][001E]\nWhat's[SP]got[SP]everyone[SP]so[SP]hot[SP]and[SP]bothered?\n[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nSomeone's[SP]pulling[SP]the[SP]strings[SP]behind[SP]all[SP]this...[1205][001E]\nLet's[SP]hurry[SP]and[SP]get[SP]going.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Alors celui d'ici était\nson oncle, et le gars\ndu 9e était son père,\nc'est ça ?[1205][001E] Qu'est-ce qui\nmet tout le monde en émoi? [E1][E2] [E3][E4][NULL][NULL]\"Eikichi\n Quelqu'un\ntire les ficelles...[1205][001E] Dépêchons-nous."
+    "texte_fr": "Alors celui d'ici était\nson oncle, et le gars\ndu 9e était son père,\nc'est ça ?[001E][1205] Qu'est-ce qui\nmet tout le monde en émoi? [E1][E2] [E3][E4][NULL][NULL]\"Eikichi\n Quelqu'un\ntire les ficelles...[001E][1205] Dépêchons-nous."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Uncle...?[1205][001E][SP]That's[SP]right...[SP]My[SP]father[SP]is[SP]further\ninside...[1205][001E][SP]I[SP]have[SP]to[SP]stop[SP]him...",
     "nom_fr": "Jun",
-    "texte_fr": "Mon oncle...?[1205][001E] C'est ça... Mon père est\nplus loin ...[1205][001E] Je dois l'arrêter..."
+    "texte_fr": "Mon oncle...?[001E][1205] C'est ça... Mon père est\nplus loin ...[001E][1205] Je dois l'arrêter..."
   },
   {
     "id": 15,

--- a/traduction/event_scripts/script_194.json
+++ b/traduction/event_scripts/script_194.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Tch...[SP]We[SP]still[SP]haven't[SP]caught[SP]up[SP]to[SP]them...[1205][001E]\nMustache[SP]Man[SP]must[SP]be[SP]pretty[SP]far[SP]ahead.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tch... On les a toujours pas rattrapés...[1205][001E]\nLe moustachu doit être bien devant."
+    "texte_fr": "Tch... On les a toujours pas rattrapés...[001E][1205]\nLe moustachu doit être bien devant."
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm...[1205][001E][SP]What[SP]do[SP]you[SP]guys[SP]think?[SP]Are[SP]we\nclose[SP]to[SP]the[SP]goal[SP]or[SP]not?",
     "nom_fr": "Maya",
-    "texte_fr": "Hmm...[1205][001E] Vous en pensez quoi?\nOn est proches du but ou pas?"
+    "texte_fr": "Hmm...[001E][1205] Vous en pensez quoi?\nOn est proches du but ou pas?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Hm...?[1205][001E][SP]Well,[SP]given[SP]how[SP]long[SP]it[SP]took[SP]us[SP]to\nmake[SP]it[SP]this[SP]far,[SP]I[SP]assume[SP]they're[SP]much\nfurther[SP]ahead...",
     "nom_fr": "Jun",
-    "texte_fr": "Hm...[1205][001E] Vu le temps qu'on a mis pour arriver\nici, je pense qu'ils sont beacoup plus\ndevant..."
+    "texte_fr": "Hm...[001E][1205] Vu le temps qu'on a mis pour arriver\nici, je pense qu'ils sont beacoup plus\ndevant..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]don't[SP]really[SP]care...[1205][001E][SP]I[SP]just[SP]wish[SP]they'd\nhurry[SP]and[SP]show[SP]their[SP]faces...",
     "nom_fr": "Ginko",
-    "texte_fr": "Je m'en fiche...[1205][001E] J'aimerais juste\nqu'ils se dépêchent de se montrer..."
+    "texte_fr": "Je m'en fiche...[001E][1205] J'aimerais juste\nqu'ils se dépêchent de se montrer..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Uhhh,[SP]hard[SP]to[SP]say,[SP]but...[1205][001E][SP]We[SP]must[SP]be[SP]almost\ncaught[SP]up[SP]with[SP]them[SP]by[SP]now,[SP]right?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Uhhh, je sais pas, mais...[1205][001E] On devrait\nbientôt les rattraper pas vrai?"
+    "texte_fr": "Uhhh, je sais pas, mais...[001E][1205] On devrait\nbientôt les rattraper pas vrai?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Okay...[1205][001E][SP]So[SP]basically,[SP]Jun-kun[SP]thinks[SP]that\n[1432][NULL][NULL][0014]they're[SP]much[SP]further[SP]ahead[1432][NULL][NULL][0014]...",
     "nom_fr": "Maya",
-    "texte_fr": "Okay...[1205][001E] Donc Jun-kun pense qu'\n[1432][NULL][NULL][0014]ils sont beaucoup plus devant[1432][NULL][NULL][0014]..."
+    "texte_fr": "Okay...[001E][1205] Donc Jun-kun pense qu'\n[1432][NULL][NULL][0014]ils sont beaucoup plus devant[1432][NULL][NULL][0014]..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Eikichi-kun[SP]thinks[SP][1432][NULL][NULL][0014]We[SP]must[SP]be[SP]almost[SP]caught\nup[SP]with[SP]them[1432][NULL][NULL][0014]...[1205][001E][SP]And[SP]Lisa[SP][1432][NULL][NULL][0014]doesn't[SP]really[SP]care.[1432][NULL][NULL][0014]",
     "nom_fr": "Maya",
-    "texte_fr": "Eikichi-kun pense [1432][NULL][NULL][0014] qu'on les a presque\nrattrapés[1432][NULL][NULL][0014]...[1205][001E] Et Lisa [1432][NULL][NULL][0014] s'en fiche un peu.[1432][NULL][NULL][0014]"
+    "texte_fr": "Eikichi-kun pense [1432][NULL][NULL][0014] qu'on les a presque\nrattrapés[1432][NULL][NULL][0014]...[001E][1205] Et Lisa [1432][NULL][NULL][0014] s'en fiche un peu.[1432][NULL][NULL][0014]"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "In[SP]that[SP]case...[1205][001E][SP]I'm[SP]going[SP]to[SP]guess[SP]they're\njust[SP]around[SP]the[SP]corner.",
     "nom_fr": "Maya",
-    "texte_fr": "Dans ce cas...[1205][001E] Je vais supposer\nqu'ils ne sont pas très loin."
+    "texte_fr": "Dans ce cas...[001E][1205] Je vais supposer\nqu'ils ne sont pas très loin."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh?[1205][001E][SP]What's[SP]this[SP]about,[SP]Maya-chan?[SP]You're\nacting[SP]kinda[SP]weird[SP]here.",
     "nom_fr": "Ginko",
-    "texte_fr": "Huh?[1205][001E] De quoi tu parles,\nMaya-chan? T'agis bizarrement là."
+    "texte_fr": "Huh?[001E][1205] De quoi tu parles,\nMaya-chan? T'agis bizarrement là."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Bear[SP]with[SP]me[SP]just[SP]a[SP]little[SP]longer...[1205][001E]\nUmm,[SP]so[SP]this[SP]might[SP]sound[SP]vague,[SP]but...",
     "nom_fr": "Maya",
-    "texte_fr": "Patiente encore un peu...[1205][001E] Ca pourrait\nparaître un peu vague, mais..."
+    "texte_fr": "Patiente encore un peu...[001E][1205] Ca pourrait\nparaître un peu vague, mais..."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "If[SP]I[SP]go[SP]by[SP]our[SP]guesses[SP]as[SP]to[SP]the[SP]distance\nleft,[SP]Jun-kun[SP]says[SP]far,[SP]I[SP]say[SP]close...[1205][001E][SP]and\nEikichi-kun[SP]is[SP]somewhere[SP]in[SP]between.",
     "nom_fr": "Maya",
-    "texte_fr": "D'après nos calculs, Jun dit que c'est\nloin, je dis que c'est proche...[1205][001E] et\nEikichi-kun est entre les deux."
+    "texte_fr": "D'après nos calculs, Jun dit que c'est\nloin, je dis que c'est proche...[001E][1205] et\nEikichi-kun est entre les deux."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Now...[1205][001E][SP]Whose[SP]guess[SP]do[SP]you[SP]agree[SP]with,\n[1113]-kun?",
     "nom_fr": "Maya",
-    "texte_fr": "Donc...[1205][001E] Avec qui t'es d'accord, [1113]-kun?"
+    "texte_fr": "Donc...[001E][1205] Avec qui t'es d'accord, [1113]-kun?"
   },
   {
     "id": 14,
@@ -339,7 +339,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm...[1205][001E][SP]Two[SP]people[SP]who[SP]don't[SP]care...",
     "nom_fr": "Maya",
-    "texte_fr": "Hm...[1205][001E] Deux indifférents..."
+    "texte_fr": "Hm...[001E][1205] Deux indifférents..."
   },
   {
     "id": 22,
@@ -354,7 +354,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Our[SP]opinions[SP]are[SP]split[SP]now,[SP]2[SP]to[SP]1[SP]to[SP]1[SP]to[SP]1,\nbut...[1205][001E][SP]How[SP]will[SP]this[SP]play[SP]out...?[1205][001E][SP]Anyways,\nlet's[SP]go.",
     "nom_fr": "Maya",
-    "texte_fr": "On n'est pas d'accord, 2 contre\n1 contre 1 contre 1, mais...[1205][001E] Ca\nva finir comment?[1205][001E] Bon, on y va."
+    "texte_fr": "On n'est pas d'accord, 2 contre\n1 contre 1 contre 1, mais...[001E][1205] Ca\nva finir comment?[001E][1205] Bon, on y va."
   },
   {
     "id": 23,
@@ -399,7 +399,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Well,[SP]I[SP]don't[SP]know[SP]about[SP]that...[1205][001E][SP]I'm[SP]pretty\nsure[SP]our[SP]journey[SP]from[SP]here[SP]on[SP]will[SP]turn[SP]out\nthe[SP]way[SP][1113]-kun[SP]agreed[SP]with...",
     "nom_fr": "Maya",
-    "texte_fr": "Je sais pas trop...[1205][001E] Je suis sûre\nque notre trajet va se dérouler\ncomme [1113]-kun l'a dit..."
+    "texte_fr": "Je sais pas trop...[001E][1205] Je suis sûre\nque notre trajet va se dérouler\ncomme [1113]-kun l'a dit..."
   },
   {
     "id": 26,
@@ -474,7 +474,7 @@
     "nom_orig": "Jun",
     "texte_orig": "What[SP]could[SP]she[SP]mean...?[1205][001E][SP]Big[SP]Maya[SP]would[SP]never\nask[SP]things[SP]like[SP]that[SP]without[SP]some[SP]sort[SP]of\npurpose[SP]behind[SP]it...",
     "nom_fr": "Jun",
-    "texte_fr": "Qu'est-ce qu'elle veut dire...?[1205][001E] Maya ne\ndemanderait jamais ca sans raison..."
+    "texte_fr": "Qu'est-ce qu'elle veut dire...?[001E][1205] Maya ne\ndemanderait jamais ca sans raison..."
   },
   {
     "id": 31,
@@ -489,7 +489,7 @@
     "nom_orig": "Jun",
     "texte_orig": "If[SP]only[SP]this[SP]were[SP]all[SP]a[SP]bad[SP]dream.[1205][001E][SP]But[SP]that\nline[SP]of[SP]thinking[SP]is[SP]just[SP]me[SP]wishing[SP]I[SP]could\nescape[SP]my[SP]sins...",
     "nom_fr": "Jun",
-    "texte_fr": "Si seulement tout ça n'était qu'un\ncauchemar.[1205][001E] Mais penser ça, c'est\njuste vouloir fuir mes péchés..."
+    "texte_fr": "Si seulement tout ça n'était qu'un\ncauchemar.[001E][1205] Mais penser ça, c'est\njuste vouloir fuir mes péchés..."
   },
   {
     "id": 32,
@@ -504,6 +504,6 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]have[SP]to[SP]take[SP]responsibility.[1205][001E][SP]No[SP]matter\nwhat[SP]punishment[SP]awaits[SP]me[SP]at[SP]the[SP]end...",
     "nom_fr": "",
-    "texte_fr": "Je dois assumer mes responsabilités.[1205][001E]\nQuel que soit le châtiment qui\nm'attend à la fin..."
+    "texte_fr": "Je dois assumer mes responsabilités.[001E][1205]\nQuel que soit le châtiment qui\nm'attend à la fin..."
   }
 ]

--- a/traduction/event_scripts/script_195.json
+++ b/traduction/event_scripts/script_195.json
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "No[SP]thanks[SP]to[SP]you...[1205][001E][SP]But[SP]I[SP]still[SP]haven't\nfigured[SP]out[SP]the[SP]pattern[SP]to[SP]it.",
     "nom_fr": "Maya",
-    "texte_fr": "Pas de merci pour toi...[1205][001E] Mais je\nn'ai toujours pas compris le schéma."
+    "texte_fr": "Pas de merci pour toi...[001E][1205] Mais je\nn'ai toujours pas compris le schéma."
   },
   {
     "id": 3,

--- a/traduction/event_scripts/script_196.json
+++ b/traduction/event_scripts/script_196.json
@@ -12,7 +12,7 @@
     "nom_orig": "Longinus[SP]#1",
     "texte_orig": "If[SP]you[SP]had[SP]just[SP]died[SP]here,[SP]your[SP]suffering\nwould[SP]be[SP]at[SP]an[SP]end...[1205][001E][SP]Marionette...[1205][001E][SP]Haven't\nyou[SP]wondered[SP]where[SP]your[SP]mother[SP]has[SP]gone...?",
     "nom_fr": "Longinus #1",
-    "texte_fr": "Si tu étais mort ici, ta souffrance\naurait pris fin...[1205][001E] Marionnette...[1205][001E] N'as-tu\npas cherché où est passée ta mère...?"
+    "texte_fr": "Si tu étais mort ici, ta souffrance\naurait pris fin...[001E][1205] Marionnette...[001E][1205] N'as-tu\npas cherché où est passée ta mère...?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Jun",
     "texte_orig": "What...?[1205][001E][SP]Ngh!",
     "nom_fr": "Jun",
-    "texte_fr": "Quoi...?[1205][001E] Ngh!"
+    "texte_fr": "Quoi...?[001E][1205] Ngh!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Jun-kun,[SP]don't[SP]let[SP]them[SP]get[SP]under[SP]your[SP]skin...[1205][001E]\nYou[SP]need[SP]to[SP]focus[SP]on[SP]stopping[SP]your[SP]father\nand[SP]returning[SP]the[SP]city[SP]to[SP]normal!",
     "nom_fr": "Maya",
-    "texte_fr": "Jun-kun, ne te laisse pas déstabiliser...[1205][001E]\nConcentre-toi sur l'arrêt de ton père et\nle retour à la normale de la ville!"
+    "texte_fr": "Jun-kun, ne te laisse pas déstabiliser...[001E][1205]\nConcentre-toi sur l'arrêt de ton père et\nle retour à la normale de la ville!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP]Maya-chan...[1205][001E][SP]What's[SP]going[SP]on?[SP]All[SP]this\nstuff[SP]about[SP][1432][NULL][NULL][0014]secrets[1432][NULL][NULL][0014]...[SP]You're[SP]acting[SP]weird.",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, Maya...[1205][001E] Qu'est-ce qui se passe? Tous\nces [1432][NULL][NULL][0014]secrets[1432][NULL][NULL][0014]... Tu agis bizarrement."
+    "texte_fr": "Hé, Maya...[001E][1205] Qu'est-ce qui se passe? Tous\nces [1432][NULL][NULL][0014]secrets[1432][NULL][NULL][0014]... Tu agis bizarrement."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Sorry...[1205][001E][SP]I[SP]don't[SP]think[SP]I[SP]should[SP]say[SP]anything\njust[SP]yet.[SP]But[SP]I'll[SP]explain[SP]myself[SP]later.",
     "nom_fr": "Maya",
-    "texte_fr": "Désolée...[1205][001E] Je ne devrais pas encore\nparler. Mais je m'expliquerai plus tard."
+    "texte_fr": "Désolée...[001E][1205] Je ne devrais pas encore\nparler. Mais je m'expliquerai plus tard."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Let's[SP]keep[SP]going.[1205][001E][SP]I[SP]think...[SP]No,[SP]I[SP]KNOW[SP]we'll\nbe[SP]catching[SP]up[SP]with[SP]Jun-kun's[SP]father[SP]soon.",
     "nom_fr": "Maya",
-    "texte_fr": "On continue.[1205][001E] Je pense... Non, je SAIS\nqu'on va rattraper le père de Jun-kun."
+    "texte_fr": "On continue.[001E][1205] Je pense... Non, je SAIS\nqu'on va rattraper le père de Jun-kun."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Maya-chan's[SP]acting[SP]strange...[1205][001E][SP]And[SP]Jun's\nmemories[SP]still[SP]seem[SP]a[SP]little[SP]mixed[SP]up.\nIs[SP]everything[SP]okay?",
     "nom_fr": "Ginko",
-    "texte_fr": "Maya agit bizarrement...[1205][001E] Et les\nsouvenirs de Jun sont encore un\npeu embrouillés. Tout va bien?"
+    "texte_fr": "Maya agit bizarrement...[001E][1205] Et les\nsouvenirs de Jun sont encore un\npeu embrouillés. Tout va bien?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Whatever[SP]you[SP]think[SP]of,[SP]happens...[1205][001E][SP]So[SP]that's\nwhy[SP]Maya-chan[SP]had[SP]the[SP]argument[SP]with[SP]that\nwhite[SP]suit[SP]about[SP]who[SP]was[SP]stronger.\n[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nYes,[SP]we'll[SP]find[SP]Jun-kun's[SP]father[SP]next.\nYou[SP]think[SP]so[SP]too,[SP]right,[SP][1113]-kun?\nRight?",
     "nom_fr": "Ginko",
-    "texte_fr": "Ce qu'on pense arrive...[1205][001E] C'est pourquoi\nMaya s'est disputée avec le type en blanc\nsur qui était le plus fort.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\n Oui, on va trouver le père de Jun. Tu\nle penses aussi, [1113]-kun? N'est-ce pas?"
+    "texte_fr": "Ce qu'on pense arrive...[001E][1205] C'est pourquoi\nMaya s'est disputée avec le type en blanc\nsur qui était le plus fort.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\n Oui, on va trouver le père de Jun. Tu\nle penses aussi, [1113]-kun? N'est-ce pas?"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "But[SP]why[SP]are[SP]our[SP]thoughts[SP]becoming[SP]reality?[1205][001E]\nThis[SP]ship[SP]became[SP]real[SP]and[SP]flies[SP]because[SP]of[SP]the\nrumors...[1205][001E][SP]But[SP]they[SP]didn't[SP]mention[SP]this.",
     "nom_fr": "Maya",
-    "texte_fr": "Pourquoi nos pensées deviennent réalité?[1205][001E]\nCe vaisseau vole grâce aux rumeurs...[1205][001E]\nMais les rumeurs ne le mentionnaient pas."
+    "texte_fr": "Pourquoi nos pensées deviennent réalité?[001E][1205]\nCe vaisseau vole grâce aux rumeurs...[001E][1205]\nMais les rumeurs ne le mentionnaient pas."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun...[1205][001E][SP]Don't[SP]you[SP]feel[SP]something...\nbuzzing...?",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun...[1205][001E] Tu ne sens\npas un bourdonnement...?"
+    "texte_fr": "[1113]-kun...[001E][1205] Tu ne sens\npas un bourdonnement...?"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "If[SP]I[SP]had[SP]to[SP]describe[SP]it...[1205][001E][SP]I'd[SP]say[SP]it[SP]feels\nlike[SP]being[SP]jostled[SP]around[SP]in[SP]a[SP]huge[SP]crowd...",
     "nom_fr": "Maya",
-    "texte_fr": "Si je devais le décrire...[1205][001E] Ce serait comme\nêtre bousculée dans une grande foule..."
+    "texte_fr": "Si je devais le décrire...[001E][1205] Ce serait comme\nêtre bousculée dans une grande foule..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]secret[SP]of[SP]Xibalba,[SP]huh?[SP]Hmmm...[SP]Could[SP]it\nbe[SP]that[SP]this[SP]is[SP]all[SP]just[SP]a[SP]dream?[1205][001E][SP]Nahhh...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le secret de Xibalba, hein? Hmm... Et\nsi tout ça n'était qu'un rêve?[1205][001E] Nan..."
+    "texte_fr": "Le secret de Xibalba, hein? Hmm... Et\nsi tout ça n'était qu'un rêve?[001E][1205] Nan..."
   },
   {
     "id": 12,
@@ -237,7 +237,7 @@
     "nom_orig": "Jun",
     "texte_orig": "After[SP]we[SP]left[SP]Sumaru[SP]ten[SP]years[SP]ago,[SP]I[SP]was\nshunted[SP]from[SP]one[SP]school[SP]to[SP]the[SP]next...[1205][001E][SP]and\ncaused[SP]problems[SP]wherever[SP]we[SP]went.",
     "nom_fr": "Jun",
-    "texte_fr": "Après avoir quitté Sumaru il y a dix ans,\nj'ai changé d'école en école...[1205][001E] et causé\ndes problèmes partout où on allait."
+    "texte_fr": "Après avoir quitté Sumaru il y a dix ans,\nj'ai changé d'école en école...[001E][1205] et causé\ndes problèmes partout où on allait."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Jun",
     "texte_orig": "That's[SP]why[SP]I've[SP]lived[SP]with[SP]Father[SP]ever[SP]since.\nTo[SP]Mother,[SP]I'm[SP]nothing[SP]more[SP]than[SP]a[SP]nuisance...[1205][001E]\nNgh...[SP]My[SP]head's[SP]hurting[SP]again...",
     "nom_fr": "Jun",
-    "texte_fr": "C'est pourquoi j'ai vécu avec Père depuis.\nPour Mère, je ne suis qu'un fardeau...[1205][001E]\nNgh... Ma tête me fait encore mal..."
+    "texte_fr": "C'est pourquoi j'ai vécu avec Père depuis.\nPour Mère, je ne suis qu'un fardeau...[001E][1205]\nNgh... Ma tête me fait encore mal..."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Big[SP]Maya's[SP]right...[1205][001E][SP]Joy,[SP]sadness,[SP]fear,\ndespair...[1205][001E][SP]Just[SP]standing[SP]around,[SP]I[SP]can[SP]feel\nall[SP]these[SP]emotions[SP]flowing[SP]into[SP]me...",
     "nom_fr": "Jun",
-    "texte_fr": "Grande Maya a raison...[1205][001E] Joie, tristesse,\npeur, désespoir...[1205][001E] Je ressens toutes ces\némotions qui affluent en moi..."
+    "texte_fr": "Grande Maya a raison...[001E][1205] Joie, tristesse,\npeur, désespoir...[001E][1205] Je ressens toutes ces\némotions qui affluent en moi..."
   },
   {
     "id": 18,

--- a/traduction/event_scripts/script_197.json
+++ b/traduction/event_scripts/script_197.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It[SP]didn't[SP]work[SP]after[SP]all...[1205][001E][SP]What's[SP]the\npattern[SP]to[SP]all[SP]this...?",
     "nom_fr": "Maya",
-    "texte_fr": "Ça n'a pas marché...[1205][001E] Qu'est-ce\nque ça veut dire...?"
+    "texte_fr": "Ça n'a pas marché...[001E][1205] Qu'est-ce\nque ça veut dire...?"
   },
   {
     "id": 1,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]think[SP]you're[SP]right...[1205][001E][SP]It's[SP]not[SP]good[SP]to[SP]keep\nhiding[SP]it.[SP]Alright,[SP]I'll[SP]take[SP]the[SP]plunge[SP]and\nspill[SP]the[SP]beans,[SP]but...",
     "nom_fr": "Maya",
-    "texte_fr": "Vous avez raison...[1205][001E] Ça ne mène à rien de le\ncacher... Je vais cracher\nle morceau, mais..."
+    "texte_fr": "Vous avez raison...[001E][1205] Ça ne mène à rien de le\ncacher... Je vais cracher\nle morceau, mais..."
   },
   {
     "id": 5,
@@ -117,7 +117,7 @@
     "nom_orig": "Jun",
     "texte_orig": "True...[1205][001E][SP]There[SP]were[SP]those[SP]traps[SP]and[SP]the[SP]incident\nwith[SP]the[SP]healing[SP]spring...[1205][001E][SP]But[SP]why...?",
     "nom_fr": "Jun",
-    "texte_fr": "Pas faux...[1205][001E] Il y avait ces pièges, et\nl'incident avec la\nsource...[1205][001E] Mais pourquoi...?"
+    "texte_fr": "Pas faux...[001E][1205] Il y avait ces pièges, et\nl'incident avec la\nsource...[001E][1205] Mais pourquoi...?"
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "*staa[1205][000A]a[1205][000A]a[1205][000A]a[1205][000A]a[1205][000A]are*[1205][001E]\n[1113],[SP]do[SP]you[SP]like[SP]me[SP]now...?",
     "nom_fr": "Ginko",
-    "texte_fr": "*fi[1205][000A]i[1205][000A]i[1205][000A]i[1205][000A]i[1205][000A]xe*[1205][001E] [1113], tu m'aimes, hein?"
+    "texte_fr": "*fi[000A][1205]i[000A][1205]i[000A][1205]i[000A][1205]i[000A][1205]xe*[001E][1205] [1113], tu m'aimes, hein?"
   },
   {
     "id": 10,
@@ -206,7 +206,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huuuh!?[SP]Seoi[SP]Lo...[1205][001E][SP]Maya-chan,[SP]you[SP]lied!",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein!? Seoi Lo...[1205][001E] Maya, t'as menti!"
+    "texte_fr": "Hein!? Seoi Lo...[001E][1205] Maya, t'as menti!"
   },
   {
     "id": 13,
@@ -221,7 +221,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huuuh!?[SP]Seoi[SP]Lo...[1205][001E][SP]Maya-chan,[SP]you[SP]lied!",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein!? Seoi Lo...[1205][001E] Maya, t'as menti!"
+    "texte_fr": "Hein!? Seoi Lo...[001E][1205] Maya, t'as menti!"
   },
   {
     "id": 14,
@@ -236,7 +236,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Calm[SP]down,[SP]calm[SP]down...[1205][001E][SP]The[SP]problem[SP]is,\nit[SP]doesn't[SP]work[SP]that[SP]easily.",
     "nom_fr": "Maya",
-    "texte_fr": "Calme-toi...[1205][001E] Le problème, c'est\nque ça marche pas si facilement."
+    "texte_fr": "Calme-toi...[001E][1205] Le problème, c'est\nque ça marche pas si facilement."
   },
   {
     "id": 15,
@@ -296,7 +296,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That's[SP]the[SP]thing...[1205][001E][SP]I've[SP]been[SP]experimenting,\nbut[SP]I[SP]just[SP]can't[SP]figure[SP]out[SP]the[SP]pattern\nbehind[SP]it.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est ça, le\nproblème...[1205][001E] J'expérimentais, mais\nje n'arrive pas à comprendre ce que c'est."
+    "texte_fr": "C'est ça, le\nproblème...[001E][1205] J'expérimentais, mais\nje n'arrive pas à comprendre ce que c'est."
   },
   {
     "id": 19,
@@ -311,7 +311,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Everyone[SP]sharing[SP]one[SP]thought[SP]hasn't[SP]done[SP]the\ntrick,[SP]and[SP]it's[SP]not[SP]just[SP]one[SP]strong[SP]belief...[1205][001E]\nMaybe[SP]there's[SP]an[SP]outside[SP]force[SP]at[SP]work.",
     "nom_fr": "Maya",
-    "texte_fr": "Une idée partagée ne suffit pas, ce\nn'est pas qu'une croyance...[1205][001E] Peut-être\nqu'une force extérieure agit."
+    "texte_fr": "Une idée partagée ne suffit pas, ce\nn'est pas qu'une croyance...[001E][1205] Peut-être\nqu'une force extérieure agit."
   },
   {
     "id": 20,
@@ -326,7 +326,7 @@
     "nom_orig": "Jun",
     "texte_orig": "You're...[1205][001E][SP]talking[SP]about[SP]Father,[SP]aren't[SP]you...?",
     "nom_fr": "Jun",
-    "texte_fr": "Tu...[1205][001E] parles de mon père, c'est ça...?"
+    "texte_fr": "Tu...[001E][1205] parles de mon père, c'est ça...?"
   },
   {
     "id": 21,
@@ -341,7 +341,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]don't[SP]know...[1205][001E][SP]There[SP]would[SP]be[SP]no[SP]reason[SP]for\nJun-kun's[SP]father[SP]to[SP]think[SP]things[SP]that[SP]would\nbenefit[SP]us.",
     "nom_fr": "Maya",
-    "texte_fr": "Je sais pas...[1205][001E] Il n'y a aucune\nraison que le père de Jun pense à\ndes choses qui nous profiteraient."
+    "texte_fr": "Je sais pas...[001E][1205] Il n'y a aucune\nraison que le père de Jun pense à\ndes choses qui nous profiteraient."
   },
   {
     "id": 22,
@@ -356,7 +356,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Still...[1205][001E][SP]We[SP]can't[SP]rule[SP]out[SP]the[SP]possibility\nthat[SP]he's[SP]just[SP]toying[SP]with[SP]us...",
     "nom_fr": "Maya",
-    "texte_fr": "Et...[1205][001E] On ne peut pas éliminer la\npossibilité qu'il joue juste avec nous..."
+    "texte_fr": "Et...[001E][1205] On ne peut pas éliminer la\npossibilité qu'il joue juste avec nous..."
   },
   {
     "id": 23,
@@ -386,7 +386,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Well,[SP]no[SP]use[SP]driving[SP]ourselves[SP]nuts[SP]over[SP]what\nwe[SP]can't[SP]figure[SP]out![SP]Just[SP]try[SP]not[SP]to[SP]think[SP]of\nanything...[1205][001E][SP]Especially[SP]anything[SP]scary.",
     "nom_fr": "Maya",
-    "texte_fr": "Bien, inutile d'essayer\nde comprendre ce qui\nnous échappe! Simplement, essayez de ne\npenser à rien...[1205][001E] Surtout\nà rien d'effrayant."
+    "texte_fr": "Bien, inutile d'essayer\nde comprendre ce qui\nnous échappe! Simplement, essayez de ne penser à rien...[001E][1205] Surtout\nà rien d'effrayant."
   },
   {
     "id": 25,
@@ -401,7 +401,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "E-Easy[SP]for[SP]you[SP]to[SP]say,[SP]but...[1205][001E]",
     "nom_fr": "Eikichi",
-    "texte_fr": "F-Facile à dire, mais...[1205][001E]"
+    "texte_fr": "F-Facile à dire, mais...[001E][1205]"
   },
   {
     "id": 26,
@@ -416,7 +416,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Oh...[1205][001E][SP]Oh[SP]shit[SP]oh[SP]shit![SP]A-A[SP]golden[SP]Pops...!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Oh...[1205][001E] Merde... Merde! Un golden Pops...!?"
+    "texte_fr": "Oh...[001E][1205] Merde... Merde! Un golden Pops...!?"
   },
   {
     "id": 27,

--- a/traduction/event_scripts/script_198.json
+++ b/traduction/event_scripts/script_198.json
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Geez...[1205][001E][SP]Eikichi[SP]hasn't[SP]gotten[SP]any[SP]smarter\nsince[SP]we[SP]were[SP]kids.",
     "nom_fr": "Ginko",
-    "texte_fr": "Pfff...[1205][001E] Eikichi est toujours\naussi stupide qu'avant."
+    "texte_fr": "Pfff...[001E][1205] Eikichi est toujours\naussi stupide qu'avant."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Thoughts[SP]becoming[SP]reality...[1205][001E][SP]Father[SP]never\ntold[SP]me[SP]anything[SP]about[SP]this...[1205][001E][SP]What[SP]in[SP]the\nworld[SP]is[SP]Xibalba?",
     "nom_fr": "Jun",
-    "texte_fr": "Les pensées qui deviennent réelles...[1205][001E]\nPère n'a jamais parlé de ça...[1205][001E]\nQu'est-ce que c'est que Xibalba?"
+    "texte_fr": "Les pensées qui deviennent réelles...[001E][1205]\nPère n'a jamais parlé de ça...[001E][1205]\nQu'est-ce que c'est que Xibalba?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "At[SP]least[SP]we[SP]know[SP]for[SP]sure[SP]now[SP]that[SP]here[SP]in\nXibalba,[SP]thoughts[SP]become[SP]reality.[1205][001E][SP]Well,[SP]some\nthoughts,[SP]anyway.",
     "nom_fr": "Maya",
-    "texte_fr": "On est maintenant sûrs qu'à Xibalba\nles pensées deviennent réelles.[1205][001E] Eh\nbah sacrées pensées, en tout cas."
+    "texte_fr": "On est maintenant sûrs qu'à Xibalba\nles pensées deviennent réelles.[001E][1205] Eh\nbah sacrées pensées, en tout cas."
   },
   {
     "id": 8,

--- a/traduction/event_scripts/script_199.json
+++ b/traduction/event_scripts/script_199.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP]Jun![SP]Your[SP]daddy's[SP]amazing[SP]and[SP]he[SP]can[SP]do\nanything,[SP]right?[SP]You[SP]think[SP]we'll[SP]finally[SP]get\nto[SP]meet[SP]him[SP]today?\n[E1][E2]\n[E3][E4][NULL][NULL]\"Jun\nM-Maybe...[1205][001E][SP]But...[SP]he's[SP]really[SP]busy,[SP]so...\n[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nI-I[SP]wish[SP]m-my[SP]dad[SP]didn't[SP]w-work[SP]at[SP]a[SP]sushi\nrestaurant...[SP]S-Seriously,[SP]I[SP]have[SP]to[SP]eat\ns-s-sushi[SP]every[SP]day.\n[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nIt's[SP]almost[SP]time[SP]for[SP]your[SP]families[SP]to[SP]start\ncoming[SP]to[SP]pick[SP]you[SP]up.\n[E1][E2]\n[E3][E4][NULL][NULL]\"Ginko\nI[SP]wonder[SP]if[SP]my[SP]mommy[SP]will[SP]be[SP]first[SP]today?\nI'm[SP]hungry!\n[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nOh,[SP]s-someone's[SP]here.[SP]I[SP]d-don't[SP]recognize\nhim...[1205][001E][SP]B-But[SP]he[SP]looks[SP]cool![E1][E2]\n[E3][E4][NULL][NULL]\"Jun's[SP]father\nI'm[SP]here[SP]to[SP]pick[SP]you[SP]up,[SP]Jun.",
     "nom_fr": "Ginko",
-    "texte_fr": "Hey, Jun! Ton papa est incroyable, il peut\ntout faire, pas vrai? Tu penses qu'on va le\nvoir aujourd'hui? [E1][E2] [E3][E4][NULL][NULL]\"Jun\n Pe-Peut-être...[1205][001E] Il...\nest occupé, donc... [E1][E2] [E3][E4][NULL][NULL]\"Eikichi\n Mon p-père\ntravaille dans un restaurant de sushi...S-Sérieux\nje dois manger des s-suhshi tout les\njours. [E1][E2] [E3][E4][NULL][NULL]\"Maya\nC'est bientôt l'heure pour vos\nfamilles de venir vous chercher. [E1][E2] [E3][E4][NULL][NULL]\"Ginko\n Je me\ndemande si ma maman sera\npremière aujourd'hui?J'ai faim! [E1][E2] [E3][E4][NULL][NULL]\"Eikichi\nOh, y'a quelqu'un. Je ne\nle reconnais pas...[1205][001E] M-Mais\nil a l'air cool! [E1][E2]\n[E3][E4][NULL][NULL]\"Père de Jun\n Je viens te chercher, Jun."
+    "texte_fr": "Hey, Jun! Ton papa est incroyable, il peut\ntout faire, pas vrai? Tu penses qu'on va le\nvoir aujourd'hui? [E1][E2] [E3][E4][NULL][NULL]\"Jun\n Pe-Peut-être...[001E][1205] Il...\nest occupé, donc... [E1][E2] [E3][E4][NULL][NULL]\"Eikichi\n Mon p-père\ntravaille dans un restaurant de sushi...S-Sérieux\nje dois manger des s-suhshi tout les\njours. [E1][E2] [E3][E4][NULL][NULL]\"Maya\nC'est bientôt l'heure pour vos\nfamilles de venir vous chercher. [E1][E2] [E3][E4][NULL][NULL]\"Ginko\n Je me\ndemande si ma maman sera\npremière aujourd'hui?J'ai faim! [E1][E2] [E3][E4][NULL][NULL]\"Eikichi\nOh, y'a quelqu'un. Je ne\nle reconnais pas...[001E][1205] M-Mais\nil a l'air cool! [E1][E2]\n[E3][E4][NULL][NULL]\"Père de Jun\n Je viens te chercher, Jun."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Th-That's[SP]right...[1205][001E][SP]That[SP]is[SP]Jun's[SP]dad\nafter[SP]all...",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est vrai...[1205][001E] C'est le\npère de Jun après tout..."
+    "texte_fr": "C'est vrai...[001E][1205] C'est le\npère de Jun après tout..."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Ngh...[SP]That's[SP]right...[1205][001E][SP]Th-That's...",
     "nom_fr": "Jun",
-    "texte_fr": "Ngh... C'est vrai...[1205][001E] C-C'est..."
+    "texte_fr": "Ngh... C'est vrai...[001E][1205] C-C'est..."
   },
   {
     "id": 4,
@@ -87,6 +87,6 @@
     "nom_orig": "Ginko",
     "texte_orig": "You[SP]were[SP]right![SP]He's[SP]super[SP]cool!\n[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nI'm[SP]glad[SP]for[SP]you,[SP]Jun-kun![SP]It's[SP]nice[SP]that\nyour[SP]father[SP]came[SP]to[SP]pick[SP]you[SP]up.\n[E1][E2]\n[E3][E4][NULL][NULL]\"Jun\nM-Mama's[SP]not[SP]waiting[SP]back[SP]home...![1205][001E][SP]Don't...!",
     "nom_fr": "",
-    "texte_fr": "T'avais raison ! Il est super cool !\n[E1][E2]\n[E3][E4][NULL][NULL]Maya\nJe suis contente pour toi, Jun-kun !\nC'est bien que ton père soit venu te chercher.\n[E1][E2]\n[E3][E4][NULL][NULL]Jun\nM-Maman m'attend pas à la maison...![1205][001E]\nNe fais pas ça...!"
+    "texte_fr": "T'avais raison ! Il est super cool !\n[E1][E2]\n[E3][E4][NULL][NULL]Maya\nJe suis contente pour toi, Jun-kun !\nC'est bien que ton père soit venu te chercher.\n[E1][E2]\n[E3][E4][NULL][NULL]Jun\nM-Maman m'attend pas à la maison...![001E][1205]\nNe fais pas ça...!"
   }
 ]

--- a/traduction/event_scripts/script_200.json
+++ b/traduction/event_scripts/script_200.json
@@ -12,7 +12,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Mama...[SP]Don't[SP]erase[SP]me...[1205][001E][SP]Don't[SP]hate[SP]me...[1205][001E]\nHelp[SP]me...[SP]Papa...",
     "nom_fr": "Jun",
-    "texte_fr": "Maman... Ne me rejette pas.[001E][1205][001E][1205].. Ne\nme hais pas... À l'aide Papa..."
+    "texte_fr": "Maman... Ne me rejette pas.[001E][001E][1205][1205].. Ne\nme hais pas... À l'aide Papa..."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Metal[SP]Mama",
     "texte_orig": "Jun...[1205][001E][SP]If[SP]not[SP]for[SP]you[SP]and[SP]Papa,[SP]I'd[SP]be[SP]free.",
     "nom_fr": "Maman en métal",
-    "texte_fr": "Jun...[1205][001E] Sans toi et Papa, je serais libre."
+    "texte_fr": "Jun...[001E][1205] Sans toi et Papa, je serais libre."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Metal[SP]Mama",
     "texte_orig": "Hahaha...[1205][001E][SP]Everything[SP]would[SP]have[SP]been[SP]better\nif[SP]you[SP]hadn't[SP]been[SP]born![SP]Now,[SP]vanish[SP]from\nthis[SP]world!",
     "nom_fr": "Maman en métal",
-    "texte_fr": "Hahaha...[1205][001E] Tout aurait été\nmieux si tu n'étais\npas venu au monde! Maintenant, disparais!"
+    "texte_fr": "Hahaha...[001E][1205] Tout aurait été\nmieux si tu n'étais\npas venu au monde! Maintenant, disparais!"
   },
   {
     "id": 4,
@@ -72,6 +72,6 @@
     "nom_orig": "Maya",
     "texte_orig": "Jun-kun![1205][001E][SP]She's[SP]only[SP]an[SP]illusion[SP]born[SP]from[SP]your\npainful[SP]memories![SP]You[SP]won't[SP]disappear!",
     "nom_fr": "",
-    "texte_fr": "Jun-kun ![1205][001E] Ce n'est qu'une illusion\nnée de tes douloureux souvenirs !\nTu ne disparaîtras pas !"
+    "texte_fr": "Jun-kun ![001E][1205] Ce n'est qu'une illusion\nnée de tes douloureux souvenirs !\nTu ne disparaîtras pas !"
   }
 ]

--- a/traduction/event_scripts/script_201.json
+++ b/traduction/event_scripts/script_201.json
@@ -27,7 +27,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Jun-kun...[1205][001E][SP]No[SP]matter[SP]who[SP]else[SP]says[SP]they[SP]don't\nneed[SP]you,[SP]we[SP]need[SP]you.",
     "nom_fr": "Maya",
-    "texte_fr": "Jun...[1205][001E] Quoi qu'en disent les\nautres, on a besoin de toi."
+    "texte_fr": "Jun...[001E][1205] Quoi qu'en disent les\nautres, on a besoin de toi."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "You[SP]would[SP]leave[SP]us[SP]behind...?[1205][001E]",
     "nom_fr": "Maya",
-    "texte_fr": "Tu nous abandonnerais...?[1205][001E]"
+    "texte_fr": "Tu nous abandonnerais...?[001E][1205]"
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I...[1205][001E][SP]I[SP]finally...[SP]remember[SP]everything...[1205][001E]\nWe[SP]need[SP]to[SP]hurry...[SP]and[SP]defeat[SP]him...",
     "nom_fr": "Jun",
-    "texte_fr": "Je...[1205][001E] Je me souviens... de\ntout[1205][001E] Vite... il faut l'arrêter"
+    "texte_fr": "Je...[001E][1205] Je me souviens... de\ntout[001E][1205] Vite... il faut l'arrêter"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "[1432][NULL][NULL][0014]Him[1432][NULL][NULL][0014]...?[1205][001E][SP]You[SP]mean[SP]your[SP]dad?",
     "nom_fr": "Ginko",
-    "texte_fr": "[1432][NULL][NULL][0014]Lui[1432][NULL][NULL][0014]...?[1205][001E] Ton père...?"
+    "texte_fr": "[1432][NULL][NULL][0014]Lui[1432][NULL][NULL][0014]...?[001E][1205] Ton père...?"
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Jun",
     "texte_orig": "You'll[SP]know[SP]when[SP]you[SP]see[SP]him.[1205][001E][SP]We[SP]have[SP]to\nkeep[SP]going...",
     "nom_fr": "Jun",
-    "texte_fr": "Vous saurez quand vous le\nverrez.[1205][001E] On doit continuer"
+    "texte_fr": "Vous saurez quand vous le\nverrez.[001E][1205] On doit continuer"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Yeah...[1205][001E][SP]We[SP]met[SP]Jun's[SP]dad[SP]back[SP]then...",
     "nom_fr": "Ginko",
-    "texte_fr": "Ouais...[1205][001E] On a connu le père de Jun..."
+    "texte_fr": "Ouais...[001E][1205] On a connu le père de Jun..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "He[SP]looked[SP]like[SP]the[SP]ghost[SP]at[SP]the[SP]clock[SP]tower,\nbut[SP]it[SP]was[SP]a[SP]completely[SP]different[SP]person.[1205][001E]\nSo[SP]which[SP]one[SP]is[SP]Jun's[SP]real[SP]dad...?",
     "nom_fr": "Ginko",
-    "texte_fr": "On aurait dit le fantôme de l'horloge,\nmais c'était quelqu'un d'autre.[1205][001E] Alors,\nqui est le vrai père de Jun...?"
+    "texte_fr": "On aurait dit le fantôme de l'horloge,\nmais c'était quelqu'un d'autre.[001E][1205] Alors,\nqui est le vrai père de Jun...?"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]fight[SP]with[SP]my[SP]old[SP]man[SP]all[SP]the[SP]time[SP]because\nI[SP]hate[SP]how[SP]he[SP]pushes[SP]his[SP]dreams[SP]on[SP]me...[1205][001E][SP]But[SP]I\nnever[SP]bothered[SP]to[SP]think[SP]about[SP]how[SP]he[SP]felt...",
     "nom_fr": "Ginko",
-    "texte_fr": "J'me dispute souvent avec mon vieux parce\nqu'il m'impose ses rêves...[1205][001E] Mais je n'ai\njamais pensé à ce qu'il ressentait..."
+    "texte_fr": "J'me dispute souvent avec mon vieux parce\nqu'il m'impose ses rêves...[001E][1205] Mais je n'ai\njamais pensé à ce qu'il ressentait..."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Back[SP]then...[1205][001E][SP]We[SP]used[SP]to[SP]speculate[SP]all[SP]the\ntime[SP]about[SP]what[SP]Jun-kun's[SP]dad[SP]was[SP]like...",
     "nom_fr": "Maya",
-    "texte_fr": "À l'époque...[1205][001E] On passait tout notre\ntemps à imaginer comment était son père"
+    "texte_fr": "À l'époque...[001E][1205] On passait tout notre\ntemps à imaginer comment était son père"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Wait...[1205][001E][SP]He[SP]can't[SP]be...[1205][001E][SP]But[SP]it's[SP]the[SP]only\nthing[SP]that[SP]makes[SP]sense...",
     "nom_fr": "Maya",
-    "texte_fr": "Attend...[1205][001E] C'est impossible [1205][001E] Mais\nc'est la seule chose sensée..."
+    "texte_fr": "Attend...[001E][1205] C'est impossible [001E][1205] Mais\nc'est la seule chose sensée..."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "You[SP]can't[SP]tell[SP]how[SP]lucky[SP]you[SP]have[SP]it[SP]until\nyou[SP]don't[SP]have[SP]it[SP]anymore...[1205][001E][SP]I[SP]hope[SP]that's\nnot[SP]the[SP]case[SP]with[SP]you...",
     "nom_fr": "Maya",
-    "texte_fr": "On ne réalise sa chance que lorsqu'on la\nperd...[1205][001E] J'espère que ce\nn'est pas ton cas..."
+    "texte_fr": "On ne réalise sa chance que lorsqu'on la\nperd...[001E][1205] J'espère que ce\nn'est pas ton cas..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]don't[SP]get[SP]this[SP]at[SP]all...[1205][001E][SP]Isn't[SP]the[SP]guy[SP]we\nmet[SP]back[SP]then[SP]Jun's[SP]dad?",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'pige rien...[1205][001E] Le type de l'autre\njour n'était pas le père de Jun?"
+    "texte_fr": "J'pige rien...[001E][1205] Le type de l'autre\njour n'était pas le père de Jun?"
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "But[SP]when[SP]I[SP]look[SP]at[SP]Big[SP]Maya[SP]and[SP]Jun,\nI[SP]think[SP]I'm[SP]probably[SP]lucky[SP]to[SP]at[SP]least\nhave[SP]a[SP]dad[SP]like[SP]mine...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mais en voyant Maya et\nJun, je me dis que j'ai\nde la chance d'avoir\nun père comme le mien..."
+    "texte_fr": "Mais en voyant Maya et\nJun, je me dis que j'ai\nde la chance d'avoir un père comme le mien..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]can't[SP]believe[SP]this...[1205][001E][SP]This[SP]is[SP]all[SP]my[SP]fault...[1205][001E]\nHow[SP]can[SP]I[SP]atone[SP]for[SP]this?[SP]Father...",
     "nom_fr": "Jun",
-    "texte_fr": "J'y crois pas...[1205][001E] Tout est de ma faute...[1205][001E]\nComment pourrais-je expier cela? Père..."
+    "texte_fr": "J'y crois pas...[001E][1205] Tout est de ma faute...[001E][1205]\nComment pourrais-je expier cela? Père..."
   },
   {
     "id": 19,
@@ -297,6 +297,6 @@
     "nom_orig": "Jun",
     "texte_orig": "Back[SP]then...[1205][001E][SP]I[SP]was[SP]jealous[SP]of[SP]everyone\nelse's[SP]happy[SP]families...[1205][001E][SP]That's[SP]why[SP]I[SP]lied\nabout[SP]mine...",
     "nom_fr": "",
-    "texte_fr": "À l'époque...[1205][001E] J'étais jaloux\ndes familles heureuses des autres...[1205][001E]\nC'est pour ça que j'ai menti au sujet de la mienne..."
+    "texte_fr": "À l'époque...[001E][1205] J'étais jaloux\ndes familles heureuses des autres...[001E][1205]\nC'est pour ça que j'ai menti au sujet de la mienne..."
   }
 ]

--- a/traduction/event_scripts/script_202.json
+++ b/traduction/event_scripts/script_202.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Th-This[SP]is[SP]it...![1205][001E][SP]I've[SP]finally[SP]found[SP]it...[1205][001E]\nThis[SP]must[SP]be[SP]the[SP]chamber[SP]where[SP]the[SP]Maians\nslumber!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "C'est...! [001E][1205][001E][1205]Je l'ai enfin trouvé... Ça doit\nêtre la chambre où les Mayas sommeillent!"
+    "texte_fr": "C'est...! [001E][001E][1205][1205]Je l'ai enfin trouvé... Ça doit\nêtre la chambre où les Mayas sommeillent!"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "H-Hello!?[1205][001E][SP]Wh-Where[SP]are[SP]you...!?[1205][001E]\nShow[SP]yourselves,[SP]Maians!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "B-Bonjour? [001E][1205][001E][1205]Où\nêtes-vous...? Montrez-vous, Mayas!"
+    "texte_fr": "B-Bonjour? [001E][001E][1205][1205]Où\nêtes-vous...? Montrez-vous, Mayas!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "I-Incredible...[1205][001E][SP]Kashihara[SP]was[SP]right[SP]all[SP]along![1205][001E]\nThe[SP]Bolontiku[SP]really[SP]exist!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "I-Incroyable.[001E][1205][001E][1205].. Kashihara avait\nraison! Bolontiku a vraiment existé!"
+    "texte_fr": "I-Incroyable.[001E][001E][1205][1205].. Kashihara avait\nraison! Bolontiku a vraiment existé!"
   },
   {
     "id": 3,
@@ -162,7 +162,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Kashihara's[SP]boy...[1205][001E][SP]Which[SP]means[SP]you're[SP]HER\nson...[1205][001E][SP]Are[SP]you[SP]going[SP]to[SP]slander[SP]your[SP]father\njust[SP]like[SP]she[SP]did!?",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Fils de Kashihara.[001E][1205][001E][1205].. Tu es son fils... Tu\nvas salir ton père comme elle l'a fait?"
+    "texte_fr": "Fils de Kashihara.[001E][001E][1205][1205].. Tu es son fils... Tu\nvas salir ton père comme elle l'a fait?"
   },
   {
     "id": 11,

--- a/traduction/event_scripts/script_203.json
+++ b/traduction/event_scripts/script_203.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Looks[SP]like[SP]she's[SP]okay.[SP]She's[SP]just[SP]out[SP]cold.[1205][001E]\nGeez,[SP]what[SP]a[SP]crazy[SP]bitch...\n[E1][E2]\n[E3][E4][NULL][NULL]\"Jun\nI[SP]think...[SP]She[SP]really[SP]was[SP]willing[SP]to[SP]die...[1205][001E]\nThe[SP]final[SP]step[SP]in[SP]the[SP]Oracle[SP]is[SP]the[SP]sacrifice\nof[SP]the[SP]Maia[SP]Maiden...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Elle s'en sort. Elle est juste\névanouie.[1205][001E] Putain, quelle folle...[E1][E2]\n[E3][E4][NULL][NULL]\"Jun\nJe pense... Elle était vraiment prête à\nmourir...[1205][001E] La dernière étape de l'Oracleest\nle sacrifice de la Vierge Maia..."
+    "texte_fr": "Elle s'en sort. Elle est juste\névanouie.[001E][1205] Putain, quelle folle...[E1][E2]\n[E3][E4][NULL][NULL]\"Jun\nJe pense... Elle était vraiment prête à\nmourir...[001E][1205] La dernière étape de l'Oracleest\nle sacrifice de la Vierge Maia..."
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Jun...[1205][001E][SP]A[SP]second[SP]ago,[SP]you[SP]said[SP]your[SP]dad[SP]was\ndead.[1205][001E][SP]Then[SP]who[SP]was[SP]that[SP]we[SP]saw...?",
     "nom_fr": "Ginko",
-    "texte_fr": "Jun...[1205][001E] Tu disais que ton père\nétait mort.[1205][001E] Alors qui était-ce...?"
+    "texte_fr": "Jun...[001E][1205] Tu disais que ton père\nétait mort.[001E][1205] Alors qui était-ce...?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Jun",
     "texte_orig": "He's[SP]not[SP]my[SP]real[SP]father...[1205][001E][SP]It[SP]must[SP]be--",
     "nom_fr": "Jun",
-    "texte_fr": "Ce n'est pas mon père...[1205][001E] Ce doit être--"
+    "texte_fr": "Ce n'est pas mon père...[001E][1205] Ce doit être--"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "An[SP]impostor[SP]born[SP]from[SP]our[SP]beliefs...[1205][001E][SP]Just[SP]like\nour[SP]shadows.[1205][001E][SP]Like[SP]the[SP]other[SP][1432][NULL][NULL][0014]me[1432][NULL][NULL][0014][SP]created\nby[SP]the[SP]circulating[SP]rumors...",
     "nom_fr": "Maya",
-    "texte_fr": "Un imposteur né de nos croyances...[1205][001E] Tout\ncomme nos Ombres.[1205][001E] Comme l'autre [1432][NULL][NULL][0014]moi[1432][NULL][NULL][0014] créé\npar les rumeurs qui circulent..."
+    "texte_fr": "Un imposteur né de nos croyances...[001E][1205] Tout\ncomme nos Ombres.[001E][1205] Comme l'autre [1432][NULL][NULL][0014]moi[1432][NULL][NULL][0014] créé\npar les rumeurs qui circulent..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "No[SP]way...[SP]Seriously!?[1205][001E][SP]I[SP]mean,[SP]yeah,[SP]we[SP]had[SP]all\nkinds[SP]of[SP]crazy[SP]theories[SP]about[SP]Jun's[SP]dad[SP]back\nthen,[SP]but...",
     "nom_fr": "Ginko",
-    "texte_fr": "Pas possible... Sérieux!?[1205][001E] Enfin,\non avait des théories folles sur\nle père de Jun à l'époque, mais..."
+    "texte_fr": "Pas possible... Sérieux!?[001E][1205] Enfin,\non avait des théories folles sur\nle père de Jun à l'époque, mais..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Does[SP]this[SP]mean...[1205][001E][SP]Rumors[SP]were[SP]coming[SP]true\nthat[SP]long[SP]ago!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ça veut dire...[1205][001E] Les rumeurs\nétaient déjà réelles!?"
+    "texte_fr": "Ça veut dire...[001E][1205] Les rumeurs\nétaient déjà réelles!?"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1432][NULL][NULL][0014]People[SP]come[SP]to[SP]know[SP]themselves[SP]through\nothers...[1432][NULL][NULL][0014][1205][001E][SP]Our[SP]ego[SP]and[SP]consciousness[SP]are\ndependent[SP]on[SP]the[SP]people[SP]around[SP]us...",
     "nom_fr": "Maya",
-    "texte_fr": "[1432][NULL][NULL][0014]Les gens se connaissent à travers\nles autres...[1432][NULL][NULL][0014][1205][001E] Notre ego et notre\nconscience dépendent des autres..."
+    "texte_fr": "[1432][NULL][NULL][0014]Les gens se connaissent à travers\nles autres...[1432][NULL][NULL][0014][001E][1205] Notre ego et notre\nconscience dépendent des autres..."
   },
   {
     "id": 9,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "And[SP]one[SP]of[SP]these[SP][1432][NULL][NULL][0014]me[1432][NULL][NULL][0014]s[SP]manifested[SP]through\nrumors...[1205][001E][SP]Talk[SP]about[SP]a[SP]sick[SP]sense[SP]of[SP]irony.",
     "nom_fr": "Maya",
-    "texte_fr": "Et l'un de ces [1432][NULL][NULL][0014]moi[1432][NULL][NULL][0014] s'est manifesté par les\nrumeurs...[1205][001E] Quel cruel sens de l'ironie."
+    "texte_fr": "Et l'un de ces [1432][NULL][NULL][0014]moi[1432][NULL][NULL][0014] s'est manifesté par les\nrumeurs...[001E][1205] Quel cruel sens de l'ironie."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Jun",
     "texte_orig": "It's[SP]all[SP]my[SP]fault...[1205][001E][SP]I[SP]didn't[SP]want[SP]you[SP]to[SP]know[SP]who\nmy[SP]real[SP]father[SP]was...[SP]so[SP]I[SP]lied[SP]to[SP]you[SP]all...",
     "nom_fr": "Jun",
-    "texte_fr": "C'est ma faute...[1205][001E] Je voulais vous\ncacher qui était mon père...\nalors je vous ai menti à tous..."
+    "texte_fr": "C'est ma faute...[001E][1205] Je voulais vous\ncacher qui était mon père...\nalors je vous ai menti à tous..."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]not[SP]your[SP]fault,[SP]Jun-kun.[1205][001E][SP]Someone's[SP]been\nwatching[SP]us[SP]all[SP]this[SP]time,[SP]ever[SP]since[SP]then.\nI'm[SP]sure[SP]of[SP]it[SP]now...",
     "nom_fr": "Maya",
-    "texte_fr": "Ce n'est pas ta\nfaute, Jun-kun.[1205][001E] Quelqu'un nous\nobservait depuis lors.\nJ'en suis certaine..."
+    "texte_fr": "Ce n'est pas ta\nfaute, Jun-kun.[001E][1205] Quelqu'un nous\nobservait depuis lors.\nJ'en suis certaine..."
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Whatever[SP]that[SP]is...[1205][001E][SP]Is[SP]it[SP]the[SP]real[SP]enemy\nwho's[SP]been[SP]making[SP]rumors[SP]come[SP]true?[1205][001E]\nBut[SP]why...?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Quoi que ce soit...[1205][001E] L'ennemi qui fait\nles rumeurs réelles?[1205][001E] Mais pourquoi...?"
+    "texte_fr": "Quoi que ce soit...[001E][1205] L'ennemi qui fait\nles rumeurs réelles?[001E][1205] Mais pourquoi...?"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Jun",
     "texte_orig": "It'll[SP]be[SP]faster[SP]to[SP]ask[SP]him[SP]in[SP]person.\nWe[SP]should[SP]meet[SP]him[SP]soon...[1205][001E][SP]I[SP]can[SP]hear[SP]him\nlaughing...[SP]Telling[SP]us[SP]to[SP]hurry[SP]to[SP]him...",
     "nom_fr": "Jun",
-    "texte_fr": "Mieux vaut lui demander en personne.\nNous devrions le rejoindre...[1205][001E] Je\nl'entends rire et nous presser..."
+    "texte_fr": "Mieux vaut lui demander en personne.\nNous devrions le rejoindre...[001E][1205] Je\nl'entends rire et nous presser..."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Yeah...[1205][001E][SP]Philemon[SP]was[SP]trying[SP]to[SP]tell[SP]us\nabout[SP]this...",
     "nom_fr": "Ginko",
-    "texte_fr": "Ouais...[1205][001E] Philémon essayait\nde nous prévenir..."
+    "texte_fr": "Ouais...[001E][1205] Philémon essayait\nde nous prévenir..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "This[SP]thing[SP]that's[SP]been[SP]watching[SP]us[SP]ever[SP]since\nthen...[SP]Why?[1205][001E][SP]Why[SP]would[SP]it[SP]do[SP]that?",
     "nom_fr": "Ginko",
-    "texte_fr": "Cette chose nous épiait depuis...[1205][001E]\nPourquoi? Mais pourquoi ferait-elle ça?"
+    "texte_fr": "Cette chose nous épiait depuis...[001E][1205]\nPourquoi? Mais pourquoi ferait-elle ça?"
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Maya",
     "texte_orig": "In[SP]the[SP]end,[SP]she[SP]was[SP]bound[SP]to[SP]her[SP]past\nemotions[SP]as[SP]well...[1205][001E][SP]The[SP]poor[SP]woman.",
     "nom_fr": "Maya",
-    "texte_fr": "Elle aussi était liée à ses émotions\npassées...[1205][001E] Cette pauvre femme."
+    "texte_fr": "Elle aussi était liée à ses émotions\npassées...[001E][1205] Cette pauvre femme."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]dead[SP]never[SP]come[SP]back,[SP]huh...[1205][001E][SP]But[SP]if[SP]that\ncauses[SP]those[SP]they[SP]leave[SP]behind[SP]to[SP]suffer\nso[SP]much...",
     "nom_fr": "Maya",
-    "texte_fr": "Les morts ne reviennent jamais,\nhein...[1205][001E] Mais si ça cause tant de\nmal à ceux laissés derrière..."
+    "texte_fr": "Les morts ne reviennent jamais,\nhein...[001E][1205] Mais si ça cause tant de\nmal à ceux laissés derrière..."
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]-kun...[1205][001E][SP]If...[1205][001E][SP]No,[SP]never[SP]mind...",
     "nom_fr": "Maya",
-    "texte_fr": "[1113]-kun...[1205][001E] Si...[1205][001E] Non, oublie ça..."
+    "texte_fr": "[1113]-kun...[001E][1205] Si...[001E][1205] Non, oublie ça..."
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Whatever[SP]we[SP]think[SP]really[SP]is[SP]becoming\nreality...[1205][001E][SP]That[SP]means[SP]this[SP]room[SP]and[SP]those\naliens[SP]all[SP]came[SP]from[SP]this[SP]lady's[SP]mind.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ce qu'on pense devient réalité...[1205][001E]\nCette salle et ces aliens viennent\nde l'esprit de cette femme."
+    "texte_fr": "Ce qu'on pense devient réalité...[001E][1205]\nCette salle et ces aliens viennent\nde l'esprit de cette femme."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "If[SP]Big[SP]Maya[SP]is[SP]right,[SP]I'm[SP]sick[SP]of[SP]being\ntoyed[SP]with[SP]like[SP]this.[1205][001E][SP]Let's[SP]hurry[SP]up[SP]and\nput[SP]a[SP]stop[SP]to[SP]it...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Si la Grande Maya a raison, j'en\nai assez d'être manipulé comme ça.[1205][001E]\nDépêchons-nous d'y mettre fin..."
+    "texte_fr": "Si la Grande Maya a raison, j'en\nai assez d'être manipulé comme ça.[001E][1205]\nDépêchons-nous d'y mettre fin..."
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Jun",
     "texte_orig": "My[SP]real[SP]father...[1205][001E][SP]probably[SP]had[SP]nothing[SP]besides\nhis[SP]fantasies[SP]divorced[SP]from[SP]reality...",
     "nom_fr": "Jun",
-    "texte_fr": "Mon vrai père...[1205][001E] n'avait rien d'autre que\nses fantasmes, coupé de la réalité..."
+    "texte_fr": "Mon vrai père...[001E][1205] n'avait rien d'autre que\nses fantasmes, coupé de la réalité..."
   },
   {
     "id": 25,
@@ -387,6 +387,6 @@
     "nom_orig": "Jun",
     "texte_orig": "But[SP]he[SP]was[SP]kind[SP]to[SP]me...[1205][001E][SP]Why[SP]wasn't[SP]I[SP]proud\nenough[SP]to[SP]claim[SP]him[SP]as[SP]my[SP]father[SP]that[SP]day...?",
     "nom_fr": "",
-    "texte_fr": "Mais il était gentil avec moi...[1205][001E]\nPourquoi n'ai-je pas été assez fier pour\nle revendiquer comme mon père ce jour-là...?"
+    "texte_fr": "Mais il était gentil avec moi...[001E][1205]\nPourquoi n'ai-je pas été assez fier pour\nle revendiquer comme mon père ce jour-là...?"
   }
 ]

--- a/traduction/event_scripts/script_204.json
+++ b/traduction/event_scripts/script_204.json
@@ -162,6 +162,6 @@
     "nom_orig": "Fuhrer",
     "texte_orig": "Aheheh...[1205][001E][SP]Fwahahahahahahaha!",
     "nom_fr": "",
-    "texte_fr": "Aheheh...[1205][001E] Fwahahahahahahaha !"
+    "texte_fr": "Aheheh...[001E][1205] Fwahahahahahahaha !"
   }
 ]

--- a/traduction/event_scripts/script_205.json
+++ b/traduction/event_scripts/script_205.json
@@ -12,7 +12,7 @@
     "nom_orig": "Fuhrer",
     "texte_orig": "You[SP]put[SP]on[SP]a[SP]good[SP]show![1205][001E][SP]I've[SP]waited[SP]ten[SP]years\nfor[SP]this,[SP]though[SP]to[SP]me[SP]it[SP]was[SP]less[SP]than[SP]the\nblink[SP]of[SP]an[SP]eye.[SP]It[SP]wouldn't[SP]be[SP]fun[SP]otherwise.",
     "nom_fr": "Führer",
-    "texte_fr": "Vous avez bien joué![1205][001E] J'ai attendu dix ans\npour ça, et pour\nmoi c'était moins qu'un clin\nd'œil. Autrement, où serait le plaisir."
+    "texte_fr": "Vous avez bien joué![001E][1205] J'ai attendu dix ans\npour ça, et pour\nmoi c'était moins qu'un clin d'œil. Autrement, où serait le plaisir."
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Collective...[SP]what...?[1205][001E][SP]This[SP]isn't[SP]outer[SP]space!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Collectif... quoi...?[1205][001E] Ce\nn'est pas l'espace!?"
+    "texte_fr": "Collectif... quoi...?[001E][1205] Ce\nn'est pas l'espace!?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "False[SP]Kashihara",
     "texte_orig": "This[SP]is[SP]the[SP]place[SP]where[SP]the[SP]guinea[SP]pigs[SP]known\nas[SP]humans[SP]are[SP]born.[1205][001E][SP]What[SP]appear[SP]to[SP]be[SP]stars\nare[SP]what[SP]you[SP]call[SP]consciousnesses.",
     "nom_fr": "Faux Kashihara",
-    "texte_fr": "C'est ici que naissent les cobayes nommés\nhumains.[1205][001E] Ce qui ressemble à des étoiles\nest ce que vous appelez des consciences."
+    "texte_fr": "C'est ici que naissent les cobayes nommés\nhumains.[001E][1205] Ce qui ressemble à des étoiles\nest ce que vous appelez des consciences."
   },
   {
     "id": 5,
@@ -117,7 +117,7 @@
     "nom_orig": "False[SP]Kashihara",
     "texte_orig": "An[SP]alien[SP]spacecraft[SP]will[SP]lead[SP]to[SP]you[SP]becoming\ngods?[1205][001E][SP]You[SP]guinea[SP]pigs[SP]are[SP]such[SP]fools.[SP]You[SP]cling\nto[SP]fantasies[SP]by[SP]desperately[SP]rationalizing[SP]them.",
     "nom_fr": "Faux Kashihara",
-    "texte_fr": "Un vaisseau alien vous\nmènerait à devenir des\ndieux?[1205][001E] Pauvres cobayes.\nVous vous agrippez à\nvos fantasmes en les rationalisant."
+    "texte_fr": "Un vaisseau alien vous\nmènerait à devenir des\ndieux?[001E][1205] Pauvres cobayes.\nVous vous agrippez à\nvos fantasmes en les rationalisant."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "[1432][NULL][NULL][0014]Guinea[SP]pigs[1432][NULL][NULL][0014]...!?[1205][001E][SP]Then[SP]what[SP]the[SP]hell[SP]are[SP]you!?\nShow[SP]us[SP]who[SP]you[SP]really[SP]are!",
     "nom_fr": "Eikichi",
-    "texte_fr": "[1432][NULL][NULL][0014]Cobayes[1432][NULL][NULL][0014]...!?[1205][001E] Mais c'est quoi ce truc!?\nMontrez-nous votre vrai visage!"
+    "texte_fr": "[1432][NULL][NULL][0014]Cobayes[1432][NULL][NULL][0014]...!?[001E][1205] Mais c'est quoi ce truc!?\nMontrez-nous votre vrai visage!"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "False[SP]Kashihara",
     "texte_orig": "Ha...[1205][001E][SP]Can't[SP]you[SP]see?[SP]I'm[SP]Jun's[SP]father.",
     "nom_fr": "Faux Kashihara",
-    "texte_fr": "Ha...[1205][001E] Vous ne voyez? Je suis son père."
+    "texte_fr": "Ha...[001E][1205] Vous ne voyez? Je suis son père."
   },
   {
     "id": 10,
@@ -192,7 +192,7 @@
     "nom_orig": "False[SP]Kashihara",
     "texte_orig": "You[SP]hated[SP]your[SP]mother[SP]who[SP]wouldn't[SP]love[SP]you\nand[SP]insulted[SP]your[SP]good-for-nothing[SP]father...[1205][001E]\nAll[SP]while[SP]embracing[SP]an[SP]illusory[SP]ideal...",
     "nom_fr": "Faux Kashihara",
-    "texte_fr": "Tu haïssais ta mère qui ne t'aimait pas\net méprisais ton père bon à rien...[1205][001E] Tout\nen chérissant un idéal illusoire..."
+    "texte_fr": "Tu haïssais ta mère qui ne t'aimait pas\net méprisais ton père bon à rien...[001E][1205] Tout\nen chérissant un idéal illusoire..."
   },
   {
     "id": 13,
@@ -222,7 +222,7 @@
     "nom_orig": "Jun",
     "texte_orig": "You're[SP]lying...[1205][001E][SP]I[SP]never[SP]wanted[SP]this[SP]chaos...[1205][001E]\nI[SP]just[SP]wanted[SP]everyone's[SP]dreams[SP]to[SP]come[SP]true...",
     "nom_fr": "Jun",
-    "texte_fr": "Tu mens...[1205][001E] Je n'ai jamais voulu\nce chaos...[1205][001E] Je voulais que les\nrêves de tous se réalisent..."
+    "texte_fr": "Tu mens...[001E][1205] Je n'ai jamais voulu\nce chaos...[001E][1205] Je voulais que les\nrêves de tous se réalisent..."
   },
   {
     "id": 15,
@@ -252,7 +252,7 @@
     "nom_orig": "Kashihara",
     "texte_orig": "Ah...[SP]Jun...[1205][001E][SP]Is[SP]that[SP]you...?[1205][001E]\nI'm[SP]so[SP]sorry...[SP]Jun...",
     "nom_fr": "Kashihara",
-    "texte_fr": "Ah... Jun...[1205][001E] C'est toi?[1205][001E] Je\nsuis si désolé... Jun..."
+    "texte_fr": "Ah... Jun...[001E][1205] C'est toi?[001E][1205] Je\nsuis si désolé... Jun..."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Kashihara",
     "texte_orig": "I[SP]wrote[SP]the[SP]In[SP]Lak'ech...[1205][001E][SP]in[SP]the[SP]hopes[SP]that\nyour[SP]generation[SP]would[SP]become[SP]ideal[SP]humans\nwho[SP]would[SP]never[SP]have[SP]to[SP]suffer...",
     "nom_fr": "Kashihara",
-    "texte_fr": "J'ai écrit l'In Lak'ech...[1205][001E] dans l'espoir\nque votre génération devienne des\nhumains idéaux sans jamais souffrir..."
+    "texte_fr": "J'ai écrit l'In Lak'ech...[001E][1205] dans l'espoir\nque votre génération devienne des\nhumains idéaux sans jamais souffrir..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Kashihara",
     "texte_orig": "But[SP]that[SP]was[SP]a[SP]fantasy...[1205][001E][SP]The[SP]people's[SP]hearts\ncannot[SP]create[SP]anything[SP]if[SP]they[SP]rely[SP]on[SP]a[SP]dream\nto[SP]search[SP]for[SP]their[SP]dreams...[SP]I[SP]was[SP]a[SP]fool...",
     "nom_fr": "Kashihara",
-    "texte_fr": "Mais ce n'était qu'un fantasme...[1205][001E] Le cœur\ndes hommes ne peut rien créer s'il cherche\nses rêves dans un rêve... J'étais un fou..."
+    "texte_fr": "Mais ce n'était qu'un fantasme...[001E][1205] Le cœur\ndes hommes ne peut rien créer s'il cherche\nses rêves dans un rêve... J'étais un fou..."
   },
   {
     "id": 19,

--- a/traduction/event_scripts/script_207.json
+++ b/traduction/event_scripts/script_207.json
@@ -72,7 +72,7 @@
     "nom_orig": "Jun's[SP]mother",
     "texte_orig": "Jun...[1205][001E][SP]Forgive[SP]me[SP]for[SP]being[SP]blind[SP]to\neverything[SP]but[SP]my[SP]dreams...",
     "nom_fr": "Mère de Jun",
-    "texte_fr": "Jun...[1205][001E] Pardonne moi d'être\naveugle à out mais mes rêves..."
+    "texte_fr": "Jun...[001E][1205] Pardonne moi d'être\naveugle à out mais mes rêves..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "False[SP]Kashihara",
     "texte_orig": "Apologizing[SP]to[SP]your[SP]father...[SP]Condemning\nyour[SP]mother...[SP]You[SP]desired[SP]all[SP]of[SP]this![1205][001E]\nSmile[SP]a[SP]little![SP]You're[SP]contradicting[SP]yourself!",
     "nom_fr": "Faux Kashihara",
-    "texte_fr": "T'excuser auprès de ton père...\nCondamner ta mère... Tu désirais tout\nça![1205][001E] Souris un peu! Tu te contredis!"
+    "texte_fr": "T'excuser auprès de ton père...\nCondamner ta mère... Tu désirais tout\nça![001E][1205] Souris un peu! Tu te contredis!"
   },
   {
     "id": 6,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I've[SP]never[SP]hated[SP]anyone[SP]so[SP]much[SP]in[SP]my[SP]life...[1205][001E]\nI[SP]won't[SP]forgive[SP]you[SP]no[SP]matter[SP]what!",
     "nom_fr": "Maya",
-    "texte_fr": "Je n'ai jamais haï quelqu'un si fort de\nma vie...[1205][001E] Je ne te pardonnerai jamais!"
+    "texte_fr": "Je n'ai jamais haï quelqu'un si fort de\nma vie...[001E][1205] Je ne te pardonnerai jamais!"
   },
   {
     "id": 10,

--- a/traduction/event_scripts/script_208.json
+++ b/traduction/event_scripts/script_208.json
@@ -12,7 +12,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "Has[SP]playing[SP]the[SP]role[SP]of[SP]a[SP]father[SP]made[SP]you[SP]soft,\nCrawling[SP]Chaos...[SP]Nyarlathotep?[1205][001E][SP]I[SP]think[SP]now\nyou[SP]should[SP]better[SP]understand[SP]what[SP]I[SP]said.",
     "nom_fr": "Philémon",
-    "texte_fr": "Jouer le rôle de père t'aurait-il attendri,\nChaos Rampant... Nyarlathotep?[1205][001E] Je pense que\ntu comprends mieux mes paroles, désormais."
+    "texte_fr": "Jouer le rôle de père t'aurait-il attendri,\nChaos Rampant... Nyarlathotep?[001E][1205] Je pense que\ntu comprends mieux mes paroles, désormais."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Nyarlathotep",
     "texte_orig": "Ha...[1205][001E][SP]You[SP]were[SP]right[SP]that[SP]these[SP]humans[SP]may\nmake[SP]for[SP]good[SP]test[SP]cases...",
     "nom_fr": "Nyarlathotep",
-    "texte_fr": "Ha...[1205][001E] Tu avais raison, ces humains\nfont de bons sujets de test..."
+    "texte_fr": "Ha...[001E][1205] Tu avais raison, ces humains\nfont de bons sujets de test..."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "We[SP]are[SP]the[SP]sources[SP]of[SP]people's[SP]souls...[1205][001E]\nIncarnations[SP]of[SP]the[SP]collective[SP]unconsciousness,\nindivisible[SP]from[SP]one[SP]another...",
     "nom_fr": "Philémon",
-    "texte_fr": "Nous sommes la source de l'âme humaine...[1205][001E]\nDes incarnations de l'inconscient\ncollectif, indissociables l'un de l'autre."
+    "texte_fr": "Nous sommes la source de l'âme humaine...[001E][1205]\nDes incarnations de l'inconscient\ncollectif, indissociables l'un de l'autre."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "We[SP]have[SP]watched[SP]man's[SP]strivings[SP]for[SP]eons...[1205][001E]\nI[SP]lead[SP]those[SP]with[SP]strong[SP]hearts,[SP]and[SP]the\nCrawling[SP]Chaos[SP]drags[SP]the[SP]weak[SP]into[SP]the[SP]abyss.",
     "nom_fr": "Philémon",
-    "texte_fr": "Nous observons l'Homme depuis des éons...[1205][001E]\nJe guide les cœurs forts, quand le Chaos\ntraîne les faibles vers l'abysse."
+    "texte_fr": "Nous observons l'Homme depuis des éons...[001E][1205]\nJe guide les cœurs forts, quand le Chaos\ntraîne les faibles vers l'abysse."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "You[SP]all[SP]showed[SP]that[SP]potential.[SP]If[SP]there[SP]were\nmore[SP]like[SP]you,[SP]man[SP]could[SP]someday[SP]reach[SP]a\nperfect[SP]state[SP]that[SP]understood[SP]its[SP]purpose.",
     "nom_fr": "Philémon",
-    "texte_fr": "Vous avez prouvé ce\npotentiel. S'il y en avait\nplus, l'Homme pourrait un\njour atteindre la\nperfection et comprendre son but."
+    "texte_fr": "Vous avez prouvé ce\npotentiel. S'il y en avait\nplus, l'Homme pourrait un jour atteindre la perfection et comprendre son but."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This...[1205][001E][SP]This[SP]was[SP]all[SP]a[SP]plot[SP]by[SP]you[SP]two!?",
     "nom_fr": "Maya",
-    "texte_fr": "Ce...[1205][001E] n'était qu'un complot entre vous!?"
+    "texte_fr": "Ce...[001E][1205] n'était qu'un complot entre vous!?"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Nyarlathotep",
     "texte_orig": "It'd[SP]be[SP]more[SP]accurate[SP]to[SP]just[SP]say[SP][1432][NULL][NULL][0014]you.[1432][NULL][NULL][0014][1205][001E]\nThe[SP]best[SP]HE[SP]can[SP]do[SP]is[SP]watch.[SP]But[SP]me...\nI'm[SP]different.\n[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nWh...[SP]Why...?",
     "nom_fr": "Nyarlathotep",
-    "texte_fr": "Il serait plus juste de dire [1432][NULL][NULL][0014]TOI.[1432][NULL][NULL][0014][1205][001E] LUI\nne peut qu'observer. Mais moi... Je\nsuis différent. [E1][E2] [E3][E4][NULL][NULL]\"Maya P... Pourquoi?"
+    "texte_fr": "Il serait plus juste de dire [1432][NULL][NULL][0014]TOI.[1432][NULL][NULL][0014][001E][1205] LUI\nne peut qu'observer. Mais moi... Je\nsuis différent. [E1][E2] [E3][E4][NULL][NULL]\"Maya P... Pourquoi?"
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I'm[SP]trying![SP]But...[SP]But...[1205][001E][SP]The[SP]bleeding\nwon't[SP]stop!",
     "nom_fr": "Ginko",
-    "texte_fr": "J'essaie! Mais... [1205][001E]\nL'hémorragie ne s'arrête pas!"
+    "texte_fr": "J'essaie! Mais... [001E][1205]\nL'hémorragie ne s'arrête pas!"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Why...[1205][001E][SP]Why[SP]aren't[SP]my[SP]spells[SP]working!?\nPhilemon!",
     "nom_fr": "Ginko",
-    "texte_fr": "Pourquoi[1205][001E] mes sorts\nne marche pas!? Philémon!"
+    "texte_fr": "Pourquoi[001E][1205] mes sorts\nne marche pas!? Philémon!"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "Nyarlathotep...[1205][001E][SP]This[SP]was[SP]your[SP]reason[SP]for\ncreating[SP]the[SP]legend[SP]of[SP]the[SP]Spear[SP]of[SP]Destiny...",
     "nom_fr": "Philémon",
-    "texte_fr": "Nyarlathotep...[1205][001E] C'est donc pour ça que tu\nas créé la légende de la Lance du Destin..."
+    "texte_fr": "Nyarlathotep...[001E][1205] C'est donc pour ça que tu\nas créé la légende de la Lance du Destin..."
   },
   {
     "id": 13,
@@ -237,7 +237,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Now...[SP]I[SP]know...[SP]what[SP]is[SP]worse...[1205][001E][SP]than\nbeing...[SP]forgotten...",
     "nom_fr": "Maya",
-    "texte_fr": "Désormais, je sais... ce qui\nest pire,[1205][001E] que d'être oubliée..."
+    "texte_fr": "Désormais, je sais... ce qui\nest pire,[001E][1205] que d'être oubliée..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's...[SP]chaining[SP]down...[SP]others...[1205][001E]\nEveryone...[SP]just...[1205][001E][SP]forget[SP]about[SP]me...\n[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nC-C'mon,[SP]Big[SP]Maya![SP]I-It's[SP]not[SP]like[SP]this[SP]is\ngoodbye...[1205][001E][SP]Y-You're[SP]gonna[SP]be[SP]there[SP]for[SP]my\ndebut[SP]show,[SP]right?",
     "nom_fr": "Maya",
-    "texte_fr": "C'est... d'enchaîner... [1205]les autres.[001E]..[1205][001E] Tout\nle monde... oubliez-moi...[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi Allez,\nMaya! C'est pas un adieu...[1205][001E] Tu seras là\npour mon premier concert, pas vrai?"
+    "texte_fr": "C'est... d'enchaîner... [1205]les autres.[001E]..[001E][1205] Tout\nle monde... oubliez-moi...[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi Allez,\nMaya! C'est pas un adieu...[001E][1205] Tu seras là\npour mon premier concert, pas vrai?"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Y-Yeah...[1205][001E][SP]You'll[SP]recover[SP]from[SP]this[SP]in[SP]no[SP]time...!",
     "nom_fr": "Ginko",
-    "texte_fr": "O-Ouais...[1205][001E] Tu vas t'en remettre vite...!"
+    "texte_fr": "O-Ouais...[001E][1205] Tu vas t'en remettre vite...!"
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Your[SP]clothes[SP]are[SP]stained,[SP]so[SP]I'll[SP]pick[SP]out\nsome[SP]new[SP]ones[SP]for[SP]you...[1205][001E][SP]We'll[SP]go[SP]shopping\ntogether...[SP]It's[SP]a[SP]promise...",
     "nom_fr": "Ginko",
-    "texte_fr": "Tes vêtements sont tachés, je t'en\nachèterai de nouveaux...[1205][001E] On ira faire\ndu shopping ensemble... C'est promis..."
+    "texte_fr": "Tes vêtements sont tachés, je t'en\nachèterai de nouveaux...[001E][1205] On ira faire\ndu shopping ensemble... C'est promis..."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I-I'll[SP]show[SP]you[SP]all[SP]my[SP]favorite[SP]place,[SP]too![1205][001E]\nThere[SP]are[SP]so[SP]many[SP]flowers[SP]blooming[SP]there...\nIt's[SP]quite[SP]beautiful...",
     "nom_fr": "Jun",
-    "texte_fr": "Je te montrerai mon endroit préféré\naussi ![1205][001E] Il y a tellement de fleurs\nqui poussent... C'est magnifique..."
+    "texte_fr": "Je te montrerai mon endroit préféré\naussi ![001E][1205] Il y a tellement de fleurs\nqui poussent... C'est magnifique..."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Th...[SP]Thanks...[SP]everyone...[1205][001E][SP]You've[SP]all...\ngrown...[SP]so[SP]strong...",
     "nom_fr": "Maya",
-    "texte_fr": "M... Merci... tout le monde...[1205][001E]\nVous êtes devenus... si forts..."
+    "texte_fr": "M... Merci... tout le monde...[001E][1205]\nVous êtes devenus... si forts..."
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Maya",
     "texte_orig": "C'mon...[SP]if[SP]you[SP]don't...[SP]stop[SP]crying...[1205][001E]\nMr.[SP]Bunbun's...[SP]gonna[SP]laugh[SP]at[SP]you...",
     "nom_fr": "Maya",
-    "texte_fr": "Allez... arrêtez de pleurer...[1205][001E] M.\nBunbun va se moquer de vous..."
+    "texte_fr": "Allez... arrêtez de pleurer...[001E][1205] M.\nBunbun va se moquer de vous..."
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Listen[SP]to[SP]me...[1205][001E][SP]Anyone...[SP]has[SP]the[SP]power...\nto[SP]achieve[SP]their[SP]dreams...[SP]Don't[SP]worry...\nI'm[SP]sure...[SP]you[SP]can[SP]all...",
     "nom_fr": "Maya",
-    "texte_fr": "Écoutez,[1205][001E]chacun... a le pouvoir de...\nréaliser ses rêves... Pas d'inquiétude...\nJe sais que vous pouvez tous..."
+    "texte_fr": "Écoutez,[001E][1205]chacun... a le pouvoir de...\nréaliser ses rêves... Pas d'inquiétude...\nJe sais que vous pouvez tous..."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Nyarlathotep",
     "texte_orig": "Haha...[SP]Anyone[SP]has[SP]the[SP]power[SP]to[SP]achieve[SP]their\ndreams,[SP]eh?[1205][001E][SP]Your[SP]namesake,[SP]deluded[SP]to[SP]the[SP]end,\nhas[SP]been[SP]sacrificed.[SP]The[SP]dream[SP]is[SP]fulfilled!",
     "nom_fr": "Nyarlathotep",
-    "texte_fr": "Haha... Chacun peut réaliser ses rêves,\nhein?[1205][001E] Et bien le rêve de cette femme étant\nde sacrifier son homonyme s'est réalisé!"
+    "texte_fr": "Haha... Chacun peut réaliser ses rêves,\nhein?[001E][1205] Et bien le rêve de cette femme étant\nde sacrifier son homonyme s'est réalisé!"
   },
   {
     "id": 24,

--- a/traduction/event_scripts/script_209.json
+++ b/traduction/event_scripts/script_209.json
@@ -12,7 +12,7 @@
     "nom_orig": "Nyarlathotep",
     "texte_orig": "Hahahahaha![1205][001E][SP]You've[SP]all[SP]learned[SP]something[SP]very\nimportant[SP]here:[SP]the[SP]undeniable[SP]truth[SP]of[SP]the\nworld[SP]that[SP]some[SP]things[SP]cannot[SP]be[SP]changed!",
     "nom_fr": "Nyarlathotep",
-    "texte_fr": "Hahahaha![1205][001E] Vous avez appris une leçon\nimportante: la vérité\nindéniable que certaines\nchoses ne peuvent être\nchangées dans le monde!"
+    "texte_fr": "Hahahaha![001E][1205] Vous avez appris une leçon\nimportante: la vérité\nindéniable que certaines choses ne peuvent être changées dans le monde!"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Nyarlathotep",
     "texte_orig": "I[SP]am[SP]the[SP]shadow[SP]of[SP]humanity.[SP]As[SP]long[SP]as[SP]there\nis[SP]darkness[SP]in[SP]your[SP]hearts,[SP]I'll[SP]never[SP]go[SP]away.\nBehold[SP]the[SP]Crawling[SP]Chaos'[SP]final[SP]ordeal!",
     "nom_fr": "Nyarlathotep",
-    "texte_fr": "Je suis l'ombre de l'humanité. Tant qu'il y\naura des ténébres dans\nvos coeurs, je serais \nlà. Voici l'ultime\ncalvaire du Chaos Rampant!"
+    "texte_fr": "Je suis l'ombre de l'humanité. Tant qu'il y\naura des ténébres dans\nvos coeurs, je serais là. Voici l'ultime calvaire du Chaos Rampant!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "There[SP]is[SP]one[SP]way[SP]left[SP]to[SP]change[SP]things...[1205][001E]\nTo[SP]erase[SP]the[SP]fact[SP]of[SP]your[SP]meeting[SP]on[SP]that\nsummer[SP]evening...",
     "nom_fr": "Philémon",
-    "texte_fr": "Il reste un moyen de changer les\nchoses...[1205][001E] Effacer votre rencontre\ndurant cette soirée d'été..."
+    "texte_fr": "Il reste un moyen de changer les\nchoses...[001E][1205] Effacer votre rencontre\ndurant cette soirée d'été..."
   },
   {
     "id": 3,
@@ -132,7 +132,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "Yes...[SP]The[SP]power[SP]that[SP]created[SP]your[SP]world[SP]is\nthe[SP]same[SP]as[SP]your[SP]inner[SP]strength...[1205][001E][SP]In[SP]this\ncollective[SP]unconsciousness,[SP]it[SP]is[SP]possible.",
     "nom_fr": "Philémon",
-    "texte_fr": "Oui... Le pouvoir ayant\ncréé votre monde est\nsemblable à votre force intérieure...[1205][001E] Dans\nl'inconscient collectif, c'est possible."
+    "texte_fr": "Oui... Le pouvoir ayant\ncréé votre monde est\nsemblable à votre force intérieure...[001E][1205] Dans\nl'inconscient collectif, c'est possible."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Are[SP]you[SP]saying...[1205][001E][SP]we[SP]can[SP]reset[SP]everything...?[1205][001E]\nIn[SP]exchange[SP]for[SP]all[SP]of[SP]it...[SP]our[SP]memories\nand[SP]pasts...",
     "nom_fr": "Jun",
-    "texte_fr": "Vous dites...[1205][001E] qu'on peut tout\nredémarrer...?[1205][001E] En échange du reste...\nnos souvenirs et notre passé..."
+    "texte_fr": "Vous dites...[001E][1205] qu'on peut tout\nredémarrer...?[001E][1205] En échange du reste...\nnos souvenirs et notre passé..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Does[SP]that[SP]mean[SP]I'll[SP]forget[SP]everyone...!?[1205][001E]\nNo...[SP]No,[SP]I[SP]don't[SP]want[SP]that![1205][001E][SP]Isn't[SP]there\nany[SP]other[SP]way!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Donc, j'oublierais tout le\nmonde...!?[1205][001E] Non... non, je veux pas![1205][001E]\nIl n'y a pas d'autres moyens!?"
+    "texte_fr": "Donc, j'oublierais tout le\nmonde...!?[001E][1205] Non... non, je veux pas![001E][1205]\nIl n'y a pas d'autres moyens!?"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "There[SP]is[SP]none[SP]here,[SP]in[SP]the[SP]seat[SP]of[SP]his[SP]power.\nHe[SP]draws[SP]strength[SP]from[SP]the[SP]negative[SP]emotions\nof[SP]people[SP]unconsciously[SP]desiring[SP]destruction...",
     "nom_fr": "Philémon",
-    "texte_fr": "Il n'y en a pas,\navec les pouvoirs actuels. Il\ntire sa force des\némotions négatives de gens\ndésirant inconsciemment la destruction..."
+    "texte_fr": "Il n'y en a pas,\navec les pouvoirs actuels. Il\ntire sa force des émotions négatives de gens désirant inconsciemment la destruction..."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "If[SP]you[SP]are[SP]to[SP]stop[SP]him,[SP]then[SP]mankind[SP]itself\nmust[SP]change...[1205][001E][SP]You[SP]must[SP]create[SP]this[SP]new[SP]world.",
     "nom_fr": "Philémon",
-    "texte_fr": "Pour l'arrêter, l'humanité elle-même doit\nchanger...[1205][001E] Vous devez\ncréer ce nouveau monde."
+    "texte_fr": "Pour l'arrêter, l'humanité elle-même doit\nchanger...[001E][1205] Vous devez\ncréer ce nouveau monde."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I'll[SP]never[SP]forget...[1205][001E][SP]I[SP]don't[SP]dare[SP]to...",
     "nom_fr": "Jun",
-    "texte_fr": "Je n'oserais...[1205][001E] jamais oublier..."
+    "texte_fr": "Je n'oserais...[001E][1205] jamais oublier..."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Damn[SP]straight...[1205][001E][SP]I'm[SP]not[SP]gonna[SP]let[SP]myself\nforget[SP]any[SP]of[SP]this!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tu l'as dit...[1205][001E] Je m'autoriserais\npas à oublier tout ça!"
+    "texte_fr": "Tu l'as dit...[001E][1205] Je m'autoriserais\npas à oublier tout ça!"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "If[SP]that[SP]bastard[SP]set[SP]all[SP]of[SP]this[SP]up,[SP]then[SP]let's\ndo[SP]this...[1205][001E][SP]We'll[SP]show[SP]him[SP]that[SP]not[SP]everything\ngoes[SP]his[SP]way.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Si ce bâtard a tout planifié,\nfaisons-le...[1205][001E] On va lui montrer que tout\nse passe toujours comme il le veut."
+    "texte_fr": "Si ce bâtard a tout planifié,\nfaisons-le...[001E][1205] On va lui montrer que tout\nse passe toujours comme il le veut."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We'll...[1205][001E][SP]meet[SP]again,[SP]won't[SP]we...?",
     "nom_fr": "Ginko",
-    "texte_fr": "On...[1205][001E] se reverra, pas vrai...?"
+    "texte_fr": "On...[001E][1205] se reverra, pas vrai...?"
   },
   {
     "id": 17,
@@ -282,7 +282,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Just[SP]a[SP]little[SP]something[SP]for[SP]luck...[1205][001E][SP]I'm[SP]sure\nI[SP]won't[SP]forget[SP]you[SP]now,[SP][1113]...\n[E1][E2]\n[E3][E4][NULL][NULL]\"Philemon\nNow...[SP]We[SP]will[SP]not[SP]see[SP]each[SP]other[SP]again[SP]for\nsome[SP]time.[SP]Is[SP]there[SP]anything[SP]you[SP]would[SP]like\nto[SP]say[SP]before[SP]you[SP]go?",
     "nom_fr": "Ginko",
-    "texte_fr": "Pour porter chance...[1205][001E] Je suis certaine de\npas t'oublier maintenant, [1113]...[E1][E2]\n[E3][E4][NULL][NULL]\"Philémon\nMaintenant... on ne se reverra pas\navant longtemps. Souhaites-tu dire quelque\nchose avant de partir?"
+    "texte_fr": "Pour porter chance...[001E][1205] Je suis certaine de\npas t'oublier maintenant, [1113]...[E1][E2]\n[E3][E4][NULL][NULL]\"Philémon\nMaintenant... on ne se reverra pas\navant longtemps. Souhaites-tu dire quelque\nchose avant de partir?"
   },
   {
     "id": 19,
@@ -322,7 +322,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "There[SP]is[SP]no[SP]need[SP]to[SP]thank[SP]me.[SP]I[SP]shall[SP]pray\nthat[SP]you[SP]break[SP]through[SP]the[SP]unwritten[SP]laws[SP]of\ndestiny[SP]and[SP]remember[SP]each[SP]other...[SP]Farewell.",
     "nom_fr": "Philémon",
-    "texte_fr": "Nul besoin de me\nremercier. Je prierais pour\nque vous surpassiez les\nlois inexprimées du\ndestin et vous rappelez de chacun... Adieu."
+    "texte_fr": "Nul besoin de me\nremercier. Je prierais pour\nque vous surpassiez les lois inexprimées du destin et vous rappelez de chacun... Adieu."
   },
   {
     "id": 21,
@@ -352,6 +352,6 @@
     "nom_orig": "Philemon",
     "texte_orig": "I[SP]am[SP]you.[SP]You[SP]are[SP]me...[1205][001E][SP]I[SP]shall[SP]always[SP]watch\nover[SP]you[SP]from[SP]within.[SP]Farewell...",
     "nom_fr": "",
-    "texte_fr": "Je suis toi. Tu es moi...[1205][001E] Je veillerai\ntoujours sur toi de l'intérieur. Adieu..."
+    "texte_fr": "Je suis toi. Tu es moi...[001E][1205] Je veillerai\ntoujours sur toi de l'intérieur. Adieu..."
   }
 ]

--- a/traduction/event_scripts/script_210.json
+++ b/traduction/event_scripts/script_210.json
@@ -42,7 +42,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Yikes![SP]This[SP]looks[SP]bad.[SP]I[SP]know[SP]you're[SP]not[SP]that\ngood[SP]at[SP]fixing[SP]stuff,[SP]so[SP]you[SP]might[SP]wanna[SP]take\nthe[SP]train[SP]home.[SP]Well,[SP]I[SP]delivered[SP]my[SP]message.",
     "nom_fr": "Lycéen",
-    "texte_fr": "Aïe, ça craint. Je\nsais que réparer des trucs\nc'est pas ta tasse\nde thé alors rentre plutôt\nen train. Voilà, le message est passée."
+    "texte_fr": "Aïe, ça craint. Je\nsais que réparer des trucs\nc'est pas ta tasse de thé alors rentre plutôt en train. Voilà, le message est passée."
   },
   {
     "id": 3,
@@ -173,7 +173,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "U-Umm...[1205][001E][SP]I-I[SP]was[SP]just[SP]waiting[SP]around![SP]I[SP]knew\nyou[SP]guys[SP]would[SP]show[SP]up[SP]soon!",
     "nom_fr": "Lisa",
-    "texte_fr": "E-Euh...[1205][001E] J-Je vous attendais! Je\nsavais que vous finiriez par arriver!"
+    "texte_fr": "E-Euh...[001E][1205] J-Je vous attendais! Je\nsavais que vous finiriez par arriver!"
   },
   {
     "id": 11,

--- a/traduction/event_scripts/script_214.json
+++ b/traduction/event_scripts/script_214.json
@@ -12,7 +12,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "[1113][SP][1112]...[1205][001E][SP]Are[SP]you[SP]going[SP]to[SP]your\nend[SP]without[SP]discovering[SP]your[SP]dream?",
     "nom_fr": "Philémon",
-    "texte_fr": "[1113][1112]...[1205][001E] Vas-tu vraiment\nen finir sans réaliser ton rêve?"
+    "texte_fr": "[1113][1112]...[001E][1205] Vas-tu vraiment\nen finir sans réaliser ton rêve?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "No[SP]matter[SP]how[SP]often[SP]one[SP]makes[SP]mistakes,\nreflecting[SP]on[SP]the[SP]past[SP]to[SP]better[SP]serve[SP]the\nfuture[SP]is[SP]man's[SP]way...[1205][001E][SP]Walk[SP]forward[SP]once[SP]more.",
     "nom_fr": "Philémon",
-    "texte_fr": "Qu'importe ses erreurs, un homme doit\nréfléchir à son passé pour mieux servir\nl'avenir...[1205][001E] Va encore de l'avant."
+    "texte_fr": "Qu'importe ses erreurs, un homme doit\nréfléchir à son passé pour mieux servir\nl'avenir...[001E][1205] Va encore de l'avant."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Philemon",
     "texte_orig": "[1113][SP][1112]...[1205][001E][SP]Are[SP]you[SP]going[SP]to[SP]your\nend[SP]without[SP]discovering[SP]your[SP]dream?",
     "nom_fr": "Philémon",
-    "texte_fr": "[1113][1112]...[1205][001E] Vas-tu vraiment\nen finir sans réaliser ton rêve?"
+    "texte_fr": "[1113][1112]...[001E][1205] Vas-tu vraiment\nen finir sans réaliser ton rêve?"
   },
   {
     "id": 3,
@@ -57,6 +57,6 @@
     "nom_orig": "Philemon",
     "texte_orig": "No[SP]matter[SP]how[SP]often[SP]one[SP]makes[SP]mistakes,\nreflecting[SP]on[SP]the[SP]past[SP]to[SP]better[SP]serve[SP]the\nfuture[SP]is[SP]man's[SP]way...[1205][001E][SP]Walk[SP]forward[SP]once[SP]more.",
     "nom_fr": "Philémon",
-    "texte_fr": "Qu'importe ses erreurs, un homme doit\nréfléchir à son passé pour mieux servir\nl'avenir...[1205][001E] Va encore de l'avant."
+    "texte_fr": "Qu'importe ses erreurs, un homme doit\nréfléchir à son passé pour mieux servir\nl'avenir...[001E][1205] Va encore de l'avant."
   }
 ]

--- a/traduction/event_scripts/script_217.json
+++ b/traduction/event_scripts/script_217.json
@@ -27,7 +27,7 @@
     "nom_orig": "Manager",
     "texte_orig": "O-Old[SP]bomb!?[SP]I[SP]mean,[SP]bombs!?[SP]I-I[SP]need[SP]to\nexplode[SP]before[SP]they[SP]get[SP]out![SP]I[SP]mean,[SP]get[SP]out\nbefore[SP]they[SP]explode!\n[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nShe[SP]seemed[SP]pretty[SP]shook[SP]up...[1205][001E][SP]C'mon,[SP]let's\nhurry[SP]and[SP]find[SP]that[SP]riddle[SP]thing[SP]so[SP]we[SP]can\ngrab[SP]our[SP]asses[SP]and[SP]run!",
     "nom_fr": "Manager",
-    "texte_fr": "V-Vieilles bombes!? Enfin,\nsortir d'ici avant\nl'explosion![E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nElle était secouée...[1205][001E]\nAllez, vite, trouvons l'énigme et filons!"
+    "texte_fr": "V-Vieilles bombes!? Enfin,\nsortir d'ici avant\nl'explosion![E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nElle était secouée...[001E][1205]\nAllez, vite, trouvons l'énigme et filons!"
   },
   {
     "id": 2,

--- a/traduction/event_scripts/script_218.json
+++ b/traduction/event_scripts/script_218.json
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I've[SP]been[SP]through[SP]some[SP]shit[SP]too,[SP]so[SP]I[SP]know...[1205][001E]\nI[SP]can't[SP]tell[SP]her[SP]to[SP]shrug[SP]it[SP]off...[1205][001E][SP]But[SP]who\nknows[SP]what[SP]she'll[SP]do[SP]if[SP]we[SP]leave[SP]her[SP]alone?",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'en ai bavé aussi, donc je sais...[1205][001E] Je\npeux pas lui dire de laisser tomber...[1205][001E]\nMais qui sait ce qu'elle ferait seule?"
+    "texte_fr": "J'en ai bavé aussi, donc je sais...[001E][1205] Je\npeux pas lui dire de laisser tomber...[001E][1205]\nMais qui sait ce qu'elle ferait seule?"
   },
   {
     "id": 4,

--- a/traduction/event_scripts/script_219.json
+++ b/traduction/event_scripts/script_219.json
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Even[SP]our[SP]Personas[SP]are[SP]useless[SP]in[SP]a[SP]situation\nlike[SP]this...[1205][001E][SP]We[SP]have[SP]to[SP]do[SP]what[SP]we[SP]can\nourselves!",
     "nom_fr": "Maya",
-    "texte_fr": "Même nos Personae sont inutiles\nici...[1205][001E] On doit faire ca nous-mêmes!"
+    "texte_fr": "Même nos Personae sont inutiles\nici...[001E][1205] On doit faire ca nous-mêmes!"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "This[SP]obsessiveness...[1205][001E][SP]The[SP]man's[SP]definitely\nnot[SP]normal.",
     "nom_fr": "Yukino",
-    "texte_fr": "Cette obsession...[1205][001E] Cet homme\nest vraiment pas normal."
+    "texte_fr": "Cette obsession...[001E][1205] Cet homme\nest vraiment pas normal."
   },
   {
     "id": 7,

--- a/traduction/event_scripts/script_221.json
+++ b/traduction/event_scripts/script_221.json
@@ -162,7 +162,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]don't[SP]see[SP]anything[SP]here[SP]either...[1205][001E]\nMaybe[SP]we're[SP]looking[SP]in[SP]the[SP]wrong[SP]room.",
     "nom_fr": "Yukino",
-    "texte_fr": "Ici non plus, je ne trouve rien...[1205][001E] On\ndevrait peut-être changer de pièce."
+    "texte_fr": "Ici non plus, je ne trouve rien...[001E][1205] On\ndevrait peut-être changer de pièce."
   },
   {
     "id": 11,

--- a/traduction/event_scripts/script_223.json
+++ b/traduction/event_scripts/script_223.json
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]get[SP]it.[SP]The[SP]descent[SP]into[SP]the[SP]netherworld\nis[SP]about[SP]Yomotsu[SP]Hirasaka[SP]from[SP]Japanese\nmyth...[1205][001E][SP]It's[SP]a[SP]play[SP]on[SP]words.",
     "nom_fr": "Maya",
-    "texte_fr": "Compris. C'est un jeu de mots sur le\nYomotsu Hirasaka des mythes japonais...[1205][001E]"
+    "texte_fr": "Compris. C'est un jeu de mots sur le\nYomotsu Hirasaka des mythes japonais...[001E][1205]"
   },
   {
     "id": 3,
@@ -147,7 +147,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Miss[SP]Elly...[1205][001E][SP]Someday[SP]I'll[SP]kindle[SP]the[SP]flame\nof[SP]love[SP]in[SP]your[SP]heart!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mlle Elly...[1205][001E] Un jour, j'allumerai\nla flamme de l'amour en vous!"
+    "texte_fr": "Mlle Elly...[001E][1205] Un jour, j'allumerai\nla flamme de l'amour en vous!"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "U-Um,[SP][1113]...[1205][001E][SP]Maya-san[SP]told[SP]me[SP]just[SP]now\nthat...[1205][001E][SP]you[SP]heard[SP]me[SP]talking[SP]to[SP]Sasaki...",
     "nom_fr": "Ginko",
-    "texte_fr": "E-Euh, [1113]...[1205][001E] Maya-san me dit que...[1205][001E]\ntu m'as entendue parler à Sasaki..."
+    "texte_fr": "E-Euh, [1113]...[001E][1205] Maya-san me dit que...[001E][1205]\ntu m'as entendue parler à Sasaki..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Sorry-ia...[1205][001E][SP]Other[SP]than[SP][1113],\nI've[SP]actually...",
     "nom_fr": "Ginko",
-    "texte_fr": "Pardon-ia...[1205][001E] À part [1113], en fait j'ai..."
+    "texte_fr": "Pardon-ia...[001E][1205] À part [1113], en fait j'ai..."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "U-Umm...[1205][001E][SP]Now's[SP]not[SP]the[SP]time[SP]for[SP]this,[SP]huh?\nI'll[SP]tell[SP]you[SP]later,[SP]maybe...",
     "nom_fr": "Ginko",
-    "texte_fr": "E-Euh...[1205][001E] C'est pas le moment, hein?\nJe te dirai plus tard, peut-être..."
+    "texte_fr": "E-Euh...[001E][1205] C'est pas le moment, hein?\nJe te dirai plus tard, peut-être..."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "All[SP]descend[SP]with[SP]smiles[SP]to[SP]the[SP]netherworld...[1205][001E]\nThere[SP]has[SP]to[SP]be[SP]a[SP]hint[SP]in[SP]there.[SP]See[SP]what[SP]you\ncan[SP]come[SP]up[SP]with,[SP][1113]-kun.",
     "nom_fr": "Maya",
-    "texte_fr": "Souriants, tous descendent aux\nenfers...[1205][001E] Il y a un indice là.\nVois ce que tu en tires, [1113]."
+    "texte_fr": "Souriants, tous descendent aux\nenfers...[001E][1205] Il y a un indice là.\nVois ce que tu en tires, [1113]."
   },
   {
     "id": 14,
@@ -252,6 +252,6 @@
     "nom_orig": "Elly",
     "texte_orig": "Aha...[1205][001E][SP]You're[SP][1113]-kun,[SP]correct?\n[E4][NULL][NULL]\"Elly\nIt's[SP]just[SP]as[SP]Yukino[SP]said.[SP]I[SP]get[SP]the[SP]same\nfeeling[SP]from[SP]you[SP]as[SP]a[SP]good[SP]friend[SP]of[SP]ours.\n[E4][NULL][NULL]\"Elly\nHe,[SP]too,[SP]was[SP]quiet[SP]and[SP]cool,[SP]but[SP]he[SP]was[SP]also\nvery[SP]strong[SP]and[SP]kind...[1205][001E][SP]and,[SP]well,[SP]my...",
     "nom_fr": "",
-    "texte_fr": "Aha...[1205][001E] Tu es [1113]-kun, c'est ça ?\n[E4][NULL][NULL]Elly\nC'est exactement ce que Yukino a dit. J'ai le\nmême sentiment qu'avec un ami à nous.\n[E4][NULL][NULL]Elly\nLui aussi était calme et cool, mais très fort\net gentil...[1205][001E] et bien, c'était mon..."
+    "texte_fr": "Aha...[001E][1205] Tu es [1113]-kun, c'est ça ?\n[E4][NULL][NULL]Elly\nC'est exactement ce que Yukino a dit. J'ai le même sentiment qu'avec un ami à nous. [E4][NULL][NULL]Elly Lui aussi était calme et cool, mais très fort et gentil...[001E][1205] et bien, c'était mon..."
   }
 ]

--- a/traduction/event_scripts/script_225.json
+++ b/traduction/event_scripts/script_225.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "His[SP]mask...[SP]It[SP]isn't[SP]here...[1205][001E][SP]Don't[SP]tell[SP]me\nhe's[SP]been[SP]here?[SP]But[SP]why...?",
     "nom_fr": "Ginko",
-    "texte_fr": "Son masque... Il n'est pas là...[1205][001E] Il\nest passé ici? Mais pourquoi...?"
+    "texte_fr": "Son masque... Il n'est pas là...[001E][1205] Il\nest passé ici? Mais pourquoi...?"
   },
   {
     "id": 1,

--- a/traduction/event_scripts/script_226.json
+++ b/traduction/event_scripts/script_226.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Yukino-san[SP]is...[1205][001E][SP]so[SP]strong...[1205][001E]",
     "nom_fr": "Ginko",
-    "texte_fr": "Yukino-san est...[1205][001E] Forte...[1205][001E]"
+    "texte_fr": "Yukino-san est...[001E][1205] Forte...[001E][1205]"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "If[SP]you[SP]ever[SP]died...[1205][001E][SP]I[SP]think[SP]I'd[SP]lose[SP]my[SP]mind...",
     "nom_fr": "Ginko",
-    "texte_fr": "Si tu mourais...[1205][001E] Je deviendrais folle..."
+    "texte_fr": "Si tu mourais...[001E][1205] Je deviendrais folle..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Holeen...[1205][001E][SP]Poor[SP]Yukino-san...[1205][001E][SP][1113]!\nAre[SP]you[SP]sure[SP]you[SP]made[SP]the[SP]right[SP]choice!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Holeen...[1205][001E] Pauvre Yukino-san...[1205][001E] [1113]!\nT'es sûr d'avoir fait le bon choix?!"
+    "texte_fr": "Holeen...[001E][1205] Pauvre Yukino-san...[001E][1205] [1113]!\nT'es sûr d'avoir fait le bon choix?!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Sorry...[1205][001E][SP]I[SP]should[SP]have[SP]known[SP]that[SP]this[SP]is\nhard[SP]on[SP]you[SP]too...",
     "nom_fr": "Ginko",
-    "texte_fr": "Désolé...[1205][001E] Ca doitêtre dur pour toi aussi..."
+    "texte_fr": "Désolé...[001E][1205] Ca doitêtre dur pour toi aussi..."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "H-Hey[SP]there![SP]What're[SP]you[SP]holding[SP]onto[SP]your\nshoulder[SP]like[SP]that[SP]for?\n[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nI-I[SP]mean,[SP]you've[SP]been[SP]doing[SP]that[SP]ever[SP]since\nthe[SP]Caracol...[1205]<[SP]Why[SP]don't[SP]we[SP]have[SP]Mr.[SP]Tomi\ntake[SP]a[SP]look[SP]at[SP]it![1205][001E][SP]J-Just[SP]kidding...",
     "nom_fr": "Eikichi",
-    "texte_fr": "H-Hey là! Pourquoi tu te tiens comme ça\nà l'épaule?[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nJ-Je veux dire, tu\nfais ça depuis le Caracol...[1205]< Pourquoion ne\nlaisserait pas Mr. Tomi y jeter\nun coup d'oeil![1205][001E] J-Je plaisante..."
+    "texte_fr": "H-Hey là! Pourquoi tu te tiens comme ça\nà l'épaule?[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nJ-Je veux dire, tu\nfais ça depuis le Caracol...[1205]< Pourquoion ne\nlaisserait pas Mr. Tomi y jeter\nun coup d'oeil![001E][1205] J-Je plaisante..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "S-Sorry...[1205][001E][SP]I'll[SP]stop[SP]trying[SP]to[SP]be[SP]funny...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pardon...[1205][001E] J'arrête mes blagues..."
+    "texte_fr": "Pardon...[001E][1205] J'arrête mes blagues..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yukki...[1205][001E][SP]I'm[SP]sorry...[1205][001E][SP]I[SP]wish[SP]there[SP]was\nanything[SP]I[SP]could[SP]do[SP]for[SP]you...",
     "nom_fr": "Maya",
-    "texte_fr": "Yukki...[1205][001E] Désolé...[1205][001E] J'aimerais\nvraiment pouvoir t'aider..."
+    "texte_fr": "Yukki...[001E][1205] Désolé...[001E][1205] J'aimerais\nvraiment pouvoir t'aider..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I'm[SP]so[SP]powerless...[1205][001E][SP]Dad...",
     "nom_fr": "Maya",
-    "texte_fr": "Je suis nulle...[1205][001E] Papa..."
+    "texte_fr": "Je suis nulle...[001E][1205] Papa..."
   },
   {
     "id": 8,
@@ -132,6 +132,6 @@
     "nom_orig": "Yukino",
     "texte_orig": "...[1205][001E]Let's[SP]go,[SP][1113]...[1205][001E][SP]There's[SP]still\nsomething[SP]I[SP]have[SP]to[SP]do...",
     "nom_fr": "",
-    "texte_fr": "...[1205][001E] Allons-y, [1113]...[1205][001E] Il y a encore\nquelque chose que je dois faire..."
+    "texte_fr": "...[001E][1205] Allons-y, [1113]...[001E][1205] Il y a encore\nquelque chose que je dois faire..."
   }
 ]

--- a/traduction/event_scripts/script_231.json
+++ b/traduction/event_scripts/script_231.json
@@ -12,7 +12,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Look[SP]at[SP]the[SP]size[SP]of[SP]it...[1205][001E][SP]I[SP]can't[SP]even[SP]make\nout[SP]the[SP]ceiling.",
     "nom_fr": "Jun",
-    "texte_fr": "Regarde sa taille...[1205][001E] Je ne\nvois même pas le plafond."
+    "texte_fr": "Regarde sa taille...[001E][1205] Je ne\nvois même pas le plafond."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That's[SP]odd,[SP]though.[SP]They[SP]know[SP]we're[SP]after\nthem...[1205][001E][SP]So[SP]isn't[SP]it[SP]a[SP]little[SP]too[SP]quiet?\nThere's[SP]not[SP]even[SP]a[SP]welcoming[SP]committee[SP]here.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est étrange quand même. Ils savent qu'on\nles chasse...[1205][001E] Pourquoi c'est si calme? Il\nn'y a personne pour nous accueillir."
+    "texte_fr": "C'est étrange quand même. Ils savent qu'on\nles chasse...[001E][1205] Pourquoi c'est si calme? Il\nn'y a personne pour nous accueillir."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm...[1205][001E][SP]I[SP]doubt[SP]they[SP]ALL[SP]died,[SP]but[SP]you're\nright,[SP]there[SP]must[SP]be[SP]some[SP]pretty[SP]devious\ntraps[SP]in[SP]here.",
     "nom_fr": "Maya",
-    "texte_fr": "Umm...[1205][001E] Je doute qu'ils\nsoient TOUS morts, mais\ntu as raison, il doit\ny avoir des pièges ici."
+    "texte_fr": "Umm...[001E][1205] Je doute qu'ils\nsoient TOUS morts, mais\ntu as raison, il doit y avoir des pièges ici."
   },
   {
     "id": 4,

--- a/traduction/event_scripts/script_232.json
+++ b/traduction/event_scripts/script_232.json
@@ -102,7 +102,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Someplace[SP]crammed[SP]full[SP]of[SP]stuff...[1205][001E]\nAny[SP]ideas,[SP][1113]?",
     "nom_fr": "Yukino",
-    "texte_fr": "Quelque part rempli d'objets..[1205][001E]\nDes idées, [1113]?"
+    "texte_fr": "Quelque part rempli d'objets..[001E][1205]\nDes idées, [1113]?"
   },
   {
     "id": 7,

--- a/traduction/event_scripts/script_245.json
+++ b/traduction/event_scripts/script_245.json
@@ -12,7 +12,7 @@
     "nom_orig": "Office[SP]lady",
     "texte_orig": "Oh?[SP]Are[SP]you[SP]hitting[SP]on[SP]me?[1205][000F][SP]If[SP]so,[SP]then[SP]sorry,\nbut[SP]I'm[SP]a[SP]little[SP]busy.[1205][000F][SP]Hm?[SP]That's[SP]not[SP]it?[1205][000F]\nHaha,[SP]sorry.[1205][000F][SP]Oh[SP]hey,[SP]do[SP]you[SP]go[SP]to[SP]Cuss[SP]High?",
     "nom_fr": "Femme de bureau",
-    "texte_fr": "Ho? Tu me dragues? [1205][000F][1205][000F][1205][000F][1205][000F]Désolée, mais je suis\noccupée. Hm? Ce n'est pas ça? Haha,\ndésolée. Oh, tu vas au lycée Kakasu?"
+    "texte_fr": "Ho? Tu me dragues? [000F][1205][000F][1205][000F][1205][000F][1205]Désolée, mais je suis\noccupée. Hm? Ce n'est pas ça? Haha,\ndésolée. Oh, tu vas au lycée Kakasu?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Office[SP]lady",
     "texte_orig": "I[SP]saw[SP]a[SP]bunch[SP]of[SP]kids[SP]from[SP]Cuss[SP]High[SP]go[SP]into\nZodiac.[1205][000F][SP]What're[SP]they[SP]up[SP]to[SP]there?",
     "nom_fr": "Femme de bureau",
-    "texte_fr": "Plein de gamins de Kakasu entrent\nau Zodiac. [1205][000F]Que font-ils là-dedans?"
+    "texte_fr": "Plein de gamins de Kakasu entrent\nau Zodiac. [000F][1205]Que font-ils là-dedans?"
   },
   {
     "id": 2,
@@ -42,6 +42,6 @@
     "nom_orig": "Office[SP]lady",
     "texte_orig": "That[SP]reminds[SP]me,[SP]rumor[SP]has[SP]it[SP]that[SP]there's\na[SP]secret[SP]lounge[SP]further[SP]inside[SP]Zodiac.[1205][000F]\nI[SP]haven't[SP]found[SP]it[SP]yet,[SP]though...",
     "nom_fr": "",
-    "texte_fr": "Ça me rappelle, il paraît qu'il y a\nun salon secret au fond du Zodiac.[1205][000F]\nJe n'ai pas encore réussi à le trouver..."
+    "texte_fr": "Ça me rappelle, il paraît qu'il y a\nun salon secret au fond du Zodiac.[000F][1205]\nJe n'ai pas encore réussi à le trouver..."
   }
 ]

--- a/traduction/event_scripts/script_248.json
+++ b/traduction/event_scripts/script_248.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "*cough*[SP]It's[SP]so[SP]dusty[SP]here...[1205][001E][SP]My[SP]perfect\nhair[SP]is[SP]going[SP]to[SP]get[SP]mussed.",
     "nom_fr": "Eikichi",
-    "texte_fr": "*tousse* Toute cette poussière...[1205][001E]\nÇa va ruiner ma super coiffure."
+    "texte_fr": "*tousse* Toute cette poussière...[001E][1205]\nÇa va ruiner ma super coiffure."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "But[SP]that[SP]feeling[SP]a[SP]moment[SP]ago...[1205][001E]\nWhat[SP]was[SP]it...?",
     "nom_fr": "Ginko",
-    "texte_fr": "Cette sensation à\nl'instant...[1205][001E] C'était quoi...?"
+    "texte_fr": "Cette sensation à\nl'instant...[001E][1205] C'était quoi...?"
   },
   {
     "id": 3,
@@ -102,7 +102,7 @@
     "nom_orig": "Teacher's[SP]ghost",
     "texte_orig": "I[SP]said...[1205][001E][SP]that[SP]time...[1205][001E][SP]must[SP]not[SP]be[SP]set\nfree...[1205][001E][SP]I[SP]said[SP]it...[1205][001E][SP]so[SP]often...",
     "nom_fr": "Fantôme du prof",
-    "texte_fr": "Je dis...[1205][001E] Le temps...[1205][001E] ne doit être\nlibéré...[1205][001E] Je l'ai tant...[1205][001E] répété..."
+    "texte_fr": "Je dis...[001E][1205] Le temps...[001E][1205] ne doit être\nlibéré...[001E][1205] Je l'ai tant...[001E][1205] répété..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "He[SP]disappeared![1205][001E][SP]But...[SP]I[SP]feel[SP]like[SP]I've...",
     "nom_fr": "Maya",
-    "texte_fr": "Disparu![1205][001E] Mais... c'est comme si je-"
+    "texte_fr": "Disparu![001E][1205] Mais... c'est comme si je-"
   },
   {
     "id": 8,
@@ -327,7 +327,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Hahaha![SP]Me,[SP]you[SP]ask?[SP]My[SP]wish[SP]was[SP]to[SP]become\na[SP]principal[SP]beloved[SP]by[SP]his[SP]students...[1205][001E]\nAs[SP]well[SP]as[SP]this[SP]fine[SP]mane[SP]you[SP]now[SP]see!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Haha! Moi, tu dis? Mon voeu était d'être\nun principal aimé et respecté par ses\nélèves...[1205][001E] Et d'avoir une belle chevelure!"
+    "texte_fr": "Haha! Moi, tu dis? Mon voeu était d'être\nun principal aimé et respecté par ses\nélèves...[001E][1205] Et d'avoir une belle chevelure!"
   },
   {
     "id": 22,
@@ -402,7 +402,7 @@
     "nom_orig": "Joker",
     "texte_orig": "This[SP]is[SP]between[SP]myself,[SP]the[SP]Giver,[SP]and\nyou,[SP]the[SP]Thief...[1205][001E][SP]A[SP]battle[SP]with\n[1112][SP][1113][SP]for[SP]my[SP]dream!",
     "nom_fr": "Joker",
-    "texte_fr": "C'est un combat pour mon rêve entre moi, le\nDonneur...[1205][001E] Et toi, [1112] [1113], le Voleur!"
+    "texte_fr": "C'est un combat pour mon rêve entre moi, le\nDonneur...[001E][1205] Et toi, [1112] [1113], le Voleur!"
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Joker",
     "texte_orig": "I'll[SP]never[SP]let[SP]you[SP]destroy[SP]my[SP]dream\nagain...[1205][001E][SP]I[SP]won't[SP]make[SP]the[SP]same\nmistake[SP]twice!",
     "nom_fr": "Joker",
-    "texte_fr": "Je ne te laisserais plus détruire mon\nrêve...[1205][001E] Je ne répéterais pas mon erreur!"
+    "texte_fr": "Je ne te laisserais plus détruire mon\nrêve...[001E][1205] Je ne répéterais pas mon erreur!"
   },
   {
     "id": 28,
@@ -447,7 +447,7 @@
     "nom_orig": "Joker",
     "texte_orig": "Time[SP]is[SP]free[SP]again...[1205][001E][SP]Heed[SP]the[SP]sound[SP]of[SP]the\nbells[SP]that[SP]toll[SP]for[SP]your[SP]dreams!",
     "nom_fr": "Joker",
-    "texte_fr": "Le temps est libéré...[1205][001E] Prenez garde\nà vos rêves pour qui sonne le glas!"
+    "texte_fr": "Le temps est libéré...[001E][1205] Prenez garde\nà vos rêves pour qui sonne le glas!"
   },
   {
     "id": 30,

--- a/traduction/event_scripts/script_249.json
+++ b/traduction/event_scripts/script_249.json
@@ -27,7 +27,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "By[SP]the[SP]way,[SP]have[SP]you[SP]heard[SP]of[SP]the[SP]Joker[SP]Game?[1205][000F]\nI[SP]heard[SP]it[SP]can[SP]grant[SP]any[SP]wish.[SP]I[SP]wonder[SP]if\nit'd[SP]help[SP]me[SP]be[SP]more[SP]like[SP]you,[SP]Senpai.",
     "nom_fr": "Lycéen",
-    "texte_fr": "Au fait, t'as entendu parler du jeu\n[1205][000F]du Joker? Apparemment, il permet\nd'exaucer n'importe quel vœu."
+    "texte_fr": "Au fait, t'as entendu parler du jeu\n[000F][1205]du Joker? Apparemment, il permet\nd'exaucer n'importe quel vœu."
   },
   {
     "id": 2,
@@ -72,7 +72,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "After[SP]all,[SP]my[SP]face[SP]is[SP]all[SP]jacked[SP]up.[1205][000F][SP]I[SP]just\nwanted[SP]a[SP]piece[SP]of[SP]the[SP]action...[1205][000F][SP]I[SP]specifically\nchose[SP]a[SP]school[SP]with[SP]a[SP]festival,[SP]too...",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "Je suis complètement défiguré. [1205][000F][1205][000F]Je voulais\nma part moi... J'ai choisi un lycée avec\nun festival pour une raison..."
+    "texte_fr": "Je suis complètement défiguré. [000F][1205][000F][1205]Je voulais\nma part moi... J'ai choisi un lycée avec\nun festival pour une raison..."
   },
   {
     "id": 5,

--- a/traduction/event_scripts/script_250.json
+++ b/traduction/event_scripts/script_250.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey,[SP][1113]...[SP]About[SP]that[SP]girl[SP]there...[1205][001E]\nShe[SP]had[SP]someone[SP]get[SP]rid[SP]of[SP]her[SP]freckles,\nright?[1205][001E][SP]Am[SP]I[SP]paranoid[SP]or[SP]could[SP]it[SP]be[SP]Joker?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, [1113]... Cette fille...[1205][001E] Elle\nn'a plus ses taches de rousseur?[1205][001E]\nJe psychote ou c'est le Joker?"
+    "texte_fr": "Hé, [1113]... Cette fille...[001E][1205] Elle\nn'a plus ses taches de rousseur?[001E][1205]\nJe psychote ou c'est le Joker?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That[SP]Maya-san[SP]chick...[1205][001E][SP]She's[SP]got[SP]her[SP]hooks\ninto[SP]me[SP]for[SP]some[SP]reason.[1205][001E][SP]Could[SP]this[SP]be[SP]the\nstart[SP]of[SP]a[SP]burning[SP]love?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Cette Maya-san...[1205][001E] Elle m'a tapé\ndans l'œil, je sais pas pourquoi.[1205][001E]\nC'est le début d'un amour fou?"
+    "texte_fr": "Cette Maya-san...[001E][1205] Elle m'a tapé\ndans l'œil, je sais pas pourquoi.[001E][1205]\nC'est le début d'un amour fou?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yo,[SP]guys![SP]You[SP]don't[SP]want[SP]to[SP]catch[SP]the[SP]weird\ndisease,[SP]right?[SP]Then[SP]why're[SP]you[SP]listening[SP]to\nthe[SP]principal?[SP]This[SP]is[SP]one[SP]creepy[SP]school...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Yo, les gars! Vous voulez pas choper la\nmaladie bizarre, non?\nAlors pourquoi écouter\nle directeur? Ce bahut est flippant..."
+    "texte_fr": "Yo, les gars! Vous voulez pas choper la\nmaladie bizarre, non?\nAlors pourquoi écouter le directeur? Ce bahut est flippant..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Gaaah![SP]Everywhere[SP]we[SP]go,[SP]it's[SP][1432][NULL][NULL][0014]principal[1432][NULL][NULL][0014]\nthis[SP]and[SP][1432][NULL][NULL][0014]principal[1432][NULL][NULL][0014][SP]that![1205][001E][SP]I[SP]wish[SP]I[SP]could've\nshown[SP]'em[SP]my[SP]sweet[SP]moves!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Raaah! Partout, c'est [1432][NULL][NULL][0014]directeur[1432][NULL][NULL][0014] ci\net [1432][NULL][NULL][0014]directeur[1432][NULL][NULL][0014] ça![1205][001E] J'aurais tellement\nvoulu montrer mes prises!"
+    "texte_fr": "Raaah! Partout, c'est [1432][NULL][NULL][0014]directeur[1432][NULL][NULL][0014] ci\net [1432][NULL][NULL][0014]directeur[1432][NULL][NULL][0014] ça![001E][1205] J'aurais tellement\nvoulu montrer mes prises!"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Hey[SP][1113],[SP]what[SP]should[SP]we[SP]do[SP]if[SP]one[SP]of[SP]us\ngets[SP]the[SP]disease...?[1205][001E][SP]Fanna![SP]No![SP]I[SP]don't[SP]even\nwanna[SP]think[SP]about[SP]it!",
     "nom_fr": "Lisa",
-    "texte_fr": "Hé [1113], on fait quoi si l'un de\nnous attrape cette maladie...?[1205][001E] Fanna!\nNon! Je veux même pas y penser!"
+    "texte_fr": "Hé [1113], on fait quoi si l'un de\nnous attrape cette maladie...?[001E][1205] Fanna!\nNon! Je veux même pas y penser!"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "*sta[1205][000F]a[1205][000F]a[1205][000F]a[1205][000F]are*\nIs[SP]Maya-san...[1205][001E][SP]Nah,[SP]it's[SP]just[SP]my[SP]imagination.\nIt's[SP]gotta[SP]be!",
     "nom_fr": "Ginko",
-    "texte_fr": "*fiiiixe* Maya-san.[1205][000F][1205][000F][1205][000F][1205][000F]..[1205][001E] Nan, c'est\njuste mon imagination. Sûrement!"
+    "texte_fr": "*fiiiixe* Maya-san.[000F][1205][000F][1205][000F][1205][000F][1205]..[001E][1205] Nan, c'est\njuste mon imagination. Sûrement!"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "H-Hey,[SP][1113],[SP]maybe[SP]the[SP]principal's[SP]right\nand[SP]we[SP]should[SP]respect[SP]the[SP]school[SP]more...[1205]([SP]Wh-What\nam[SP]I[SP]saying!?[SP]We[SP]gotta[SP]destroy[SP]the[SP]emblems!",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, [1113], le dirlo a peut-être raison,\nrespectons plus le lycée...[1205]( Q-Quoi!?\nQu'est-ce que je dis!?\nFaut casser les emblèmes!"
+    "texte_fr": "Hé, [1113], le dirlo a peut-être raison,\nrespectons plus le lycée...[1205]( Q-Quoi!?\nQu'est-ce que je dis!? Faut casser les emblèmes!"
   },
   {
     "id": 8,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Wh-Whoa,[SP]hold[SP]on[SP]there![1205][001E][SP]That's[SP]not[SP]why[SP]we[SP]came\nto[SP]interview[SP]students.[SP]We[SP]were[SP]just[SP]here[SP]to\ninvestigate[SP]Joker[SP]and[SP]the[SP]emblem[SP]curse...",
     "nom_fr": "Maya",
-    "texte_fr": "W-Whoa, doucement![1205][001E] On n'est pas venues\ninterviewer les élèves pour ça. On voulait\njuste enquêter sur\nle Joker et lamalédiction..."
+    "texte_fr": "W-Whoa, doucement![001E][1205] On n'est pas venues\ninterviewer les élèves pour ça. On voulait\njuste enquêter sur le Joker et lamalédiction..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Mmmm,[SP]I[SP]don't[SP]like[SP]getting[SP]the[SP]stinkeye[SP]just\nbecause[SP]I'm[SP]a[SP]journalist...[1205][001E][SP]I'm[SP]not[SP]here[SP]to\nhurt[SP]anyone[SP]with[SP]my[SP]articles.",
     "nom_fr": "Maya",
-    "texte_fr": "Mmmm, j'aime pas qu'on me fusille du\nregard car je suis journaliste...[1205][001E] Mes\narticles ne sont pas là pour blesser."
+    "texte_fr": "Mmmm, j'aime pas qu'on me fusille du\nregard car je suis journaliste...[001E][1205] Mes\narticles ne sont pas là pour blesser."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yeah,[SP]the[SP]students[SP]here[SP]are[SP]acting[SP]weird...[1205][001E]\nIf[SP]what[SP][1113]-kun[SP]says[SP]is[SP]true,[SP]we[SP]can\nassume[SP]the[SP]principal[SP]is[SP]in[SP]league[SP]with[SP]Joker.",
     "nom_fr": "Maya",
-    "texte_fr": "Ouais, les élèves font les bizarres...[1205][001E] Si\n[1113]-kun dit vrai, on peut supposer\nque le dirlo est allié au Joker."
+    "texte_fr": "Ouais, les élèves font les bizarres...[001E][1205] Si\n[1113]-kun dit vrai, on peut supposer\nque le dirlo est allié au Joker."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Meaning[SP]if[SP]we[SP]find[SP]the[SP]principal,[SP]we[SP]may[SP]find\nJoker[SP]with[SP]him...[1205][001E][SP]Heheh![SP]This[SP]is[SP]my[SP]chance\nfor[SP]a[SP]real[SP]scoop!",
     "nom_fr": "Maya",
-    "texte_fr": "Donc si on trouve le dirlo, le Joker sera\nsûrement avec...[1205][001E] Héhé! À\nmoi le super scoop!"
+    "texte_fr": "Donc si on trouve le dirlo, le Joker sera\nsûrement avec...[001E][1205] Héhé! À\nmoi le super scoop!"
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Awww,[SP]don't[SP]get[SP]upset.[1205][001E][SP]Isn't[SP]being[SP]a[SP]secret\nhero[SP]that[SP]no[SP]one[SP]knows[SP]about[SP]cool[SP]in[SP]its\nown[SP]way?",
     "nom_fr": "Maya",
-    "texte_fr": "Awww, te fâche pas.[1205][001E] Être un héros\ninconnu, c'est cool à sa façon, non?"
+    "texte_fr": "Awww, te fâche pas.[001E][1205] Être un héros\ninconnu, c'est cool à sa façon, non?"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "We[SP]should[SP]get[SP]moving[SP]on[SP]destroying[SP]those\nemblems.[1205][001E][SP]No[SP]wonder[SP]everyone's[SP]scared,[SP]if\nyou[SP]can't[SP]tell[SP]when[SP]the[SP]curse[SP]will[SP]hit.",
     "nom_fr": "Yukino",
-    "texte_fr": "On devrait se bouger pour détruire ces\nemblèmes.[1205][001E] Pas étonnant que tous aient\npeur si la malédiction frappe au hasard."
+    "texte_fr": "On devrait se bouger pour détruire ces\nemblèmes.[001E][1205] Pas étonnant que tous aient\npeur si la malédiction frappe au hasard."
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "That[SP]reminds[SP]me,[SP]one[SP]of[SP]the[SP]students[SP]mentioned\nemblems[SP]in[SP]the[SP]teachers'[SP]lounge.[1205][000F][SP]I[SP]think[SP]the\nones[SP]there[SP]might[SP]be[SP]our[SP]last[SP]ones.",
     "nom_fr": "Yukino",
-    "texte_fr": "Ça me rappelle, un élève a mentionné des\nemblèmes dans la salle des profs. [1205][000F]Ceux-là\npourraient bien être les derniers."
+    "texte_fr": "Ça me rappelle, un élève a mentionné des\nemblèmes dans la salle des profs. [000F][1205]Ceux-là\npourraient bien être les derniers."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Damn[SP]that[SP]Hamya...[1205][001E][SP]First[SP]he[SP]has[SP]his[SP]way[SP]with\nSt.[SP]Hermelin,[SP]and[SP]now[SP]he's[SP]messing[SP]with[SP]this\nschool[SP]too.",
     "nom_fr": "Yukino",
-    "texte_fr": "Satané Hamya...[1205][001E] Il a embêté St. Hermelin,\net maintenant il ruine ce lycée aussi."
+    "texte_fr": "Satané Hamya...[001E][1205] Il a embêté St. Hermelin,\net maintenant il ruine ce lycée aussi."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "It's[SP]about[SP]time[SP]someone[SP]did[SP]something.[1205][001E][SP]I[SP]owe\nhim[SP]a[SP]couple,[SP]too.[1205][001E][SP]Heheheheh...[1205][001E][SP]And[SP]I'm[SP]not[SP]a\nstudent[SP]anymore...",
     "nom_fr": "Yukino",
-    "texte_fr": "Il fallait bien agir.[1205][001E] J'ai des\ncomptes à régler avec lui.[1205][001E] Héhé...[1205][001E]\nEt je ne suis plus étudiante..."
+    "texte_fr": "Il fallait bien agir.[001E][1205] J'ai des\ncomptes à régler avec lui.[001E][1205] Héhé...[001E][1205]\nEt je ne suis plus étudiante..."
   },
   {
     "id": 20,
@@ -372,7 +372,7 @@
     "nom_orig": "Ill[SP]male[SP]student",
     "texte_orig": "Y-Yeah...[SP]If[SP]the[SP]principal[SP]says[SP]so...\nEven[SP]though[SP]I'm[SP]cursed,[SP]I[SP]gotta[SP]respect\nthe[SP]school...",
     "nom_fr": "Élève malade (G)",
-    "texte_fr": "O-Ouais... Si le directeur\nle dit... Même si\nje suis maudit, je\ndois respecter le lycée..."
+    "texte_fr": "O-Ouais... Si le directeur\nle dit... Même si\nje suis maudit, je dois respecter le lycée..."
   },
   {
     "id": 25,
@@ -477,7 +477,7 @@
     "nom_orig": "Ill[SP]female[SP]student",
     "texte_orig": "Hrgh...[SP]I[SP]gotta[SP]clean[SP]up,[SP]'cause[SP]the[SP]principal\nsaid[SP]so.[SP]Even[SP]with[SP]my[SP]face[SP]like[SP]this...[SP]Dammit,\nI'm[SP]starting[SP]to[SP]get[SP]really[SP]mad!",
     "nom_fr": "Élève malade (F)",
-    "texte_fr": "Argh... Je dois nettoyer, parce que le\ndirecteur l'a dit. Même avec cette tête...\nBon sang, je commence\nvraiment à m'énerver!"
+    "texte_fr": "Argh... Je dois nettoyer, parce que le\ndirecteur l'a dit. Même avec cette tête...\nBon sang, je commence vraiment à m'énerver!"
   },
   {
     "id": 32,
@@ -507,7 +507,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "It's[SP]happened[SP]ever[SP]since[SP]the[SP]big[SP]clock[SP]started\nagain...[1205][000F][SP]Even[SP]the[SP]students[SP]who[SP]took[SP]their\nemblems[SP]off[SP]got[SP]sick,[SP]one[SP]after[SP]another...",
     "nom_fr": "Élève bandé (G)",
-    "texte_fr": "C'est arrivé dès que\nla grande horloge s'est\n[1205][000F]remise en marche... Même les élèves sans\nleur emblème tombent malades, un par un..."
+    "texte_fr": "C'est arrivé dès que\nla grande horloge s'est\n[000F][1205]remise en marche... Même les élèves sans leur emblème tombent malades, un par un..."
   },
   {
     "id": 34,
@@ -522,7 +522,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "This[SP]school[SP]really[SP]is[SP]cursed...[1205][000F][SP]This[SP]is[SP]no\ntime[SP]to[SP]be[SP]hosting[SP]a[SP]school[SP]festival...[1205][000F]\nI[SP]hope[SP]everyone[SP]else[SP]gets[SP]sick[SP]too...",
     "nom_fr": "Élève bandé (G)",
-    "texte_fr": "Ce lycée est vraiment maudit.[1205][000F][1205][000F].. Ce n'est\npas l'heure de faire la fête... J'espère\nque les autres seront malades..."
+    "texte_fr": "Ce lycée est vraiment maudit.[000F][1205][000F][1205].. Ce n'est\npas l'heure de faire la fête... J'espère\nque les autres seront malades..."
   },
   {
     "id": 35,
@@ -537,7 +537,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "Those[SP]girls[SP]are[SP]journalists[SP]from[SP]Coolest,\nright?[1205][001E][SP]Looks[SP]like[SP]the[SP]paparazzi[SP]have\nalready[SP]sniffed[SP]out[SP]the[SP]story[SP]here...",
     "nom_fr": "Élève bandé (G)",
-    "texte_fr": "Ces filles sont journalistes pour Coolest,\nnon?[1205][001E] On dirait que les paparazzis ont déjà\nflairé l'affaire ici..."
+    "texte_fr": "Ces filles sont journalistes pour Coolest,\nnon?[001E][1205] On dirait que les paparazzis ont déjà\nflairé l'affaire ici..."
   },
   {
     "id": 36,
@@ -567,7 +567,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "This[SP]school's[SP]cursed...[1205][000F][SP]So[SP]what's[SP]the[SP]point\nin[SP]taking[SP]good[SP]care[SP]of[SP]it?[1205][000F][SP]Well,[SP]might[SP]as\nwell[SP]still[SP]obey[SP]our[SP]principal...",
     "nom_fr": "Élève bandé (G)",
-    "texte_fr": "Ce lycée est maudit.[1205][000F][1205][000F].. Alors à quoi\nbon en prendre soin? Eh bien, autant\ncontinuer d'obéir à notre directeur..."
+    "texte_fr": "Ce lycée est maudit.[000F][1205][000F][1205].. Alors à quoi\nbon en prendre soin? Eh bien, autant\ncontinuer d'obéir à notre directeur..."
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "This[SP]makes[SP]no[SP]sense...[1205][000F][SP]The[SP]curse[SP]is[SP]lifted,\nbut[SP]the[SP]festival's[SP]still[SP]canceled?[1205][000F][SP]Well,[SP]not\nmuch[SP]point[SP]if[SP]no[SP]girls[SP]come,[SP]I[SP]guess...",
     "nom_fr": "Élève (Garçon)",
-    "texte_fr": "Ça n'a aucun sens.[1205][000F][1205][000F].. Malédiction levée,\nmais la fête est annulée? Pas d'intérêt\nsi aucune fille ne vient, je suppose..."
+    "texte_fr": "Ça n'a aucun sens.[000F][1205][000F][1205].. Malédiction levée,\nmais la fête est annulée? Pas d'intérêt\nsi aucune fille ne vient, je suppose..."
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "This[SP]makes[SP]no[SP]sense...[1205][000F][SP]The[SP]curse[SP]is[SP]lifted,\nbut[SP]the[SP]festival's[SP]still[SP]canceled?[1205][000F][SP]I[SP]guess[SP]it's\nunderstandable[SP]since[SP]the[SP]principal[SP]just[SP]died...",
     "nom_fr": "Élève (Garçon)",
-    "texte_fr": "Ça n'a aucun sens.[1205][1205].[000F][000F].\nLa malédiction est levée,\nmais la fête\nest annulée? C'est compréhensible\nvu que le directeur vient de mourir..."
+    "texte_fr": "Ça n'a aucun sens.[1205][1205].[000F][000F].\nLa malédiction est levée,\nmais la fête est annulée? C'est compréhensible vu que le directeur vient de mourir..."
   },
   {
     "id": 40,
@@ -612,7 +612,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "Everyone[SP]would[SP]run[SP]away[SP]if[SP]they[SP]could.[SP]But[SP]we\ncan't[SP]disobey[SP]the[SP]principal...[SP]I[SP]can't[SP]go[SP]home\nuntil[SP]the[SP]committee[SP]meeting[SP]is[SP]over,[SP]either.",
     "nom_fr": "Élève bandée (F)",
-    "texte_fr": "Tout le monde s'enfuirait si possible. Mais\non ne peut désobéir au directeur... Je ne\npeux pas rentrer avant\nla fin de la réunion."
+    "texte_fr": "Tout le monde s'enfuirait si possible. Mais\non ne peut désobéir au directeur... Je ne\npeux pas rentrer avant la fin de la réunion."
   },
   {
     "id": 41,
@@ -687,7 +687,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "That[SP]reminds[SP]me,[SP]one[SP]of[SP]the[SP]students[SP]mentioned\nan[SP]emblem[SP]in[SP]the[SP]teacher's[SP]lounge.[1205][000F][SP]I[SP]think[SP]the\none[SP]there[SP]might[SP]be[SP]our[SP]last[SP]one.",
     "nom_fr": "Yukino",
-    "texte_fr": "Ça me rappelle, un élève a mentionné un\nemblème dans la salle des profs. [1205][000F]Celui-là\npourrait bien être notre dernier."
+    "texte_fr": "Ça me rappelle, un élève a mentionné un\nemblème dans la salle des profs. [000F][1205]Celui-là\npourrait bien être notre dernier."
   },
   {
     "id": 46,

--- a/traduction/event_scripts/script_251.json
+++ b/traduction/event_scripts/script_251.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Is[SP]this[SP]because[SP]of[SP]the[SP]rumors[SP]too?[1205][000F][SP]Like,[SP]the\nrumor[SP]came[SP]true[SP]and[SP]brought[SP]that[SP]principal\nback[SP]to[SP]life?[1205][000F][SP]Seriously[SP]here?[SP]Seriously?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est aussi à cause des rumeurs? [1205][000F][1205][000F]Genre, la\nrumeur est devenue réalité et a ramené ce\ndirlo à la vie? Sérieusement là? Sérieux?"
+    "texte_fr": "C'est aussi à cause des rumeurs? [000F][1205][000F][1205]Genre, la\nrumeur est devenue réalité et a ramené ce\ndirlo à la vie? Sérieusement là? Sérieux?"
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Man,[SP]though...[1205][000F][SP]First[SP]the[SP]disease,[SP]now[SP]this.\nThat[SP]damn[SP]principal[SP]keeps[SP]taking[SP]credit[SP]for[SP]all\nour[SP]finest[SP]moments...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mec... [1205][000F]D'abord la\nmaladie, maintenant ça. Ce\nfoutu dirlo nous\nvole toujours la vedette..."
+    "texte_fr": "Mec... [000F][1205]D'abord la\nmaladie, maintenant ça. Ce\nfoutu dirlo nous vole toujours la vedette..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Principal[SP]Hanya...?[1205][000F][SP]What's[SP]going[SP]on?[1205][000F][SP]Was[SP]the\nprincipal[SP]the[SP]one[SP]who[SP]thrashed[SP]those[SP]Last\nBattalion[SP]goons[SP]on[SP]the[SP]floor[SP]there?",
     "nom_fr": "Ginko",
-    "texte_fr": "Proviseur Hanya.[1205][000F][1205][000F]..? Que se passe-t-il?\nC'est lui qui a mis au tapis les\nsbires du Bataillon là-bas?"
+    "texte_fr": "Proviseur Hanya.[000F][1205][000F][1205]..? Que se passe-t-il?\nC'est lui qui a mis au tapis les\nsbires du Bataillon là-bas?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh?[1205][000A][SP]Principal[SP]Hanya[SP]again...",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein?[1205][000A] Encore le dirlo..."
+    "texte_fr": "Hein?[000A][1205] Encore le dirlo..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "The[SP]power[SP]of[SP]rumors[SP]really[SP]is[SP]crazy...[1205][000F][SP]I[SP]can't\nbelieve[SP]Hanya[SP]turned[SP]into[SP]such[SP]a[SP]nice[SP]guy...",
     "nom_fr": "Ginko",
-    "texte_fr": "Les rumeurs, c'est fou... [1205][000F]J'en reviens\npas que Hanya soit devenu si sympa..."
+    "texte_fr": "Les rumeurs, c'est fou... [000F][1205]J'en reviens\npas que Hanya soit devenu si sympa..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm...[1205][000F][SP]That[SP]principal[SP]seems[SP]to[SP]have[SP]cleaned[SP]up\nhis[SP]act[SP]a[SP]lot...[1205][000F][SP]Oh![SP]You[SP]think[SP]it's[SP]because\nof[SP]the[SP]rumors?",
     "nom_fr": "Maya",
-    "texte_fr": "Hmm.[1205][000F][1205][000F].. Ce directeur a l'air d'avoir\nfait beaucoup le ménage... Oh! Vous\npensez que c'est dû aux rumeurs?"
+    "texte_fr": "Hmm.[000F][1205][000F][1205].. Ce directeur a l'air d'avoir\nfait beaucoup le ménage... Oh! Vous\npensez que c'est dû aux rumeurs?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Remember[SP]how[SP]after[SP]the[SP]disease[SP]cleared[SP]up,\neveryone[SP]at[SP]Sevens[SP]was[SP]talking[SP]about[SP]what[SP]a\ngreat[SP]hero[SP]the[SP]principal[SP]was?[1205][000F][SP]It[SP]came[SP]true!",
     "nom_fr": "Maya",
-    "texte_fr": "Après la maladie, tous à Seven disaient\nque le dirlo était un grand héros, vous\nvous souvenez? [1205][000F]C'est devenu vrai!"
+    "texte_fr": "Après la maladie, tous à Seven disaient\nque le dirlo était un grand héros, vous\nvous souvenez? [000F][1205]C'est devenu vrai!"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "He's[SP]here[SP]too!?[1205][000F][SP]But[SP]he[SP]was[SP]in[SP]a[SP]different\nroom[SP]just[SP]a[SP]moment[SP]ago...[1205][000F][SP]Did[SP]he[SP]pass[SP]us\nsomewhere...?",
     "nom_fr": "Maya",
-    "texte_fr": "Il est là![1205][000F][1205][000F]? Mais il était dans une autre\npièce à l'instant... Il nous a doublés...?"
+    "texte_fr": "Il est là![000F][1205][000F][1205]? Mais il était dans une autre\npièce à l'instant... Il nous a doublés...?"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Looks[SP]like[SP]Sevens[SP]is[SP]in[SP]good[SP]hands.[1205][000A][SP]We[SP]should\nhurry[SP]to[SP]Xibalba.",
     "nom_fr": "Maya",
-    "texte_fr": "Seven est entre de bonnes\nmains.[1205][000A] Vite, vers Xibalba."
+    "texte_fr": "Seven est entre de bonnes\nmains.[000A][1205] Vite, vers Xibalba."
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Jun",
     "texte_orig": "But[SP]it[SP]wasn't[SP]I[SP]who[SP]led[SP]him[SP]to[SP]his[SP]ideal.[1205][000F]\nIt[SP]was[SP]the[SP]students[SP]of[SP]this[SP]school.",
     "nom_fr": "Jun",
-    "texte_fr": "Ce n'est pas moi qui l'ai mené à son\n[1205][000F]idéal. Ce sont les élèves d'ici."
+    "texte_fr": "Ce n'est pas moi qui l'ai mené à son\n[000F][1205]idéal. Ce sont les élèves d'ici."
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Ah,[SP][1112]![1205][000F][SP]Your[SP]blows[SP]not[SP]long[SP]ago\ntruly[SP]hit[SP]home[SP]in[SP]my[SP]heart.",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Ah, [1112]! [1205][000F]Vos coups ont\nvraiment touché mon cœur."
+    "texte_fr": "Ah, [1112]! [000F][1205]Vos coups ont\nvraiment touché mon cœur."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "It's[SP]because[SP]of[SP]you[SP]kids[SP]that[SP]I[SP]was[SP]able[SP]to\nreturn[SP]like[SP]this.[1205][000F][SP]I[SP]have[SP]to[SP]thank[SP]you.",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "C'est grâce à vous les jeunes que j'ai pu\nrevenir ainsi. [1205][000F]Je dois vous remercier."
+    "texte_fr": "C'est grâce à vous les jeunes que j'ai pu\nrevenir ainsi. [000F][1205]Je dois vous remercier."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "The[SP]students[SP]gave[SP]me[SP]the[SP]gist[SP]of[SP]what's\ngoing[SP]on.[1205][000F][SP]You[SP]hurry[SP]on[SP]and[SP]save[SP]Ms.[SP]Okamura.[1205][000F]\nDon't[SP]worry![SP]I'll[SP]keep[SP]the[SP]peace[SP]at[SP]Sevens!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Les élèves m'ont dit l'essentiel. [1205]Foncez\n[1205][000F][000F]sauver Mme Okamura. Ne vous en faites\npas! Je garderai la paix à Seven!"
+    "texte_fr": "Les élèves m'ont dit l'essentiel. [1205]Foncez\n[000F][1205][000F]sauver Mme Okamura. Ne vous en faites\npas! Je garderai la paix à Seven!"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Well?[1205][0008][SP]What[SP]are[SP]you[SP]waiting[SP]for?[1205][000A][SP]Don't[SP]worry\nabout[SP]Sevens.[SP]Hurry[SP]and[SP]save[SP]Ms.[SP]Okamura!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Eh bien?[1205][0008] Qu'attendez-vous?[1205][000A] Oubliez\nSeven. Foncez sauver Mme Okamura!"
+    "texte_fr": "Eh bien?[0008][1205] Qu'attendez-vous?[000A][1205] Oubliez\nSeven. Foncez sauver Mme Okamura!"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Principal[SP]Hanya[SP]is[SP]awesome[SP]after[SP]all![1205][000F]\nHe'll[SP]always[SP]be[SP]our[SP]hero!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Le Proviseur Hanya assure!\n[1205][000F]Il restera notre héros!"
+    "texte_fr": "Le Proviseur Hanya assure!\n[000F][1205]Il restera notre héros!"
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I-I[SP]saw[SP]it[SP]with[SP]my[SP]own[SP]eyes...[1205][000A][SP]A[SP]guy[SP]wearing\na[SP]mask[SP]took[SP]Ms.[SP]Ideal[SP]and[SP]walked[SP]into[SP]the\npillar[SP]of[SP]light[SP]in[SP]the[SP]courtyard!",
     "nom_fr": "Lycéen",
-    "texte_fr": "J-Je l'ai vu de mes propres yeux...[1205][000A] Un\ngars masqué a pris Mme Idéal et a marché\ndans le pilier de lumière de la cour!"
+    "texte_fr": "J-Je l'ai vu de mes propres yeux...[000A][1205] Un\ngars masqué a pris Mme Idéal et a marché\ndans le pilier de lumière de la cour!"
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "The[SP]Last[SP]Battalion...[1205][000A][SP]They[SP]went[SP]in...[1205][000A]\nHm?[SP]I[SP]mean[SP]they[SP]went[SP]into[SP]that[SP]pillar[SP]of\nlight[SP]in[SP]the[SP]courtyard...",
     "nom_fr": "Lycéen",
-    "texte_fr": "Le Bataillon...[1205][000A] Ils sont\nentrés...[1205][000A] Hm? Je veux\ndire, dans ce pilier\nde lumière de la cour..."
+    "texte_fr": "Le Bataillon...[000A][1205] Ils sont\nentrés...[000A][1205] Hm? Je veux\ndire, dans ce pilier de lumière de la cour..."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Tons[SP]of[SP]them,[SP]too...[1205][000A][SP]I[SP]wonder[SP]what[SP]they're\nup[SP]to...[1205][000A][SP]Heeheehee...",
     "nom_fr": "Lycéen",
-    "texte_fr": "Des tas de gars...[1205][000A] Que préparent-ils\nau juste...?[1205][000A] Héhéhé..."
+    "texte_fr": "Des tas de gars...[000A][1205] Que préparent-ils\nau juste...?[000A][1205] Héhéhé..."
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "I[SP]really[SP]like[SP]Principal[SP]Hanya![1205][000F][SP]I[SP]mean,[SP]he's\nso[SP]nice,[SP]and[SP]strong,[SP]and[SP]just...[SP]amazing![1205][000A]\nWho[SP]wouldn't[SP]love[SP]him?[SP]It's[SP]perfectly[SP]normal!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "J'adore le Proviseur Hanya! [1205][000F]Il est si\ngentil, fort, et juste... incroyable![1205][000A]\nQui ne l'aimerait pas? C'est normal!"
+    "texte_fr": "J'adore le Proviseur Hanya! [000F][1205]Il est si\ngentil, fort, et juste... incroyable![000A][1205]\nQui ne l'aimerait pas? C'est normal!"
   },
   {
     "id": 22,
@@ -342,6 +342,6 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "This[SP]is[SP]terrible![SP]Just[SP]terrible![1205][000F][SP]Ms.[SP]Saeko[SP]is\ncaught[SP]somewhere,[SP]too![1205][000F][SP]But[SP]I'm[SP]sure[SP]Principal\nHanya[SP]will[SP]save[SP]her.",
     "nom_fr": "",
-    "texte_fr": "C'est terrible ! Vraiment terrible ![1205][000F]\nMme Saeko est aussi prisonnière quelque part ![1205][000F]\nMais je suis sûre que le Proviseur Hanya va la sauver."
+    "texte_fr": "C'est terrible ! Vraiment terrible ![000F][1205]\nMme Saeko est aussi prisonnière quelque part ![000F][1205]\nMais je suis sûre que le Proviseur Hanya va la sauver."
   }
 ]

--- a/traduction/event_scripts/script_252.json
+++ b/traduction/event_scripts/script_252.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]don't[SP]really[SP]get[SP]what's[SP]going[SP]on[SP]here,\nbut[SP]the[SP]dude's[SP]got[SP]skills.[1205][000F][SP]If[SP]he[SP]can[SP]use\na[SP]Persona,[SP]too,[SP]he[SP]should[SP]be[SP]fine.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je pige pas tout, mais ce mec gère.\n[1205][000F]S'il a une Persona, il s'en sortira."
+    "texte_fr": "Je pige pas tout, mais ce mec gère.\n[000F][1205]S'il a une Persona, il s'en sortira."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Noooo...[1205][000A][SP]All[SP]that[SP]praise[SP]should[SP]have[SP]been\nmine...![1205][000F][SP]*sniff*[SP]I'm[SP]so[SP]jealous.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Non..[1205].[1205][000A] Ces éloges auraient dû être\npour moi.[000F]..! *sniff* Je suis jaloux."
+    "texte_fr": "Non..[1205].[000A][1205] Ces éloges auraient dû être\npour moi.[000F]..! *sniff* Je suis jaloux."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hoisamuro![SP]That's[SP]awesome,[SP]that[SP]Brown-san\nwill[SP]fight[SP]with[SP]us![1205][000F][SP]I[SP]don't[SP]think[SP]we[SP]have\nto[SP]worry[SP]about[SP]Sevens[SP]now.",
     "nom_fr": "Ginko",
-    "texte_fr": "Hoisamuro! C'est génial que Brown-san\nse batte avec nous! [1205][000F]Je crois qu'on\nn'a plus à s'inquiéter pour Seven."
+    "texte_fr": "Hoisamuro! C'est génial que Brown-san\nse batte avec nous! [000F][1205]Je crois qu'on\nn'a plus à s'inquiéter pour Seven."
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "He's[SP]fought[SP]alongside[SP]Yukki,[SP]after[SP]all.\nThe[SP]Last[SP]Battalion[SP]should[SP]be[SP]a[SP]breeze[SP]for[SP]him.[1205][000F]\nWe[SP]need[SP]to[SP]get[SP]to[SP]Xibalba!",
     "nom_fr": "Maya",
-    "texte_fr": "Il a combattu avec Yukki. Le Bataillon sera\nfacile pour lui. [1205][000F]On doit foncer à Xibalba!"
+    "texte_fr": "Il a combattu avec Yukki. Le Bataillon sera\nfacile pour lui. [000F][1205]On doit foncer à Xibalba!"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Jun",
     "texte_orig": "This[SP]warmth...[1205][000A][SP]Yukino-san's[SP]Persona[SP]is\nreacting...[1205][000F][SP]It's[SP]as[SP]if[SP]it[SP]recognizes\nBrown-san's[SP]presence...",
     "nom_fr": "Jun",
-    "texte_fr": "Cette chaleur.[1205]..[1205][000A] La Persona de Yukino\n[000F]réagit... Elle reconnaît Brown-san..."
+    "texte_fr": "Cette chaleur.[1205]..[000A][1205] La Persona de Yukino\n[000F]réagit... Elle reconnaît Brown-san..."
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "???",
     "texte_orig": "Whoa,[SP]have[SP]I[SP]introduced[SP]myself[SP]yet?[1205][000F][SP]Not[SP]that[SP]I\nneed[SP]any[SP]introduction,[SP]but[SP]it's[SP]good[SP]business!\nAnyway,[SP]I'm[SP]Uesugi.[SP]Call[SP]me[SP]Brown,[SP]if[SP]you[SP]like.",
     "nom_fr": "???",
-    "texte_fr": "Whoa, je me suis présenté? [1205][000F]Pas besoin,\nmais les affaires sont les affaires!\nBref, je suis Uesugi. Dites Brown."
+    "texte_fr": "Whoa, je me suis présenté? [000F][1205]Pas besoin,\nmais les affaires sont les affaires!\nBref, je suis Uesugi. Dites Brown."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Brown",
     "texte_orig": "Elly[SP]filled[SP]me[SP]in,[SP]so[SP]I'll[SP]handle[SP]things[SP]here.\nYou[SP]guys[SP]go[SP]rescue[SP]that[SP]Ms.[SP]Ideal[SP]lady.[1205][000F]\nGood[SP]luck,[SP]guys!",
     "nom_fr": "Brown",
-    "texte_fr": "Elly m'a briefé, alors je gère ici. Allez\nsecourir cette Mme Idéal. [1205][000F]Bonne chance, les\ngars!"
+    "texte_fr": "Elly m'a briefé, alors je gère ici. Allez\nsecourir cette Mme Idéal. [000F][1205]Bonne chance, les\ngars!"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Brown",
     "texte_orig": "Ah,[SP]there[SP]you[SP]are.[1205][000A][SP]As[SP]you[SP]can[SP]see,[SP]I've[SP]got\nthis[SP]place[SP]locked[SP]down[SP]tight.[1205][000F][SP]I[SP]barely[SP]tapped\nthese[SP]guys![1205][000F][SP]I'm[SP]pretty[SP]strong,[SP]huh?[1205][0008][SP]Mwahahaha!\n[E3][E4][NULL][NULL]\"Brown\n...But[SP]jokes[SP]aside...[1205][000A][SP]Elly[SP]filled[SP]me[SP]in[SP]on\nwhat's[SP]happening.[1205][000F][SP]You[SP]guys[SP]go[SP]rescue[SP]this\nMs.[SP]Ideal[SP]lady.[SP]I'll[SP]handle[SP]things[SP]here.",
     "nom_fr": "Brown",
-    "texte_fr": "Ah, vous voilà.[1205][1205][1205][1205][000A] Comme\nvous pouvez le voir, je\ntiens bien la place.\n[000F][000F][000F]J'ai à peine effleuré ces\ngars! Je suis\nsuper fort, hein?[1205][0008] Mwahahaha![E3][E4][NULL][NULL]\"Brown\n ... Mais blague à part...[1205][000A] Elly m'a\nbriefé sur la situation. Allez secourir cetteMme\nIdéal. Je vais gérer les choses ici."
+    "texte_fr": "Ah, vous voilà.[1205][1205][1205][000A][1205] Comme\nvous pouvez le voir, je\ntiens bien la place.\n[000F][000F][000F]J'ai à peine effleuré ces\ngars! Je suis\nsuper fort, hein?[0008][1205] Mwahahaha![E3][E4][NULL][NULL]\"Brown\n ... Mais blague à part...[000A][1205] Elly m'a\nbriefé sur la situation. Allez secourir cetteMme\nIdéal. Je vais gérer les choses ici."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Brown",
     "texte_orig": "You're[SP]still[SP]here?[1205][000A][SP]Go[SP]rescue[SP]that[SP]teacher![1205][000A]\nYou[SP]can[SP]get[SP]to[SP]Xibalba[SP]from[SP]the[SP]courtyard,\nright?",
     "nom_fr": "Brown",
-    "texte_fr": "Encore là?[1205][000A] Allez secourir cette prof![1205][000A]\nAllez à Xibalba par la cour, non?"
+    "texte_fr": "Encore là?[000A][1205] Allez secourir cette prof![000A][1205]\nAllez à Xibalba par la cour, non?"
   },
   {
     "id": 12,
@@ -222,7 +222,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I-I[SP]saw[SP]it[SP]with[SP]my[SP]own[SP]eyes...[1205][000A][SP]A[SP]guy[SP]wearing\na[SP]mask[SP]took[SP]Ms.[SP]Ideal[SP]and[SP]walked[SP]into[SP]the\npillar[SP]of[SP]light[SP]in[SP]the[SP]courtyard!",
     "nom_fr": "Lycéen",
-    "texte_fr": "J-Je l'ai vu de mes propres yeux...[1205][000A] Un\ngars masqué a pris Mme Idéal et a marché\ndans le pilier de lumière de la cour!"
+    "texte_fr": "J-Je l'ai vu de mes propres yeux...[000A][1205] Un\ngars masqué a pris Mme Idéal et a marché\ndans le pilier de lumière de la cour!"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "The[SP]Last[SP]Battalion...[1205][000A][SP]They[SP]went[SP]in...[1205][000A]\nHm?[SP]I[SP]mean[SP]they[SP]went[SP]into[SP]that[SP]pillar[SP]of\nlight[SP]in[SP]the[SP]courtyard...",
     "nom_fr": "Lycéen",
-    "texte_fr": "Le Bataillon...[1205][000A] Ils sont entrés...[1205][000A]\nHm? Je veux dire, dans ce pilier\nde lumière dans la cour..."
+    "texte_fr": "Le Bataillon...[000A][1205] Ils sont entrés...[000A][1205]\nHm? Je veux dire, dans ce pilier\nde lumière dans la cour..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Tons[SP]of[SP]them,[SP]too...[1205][000A][SP]I[SP]wonder[SP]what[SP]they're\nup[SP]to...[1205][000A][SP]Heeheehee...",
     "nom_fr": "Lycéen",
-    "texte_fr": "Des tas de gars...[1205][000A] Que préparent-ils\nau juste...?[1205][000A] Héhéhé..."
+    "texte_fr": "Des tas de gars...[000A][1205] Que préparent-ils\nau juste...?[000A][1205] Héhéhé..."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "Awww,[SP]I[SP]can't[SP]make[SP]up[SP]my[SP]mind.[1205][000F][SP][1112]-senpai\nis[SP]cool,[SP]but[SP]Brown-san[SP]is[SP]pretty[SP]hot[SP]himself![1205][000F]\n*sigh*[SP]What[SP]should[SP]I[SP]do?",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Awww, j'hésite trop. [1205][000F][1205][000F][1112]-senpai\nest cool, mais Brown-san est\nmignon aussi! *soupir* Que faire?"
+    "texte_fr": "Awww, j'hésite trop. [000F][1205][000F][1205][1112]-senpai\nest cool, mais Brown-san est\nmignon aussi! *soupir* Que faire?"
   },
   {
     "id": 18,
@@ -282,6 +282,6 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "This[SP]is[SP]terrible![SP]Just[SP]terrible![1205][000F][SP]Ms.[SP]Saeko[SP]is\ncaught[SP]somewhere,[SP]too![1205][000F][SP]But[SP]I'm[SP]sure[SP]Principal\nHanya[SP]will[SP]save[SP]her.",
     "nom_fr": "",
-    "texte_fr": "C'est terrible ! Vraiment terrible ![1205][000F]\nMme Saeko est aussi prisonnière quelque part ![1205][000F]\nMais je suis sûre que le Proviseur Hanya va la sauver."
+    "texte_fr": "C'est terrible ! Vraiment terrible ![000F][1205]\nMme Saeko est aussi prisonnière quelque part ![000F][1205]\nMais je suis sûre que le Proviseur Hanya va la sauver."
   }
 ]

--- a/traduction/event_scripts/script_254.json
+++ b/traduction/event_scripts/script_254.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What[SP]the[SP]hell!?[SP]If[SP]you[SP]want[SP]my[SP]emblem,[SP]come[SP]and\nget[SP]it[SP]yourself![SP]You[SP]just[SP]want[SP]other[SP]people[SP]to\nsolve[SP]your[SP]problems![E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nSheesh...[1205][001E][SP]How[SP]come[SP]I[SP]gotta[SP]deal[SP]with[SP]your\nschool's[SP]problems[SP]too?[1205][001E][SP]I'm[SP]too[SP]damn[SP]nice,\nis[SP]why.[SP]Don't[SP]you[SP]think?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est quoi ce bordel!?\nSi tu veux mon insigne,\nviens le prendre! Tu veux juste que les\nautres règlent tes soucis![E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nPfff...[1205][001E] Pourquoi je dois\ngérer les problèmes de ton\nbahut?[1205][001E] Je suis trop\nsympa. Vous trouvez pas?"
+    "texte_fr": "C'est quoi ce bordel!?\nSi tu veux mon insigne,\nviens le prendre! Tu veux juste que les\nautres règlent tes soucis![E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nPfff...[001E][1205] Pourquoi je dois\ngérer les problèmes de ton\nbahut?[001E][1205] Je suis trop\nsympa. Vous trouvez pas?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "First[SP]you[SP]let[SP]other[SP]people[SP]do[SP]your[SP]work,[SP]now\nyou're[SP]bribing[SP]me!?[1205][001E][SP]My[SP]emblem's[SP]already[SP]gone!\nAnd[SP]if[SP]it[SP]wasn't,[SP]I[SP]wouldn't[SP]sell[SP]it[SP]to[SP]YOU!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tu laisses les autres bosser et tu\nm'achètes!?[1205][001E] J'ai plus mon insigne!\nEt je te le vendrais pas à TOI!"
+    "texte_fr": "Tu laisses les autres bosser et tu\nm'achètes!?[001E][1205] J'ai plus mon insigne!\nEt je te le vendrais pas à TOI!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey,[SP][1113],[SP]are[SP]all[SP]the[SP]dudes[SP]at[SP]your\nschool[SP]puffed-up[SP]candyasses[SP]like[SP]this!?[1205][001E]\nYou[SP]better[SP]get[SP]'em[SP]in[SP]line,[SP]like[SP]I[SP]do!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, [1113], tous les mecs de ton lycée\nsont des chochottes comme lui!?[1205][001E] Tu\nferais bien de les recadrer, comme moi!"
+    "texte_fr": "Hé, [1113], tous les mecs de ton lycée\nsont des chochottes comme lui!?[001E][1205] Tu\nferais bien de les recadrer, comme moi!"
   },
   {
     "id": 3,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP][1113]?[SP]You[SP]think[SP]the[SP]Undie[SP]Boss[SP]is\nsincere[SP]about[SP]being[SP]a[SP]leader?[1205][001E][SP]Guys[SP]like[SP]him\nare[SP]pretty[SP]rare[SP]these[SP]days.",
     "nom_fr": "Ginko",
-    "texte_fr": "[1113]? Le Boss des calbutes est un vrai leader?[1205][001E]\nLes mecs comme lui sont rares de nos jours."
+    "texte_fr": "[1113]? Le Boss des calbutes est un vrai leader?[001E][1205]\nLes mecs comme lui sont rares de nos jours."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Wow,[SP]Lisa-chan's[SP]scary[SP]sometimes.[1205][001E][SP]Looks[SP]like\nshe's[SP]got[SP]it[SP]for[SP]you[SP]something[SP]fierce.[1205][001E]\nEikichi-kun,[SP]on[SP]the[SP]other[SP]hand...",
     "nom_fr": "Maya",
-    "texte_fr": "Wow, Lisa-chan fait peur parfois.[1205][001E] On\ndirait qu'elle en pince pour toi\ngravement.[1205][001E] Eikichi-kun, par contre..."
+    "texte_fr": "Wow, Lisa-chan fait peur parfois.[001E][1205] On\ndirait qu'elle en pince pour toi\ngravement.[001E][1205] Eikichi-kun, par contre..."
   },
   {
     "id": 10,
@@ -192,7 +192,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Where's[SP]that[SP]Hamya[SP]hiding?[1205][000A][SP]He[SP]has[SP]to[SP]be[SP]in\nthis[SP]school[SP]somewhere.",
     "nom_fr": "Yukino",
-    "texte_fr": "Où se cache ce Hamya?[1205][000A] Il doit\nêtre dans ce bahut quelque part."
+    "texte_fr": "Où se cache ce Hamya?[000A][1205] Il doit\nêtre dans ce bahut quelque part."
   },
   {
     "id": 13,
@@ -222,7 +222,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Setting[SP]an[SP]example[SP]is[SP]a[SP]lot[SP]harder[SP]than[SP]it\nlooks.[1205][001E][SP]He[SP]may[SP]not[SP]seem[SP]like[SP]it,[SP]but[SP]I'm[SP]sure\nhe's[SP]been[SP]through[SP]a[SP]lot.",
     "nom_fr": "Yukino",
-    "texte_fr": "Montrer l'exemple est très dur.[1205][001E]\nMalgré les apparences, je suis sûre\nqu'il a vécu beaucoup de choses."
+    "texte_fr": "Montrer l'exemple est très dur.[001E][1205]\nMalgré les apparences, je suis sûre\nqu'il a vécu beaucoup de choses."
   },
   {
     "id": 15,
@@ -267,7 +267,7 @@
     "nom_orig": "Ill[SP]male[SP]student",
     "texte_orig": "Waaaaah![SP]Noooo![1205][001E][SP]Th-The[SP]curse![SP]It's[SP]got[SP]me!\nTh-This[SP]is[SP]all[SP]your[SP]fault,[SP]Senpai!",
     "nom_fr": "Lycéen malade",
-    "texte_fr": "Waaah! Noooon![1205][001E] L-La malédiction m'a\neu! C-C'est votre faute, Senpai!"
+    "texte_fr": "Waaah! Noooon![001E][1205] L-La malédiction m'a\neu! C-C'est votre faute, Senpai!"
   },
   {
     "id": 18,
@@ -327,7 +327,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "This[SP]school[SP]really[SP]is[SP]cursed.[SP]If[SP]this[SP]keeps\nup,[SP]even[SP]I'll...[1205][001E][SP]No![SP]Not[SP]me![SP]Not[SP]when[SP]I\nfinally[SP]got[SP]a[SP]cute[SP]boyfriend!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Ce lycée est maudit. Si ça continue,\nmême moi je vais...[1205][001E] Non! Pas moi!\nSurtout avec mon nouveau copain!"
+    "texte_fr": "Ce lycée est maudit. Si ça continue,\nmême moi je vais...[001E][1205] Non! Pas moi!\nSurtout avec mon nouveau copain!"
   },
   {
     "id": 22,
@@ -372,7 +372,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "Gotta[SP]hurry...[1205][0008][SP]Gotta[SP]hurry...[1205][000A][SP]Umm,[SP]where[SP]else\ndid[SP]I[SP]see[SP]'em?[1205][000F][SP]Oh,[SP]right,[SP]the[SP]teachers'\nlounge![1205][000F][SP]There's[SP]emblems[SP]there[SP]too!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Faut se dépêcher.[1205][1205]..[1205][0008] Vite...[1205][000A] Euh, où\n[000F][000F]en ai-je vu d'autres? Ah, la salle\ndes profs! Y'a des insignes là-bas!"
+    "texte_fr": "Faut se dépêcher.[1205][1205]..[0008][1205] Vite...[000A][1205] Euh, où\n[000F][000F]en ai-je vu d'autres? Ah, la salle\ndes profs! Y'a des insignes là-bas!"
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "If[SP]you[SP]don't[SP]hurry,[SP]I'll[SP]get[SP]sick[SP]too![1205][000A]\nPlease[SP]go[SP]destroy[SP]the[SP]emblems[SP]in[SP]the\nteachers'[SP]lounge!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Dépêchez-vous ou je serai malade![1205][000A] Allez\ndétruire les insignes dans\nla salle des profs!"
+    "texte_fr": "Dépêchez-vous ou je serai malade![000A][1205] Allez\ndétruire les insignes dans\nla salle des profs!"
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "One[SP]of[SP]us...[1205][000A][SP]I-I[SP]mean--[1205][000A]I[SP]feel[SP]bad[SP]about[SP]what\nhappened[SP]to[SP]the[SP]principal,[SP]but[SP]I'm[SP]glad[SP]the\ncurse[SP]is[SP]lifted.",
     "nom_fr": "Lycéenne",
-    "texte_fr": "L'un des nôtres...[1205][000A] J-Je veux dire--[1205][000A]\nJe me sens mal pour le dirlo, mais\nravie que la malédiction soit levée."
+    "texte_fr": "L'un des nôtres...[000A][1205] J-Je veux dire--[000A][1205]\nJe me sens mal pour le dirlo, mais\nravie que la malédiction soit levée."
   },
   {
     "id": 28,
@@ -477,7 +477,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "I[SP]didn't[SP]believe[SP]him,[SP]of[SP]course,[SP]but[SP]look\nwhat's[SP]happened[SP]ever[SP]since[SP]it[SP]started[SP]ticking\nagain.[SP]Could[SP]it[SP]have[SP]been[SP]true...?",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "Je ne l'ai pas cru, bien sûr, mais regardez\nce qui se passe depuis qu'elle refait\ntic-tac. Se pourrait-il\nque ce soit vrai...?"
+    "texte_fr": "Je ne l'ai pas cru, bien sûr, mais regardez\nce qui se passe depuis qu'elle refait\ntic-tac. Se pourrait-il que ce soit vrai...?"
   },
   {
     "id": 32,
@@ -522,7 +522,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "Ever[SP]since[SP]that[SP]clock[SP]started,[SP]the[SP]whole\nschool's[SP]like,[SP]panicking?[SP]I[SP]wanna[SP]leave,[SP]but\nthe[SP]principal[SP]says[SP]no?[SP]And[SP]I[SP]like[SP]him,[SP]so...?",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Depuis que l'horloge a\ndémarré, genre, tout le\nbahut panique? Je veux\npartir, mais le dirlo a\ndit non? Et comme je l'aime bien, alors...?"
+    "texte_fr": "Depuis que l'horloge a\ndémarré, genre, tout le\nbahut panique? Je veux partir, mais le dirlo a dit non? Et comme je l'aime bien, alors...?"
   },
   {
     "id": 35,
@@ -597,7 +597,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "Gotta[SP]hurry...[1205][0008][SP]Gotta[SP]hurry...[1205][000A][SP]Umm,[SP]where[SP]else\ndid[SP]I[SP]see[SP]'em?[1205][000F][SP]Oh,[SP]right,[SP]the[SP]teachers'\nlounge![1205][000F][SP]There's[SP]emblems[SP]there[SP]too!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Faut se dépêcher.[1205][1205]..[1205][0008] Vite...[1205][000A] Euh, où\n[000F][000F]en ai-je vu d'autres? Ah, la salle\ndes profs! Y'a des insignes là-bas!"
+    "texte_fr": "Faut se dépêcher.[1205][1205]..[0008][1205] Vite...[000A][1205] Euh, où\n[000F][000F]en ai-je vu d'autres? Ah, la salle\ndes profs! Y'a des insignes là-bas!"
   },
   {
     "id": 40,
@@ -612,7 +612,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "If[SP]you[SP]don't[SP]hurry,[SP]I'll[SP]get[SP]sick[SP]too![1205][000A]\nPlease[SP]go[SP]destroy[SP]the[SP]emblems[SP]in[SP]the\nteachers'[SP]lounge!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Dépêchez-vous ou je serai malade![1205][000A] Allez\ndétruire les insignes dans\nla salle des profs!"
+    "texte_fr": "Dépêchez-vous ou je serai malade![000A][1205] Allez\ndétruire les insignes dans\nla salle des profs!"
   },
   {
     "id": 41,

--- a/traduction/event_scripts/script_255.json
+++ b/traduction/event_scripts/script_255.json
@@ -12,7 +12,7 @@
     "nom_orig": "Baseball[SP]player",
     "texte_orig": "I've[SP]finally[SP]got[SP]a[SP]spot[SP]in[SP]the[SP]starting[SP]lineup!\nHeheh,[SP]no[SP]one[SP]can[SP]call[SP]me[SP]a[SP]benchwarmer[SP]now!\nBig[SP]leagues,[SP]here[SP]I[SP]come![SP]Bring[SP]on[SP]the[SP]groupies!",
     "nom_fr": "Joueur de baseball",
-    "texte_fr": "J'ai enfin une place\nde titulaire! Héhé, plus\npersonne ne me traitera de remplaçant! La\nligue majeure, j'arrive!\nÀ moi les groupies!"
+    "texte_fr": "J'ai enfin une place\nde titulaire! Héhé, plus\npersonne ne me traitera de remplaçant! La ligue majeure, j'arrive! À moi les groupies!"
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "But[SP]the[SP]name's[SP]so[SP]long[SP]that[SP]most[SP]people[SP]find[SP]it\neasier[SP]to[SP]say[SP]Sevens.[SP]I[SP]always[SP]liked[SP]the[SP]emblem\ndesign,[SP]but[SP]not[SP]once[SP]I[SP]found[SP]out[SP]it's[SP]cursed.",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Mais le nom est si\nlong que la plupart disent\njuste Seven. J'aimais bien le design de\nl'emblème, mais plus\ndepuis qu'il est maudit."
+    "texte_fr": "Mais le nom est si\nlong que la plupart disent\njuste Seven. J'aimais bien le design de l'emblème, mais plus depuis qu'il est maudit."
   },
   {
     "id": 3,

--- a/traduction/event_scripts/script_256.json
+++ b/traduction/event_scripts/script_256.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Alright,[SP]time[SP]to[SP]draw[SP]my[SP]love[SP]gun![1205][001E][SP]C'mere,\nmy[SP]little[SP]kittycat![SP]Want[SP]a[SP]real[SP]rock[SP]star\nto[SP]write[SP]you[SP]a[SP]love[SP]song?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je dégaine mon flingue d'amour![1205][001E]\nViens, chaton! Tu veux qu'une\nrock star t'écrive une chanson?"
+    "texte_fr": "Je dégaine mon flingue d'amour![001E][1205]\nViens, chaton! Tu veux qu'une\nrock star t'écrive une chanson?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "*sta[1205][000A]a[1205][000A]a[1205][000A]a[1205][000A]a[1205][000A]a[1205][000A]are*[1205][001E]\nHm?[SP]What[SP]am[SP]I[SP]doing,[SP]you[SP]ask?",
     "nom_fr": "Eikichi",
-    "texte_fr": "*fii[1205][000A]i[1205][000A]i[1205][000A]i[1205][000A]i[1205][000A]i[1205][000A]xe*[1205][001E] Hm? Ce que je fais?"
+    "texte_fr": "*fii[000A][1205]i[000A][1205]i[000A][1205]i[000A][1205]i[000A][1205]i[000A][1205]xe*[001E][1205] Hm? Ce que je fais?"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I'm[SP]sending[SP]a[SP]smoldering[SP]gaze[SP]at[SP]the[SP]babe[SP]over\nthere![1205][001E][SP]Look[SP]at[SP]her,[SP]her[SP]face[SP]is[SP]all[SP]red[SP]now.\nShe's[SP]under[SP]my[SP]spell!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je lance un regard de braise à la\nfille là-bas![1205][001E] Regarde, elle est toute\nrouge. Elle est sous mon charme!"
+    "texte_fr": "Je lance un regard de braise à la\nfille là-bas![001E][1205] Regarde, elle est toute\nrouge. Elle est sous mon charme!"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Oh[SP]my[SP]god![SP]M-My[SP]kittycat...[1205][001E][SP]What[SP]a[SP]horrible\nsight...!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mon dieu! M-Mon\nchaton...[1205][001E] Quelle horreur...!"
+    "texte_fr": "Mon dieu! M-Mon\nchaton...[001E][1205] Quelle horreur...!"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Dammit![SP]That[SP]Hanya[SP]bastard's[SP]not[SP]getting[SP]away\nwith[SP]this![1205][001E][SP]Just[SP]sit[SP]tight,[SP]okay?[SP]I[SP]swear[SP]I'll\nget[SP]you[SP]back[SP]to[SP]normal!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Bon sang! Cet enfoiré de Hanya ne s'en\ntirera pas comme ça![1205][001E] Reste là, ok? Je\njure de te rendre ta vraie forme!"
+    "texte_fr": "Bon sang! Cet enfoiré de Hanya ne s'en\ntirera pas comme ça![001E][1205] Reste là, ok? Je\njure de te rendre ta vraie forme!"
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Sorry,[SP]babe.[1205][001E][SP]I[SP]know[SP]how[SP]strong[SP]your[SP]feelings\nfor[SP]me[SP]are,[SP]but[SP]I[SP]gotta[SP]go...[SP]Adios!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Désolé bébé.[1205][001E] Je sais que tu m'aimes,\nmais je dois y aller... Adios!"
+    "texte_fr": "Désolé bébé.[001E][1205] Je sais que tu m'aimes,\nmais je dois y aller... Adios!"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Hey,[SP][1113]?[1205][001E][SP]Was[SP]it[SP]really[SP]the[SP]best[SP]idea[SP]to\nbring[SP]this[SP]guy[SP]along?[SP]I'm[SP]honestly[SP]getting\nworried[SP]now...",
     "nom_fr": "Lisa",
-    "texte_fr": "Hé, [1113]?[1205][001E] C'était vraiment une\nbonne idée de l'emmener? Je\ncommence vraiment à m'inquiéter..."
+    "texte_fr": "Hé, [1113]?[001E][1205] C'était vraiment une\nbonne idée de l'emmener? Je\ncommence vraiment à m'inquiéter..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "He's[SP]so[SP]naive[SP]it[SP]goes[SP]past[SP]being[SP]funny[SP]to[SP]just\nplain[SP]sad...[1205][001E][SP]I[SP]wonder[SP]if[SP]he's[SP]been[SP]like[SP]that\never[SP]since[SP]he[SP]was[SP]little.",
     "nom_fr": "Ginko",
-    "texte_fr": "Il est si naïf que ce n'est plus\ndrôle mais juste triste...[1205][001E] Je me\ndemande s'il a toujours été comme ça."
+    "texte_fr": "Il est si naïf que ce n'est plus\ndrôle mais juste triste...[001E][1205] Je me\ndemande s'il a toujours été comme ça."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aaaah![SP]I'm[SP]scaaared[SP]of[SP]ghosts,[SP][1113]![1205][001E]\nWon't[SP]you[SP]protect[SP]a[SP]weak[SP]little[SP]girl?[1205][001E]\nAwwww![SP]You're[SP]soooo[SP]stro[1205][000A]oo[1205][000A]ong,[SP][1113]!",
     "nom_fr": "Ginko",
-    "texte_fr": "Aaaah! J'ai peeeur des fantômes, [1113]![1205][001E]\nTu veux bien protéger une fille fragile?[1205][001E]\nAww! T'es siiii fo[1205][000A]oo[1205][000A]ort, [1113]!"
+    "texte_fr": "Aaaah! J'ai peeeur des fantômes, [1113]![001E][1205]\nTu veux bien protéger une fille fragile?[001E][1205]\nAww! T'es siiii fo[000A][1205]oo[000A][1205]ort, [1113]!"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#11![1205][001E][SP][1432][NULL][NULL][0014]Hoisamuro[1432][NULL][NULL][0014][SP]means\nto[SP]be[SP]happy![SP]I[SP]use[SP]it[SP]sometimes[SP]instead[SP]of\nsaying[SP][1432][NULL][NULL][0014]Yay![1432][NULL][NULL][0014]",
     "nom_fr": "Ginko",
-    "texte_fr": "Leçon n°11 de Lisa![1205][001E] [1432][NULL][NULL][0014]Hoisamuro[1432][NULL][NULL][0014] c'est être\nravi! Je le dis des fois au lieu de [1432][NULL][NULL][0014]Ouais![1432][NULL][NULL][0014]"
+    "texte_fr": "Leçon n°11 de Lisa![001E][1205] [1432][NULL][NULL][0014]Hoisamuro[1432][NULL][NULL][0014] c'est être\nravi! Je le dis des fois au lieu de [1432][NULL][NULL][0014]Ouais![1432][NULL][NULL][0014]"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Eikichi-kun[SP]is[SP]so[SP]funny![1205][001E][SP]Well,[SP]they[SP]say[SP]that\nlove[SP]is[SP]the[SP]great[SP]misunderstanding,[SP]after[SP]all.\nMaybe[SP]this[SP]is[SP]how[SP]it[SP]happens.",
     "nom_fr": "Maya",
-    "texte_fr": "Eikichi-kun est si drôle![1205][001E] L'amour est le\nplus grand des malentendus, après tout.\nC'est peut-être comme ça que ça arrive."
+    "texte_fr": "Eikichi-kun est si drôle![001E][1205] L'amour est le\nplus grand des malentendus, après tout.\nC'est peut-être comme ça que ça arrive."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Isn't[SP]Lisa[SP]being[SP]a[SP]little[SP]melodramatic?[1205][001E]\nShe[SP]punches[SP]out[SP]demons[SP]all[SP]the[SP]time.[1205][001E][SP]It[SP]must\nbe[SP]tough[SP]being[SP]you,[SP][1113]-kun.",
     "nom_fr": "Maya",
-    "texte_fr": "Lisa en fait trop, non?[1205][001E] Elle cogne\ndes démons sans arrêt.[1205][001E] Ça doit\nêtre dur d'être toi, [1113]-kun."
+    "texte_fr": "Lisa en fait trop, non?[001E][1205] Elle cogne\ndes démons sans arrêt.[001E][1205] Ça doit\nêtre dur d'être toi, [1113]-kun."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Did[SP]you[SP]sense[SP]it[SP]too,[SP][1113]-kun?\nThat[SP]Joker[SP]boy[SP]was[SP]definitely[SP]crying...[1205][001E]\nSuch[SP]solitude[SP]and[SP]anxiety...",
     "nom_fr": "Maya",
-    "texte_fr": "L'as-tu senti, [1113]-kun? Le Joker\npleurait...[1205][001E] Tant de\nsolitude et d'anxiété..."
+    "texte_fr": "L'as-tu senti, [1113]-kun? Le Joker\npleurait...[001E][1205] Tant de\nsolitude et d'anxiété..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1432][NULL][NULL][0014]That[SP]Joker[SP]boy,[1432][NULL][NULL][0014][SP]huh...?[1205][001E][SP]If[SP]nobody[SP]knows\nwho[SP]Joker[SP]is,[SP]why[SP]do[SP]I[SP]keep[SP]referring[SP]to\nhim[SP]that[SP]way...?",
     "nom_fr": "Maya",
-    "texte_fr": "[1432][NULL][NULL][0014]Ce garçon, Joker,[1432][NULL][NULL][0014] hein...?[1205][001E] Si nul ne le\nconnaît, pourquoi je l'appelle ainsi...?"
+    "texte_fr": "[1432][NULL][NULL][0014]Ce garçon, Joker,[1432][NULL][NULL][0014] hein...?[001E][1205] Si nul ne le\nconnaît, pourquoi je l'appelle ainsi...?"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "[1432][NULL][NULL][0014]Love[SP]is[SP]the[SP]great[SP]misunderstanding,[1432][NULL][NULL][0014][SP]huh?[1205][001E]\nI[SP]wonder[SP]if[SP]that's[SP]true...",
     "nom_fr": "Yukino",
-    "texte_fr": "[1432][NULL][NULL][0014]L'amour est le grand malentendu,[1432][NULL][NULL][0014]\nhein?[1205][001E] Est-ce vraiment vrai...?"
+    "texte_fr": "[1432][NULL][NULL][0014]L'amour est le grand malentendu,[1432][NULL][NULL][0014]\nhein?[001E][1205] Est-ce vraiment vrai...?"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "[1432][NULL][NULL][0014]A[1205][000F]-Awww...![SP]S-So...[1205][000A][SP]stroooo[1205][000F]ooong![1432][NULL][NULL][0014][1205][001E]\n*gasp*",
     "nom_fr": "Yukino",
-    "texte_fr": "[1432][NULL][NULL][0014]A-Aww.[1205][000F][1205][000F]..! S-Si...[1205][000A] foooooooort![1432][NULL][NULL][0014][1205][001E] *gasp*"
+    "texte_fr": "[1432][NULL][NULL][0014]A-Aww.[000F][1205][000F][1205]..! S-Si...[000A][1205] foooooooort![1432][NULL][NULL][0014][001E][1205] *gasp*"
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Y-You[SP]moron![SP]What're[SP]you[SP]lookin'[SP]at!?[1205][001E][SP]I-I[SP]scared\nyou[SP]just[SP]now?[SP]Then[SP]mind[SP]your[SP]own[SP]business![1205][001E]\nA-And[SP]keep[SP]quiet[SP]about[SP]this,[SP]or[SP]else!",
     "nom_fr": "Yukino",
-    "texte_fr": "I-Idiot! Tu regardes quoi!?[1205][001E] J-Je t'ai fait\npeur? Alors mêle-toi de tes affaires![1205][001E] E-Et\nn'en parle à personne, sinon!"
+    "texte_fr": "I-Idiot! Tu regardes quoi!?[001E][1205] J-Je t'ai fait\npeur? Alors mêle-toi de tes affaires![001E][1205] E-Et\nn'en parle à personne, sinon!"
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "That[SP]big[SP]clock's[SP]stopped[SP]for[SP]good.[SP]I[SP]hope[SP]that\nputs[SP]the[SP]ghost's[SP]mind[SP]to[SP]rest.[1205][001E][SP]He[SP]shouldn't[SP]be\nchained[SP]down[SP]by[SP]worries[SP]in[SP]death[SP]like[SP]that.",
     "nom_fr": "Yukino",
-    "texte_fr": "L'horloge s'est arrêtée. J'espère que ça\napaisera le fantôme.[1205][001E] Il ne devrait pas être\nenchaîné par des soucis\ndans la mort comme ça."
+    "texte_fr": "L'horloge s'est arrêtée. J'espère que ça\napaisera le fantôme.[001E][1205] Il ne devrait pas être\nenchaîné par des soucis\ndans la mort comme ça."
   },
   {
     "id": 20,
@@ -402,7 +402,7 @@
     "nom_orig": "Ill[SP]female[SP]student",
     "texte_orig": "*sniffle*[1205][001E][SP]Now[SP]my[SP]face[SP]is[SP]like[SP]this[SP]too...[1205][001E]\nAnd[SP]that[SP]Boss[SP]is[SP]still[SP]terrifying[SP]me...\n*sob*",
     "nom_fr": "Lycéenne malade",
-    "texte_fr": "*snif*[1205][001E] Mon visage est comme ça aussi...[1205][001E]\nEt ce Boss me terrifie encore... *sob*"
+    "texte_fr": "*snif*[001E][1205] Mon visage est comme ça aussi...[001E][1205]\nEt ce Boss me terrifie encore... *sob*"
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "*sniffle*[1205][001E][SP]The[SP]curse[SP]has[SP]been[SP]lifted,[SP]but[SP]that\ndastardly[SP]Boss[SP]is[SP]still[SP]here...[1205][001E][SP]I[SP]bet[SP]he's\ngoing[SP]to[SP]try[SP]something[SP]funny[SP]with[SP]me...[SP]*sob*",
     "nom_fr": "Lycéenne",
-    "texte_fr": "*snif*[1205][001E] La malédiction est levée, mais cet\ninfâme Boss est toujours\nlà...[1205][001E] Je parie qu'il\nva essayer un\ntruc bizarre avec moi...*sanglot*"
+    "texte_fr": "*snif*[001E][1205] La malédiction est levée, mais cet\ninfâme Boss est toujours\nlà...[001E][1205] Je parie qu'il\nva essayer un\ntruc bizarre avec moi...*sanglot*"
   },
   {
     "id": 28,
@@ -537,7 +537,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "Oh,[SP]Senpai,[SP]have[SP]you[SP]seen[SP]Chikarin?[1205][001E][SP]Hmm...[1205][000F]\nDammit,[SP]I[SP]bet[SP]she's[SP]wolfing[SP]down[SP]burgers\nat[SP]Peace[SP]Diner[SP]again!",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "Oh, Senpai, t'as vu Chikarin?[1205][1205][001E] Hmm...\n[000F]Bon sang, je parie qu'elle s'empiffre\nencore de burgers au Peace Diner!"
+    "texte_fr": "Oh, Senpai, t'as vu Chikarin?[1205][001E][1205] Hmm...\n[000F]Bon sang, je parie qu'elle s'empiffre\nencore de burgers au Peace Diner!"
   },
   {
     "id": 36,
@@ -582,7 +582,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "That[SP]should've[SP]been[SP]the[SP]last[SP]emblem[SP]here.[SP]Have\nyou[SP]been[SP]to[SP]the[SP]other[SP]classes?[SP]Then[SP]the[SP]only\nones[SP]left[SP]should[SP]be[SP]in[SP]the[SP]teachers'[SP]lounge.",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "Ça devrait être le\ndernier insigne ici. Vous\navez fait les autres classes? Alors il ne\ndoit en rester que dans la salle des profs."
+    "texte_fr": "Ça devrait être le\ndernier insigne ici. Vous\navez fait les autres classes? Alors il ne doit en rester que dans la salle des profs."
   },
   {
     "id": 39,
@@ -612,7 +612,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High?[1205][000F]\nRumor[SP]has[SP]it[SP]he's[SP]stronger[SP]than[SP]the[SP]Boss.\nHe[SP]won't[SP]attack[SP]Sevens,[SP]will[SP]he?",
     "nom_fr": "Lycéen",
-    "texte_fr": "Tu connais le nouveau Leader du Lycée\nKakasu? [1205][000F]La rumeur dit qu'il est plus fort\nque le Boss. Il\nn'attaquera pas Seven, hein?"
+    "texte_fr": "Tu connais le nouveau Leader du Lycée\nKakasu? [000F][1205]La rumeur dit qu'il est plus fort\nque le Boss. Il n'attaquera pas Seven, hein?"
   },
   {
     "id": 41,
@@ -642,7 +642,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "That[SP]should've[SP]been[SP]the[SP]last[SP]emblem[SP]here.[SP]Have\nyou[SP]been[SP]to[SP]the[SP]other[SP]classes?[SP]Then[SP]the[SP]only\nones[SP]left[SP]should[SP]be[SP]in[SP]the[SP]teachers'[SP]lounge.",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "Ça devrait être le\ndernier insigne ici. Vous\navez fait les autres classes? Alors il ne\ndoit en rester que dans la salle des profs."
+    "texte_fr": "Ça devrait être le\ndernier insigne ici. Vous\navez fait les autres classes? Alors il ne doit en rester que dans la salle des profs."
   },
   {
     "id": 43,

--- a/traduction/event_scripts/script_257.json
+++ b/traduction/event_scripts/script_257.json
@@ -57,6 +57,6 @@
     "nom_orig": "Janitor",
     "texte_orig": "I[SP]wonder[SP]how[SP]many[SP]years[SP]it's[SP]been[SP]since[SP]that\ntragedy...[1205][001E][SP]It[SP]was[SP]gruesome.[SP]Namu[SP]Amida[SP]Butsu,\nNamu[SP]Amida[SP]Butsu...[1205]<[SP]Well,[SP]dinnertime!",
     "nom_fr": "",
-    "texte_fr": "Je me demande combien d'années ont passé\ndepuis cette tragédie...[1205][001E] C'était horrible.\nNamu Amida Butsu, Namu Amida Butsu...[1205]< Bah, c'est l'heure du dîner !"
+    "texte_fr": "Je me demande combien d'années ont passé\ndepuis cette tragédie...[001E][1205] C'était horrible.\nNamu Amida Butsu, Namu Amida Butsu...[1205]< Bah, c'est l'heure du dîner !"
   }
 ]

--- a/traduction/event_scripts/script_258.json
+++ b/traduction/event_scripts/script_258.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Dude...[1205][001E][SP]This[SP]box[SP]has[SP]ropes[SP]and[SP]candles[SP]in[SP]it...[1205][001E]\nNah,[SP]never[SP]mind.[SP]Get[SP]your[SP]mind[SP]out[SP]of[SP]the\ngutter,[SP]Eikichi!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mec...[1205][001E] Des cordes et des bougies\ndans cette boîte...[1205][001E] Non, oublie.\nSors ça de ta tête, Eikichi!"
+    "texte_fr": "Mec...[001E][1205] Des cordes et des bougies\ndans cette boîte...[001E][1205] Non, oublie.\nSors ça de ta tête, Eikichi!"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Sturdy[SP]ropes[SP]and[SP]candles...[1205][001E][SP]A[SP]man[SP]and\na[SP]woman...[1205][001E][SP]N-No,[SP]there's[SP]probably[SP]a[SP]perfectly\ngood[SP]explanation.[SP]There's[SP]gotta[SP]be!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Cordes solides et bougies...[1205][001E] Un homme\net une femme...[1205][001E] N-Non, il y a sûrement\nune très bonne explication. Il le faut!"
+    "texte_fr": "Cordes solides et bougies...[001E][1205] Un homme\net une femme...[001E][1205] N-Non, il y a sûrement\nune très bonne explication. Il le faut!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yep,[SP]we[SP]found[SP]the[SP]key,[SP]Gramps...[1205][001E][SP]Sooo...\nAbout[SP]that[SP]box...[1205][001E][SP]Aaaah,[SP]forget[SP]it!\nI[SP]can't[SP]bring[SP]myself[SP]to[SP]ask!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ouais, on a la clé, pépé...[1205][001E] Alors... Cette\nboîte...[1205][001E] Aaaah, oublie! J'ose pas demander!"
+    "texte_fr": "Ouais, on a la clé, pépé...[001E][1205] Alors... Cette\nboîte...[001E][1205] Aaaah, oublie! J'ose pas demander!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]get[SP]you[SP]now,[SP]Gramps...[1205][001E][SP]Old[SP]or[SP]young,\na[SP]man[SP]is[SP]a[SP]man[SP]is[SP]a[SP]man!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je pige, pépé...[1205][001E] Vieux ou\njeune, un homme est un homme!"
+    "texte_fr": "Je pige, pépé...[001E][1205] Vieux ou\njeune, un homme est un homme!"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Gwuh!?[1205][001E][SP]This[SP]is[SP]a[SP]poster[SP]of[SP]Sayuri[SP]Yoshikawa...[1205][001E]\nGramps[SP]here[SP]has[SP]the[SP]same[SP]taste[SP]in[SP]women[SP]as\nmy[SP]pervy[SP]old[SP]man...",
     "nom_fr": "Lisa",
-    "texte_fr": "Hein!?[1205][001E] Un poster\nde Sayuri Yoshikawa...[1205][001E] Pépé\na les mêmes goûts que mon père pervers..."
+    "texte_fr": "Hein!?[001E][1205] Un poster\nde Sayuri Yoshikawa...[001E][1205] Pépé\na les mêmes goûts que mon père pervers..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#4![1205][001E][SP][1432][NULL][NULL][0014]Houshounah[1432][NULL][NULL][0014][SP]means\nthat[SP]you're[SP]sad[SP]or[SP]pained.[SP]Don't[SP]make[SP]me[SP]say\nit[SP]too[SP]often,[SP]okay?",
     "nom_fr": "Ginko",
-    "texte_fr": "Leçon n°4 de Lisa![1205][001E] [1432][NULL][NULL][0014]Houshounah[1432][NULL][NULL][0014]\nveut dire être triste ou blessé.\nNe m'oblige pas à le répéter, ok?"
+    "texte_fr": "Leçon n°4 de Lisa![001E][1205] [1432][NULL][NULL][0014]Houshounah[1432][NULL][NULL][0014]\nveut dire être triste ou blessé.\nNe m'oblige pas à le répéter, ok?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Helloooo...?[SP]Wai[SP]Wai?[1205][001E][SP]We[SP]told[SP]you[SP]already,\nwe[SP]found[SP]the[SP]key.[1205][001E][SP]It[SP]was[SP]hanging[SP]on[SP]your\nneck![SP]Like[SP]this![SP]Remember!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Alooors...? Wai Wai?[1205][001E] On l'a déjà\ndit, on a la clé.[1205][001E] Elle pendait à ton\ncou! Comme ça! Tu t'en souviens!?"
+    "texte_fr": "Alooors...? Wai Wai?[001E][1205] On l'a déjà\ndit, on a la clé.[001E][1205] Elle pendait à ton\ncou! Comme ça! Tu t'en souviens!?"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#8![1205][001E][SP][1432][NULL][NULL][0014]Chinyan[1432][NULL][NULL][0014]...\nmeans[SP]lover![SP]Did[SP]you[SP]know[SP]that?",
     "nom_fr": "Ginko",
-    "texte_fr": "Leçon cantonais 8 de Lisa![1205][001E] [1432][NULL][NULL][0014]Chinyan[1432][NULL][NULL][0014]...\nveut dire amant! Tu savais?"
+    "texte_fr": "Leçon cantonais 8 de Lisa![001E][1205] [1432][NULL][NULL][0014]Chinyan[1432][NULL][NULL][0014]...\nveut dire amant! Tu savais?"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Looks[SP]like[SP]nothing[SP]here[SP]has[SP]an[SP]emblem[SP]on[SP]it.[1205][001E]\nShouldn't[SP]we[SP]keep[SP]searching[SP]elsewhere?",
     "nom_fr": "Maya",
-    "texte_fr": "Rien ici n'a d'emblème.[1205][001E] On\ndevrait chercher ailleurs, non?"
+    "texte_fr": "Rien ici n'a d'emblème.[001E][1205] On\ndevrait chercher ailleurs, non?"
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Well,[SP]now[SP]we[SP]can[SP]get[SP]into[SP]the[SP]clock[SP]tower.[1205][001E]\nQuestion[SP]is,[SP]what's[SP]that[SP]principal[SP]going[SP]to[SP]do\nnext?[1205][001E][SP]We[SP]should[SP]be[SP]careful,[SP][1113]-kun.",
     "nom_fr": "Maya",
-    "texte_fr": "Bien, on peut entrer dans la tour de\nl'horloge.[1205][001E] La question c'est, que va faire\nce dirlo ensuite?[1205][001E] Prudence, [1113]-kun."
+    "texte_fr": "Bien, on peut entrer dans la tour de\nl'horloge.[001E][1205] La question c'est, que va faire\nce dirlo ensuite?[001E][1205] Prudence, [1113]-kun."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Geez,[SP]the[SP]curse[SP]sure[SP]lifted[SP]quick.[1205][001E][SP]I[SP]was[SP]half\njoking[SP]when[SP]I[SP]suggested[SP]it,[SP]but[SP]could[SP]this\nmean[SP]rumors[SP]really[SP]are[SP]becoming[SP]reality?",
     "nom_fr": "Maya",
-    "texte_fr": "La malédiction s'est vite levée.[1205][001E] Je\nplaisantais à moitié, mais ça veut dire\nque les rumeurs deviennent réalité?"
+    "texte_fr": "La malédiction s'est vite levée.[001E][1205] Je\nplaisantais à moitié, mais ça veut dire\nque les rumeurs deviennent réalité?"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "We[SP]keep[SP]having[SP]to[SP]fend[SP]off[SP]demons,[SP]but[SP]it\nseems[SP]like[SP]most[SP]people[SP]don't[SP]even[SP]notice.[1205][001E]\nLet's[SP]just[SP]keep[SP]calling[SP]them[SP][1432][NULL][NULL][0014]assassins.[1432][NULL][NULL][0014]",
     "nom_fr": "Yukino",
-    "texte_fr": "On repousse des démons, mais la\nplupart des gens ne le remarquent\npas.[1205][001E] Appelons-les toujours [1432][NULL][NULL][0014]assassins.[1432][NULL][NULL][0014]"
+    "texte_fr": "On repousse des démons, mais la\nplupart des gens ne le remarquent\npas.[001E][1205] Appelons-les toujours [1432][NULL][NULL][0014]assassins.[1432][NULL][NULL][0014]"
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "That[SP]Hamya[SP]has[SP]a[SP]key[SP]too,[SP]right?[1205][001E][SP]So[SP]I'll[SP]get\nto[SP]see[SP]him[SP]at[SP]last...[1205][001E][SP]It's[SP]been[SP]three[SP]years,\nso[SP]I[SP]gotta[SP]make[SP]this[SP]count.[1205][001E][SP]Heheheheh...",
     "nom_fr": "Yukino",
-    "texte_fr": "Ce Hamya a une clé aussi, non?[1205][001E] Je vais\nenfin le voir...[1205][001E] Ça fait trois ans,\nalors il faut que ça compte.[1205][001E] Héhéhéhé..."
+    "texte_fr": "Ce Hamya a une clé aussi, non?[001E][1205] Je vais\nenfin le voir...[001E][1205] Ça fait trois ans,\nalors il faut que ça compte.[001E][1205] Héhéhéhé..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Rumors[SP]becoming[SP]reality?[1205][001E][SP]It[SP]sounds[SP]absurd,\nbut[SP]what[SP]happened[SP]back[SP]then[SP]seemed[SP]just[SP]as\nnonsensical.[SP]We'll[SP]just[SP]have[SP]to[SP]roll[SP]with[SP]it.",
     "nom_fr": "Yukino",
-    "texte_fr": "Les rumeurs deviennent réalité?[1205][001E] C'est\nabsurde, mais ce qui s'est passé à l'époque\nl'était tout autant. On\nva devoir faire avec."
+    "texte_fr": "Les rumeurs deviennent réalité?[001E][1205] C'est\nabsurde, mais ce qui s'est passé à l'époque\nl'était tout autant. On va devoir faire avec."
   },
   {
     "id": 16,
@@ -402,7 +402,7 @@
     "nom_orig": "Caretaker",
     "texte_orig": "Hohoho...[SP]That[SP]boy[SP]from[SP]Kasugayama[SP]High[SP]is\nso[SP]funny.[1205][000F][SP]I[SP]don't[SP]know[SP]why,[SP]but[SP]he[SP]said[SP]to\nme,[SP][1432][NULL][NULL][0014]Best[SP]of[SP]luck[SP]to[SP]you[SP]both.[1432][NULL][NULL][0014]",
     "nom_fr": "Infirmière",
-    "texte_fr": "Hohoho... Ce garçon de Kasugayama est\nsi drôle. [1205][000F]Sans savoir pourquoi, il\nm'a dit: [1432][NULL][NULL][0014]Bonne chance à vous deux.[1432][NULL][NULL][0014]"
+    "texte_fr": "Hohoho... Ce garçon de Kasugayama est\nsi drôle. [000F][1205]Sans savoir pourquoi, il\nm'a dit: [1432][NULL][NULL][0014]Bonne chance à vous deux.[1432][NULL][NULL][0014]"
   },
   {
     "id": 25,

--- a/traduction/event_scripts/script_259.json
+++ b/traduction/event_scripts/script_259.json
@@ -72,7 +72,7 @@
     "nom_orig": "???",
     "texte_orig": "Whew...[1205][001E][SP]No[SP]significant[SP]changes[SP]today[SP]either.[1205][001E]\nThe[SP]usual[SP]odd[SP]magnetism...[1205][001E][SP]I[SP]hope[SP]it[SP]stays\nat[SP]this[SP]level[SP]through[SP]the[SP]month...",
     "nom_fr": "???",
-    "texte_fr": "Ouf...[1205][001E] Aucun changement aujourd'hui\nnon plus.[1205][001E] Ce magnétisme étrange...[1205][001E]\nPourvu que ça reste ainsi ce mois..."
+    "texte_fr": "Ouf...[001E][1205] Aucun changement aujourd'hui\nnon plus.[001E][1205] Ce magnétisme étrange...[001E][1205]\nPourvu que ça reste ainsi ce mois..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Hm?[1205][001E][SP]You're[SP]one[SP]of[SP]Ms.[SP]Saeko's[SP]students...[1205][001E]\nDon't[SP]get[SP]too[SP]close[SP]to[SP]the[SP]Narurato[SP]Stone.\nWe[SP]don't[SP]know[SP]what[SP]effect[SP]it[SP]has[SP]on[SP]people.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Hm?[1205][001E] Tu es un des élèves de Mme Saeko...[1205][001E] Ne\nt'approche pas trop de la Pierre de\nNarurato. On ignore ses\neffets sur les gens."
+    "texte_fr": "Hm?[001E][1205] Tu es un des élèves de Mme Saeko...[001E][1205] Ne\nt'approche pas trop de la Pierre de\nNarurato. On ignore ses effets sur les gens."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Hm?[SP]Ms.[SP]Saeko?[SP]I[SP]don't[SP]know...[SP]I[SP]haven't\nnoticed[SP]her[SP]around.[1205][000F][SP]Maybe[SP]she's[SP]somewhere\nelse.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Hm? Mme Saeko? Je l'ignore... Je ne l'ai\npas vue ici. [1205][000F]Elle est peut-être ailleurs."
+    "texte_fr": "Hm? Mme Saeko? Je l'ignore... Je ne l'ai\npas vue ici. [000F][1205]Elle est peut-être ailleurs."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Ms.[SP]Ideal's[SP]been[SP]teaching[SP]here[SP]for[SP]11[SP]years,\nright?[SP]She's[SP]always[SP]saying[SP]weird[SP]stuff,[SP]but\nlately[SP]she[SP]seems[SP]nervous[SP]about[SP]some[SP]oracle.",
     "nom_fr": "Lycéen",
-    "texte_fr": "Mme Idéal enseigne ici depuis 11 ans, non?\nElle dit toujours des trucs bizarres, mais\nrécemment elle est\nnerveuse à cause d'unoracle."
+    "texte_fr": "Mme Idéal enseigne ici depuis 11 ans, non?\nElle dit toujours des trucs bizarres, mais\nrécemment elle est nerveuse à cause d'unoracle."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "Hey,[SP][1113]-kun![SP]Did[SP]you[SP]hear[SP]the[SP]rumor[SP]that\nthe[SP]principal's[SP]statue[SP]moves[SP]on[SP]its[SP]own?\nI[SP]like[SP]the[SP]guy,[SP]but[SP]that's[SP]super[SP]creepy.",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Hé, [1113]-kun! T'as entendu la rumeur comme\nquoi la statue du\ndirlo bouge toute seule? Je\nl'aime bien, mais c'est super flippant."
+    "texte_fr": "Hé, [1113]-kun! T'as entendu la rumeur comme\nquoi la statue du\ndirlo bouge toute seule? Je l'aime bien, mais c'est super flippant."
   },
   {
     "id": 9,

--- a/traduction/event_scripts/script_260.json
+++ b/traduction/event_scripts/script_260.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": ".[1205][000F].[1205][000F].[1205][000F].[1205][000F].[1205][000F].It's[SP]movin'.[E1][E2]\n[E3][E4][NULL][NULL]\"Lisa\nYep.[SP]It's[SP]movin'.",
     "nom_fr": "Eikichi",
-    "texte_fr": ".[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]..... Ça bouge.[E1][E2] [E3][E4][NULL][NULL]\"Lisa Ouais. Ça bouge."
+    "texte_fr": ".[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]..... Ça bouge.[E1][E2] [E3][E4][NULL][NULL]\"Lisa Ouais. Ça bouge."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": ".[1205][000F].[1205][000F].[1205][000F].[1205][000F].[1205][000F].So[SP]that[SP]settles[SP]it?",
     "nom_fr": "Eikichi",
-    "texte_fr": ".[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]..... Alors c'est sûr?"
+    "texte_fr": ".[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]..... Alors c'est sûr?"
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Gaaaaah![SP]Hell[SP]no![SP]That's[SP]impossible![SP]How[SP]could\nsomething[SP]this[SP]ridiculous[SP]actually[SP]happen!?[1205][001E]\nM-My[SP]3,000[SP]yen...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Gaaaah! Impossible! Comment un truc aussi\nridicule peut arriver!?[1205][001E] M-Mes 3000 yens..."
+    "texte_fr": "Gaaaah! Impossible! Comment un truc aussi\nridicule peut arriver!?[001E][1205] M-Mes 3000 yens..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "It's[SP]like[SP]we[SP]heard![SP]Rumors[SP]are[SP]coming[SP]true.[1205][001E]\nWoohoo,[SP]I'm[SP]3,000[SP]yen[SP]richer[SP]now![SP]Let's[SP]go\nget[SP]some[SP]dinner,[SP][1113]!",
     "nom_fr": "Lisa",
-    "texte_fr": "Comme on disait! Les rumeurs se\nréalisent.[1205][001E] Youhou, 3000 yens de plus\npour moi! Allons dîner, [1113]!"
+    "texte_fr": "Comme on disait! Les rumeurs se\nréalisent.[001E][1205] Youhou, 3000 yens de plus\npour moi! Allons dîner, [1113]!"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "It's[SP]like[SP]we[SP]heard![SP]Rumors[SP]are[SP]coming[SP]true.[1205][001E]\nWoohoo,[SP]I'm[SP]3,000[SP]yen[SP]richer[SP]now![SP]Let's[SP]go\nget[SP]some[SP]dinner,[SP][1113]!",
     "nom_fr": "Ginko",
-    "texte_fr": "Comme on disait! Les rumeurs se réalisent.[1205][001E]\nYouhou, 3000 yens de plus pour moi! Allons\ndîner, [1113]! Pierre Narurato Un mégalithe\ndéterré à la construction du lycée. Fait de\nthamatite, il possède un magnétisme anormal.[E1][E2] \nLa légende dit que c'est une pierre\ngardienne où l'être\ncéleste Hiremon a scellé\nle démon Narurato Hotefu. Statue en\nl'honneur du directeur Hanya [NULL][NULL]Regardez-moi!\nSuivez-moi! Ne comptez pas sur moi![NULL][NULL]\nest lacitation contradictoire écrite ici. La\nregarder vous met étrangement en colère..."
+    "texte_fr": "Comme on disait! Les rumeurs se réalisent.[001E][1205]\nYouhou, 3000 yens de plus pour moi! Allons\ndîner, [1113]! Pierre Narurato Un mégalithe\ndéterré à la construction du lycée. Fait de\nthamatite, il possède un magnétisme anormal.[E1][E2] \nLa légende dit que c'est une pierre\ngardienne où l'être\ncéleste Hiremon a scellé\nle démon Narurato Hotefu. Statue en\nl'honneur du directeur Hanya [NULL][NULL]Regardez-moi!\nSuivez-moi! Ne comptez pas sur moi![NULL][NULL]\nest lacitation contradictoire écrite ici. La\nregarder vous met étrangement en colère..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Alright,[SP]alright![1205][001E][SP]I[SP]admit[SP]it![SP]Rumors[SP]are\ncoming[SP]true![SP]Dammit...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ça va, ça va![1205][001E] J'avoue! Les\nrumeurs se réalisent! Bon sang..."
+    "texte_fr": "Ça va, ça va![001E][1205] J'avoue! Les\nrumeurs se réalisent! Bon sang..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "A[SP]memorial[SP]service[SP]for[SP]the[SP]principal?[1205][001E][SP]Uh-oh...\nThis[SP]is[SP]because[SP]of[SP]what[SP]you[SP]said,[SP][1113].\nI'm[SP]washing[SP]my[SP]hands[SP]of[SP]this[SP]one!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Une cérémonie pour le directeur?[1205][001E] Oh\noh... C'est à cause de ce que t'as\ndit, [1113]. Je m'en lave les mains!"
+    "texte_fr": "Une cérémonie pour le directeur?[001E][1205] Oh\noh... C'est à cause de ce que t'as\ndit, [1113]. Je m'en lave les mains!"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That[SP]lady's[SP]called[SP]Ms.[SP]Ideal,[SP]right?[1205][000F][SP]She[SP]seems\nlike[SP]a[SP]pretty[SP]weird[SP]teacher.[SP]Like[SP]she'd[SP]be[SP]more\nat[SP]home[SP]as[SP]an[SP]archaeologist...[SP]or[SP]a[SP]ninja.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Cette dame, c'est Mme Idéale, non?\n[1205][000F]Elle a l'air d'une prof bizarre. Elle\nferait mieux archéologue... ou ninja."
+    "texte_fr": "Cette dame, c'est Mme Idéale, non?\n[000F][1205]Elle a l'air d'une prof bizarre. Elle\nferait mieux archéologue... ou ninja."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "I[SP]think[SP]that[SP]stubborn[SP]Undie[SP]Boss[SP]finally[SP]gets\nwhat's[SP]going[SP]on.[1205][001E][SP]I'm[SP]glad[SP]I[SP]made[SP]that[SP]bet[SP]with\nhim[SP]on[SP]the[SP]way[SP]here!",
     "nom_fr": "Lisa",
-    "texte_fr": "Je crois que ce têtu de Boss des\nCalbutes a enfin compris.[1205][001E] Contente\nd'avoir parié avec lui en venant!"
+    "texte_fr": "Je crois que ce têtu de Boss des\nCalbutes a enfin compris.[001E][1205] Contente\nd'avoir parié avec lui en venant!"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]think[SP]that[SP]stubborn[SP]Undie[SP]Boss[SP]finally[SP]gets\nwhat's[SP]going[SP]on.[1205][001E][SP]I'm[SP]glad[SP]I[SP]made[SP]that[SP]bet[SP]with\nhim[SP]on[SP]the[SP]way[SP]here!",
     "nom_fr": "Ginko",
-    "texte_fr": "Je crois que ce têtu de Boss des\nCalbutes a enfin compris.[1205][001E] Contente\nd'avoir parié avec lui en venant!"
+    "texte_fr": "Je crois que ce têtu de Boss des\nCalbutes a enfin compris.[001E][1205] Contente\nd'avoir parié avec lui en venant!"
   },
   {
     "id": 13,
@@ -237,7 +237,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Wow![SP]The[SP]statue[SP]really[SP]is[SP]walking[SP]around...[1205][001E]\nThis[SP]is[SP]because[SP]of[SP]the[SP]rumor,[SP]huh?",
     "nom_fr": "Maya",
-    "texte_fr": "Ouah! La statue se balade vraiment...[1205][001E]\nC'est à cause de la rumeur, hein?"
+    "texte_fr": "Ouah! La statue se balade vraiment...[001E][1205]\nC'est à cause de la rumeur, hein?"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yikes...[1205][001E][SP]I[SP]think[SP]it's[SP]a[SP]little[SP]late[SP]now[SP]to\nstart[SP]suggesting[SP]he[SP]lived...",
     "nom_fr": "Maya",
-    "texte_fr": "Oh là là...[1205][001E] C'est un peu tard\npour suggérer qu'il a survécu..."
+    "texte_fr": "Oh là là...[001E][1205] C'est un peu tard\npour suggérer qu'il a survécu..."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Well,[SP]so[SP]what!?[SP]Nothing[SP]we[SP]can[SP]do[SP]now![1205][001E][SP]No[SP]use\ncrying[SP]over[SP]spilt[SP]milk,[SP]I[SP]guess.[1205][001E][SP]It[SP]was[SP]just\nanother[SP]student[SP]prank...",
     "nom_fr": "Maya",
-    "texte_fr": "Et alors!? On n'y peut plus rien![1205][001E]\nCe qui est fait est fait.[1205][001E] C'était\njuste une blague de lycéens..."
+    "texte_fr": "Et alors!? On n'y peut plus rien![001E][1205]\nCe qui est fait est fait.[001E][1205] C'était\njuste une blague de lycéens..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hey,[SP][1113]-kun...[1205][001E][SP]Doesn't[SP]that[SP]teacher\nlook[SP]like[SP]she[SP]knows[SP]something?[SP]I[SP]asked[SP]to\ninterview[SP]her,[SP]but[SP]she[SP]brushed[SP]me[SP]off.",
     "nom_fr": "Maya",
-    "texte_fr": "Hé, [1113]-kun...[1205][001E] On dirait que cette\nprof sait quelque chose, non? J'ai voulu\nl'interviewer, elle m'a envoyée balader."
+    "texte_fr": "Hé, [1113]-kun...[001E][1205] On dirait que cette\nprof sait quelque chose, non? J'ai voulu\nl'interviewer, elle m'a envoyée balader."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Doesn't[SP]seem[SP]like[SP]it's[SP]motorized...[1205][001E]\nWho'd[SP]have[SP]thought,[SP]huh?",
     "nom_fr": "Yukino",
-    "texte_fr": "Ça n'a pas l'air motorisé...[1205][001E]\nQui l'eût cru, hein?"
+    "texte_fr": "Ça n'a pas l'air motorisé...[001E][1205]\nQui l'eût cru, hein?"
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Maya-san...[1205][001E][SP]She's[SP]a[SP]character[SP]sometimes.",
     "nom_fr": "Yukino",
-    "texte_fr": "Maya-san...[1205][001E] Quel numéro, parfois."
+    "texte_fr": "Maya-san...[001E][1205] Quel numéro, parfois."
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "By[SP]the[SP]way,[SP][1113]...[SP]Is[SP]that[SP]big[SP]rock[SP]a\nHiremon[SP]Stone?[1205][001E][SP]We[SP]had[SP]something[SP]like[SP]it[SP]at\nSt.[SP]Hermelin[SP]too...",
     "nom_fr": "Yukino",
-    "texte_fr": "Au fait, [1113]... Ce rocher, c'est une\nPierre Hiremon?[1205][001E] On avait pareil à St.\nHermelin..."
+    "texte_fr": "Au fait, [1113]... Ce rocher, c'est une\nPierre Hiremon?[001E][1205] On avait pareil à St.\nHermelin..."
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Huh?[SP]It's[SP]the[SP]Narurato[SP]Stone?[1205][001E][SP]Really...\nI[SP]guess[SP]it[SP]does[SP]seem[SP]different[SP]from[SP]the[SP]one\nI[SP]remember...[SP]It[SP]creeps[SP]me[SP]out[SP]a[SP]little.",
     "nom_fr": "Yukino",
-    "texte_fr": "Hein? C'est la Pierre Narurato?[1205][001E] Ah oui...\nElle est différente de celle de mes\nsouvenirs... Elle me met mal à l'aise."
+    "texte_fr": "Hein? C'est la Pierre Narurato?[001E][1205] Ah oui...\nElle est différente de celle de mes\nsouvenirs... Elle me met mal à l'aise."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Is[SP]that[SP]big[SP]rock[SP]a[SP]Hiremon[SP]Stone?[1205][001E][SP]We[SP]had\nsomething[SP]like[SP]it[SP]at[SP]St.[SP]Hermelin[SP]too...",
     "nom_fr": "Yukino",
-    "texte_fr": "Ce rocher, c'est une Pierre Hiremon?[1205][001E]\nOn avait pareil à St. Hermelin..."
+    "texte_fr": "Ce rocher, c'est une Pierre Hiremon?[001E][1205]\nOn avait pareil à St. Hermelin..."
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Huh?[SP]It's[SP]the[SP]Narurato[SP]Stone?[1205][001E][SP]Really...\nI[SP]guess[SP]it[SP]does[SP]seem[SP]different[SP]from[SP]the[SP]one\nI[SP]remember...[SP]It[SP]creeps[SP]me[SP]out[SP]a[SP]little.",
     "nom_fr": "Yukino",
-    "texte_fr": "Hein? C'est la Pierre Narurato?[1205][001E] Ah oui...\nElle est différente de celle de mes\nsouvenirs... Elle me met mal à l'aise."
+    "texte_fr": "Hein? C'est la Pierre Narurato?[001E][1205] Ah oui...\nElle est différente de celle de mes\nsouvenirs... Elle me met mal à l'aise."
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "C-Could[SP]the[SP]Narurato[SP]Stone[SP]be[SP]affecting[SP]the\nstatue...?[1205][001E][SP]Th-This[SP]is[SP]terrible...[1205][001E][SP]Kashihara,\nwhat[SP]should[SP]I[SP]do...?",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "L-La Pierre Narurato affecterait\nla statue...?[1205][001E] C-C'est terrible...[1205][001E]\nKashihara, que dois-je faire...?"
+    "texte_fr": "L-La Pierre Narurato affecterait\nla statue...?[001E][1205] C-C'est terrible...[001E][1205]\nKashihara, que dois-je faire...?"
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Hm!?[1205][001E][SP]What[SP]are[SP]you[SP]kids[SP]doing[SP]here!?[SP]You[SP]must\nleave[SP]at[SP]once!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Hm!?[1205][001E] Que faites-vous ici!?\nPartez tout de suite!"
+    "texte_fr": "Hm!?[001E][1205] Que faites-vous ici!?\nPartez tout de suite!"
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "[1432][NULL][NULL][0014]Why[1432][NULL][NULL][0014]...!?[1205][001E][SP]L-Look[SP]at[SP]the[SP]statue![SP]I-It's[SP]walking\naround![SP]D-Don't[SP]you[SP]think[SP]that's[SP]dangerous!?",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "[1432][NULL][NULL][0014]Pourquoi[1432][NULL][NULL][0014]...!?[1205][001E] R-Regardez la statue! E-Elle\nse balade! C-C'est dangereux, non !?"
+    "texte_fr": "[1432][NULL][NULL][0014]Pourquoi[1432][NULL][NULL][0014]...!?[001E][1205] R-Regardez la statue! E-Elle\nse balade! C-C'est dangereux, non !?"
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]clock's[SP]been[SP]destroyed,[SP]but[SP]it's[SP]too[SP]late...[1205][001E]\nOne[SP]line[SP]of[SP]the[SP]Oracle[SP]is[SP]already[SP]fulfilled.[1205][001E]\nThe[SP]wheel[SP]of[SP]fortune[SP]is[SP]already[SP]moving!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "L'horloge est détruite, mais trop tard...[1205][001E]\nUn vers de l'Oracle s'est déjà réalisé.[1205][001E]\nLa roue du destin est en marche!"
+    "texte_fr": "L'horloge est détruite, mais trop tard...[001E][1205]\nUn vers de l'Oracle s'est déjà réalisé.[001E][1205]\nLa roue du destin est en marche!"
   },
   {
     "id": 29,

--- a/traduction/event_scripts/script_261.json
+++ b/traduction/event_scripts/script_261.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]looove[SP]sushi![1205][001E][SP]I[SP]stay[SP]away[SP]from[SP]grilled[SP]or\nbroiled[SP]fish,[SP]though,[SP]ever[SP]since[SP]a[SP]bone[SP]got\nstuck[SP]in[SP]my[SP]throat[SP]when[SP]I[SP]was[SP]little.",
     "nom_fr": "Ginko",
-    "texte_fr": "J'adooore les sushis![1205][001E] J'évite le\npoisson grillé depuis qu'une arête\nm'est restée en travers de la gorge."
+    "texte_fr": "J'adooore les sushis![001E][1205] J'évite le\npoisson grillé depuis qu'une arête\nm'est restée en travers de la gorge."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]remember[SP]when[SP]this[SP]place[SP]got[SP]a[SP]writeup[SP]in[SP]our\nsister[SP]magazine,[SP]Gourmet[SP]King.[1205][001E][SP]It[SP]got[SP]three[SP]stars\nfor[SP]its[SP]price,[SP]flavor,[SP]and[SP]generous[SP]portions.",
     "nom_fr": "Maya",
-    "texte_fr": "Cet endroit a été mentionné dans notre\nmagazine partenaire, Gourmet King.[1205][001E] Trois\nétoiles pour le prix,\nla saveur et les portions."
+    "texte_fr": "Cet endroit a été mentionné dans notre\nmagazine partenaire, Gourmet King.[001E][1205] Trois\nétoiles pour le prix,\nla saveur et les portions."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "There's[SP]Toro,[SP]munching[SP]on[SP]toro...[1205][001E][SP]He[SP]and[SP]I\nwere[SP]classmates[SP]in[SP]high[SP]school.[SP]Poor[SP]guy\ngot[SP]picked[SP]on[SP]a[SP]lot.",
     "nom_fr": "Yukino",
-    "texte_fr": "Tiens, Toro mange du toro...[1205][001E] On\nétait dans la même classe au lycée.\nCe gars se faisait souvent embêter."
+    "texte_fr": "Tiens, Toro mange du toro...[001E][1205] On\nétait dans la même classe au lycée.\nCe gars se faisait souvent embêter."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "So[SP]he's[SP]a[SP]top-ranking[SP]salesman[SP]now,[SP]huh?\nGood[SP]for[SP]him![SP]It[SP]brightens[SP]my[SP]day[SP]a[SP]little\nhearing[SP]that.",
     "nom_fr": "Yukino",
-    "texte_fr": "Il est maintenant vendeur\nde haut rang? Bravo\npour lui! Ça me\nréjouit un peu d'entendre ça."
+    "texte_fr": "Il est maintenant vendeur\nde haut rang? Bravo\npour lui! Ça me réjouit un peu d'entendre ça."
   },
   {
     "id": 4,
@@ -125,7 +125,7 @@
     "nom_orig": "Chef",
     "texte_orig": "Okay,[SP]then![1205][000A][SP]Anything[SP]else?\n[1208][0004]Dine[SP]in\nTalk[SP]with[SP]the[SP]chef\nCancel\nLeave",
     "nom_fr": "Chef",
-    "texte_fr": "Parfait![1205][000A] Autre chose?\n[1208][0004]Manger ici\nParler au chef\nAnnuler\nPartir",
+    "texte_fr": "Parfait![000A][1205] Autre chose?\n[1208][0004]Manger ici\nParler au chef\nAnnuler\nPartir",
     "question_orig": "Okay,[SP]then![1205][000A][SP]Anything[SP]else?",
     "choix_orig": [
       "Dine[SP]in",
@@ -404,7 +404,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Whoa...[1205][001E][SP]The[SP]principal[SP]at[SP]Sevens[SP]suddenly[SP]grew\nsome[SP]hair?[SP]I[SP]wonder[SP]if[SP]that[SP]was[SP]his[SP]request\nfor[SP]Joker.",
     "nom_fr": "Toro",
-    "texte_fr": "Ouah...[1205][001E] Le directeur de Seven a\npoussé des cheveux? Je me demande\nsi c'était sa requête pour Joker."
+    "texte_fr": "Ouah...[001E][1205] Le directeur de Seven a\npoussé des cheveux? Je me demande\nsi c'était sa requête pour Joker."
   },
   {
     "id": 20,
@@ -434,7 +434,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh...[SP]You[SP]were[SP]at[SP]Sevens'[SP]clock[SP]tower...[1205][000F][SP]and\nyou[SP]saw[SP]a[SP]real[SP]ghost?[SP]Yikes,[SP]I'm[SP]not[SP]much[SP]for\nspooky[SP]stuff.[1205][000F][SP]I'll[SP]tell[SP]you[SP]a[SP]story[SP]instead.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hm... À la tour de Seven, un vrai fantôme?\n[1205][000F][1205][000F]Oh là là, les trucs effrayants, c'est pas\nmon truc. Voici une histoire à la place."
+    "texte_fr": "Hm... À la tour de Seven, un vrai fantôme?\n[000F][1205][000F][1205]Oh là là, les trucs effrayants, c'est pas\nmon truc. Voici une histoire à la place."
   },
   {
     "id": 22,
@@ -509,7 +509,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "You[SP]know[SP]the[SP][E4][NULL][NULL][0006]Jolly[SP]Roger[E4][NULL][NULL][0002][SP]cafe[SP]in[SP]Kounan?[1205][000F]\nThey[SP]supposedly[SP]sell[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002].[1205][000F][SP]Their\nselection[SP]is[SP][E4][NULL][NULL][0006]cheap[SP]and[SP]low[SP]quality[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Vous connaissez [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à Kounan?\n[1205][000F][1205][000F]Ils vendent de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. Leur choix\nest [E4][NULL][NULL][0006]bon marché, mauvaise qualité[E4][NULL][NULL][0002]."
+    "texte_fr": "Vous connaissez [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à Kounan?\n[000F][1205][000F][1205]Ils vendent de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. Leur choix\nest [E4][NULL][NULL][0006]bon marché, mauvaise qualité[E4][NULL][NULL][0002]."
   },
   {
     "id": 27,
@@ -524,7 +524,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh...[1205][001E][SP]Something[SP]terrible[SP]will[SP]happen[SP]if[SP]the\nclock[SP]at[SP]Sevens[SP]starts[SP]again?[SP]That's[SP]pretty\nout-there.[SP]Well,[SP]here's[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hm...[1205][001E] Quelque chose de terrible si\nl'horloge de Seven repart? C'est\nbizarre. Voilà ce que je sais."
+    "texte_fr": "Hm...[001E][1205] Quelque chose de terrible si\nl'horloge de Seven repart? C'est\nbizarre. Voilà ce que je sais."
   },
   {
     "id": 28,
@@ -539,7 +539,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "The[SP]rumor[SP]is[SP]that[SP][E4][NULL][NULL][0006]Rosa[SP]Candida[E4][NULL][NULL][0002][SP]sells\n[E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]They[SP]have[SP][E4][NULL][NULL][0006]reasonable[SP]prices,\nbut[SP]low-quality[SP]stuff[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "[E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002] vend de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [1205][000F][E4][NULL][NULL][0006]Prix\nraisonnables, mais qualité médiocre[E4][NULL][NULL][0002]."
+    "texte_fr": "[E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002] vend de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [000F][1205][E4][NULL][NULL][0006]Prix\nraisonnables, mais qualité médiocre[E4][NULL][NULL][0002]."
   },
   {
     "id": 29,
@@ -569,7 +569,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "There's[SP]a[SP]rumor[SP]you[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002][SP]at\n[E4][NULL][NULL][0006]Anima[SP]Mundi[E4][NULL][NULL][0002][SP]in[SP]Yumezaki.[1205][000F][SP]Their[SP]stuff[SP]is\n[E4][NULL][NULL][0006]cheap[SP]and[SP]subpar[SP]quality[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "De [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002] chez\n[E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002] à Yumezaki.\n[1205][000F]Leur sélection: [E4][NULL][NULL][0006]bon marché, piètre qualité[E4][NULL][NULL][0002]."
+    "texte_fr": "De [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002] chez\n[E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002] à Yumezaki.\n[000F][1205]Leur sélection: [E4][NULL][NULL][0006]bon marché, piètre qualité[E4][NULL][NULL][0002]."
   },
   {
     "id": 31,
@@ -629,7 +629,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "There's[SP]a[SP]shop[SP]called[SP][E4][NULL][NULL][0006]London[SP]Clothier[E4][NULL][NULL][0002][SP]in[SP]Kounan\nthat[SP]even[SP]tailors[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]The[SP][E4][NULL][NULL][0006]quality[SP]is\nsubpar,[SP]but[SP]they're[SP]cheap[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "[E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] à Kounan confectionne de\n[E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [1205][000F][E4][NULL][NULL][0006]Qualité médiocre, mais pas\ncher[E4][NULL][NULL][0002]."
+    "texte_fr": "[E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] à Kounan confectionne de\n[E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [000F][1205][E4][NULL][NULL][0006]Qualité médiocre, mais pas\ncher[E4][NULL][NULL][0002]."
   },
   {
     "id": 35,
@@ -659,7 +659,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "What[SP]is[SP]that[SP]exactly?[1205][000F][SP]Some[SP]kind[SP]of[SP]special\njob...?[1205][000F][SP]Well,[SP]anyways.[SP]Here's[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "C'est quoi exactement? [1205][000F][1205][000F]Un genre de métier\nspécial...? Bref. Voilà ce que je sais."
+    "texte_fr": "C'est quoi exactement? [000F][1205][000F][1205]Un genre de métier\nspécial...? Bref. Voilà ce que je sais."
   },
   {
     "id": 37,
@@ -719,7 +719,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Do[SP]you[SP]know[SP]the[SP]arcade[SP][E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]?[1205][000F][SP]I[SP]hear[SP]that[SP]place\nis[SP]really[SP]a[SP][E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002],[SP]and[SP]people[SP]can[SP]make[SP]a[SP][E4][NULL][NULL][0006]ton\nof[SP]money[SP]on[SP]the[SP]slots[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Vous connaissez [E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]? [1205][000F]C'est en réalité\nun [E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002], et on peut se faire une\n[E4][NULL][NULL][0006]belle somme aux machines à sous[E4][NULL][NULL][0002]."
+    "texte_fr": "Vous connaissez [E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]? [000F][1205]C'est en réalité\nun [E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002], et on peut se faire une\n[E4][NULL][NULL][0006]belle somme aux machines à sous[E4][NULL][NULL][0002]."
   },
   {
     "id": 41,
@@ -749,7 +749,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh?[SP]Masked[SP]Circle?[SP]I've[SP]never[SP]heard[SP]of[SP]it.[1205][000F]\nIs[SP]that[SP]some[SP]kind[SP]of[SP]organization?[SP]And[SP]these\npeople[SP]are[SP]here,[SP]in[SP]this[SP]city?",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hm? Cercle masqué? Jamais entendu\n[1205][000F]parler. C'est une organisation? Et\nils sont ici, dans cette ville?"
+    "texte_fr": "Hm? Cercle masqué? Jamais entendu\n[000F][1205]parler. C'est une organisation? Et\nils sont ici, dans cette ville?"
   },
   {
     "id": 43,
@@ -764,7 +764,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "That's[SP]big.[SP]I[SP]should[SP]look[SP]into[SP]it[SP]immediately.[1205][000F]\nHmm,[SP]maybe[SP]the[SP]girl[SP]at[SP]Peace[SP]Diner[SP]might[SP]know\nmore.[SP]Have[SP]you[SP]tried[SP]asking[SP]her[SP]about[SP]them?",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "C'est sérieux. Je dois me renseigner.\n[1205][000F]Hmm, la fille de Peace Diner en sait\npeut-être plus. Lui avez-vous demandé?"
+    "texte_fr": "C'est sérieux. Je dois me renseigner.\n[000F][1205]Hmm, la fille de Peace Diner en sait\npeut-être plus. Lui avez-vous demandé?"
   },
   {
     "id": 44,
@@ -779,7 +779,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Looks[SP]like[SP]you've[SP]got[SP]a[SP]lot[SP]of[SP]rumors[SP]ready\nto[SP]unload.[1205][000F][SP]I'll[SP]gather[SP]some[SP]new[SP]ones[SP]too,\nso[SP]let's[SP]swap[SP]stories[SP]then.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "On dirait que vous avez des rumeurs\nà partager. [1205][000F]Je vais en collecter\naussi, alors échangeons bientôt."
+    "texte_fr": "On dirait que vous avez des rumeurs\nà partager. [000F][1205]Je vais en collecter\naussi, alors échangeons bientôt."
   },
   {
     "id": 45,
@@ -899,7 +899,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "Hwaha![SP]I've[SP]finally[SP]been[SP]promoted[SP]to[SP]president.\nEating[SP]sushi[SP]at[SP]lunch[SP]while[SP]my[SP]underlings[SP]do\nall[SP]the[SP]work[SP]proves[SP]I've[SP]gone[SP]up[SP]the[SP]ladder!",
     "nom_fr": "PDG",
-    "texte_fr": "Hahaha! J'ai enfin été promu président.\nManger des sushis le midi pendant que mes\nsubordonnés bossent prouve\nque j'ai réussi!"
+    "texte_fr": "Hahaha! J'ai enfin été promu président.\nManger des sushis le midi pendant que mes\nsubordonnés bossent prouve que j'ai réussi!"
   },
   {
     "id": 53,
@@ -1004,7 +1004,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "The[SP]third[SP]member[SP]of[SP]Muses[SP]has[SP]finally[SP]been\nannounced![1205][000F][SP]Sadly,[SP]I[SP]only[SP]heard[SP]her[SP]voice[SP]over\nthe[SP]radio...[SP]I[SP]can't[SP]wait[SP]to[SP]see[SP]her[SP]face!",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Le troisième membre des Muses enfin\n[1205][000F]annoncé! Hélas, que sa voix à la\nradio... J'ai hâte de voir son visage!"
+    "texte_fr": "Le troisième membre des Muses enfin\n[000F][1205]annoncé! Hélas, que sa voix à la\nradio... J'ai hâte de voir son visage!"
   },
   {
     "id": 60,
@@ -1034,7 +1034,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Smile[SP]Hirasaka's[SP]just[SP]an[SP]ordinary[SP]train\nstation.[1205][000F][SP]What[SP]do[SP]the[SP]terrorists[SP]hope[SP]to\ngain[SP]by[SP]blowing[SP]it[SP]up?",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Smile Hirasaka n'est qu'une gare ordinaire.\n[1205][000F]Qu'espèrent les terroristes\nà la faire sauter?"
+    "texte_fr": "Smile Hirasaka n'est qu'une gare ordinaire.\n[000F][1205]Qu'espèrent les terroristes\nà la faire sauter?"
   },
   {
     "id": 62,
@@ -1064,7 +1064,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "But[SP]if[SP]there[SP]is[SP]a[SP]group[SP]fighting[SP]the[SP]Masked\nCircle...[SP]That's[SP]pretty[SP]interesting[SP]in[SP]its\nown[SP]right.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Mais s'il existe un groupe qui combat le\nCercle masqué... C'est\nplutôt intéressant en\nsoi."
+    "texte_fr": "Mais s'il existe un groupe qui combat le\nCercle masqué... C'est\nplutôt intéressant en soi."
   },
   {
     "id": 64,
@@ -1109,7 +1109,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Rumor[SP]has[SP]it[SP]that[SP]the[SP]ghost[SP]Hanako-san[SP]is\nhaunting[SP]Sevens.[1205][000F][SP]Does[SP]she[SP]actually[SP]exist?",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "On dit que le fantôme Hanako-san\nhante Seven. [1205][000F]Existe-t-elle vraiment?"
+    "texte_fr": "On dit que le fantôme Hanako-san\nhante Seven. [000F][1205]Existe-t-elle vraiment?"
   },
   {
     "id": 67,
@@ -1139,7 +1139,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "I[SP]heard[SP]the[SP]ghost[SP]of[SP]an[SP]idol[SP]who[SP]starved[SP]to\ndeath[SP]at[SP]Aoba[SP]Park[SP]is[SP]appearing[SP]there.[SP]That's\none[SP]of[SP]the[SP]saddest[SP]things[SP]I've[SP]ever[SP]heard...",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Le fantôme d'une idole\nmorte de faim au parc\nAoba y apparaît. C'est l'une des choses les\nplus tristes que j'aie entendues..."
+    "texte_fr": "Le fantôme d'une idole\nmorte de faim au parc\nAoba y apparaît. C'est l'une des choses les plus tristes que j'aie entendues..."
   },
   {
     "id": 69,
@@ -1214,7 +1214,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "There've[SP]been[SP]sightings[SP]of[SP]the[SP]Jumping[SP]Geezer\nat[SP]Mt.[SP]Katatsumuri.[SP]I[SP]thought[SP]it[SP]showed[SP]up[SP]on\nroads[SP]and[SP]tunnels...[SP]add[SP]mountains[SP]to[SP]the[SP]list.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "On a aperçu le Vieux Sauteur au Mont\nKatatsumuri. Je croyais\nqu'il apparaissait sur\nles routes et\ntunnels... Ajoutons les montagnes."
+    "texte_fr": "On a aperçu le Vieux Sauteur au Mont\nKatatsumuri. Je croyais\nqu'il apparaissait sur les routes et tunnels... Ajoutons les montagnes."
   },
   {
     "id": 74,
@@ -1229,7 +1229,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Gah...[1205][000F][SP]I[SP]heard[SP]something[SP]awful...[1205][000F][SP]K-Kudan's...\nKudan's[SP]at[SP]the[SP]abandoned[SP]factory...[1205][000F][SP]No,[SP]I[SP]don't\nwant[SP]to[SP]think[SP]about[SP]it![E1][E2]\n\n\n[E3][E4][NULL][NULL]\"Sushi[SP]Royalty\nYou[SP]know[SP]about[SP]Giga[SP]Macho's[SP]secret[SP]CD?[1205][000F]\nI[SP]hear[SP]there[SP]is[SP]one.[SP]I'd[SP]love[SP]to[SP]know[SP]what\nkind[SP]of[SP]tracks[SP]are[SP]on[SP]it.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Argh.[1205][000F][1205][000F][1205][000F][1205][000F].. J'ai ouï quelque chose\nd'horrible... Kudan... Kudan est à\nl'usine abandonnée... Non,\nj'veux pasy penser![E1][E2]\n[E3][E4][NULL][NULL]\"Sushi Royalty\nVous savez pour\nle CD de Giga Macho? On dit\nqu'il existe.Je veux savoir quels morceaux sont dessus."
+    "texte_fr": "Argh.[000F][1205][000F][1205][000F][1205][000F][1205].. J'ai ouï quelque chose\nd'horrible... Kudan... Kudan est à\nl'usine abandonnée... Non,\nj'veux pasy penser![E1][E2]\n[E3][E4][NULL][NULL]\"Sushi Royalty\nVous savez pour\nle CD de Giga Macho? On dit\nqu'il existe.Je veux savoir quels morceaux sont dessus."
   },
   {
     "id": 75,
@@ -1244,7 +1244,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "The[SP]dreaded[SP]Dresser[SP]Hag[SP]is[SP]apparently[SP]showing\nup[SP]at[SP]the[SP]abandoned[SP]factory[SP]in[SP]Kounan.[1205][000F][SP]What\nkind[SP]of[SP]monster[SP]is[SP]that,[SP]I[SP]ask[SP]you?",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "La Sorcière du Placard semble\napparaître à l'usine abandonnée de\n[1205][000F]Kounan. C'est quoi comme monstre, ça?"
+    "texte_fr": "La Sorcière du Placard semble\napparaître à l'usine abandonnée de\n[000F][1205]Kounan. C'est quoi comme monstre, ça?"
   },
   {
     "id": 76,
@@ -1274,7 +1274,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "I[SP]hear[SP]Time[SP]Castle[SP]in[SP]Rengedai[SP]sells[SP]real\nweapons.[SP]Sounds[SP]dangerous...[SP]It's[SP]good[SP]quality\nstuff,[SP]but[SP]it's[SP]pricey.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Time Castle à Rengedai\nvend de vraies armes.\nDangereux... Bonne qualité,\nmais c'est cher."
+    "texte_fr": "Time Castle à Rengedai\nvend de vraies armes.\nDangereux... Bonne qualité, mais c'est cher."
   },
   {
     "id": 78,
@@ -1289,7 +1289,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "I[SP]hear[SP]Time[SP]Castle[SP]in[SP]Rengedai[SP]sells[SP]real\nweapons.[SP]Sounds[SP]dangerous...[SP]It's[SP]cheap,\nsubpar[SP]stuff.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Time Castle à Rengedai\nvend de vraies armes.\nDangereux... Bon marché,\nmais piètre qualité."
+    "texte_fr": "Time Castle à Rengedai\nvend de vraies armes.\nDangereux... Bon marché, mais piètre qualité."
   },
   {
     "id": 79,
@@ -1484,7 +1484,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Jolly[SP]Roger[SP]in[SP]Kounan[SP]sells[SP]real[SP]weapons,\nI[SP]hear.[SP]They[SP]pay[SP]a[SP]lot[SP]on[SP]resale,[SP]but[SP]their\nselection[SP]is[SP]pretty[SP]bad.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Jolly Roger à Kounan\nvendrait de vraies armes.\nBon prix de\nrachat, mais sélection mauvaise."
+    "texte_fr": "Jolly Roger à Kounan\nvendrait de vraies armes.\nBon prix de rachat, mais sélection mauvaise."
   },
   {
     "id": 92,
@@ -1769,7 +1769,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "I[SP]hear[SP]that[SP]the[SP]prizes[SP]for[SP]the[SP]magazine\nsweepstakes[SP]are[SP]real[SP]weapons[SP]and[SP]items.\nYou[SP]rarely[SP]win,[SP]but[SP]the[SP]prizes[SP]are[SP]good.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Les lots des tirages de magazines sont de\nvraies armes et objets.\nRares à gagner, mais\nbons."
+    "texte_fr": "Les lots des tirages de magazines sont de\nvraies armes et objets.\nRares à gagner, mais bons."
   },
   {
     "id": 111,

--- a/traduction/event_scripts/script_262.json
+++ b/traduction/event_scripts/script_262.json
@@ -27,7 +27,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "Bad[SP]luck,[SP][1113]-senpai.[SP]I'm[SP]surprised\nat[SP]how[SP]popular[SP]Principal[SP]Hanya[SP]is.[1205][001E][SP]He's\nawful,[SP]but[SP]I[SP]like[SP]him...[SP]Why[SP]is[SP]that?",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Pas de bol, [1113]-senpai.[1205][001E]\nSurprenant que le proviseur plaise autant.\nIl est affreux, mais je l'adore..."
+    "texte_fr": "Pas de bol, [1113]-senpai.[001E][1205]\nSurprenant que le proviseur plaise autant.\nIl est affreux, mais je l'adore..."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "[1113]-senpai!?[SP]This[SP]is[SP]so[SP]sudden...[1205][001E]\nI'm[SP]inexperienced...[SP]My[SP]heart's[SP]not\nready...[1205][001E][SP]But[SP]maybe[SP]for[SP]you,[SP]I[SP]could...!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "[1113]-senpai!? C'est si soudain.[1205][1205].[001E][001E]. Je n'ai\npas l'habitude... Mon\ncœur s'emballe... Mais\navec toi, je pourrais essayer!"
+    "texte_fr": "[1113]-senpai!? C'est si soudain.[1205][1205].[001E][001E]. Je n'ai\npas l'habitude... Mon\ncœur s'emballe... Mais avec toi, je pourrais essayer!"
   },
   {
     "id": 4,
@@ -72,6 +72,6 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "Huh?[SP]Ms.[SP]Saeko?[1205][001E][SP]I[SP]dunno...[SP]Maybe[SP]in[SP]the\nteacher's[SP]lounge[SP]on[SP]the[SP]second[SP]floor?[1205][001E][SP]*sigh*\nOf[SP]course[SP]it[SP]wasn't[SP]me[SP]you're[SP]after...",
     "nom_fr": "",
-    "texte_fr": "Hein ? Mme Saeko ?[1205][001E] Je sais pas...\nDans la salle des profs au deuxième étage ?[1205][001E]\n*soupir* Bien sûr que c'est pas moi que vous cherchez..."
+    "texte_fr": "Hein ? Mme Saeko ?[001E][1205] Je sais pas...\nDans la salle des profs au deuxième étage ?[001E][1205]\n*soupir* Bien sûr que c'est pas moi que vous cherchez..."
   }
 ]

--- a/traduction/event_scripts/script_263.json
+++ b/traduction/event_scripts/script_263.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "So[SP]he[SP]feels[SP]fine[SP]as[SP]long[SP]as[SP]he's[SP]safe?[1205][001E]\nLooks[SP]like[SP]all[SP]the[SP]guys[SP]at[SP]Sevens[SP]are\nlameasses.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tant qu'il est en sûreté, ça va?[1205][001E] Tous\nles gars de Seven sont des mauviettes."
+    "texte_fr": "Tant qu'il est en sûreté, ça va?[001E][1205] Tous\nles gars de Seven sont des mauviettes."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]guys[SP]aside,[SP]I[SP]hate[SP]to[SP]see[SP]a[SP]lady[SP]like\nyou[SP]so[SP]sad.[1205][001E][SP]Dry[SP]those[SP]eyes,[SP]little[SP]girl!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Les gars, ça va. Mais voir une dame aussi\ntriste...[1205][001E] Sèche ces larmes, petite!"
+    "texte_fr": "Les gars, ça va. Mais voir une dame aussi\ntriste...[001E][1205] Sèche ces larmes, petite!"
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Don't[SP]fret[SP]over[SP]how[SP]to[SP]thank[SP]me.[SP]If[SP]you[SP]insist\non[SP]a[SP]reward,[SP]a[SP]kiss[SP]will[SP]be[SP]enough.[1205][001E][SP]I'd[SP]risk\nmy[SP]life[SP]over[SP]one[SP]kiss[SP]from[SP]you!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ne te soucie pas. Si tu veux me\nrécompenser, un baiser suffit.[1205][001E] Je\nrisquerais ma vie pour ton baiser!"
+    "texte_fr": "Ne te soucie pas. Si tu veux me\nrécompenser, un baiser suffit.[001E][1205] Je\nrisquerais ma vie pour ton baiser!"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "L-Little[SP]girl...[1205][001E][SP]Th-That[SP]was[SP]one[SP]whopper[SP]of[SP]a\nkiss...[1205][001E][SP]I-I[SP]doubt[SP]we'll[SP]meet[SP]again,[SP]though...",
     "nom_fr": "Eikichi",
-    "texte_fr": "P-Petite...[1205][001E] C-C'était un sacré baiser...[1205][001E]\nJ-Je doute qu'on se reverra, pourtant..."
+    "texte_fr": "P-Petite...[001E][1205] C-C'était un sacré baiser...[001E][1205]\nJ-Je doute qu'on se reverra, pourtant..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#2![1205][001E][SP][1432][NULL][NULL][0014]Wai![1432][NULL][NULL][0014][SP]is[SP]used\nlike[SP][1432][NULL][NULL][0014]Hey![1432][NULL][NULL][0014][SP]when[SP]you're[SP]calling[SP]to[SP]someone.",
     "nom_fr": "Lisa",
-    "texte_fr": "Cours de cantonais de Lisa #2![1205][001E] [1432][NULL][NULL][0014]Wai![1432][NULL][NULL][0014]\ns'utilise comme [1432][NULL][NULL][0014]Hé![1432][NULL][NULL][0014] pour appeler quelqu'un."
+    "texte_fr": "Cours de cantonais de Lisa #2![001E][1205] [1432][NULL][NULL][0014]Wai![1432][NULL][NULL][0014]\ns'utilise comme [1432][NULL][NULL][0014]Hé![1432][NULL][NULL][0014] pour appeler quelqu'un."
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#2![1205][001E][SP][1432][NULL][NULL][0014]Wai![1432][NULL][NULL][0014][SP]is[SP]used\nlike[SP][1432][NULL][NULL][0014]Hey![1432][NULL][NULL][0014][SP]when[SP]you're[SP]calling[SP]to[SP]someone.",
     "nom_fr": "Ginko",
-    "texte_fr": "Cours de cantonais de Lisa #2![1205][001E] [1432][NULL][NULL][0014]Wai![1432][NULL][NULL][0014]\ns'utilise comme [1432][NULL][NULL][0014]Hé![1432][NULL][NULL][0014] pour appeler quelqu'un."
+    "texte_fr": "Cours de cantonais de Lisa #2![001E][1205] [1432][NULL][NULL][0014]Wai![1432][NULL][NULL][0014]\ns'utilise comme [1432][NULL][NULL][0014]Hé![1432][NULL][NULL][0014] pour appeler quelqu'un."
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#5![1205][001E][SP][1432][NULL][NULL][0014]Kehhei[1432][NULL][NULL][0014][SP]means\n[1432][NULL][NULL][0014]how[SP]annoying.[1432][NULL][NULL][0014][SP]You[SP]usually[SP]use[SP]it[SP]when[SP]you\nwant[SP]people[SP]to[SP]know[SP]you're[SP]pissed!",
     "nom_fr": "Ginko",
-    "texte_fr": "Cours de cantonais de Lisa #5![1205][001E] [1432][NULL][NULL][0014]Kehhei[1432][NULL][NULL][0014]\nsignifie [1432][NULL][NULL][0014]quelle plaie.[1432][NULL][NULL][0014] On l'utilise\nquand on veut montrer qu'on est agacé!"
+    "texte_fr": "Cours de cantonais de Lisa #5![001E][1205] [1432][NULL][NULL][0014]Kehhei[1432][NULL][NULL][0014]\nsignifie [1432][NULL][NULL][0014]quelle plaie.[1432][NULL][NULL][0014] On l'utilise\nquand on veut montrer qu'on est agacé!"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#7![1205][001E][SP]You[SP]say[SP][1432][NULL][NULL][0014]Kaumena[1432][NULL][NULL][0014]\nwhen[SP]you're[SP]asking[SP]for[SP]help![SP]Remember[SP]that!",
     "nom_fr": "Ginko",
-    "texte_fr": "Cours de cantonais de Lisa #7![1205][001E] On dit [1432][NULL][NULL][0014]\nKaumena[1432][NULL][NULL][0014] pour demander\nde l'aide! Retiens ça!"
+    "texte_fr": "Cours de cantonais de Lisa #7![001E][1205] On dit [1432][NULL][NULL][0014]\nKaumena[1432][NULL][NULL][0014] pour demander\nde l'aide! Retiens ça!"
   },
   {
     "id": 11,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Sure,[SP]the[SP]students[SP]are[SP]acting[SP]strange...[1205][000A]\nBut[SP]there's[SP]nothing[SP]inherently[SP]wrong[SP]with[SP]the\nprincipal's[SP]orders[SP]to[SP]respect[SP]the[SP]school.",
     "nom_fr": "Maya",
-    "texte_fr": "Certes, les élèves agissent bizarrement...[1205][000A]\nMais il n'y a rien de fondamentalement\nmauvais dans les ordres du directeur."
+    "texte_fr": "Certes, les élèves agissent bizarrement...[000A][1205]\nMais il n'y a rien de fondamentalement\nmauvais dans les ordres du directeur."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]can't[SP]put[SP]my[SP]finger[SP]on[SP]it,[SP]but[SP]it[SP]feels[SP]like\nthere's[SP]some[SP]kind[SP]of[SP]discrepancy[SP]here...[1205][000F][SP]I[SP]just\nget[SP]this[SP]feeling...",
     "nom_fr": "Maya",
-    "texte_fr": "Je ne peux pas le définir, mais il y a\ncomme une incohérence ici.[1205][000F].. Je le sens..."
+    "texte_fr": "Je ne peux pas le définir, mais il y a\ncomme une incohérence ici.[000F][1205].. Je le sens..."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hahah...[SP]It's[SP]cute[SP]how[SP]embarrassed[SP]Eikichi-kun\nis.[SP]I[SP]bet[SP]this[SP]will[SP]stay[SP]with[SP]him[SP]for[SP]a[SP]long\ntime.[1205][000F][SP]Wish[SP]I[SP]could[SP]relive[SP]my[SP]high[SP]school[SP]days..",
     "nom_fr": "Maya",
-    "texte_fr": "Hahah... C'est mignon comme Eikichi-kun\nest gêné. Ça va lui rester un bon moment.\n[1205][000F]J'aimerais revivre mes années de lycée..."
+    "texte_fr": "Hahah... C'est mignon comme Eikichi-kun\nest gêné. Ça va lui rester un bon moment.\n[000F][1205]J'aimerais revivre mes années de lycée..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "How[SP]in[SP]the[SP]world[SP]can[SP]that[SP]guy[SP]deliver[SP]lines\nlike[SP]that[SP]with[SP]a[SP]straight[SP]face?[1205][001E][SP]Eh,[SP]I'm[SP]sure\nhe's[SP]just[SP]trying[SP]to[SP]cheer[SP]her[SP]up.",
     "nom_fr": "Yukino",
-    "texte_fr": "Comment ce type peut-il dire ça avec\nun visage impassible?[1205][001E] Bah, il cherche\nsûrement à la remonter le moral."
+    "texte_fr": "Comment ce type peut-il dire ça avec\nun visage impassible?[001E][1205] Bah, il cherche\nsûrement à la remonter le moral."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "[1432][NULL][NULL][0014]Little[SP]girl[1432][NULL][NULL][0014]?[SP]My[SP]skin's[SP]starting[SP]to[SP]crawl...[1205][001E]\nIs[SP]his[SP]head[SP]really[SP]okay?",
     "nom_fr": "Yukino",
-    "texte_fr": "[1432][NULL][NULL][0014]Petite[1432][NULL][NULL][0014]? J'en ai la chair de\npoule...[1205][001E] Il va vraiment bien, lui?"
+    "texte_fr": "[1432][NULL][NULL][0014]Petite[1432][NULL][NULL][0014]? J'en ai la chair de\npoule...[001E][1205] Il va vraiment bien, lui?"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Wow,[SP]I'm[SP]kind[SP]of[SP]impressed.[1205][001E][SP]Looks[SP]like[SP]Eikichi\nhas[SP]his[SP]sweet[SP]side.",
     "nom_fr": "Yukino",
-    "texte_fr": "Waouh, pas mal.[1205][001E] Eikichi a\nquand même son côté doux."
+    "texte_fr": "Waouh, pas mal.[001E][1205] Eikichi a\nquand même son côté doux."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "What[SP]do[SP]you[SP]want!?[1205][001E][SP]The[SP]committee[SP]meeting's\nover,[SP]so[SP]I'm[SP]allowed[SP]to[SP]go[SP]home![1205][001E][SP]I[SP]can[SP]leave\nwithout[SP]disobeying[SP]the[SP]principal!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Qu'est-ce que vous voulez!?[1205][001E] La réunion\ndu comité est finie, je peux rentrer![1205][001E]\nJe pars sans désobéir au directeur!"
+    "texte_fr": "Qu'est-ce que vous voulez!?[001E][1205] La réunion\ndu comité est finie, je peux rentrer![001E][1205]\nJe pars sans désobéir au directeur!"
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "You[SP]won't[SP]catch[SP]me[SP]getting[SP]cursed![1205][001E][SP]I've[SP]had\nenough[SP]of[SP]all[SP]this![1205][001E][SP]But[SP]I'll[SP]still[SP]be[SP]here\nagain[SP]tomorrow...[1205][001E][SP]*sigh*",
     "nom_fr": "Lycéen",
-    "texte_fr": "Pas question que je sois maudit![1205][001E] J'en\nai assez de tout ça![1205][001E] Mais je serai là\ndemain quand même...[1205][001E] *soupir*"
+    "texte_fr": "Pas question que je sois maudit![001E][1205] J'en\nai assez de tout ça![001E][1205] Mais je serai là\ndemain quand même...[001E][1205] *soupir*"
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Ill[SP]female[SP]student",
     "texte_orig": "*sob*[1205][001E][SP]Waaaah...[SP]I[SP]didn't[SP]make[SP]it![1205][001E][SP]My[SP]club\nmeeting[SP]was[SP]over,[SP]so[SP]I[SP]was[SP]gonna[SP]hurry\nhome...[SP]before...[1205][001E][SP]*sob*",
     "nom_fr": "Lycéenne malade",
-    "texte_fr": "*sanglots*[1205][001E] Waaah... J'ai raté![1205][001E] Mon\nclub venait de finir et j'allais\nrentrer... avant...[1205][001E] *sanglots*"
+    "texte_fr": "*sanglots*[001E][1205] Waaah... J'ai raté![001E][1205] Mon\nclub venait de finir et j'allais\nrentrer... avant...[001E][1205] *sanglots*"
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Ill[SP]female[SP]student",
     "texte_orig": "*sob*[1205][001E][SP]I'm[SP]cleaning[SP]up,[SP]like[SP]the[SP]principal[SP]told\nus[SP]to...[1205][001E][SP]I'd[SP]do[SP]anything,[SP]even[SP]kiss[SP]a[SP]boy,\nif[SP]it[SP]would[SP]fix[SP]my[SP]face...",
     "nom_fr": "Lycéenne malade",
-    "texte_fr": "*sanglots*[1205][001E] Je nettoie comme demandé...[1205][001E]\nJe ferais tout, même embrasser un\ngars, pour retrouver mon visage..."
+    "texte_fr": "*sanglots*[001E][1205] Je nettoie comme demandé...[001E][1205]\nJe ferais tout, même embrasser un\ngars, pour retrouver mon visage..."
   },
   {
     "id": 22,
@@ -342,6 +342,6 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "I[SP]heard[SP]it[SP]was[SP]the[SP]principal[SP]who[SP]lifted[SP]the\ncurse.[1205][000F][SP]But[SP]the[SP]Boss[SP]did[SP]his[SP]part,[SP]too![1205][000F][SP]As\nthanks,[SP]I[SP]gave[SP]him[SP]my[SP]first[SP]kiss...",
     "nom_fr": "",
-    "texte_fr": "J'ai entendu que c'est le proviseur\nqui a levé la malédiction.[1205][000F] Mais le Boss\na aussi fait sa part ![1205][000F] En remerciement, je lui ai donné mon premier baiser..."
+    "texte_fr": "J'ai entendu que c'est le proviseur\nqui a levé la malédiction.[000F][1205] Mais le Boss\na aussi fait sa part ![000F][1205] En remerciement, je lui ai donné mon premier baiser..."
   }
 ]

--- a/traduction/event_scripts/script_264.json
+++ b/traduction/event_scripts/script_264.json
@@ -12,7 +12,7 @@
     "nom_orig": "Noriko",
     "texte_orig": "Hello,[SP][1112]-senpai![SP]It's[SP]been[SP]a[SP]while\nsince[SP]Sister...[1205][001E][SP]since[SP]Anna-senpai[SP]from[SP]your\nclass[SP]quit[SP]school.",
     "nom_fr": "Noriko",
-    "texte_fr": "Salut, [1112]! Ca fait un bail depuis que ma\nso...[1205][001E] depuis\nqu'Anna-senpai est déscolarisée."
+    "texte_fr": "Salut, [1112]! Ca fait un bail depuis que ma\nso...[001E][1205] depuis\nqu'Anna-senpai est déscolarisée."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Noriko",
     "texte_orig": "But[SP]then...[1205][001E][SP]Oh,[SP]poor[SP]Sister...[1205][001E][SP]*sniff*[1205][001E]\nE-Eheheh...[SP]I[SP]shouldn't[SP]be[SP]crying[SP]like[SP]this,\nhuh?[SP]I[SP]ought[SP]to[SP]look[SP]after[SP]her[SP]running[SP]shoes!",
     "nom_fr": "Noriko",
-    "texte_fr": "Mais...[1205][001E] La pauvre...[1205][001E] *sniff*[1205][001E] Oh... Je ne\ndevrais pas pleurer comme ca... Je devrais\nplutôt m'occuper de ses chaussures!"
+    "texte_fr": "Mais...[001E][1205] La pauvre...[001E][1205] *sniff*[001E][1205] Oh... Je ne\ndevrais pas pleurer comme ca... Je devrais\nplutôt m'occuper de ses chaussures!"
   },
   {
     "id": 3,
@@ -102,7 +102,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "The[SP]shoes[SP]Noriko[SP]is[SP]taking[SP]care[SP]of[SP]are[SP]Anna-\nsenpai's.[SP]She[SP]insists[SP]Senpai[SP]is[SP]coming[SP]back...[1205][001E]\nShe's[SP]been[SP]looking[SP]all[SP]over[SP]for[SP]her[SP]at[SP]night.",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Les chaussures dont Noriko s'occupe sont\ncelles d'Anna-senpai. Elle dit qu'elle \nreviendra...[1205][001E] La nuit,\nelle la cherche partout."
+    "texte_fr": "Les chaussures dont Noriko s'occupe sont\ncelles d'Anna-senpai. Elle dit qu'elle \nreviendra...[001E][1205] La nuit,\nelle la cherche partout."
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "I[SP]wonder[SP]if[SP]it's[SP]true...[1205][001E][SP]Hm?[SP]I[SP]meant[SP]the\nJoker[SP]Game.",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "Je me demande si c'est\nvrai...[1205][001E] Hm? Le jeu du joker."
+    "texte_fr": "Je me demande si c'est\nvrai...[001E][1205] Hm? Le jeu du joker."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "I[SP]heard[SP]a[SP]friend[SP]of[SP]a[SP]friend[SP]upped[SP]his[SP]grades[SP]with\nthat[SP]method.[SP]If[SP]it[SP]can[SP]work[SP]miracles[SP]like[SP]that,\nI[SP]wonder[SP]if[SP]it[SP]can[SP]cure[SP]this[SP]disease...",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "Un ami d'un ami a amelioré ses notes\navec cette méthode. Si ça fait des\nmiracles, je me demande\nsi ça peut guérir..."
+    "texte_fr": "Un ami d'un ami a amelioré ses notes\navec cette méthode. Si ça fait des\nmiracles, je me demande si ça peut guérir..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "Heh...[SP]You[SP]can't[SP]tell[SP]who[SP]I[SP]am[SP]like[SP]this,[SP]huh?\nFor[SP]all[SP]you[SP]know[SP]I'm[SP]the[SP]world's[SP]cutest[SP]girl.[1205][001E]\nHehe...[SP]Alas,[SP]I'm[SP]just[SP]an[SP]ugly[SP]duckling...",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "T'arrives pas à savoir qui je suis\ncomme ca? Je suis peut-être la plus\nbelle.[1205][001E] Hélas, je suis ignoble..."
+    "texte_fr": "T'arrives pas à savoir qui je suis\ncomme ca? Je suis peut-être la plus\nbelle.[001E][1205] Hélas, je suis ignoble..."
   },
   {
     "id": 11,

--- a/traduction/event_scripts/script_265.json
+++ b/traduction/event_scripts/script_265.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Wait...[SP]With[SP]demons[SP]popping[SP]up[SP]all[SP]over,[SP]why\nwould[SP]I[SP]be[SP]surprised[SP]if[SP]she's[SP]real?[1205][001E][SP]I[SP]gotta[SP]get\nwith[SP]the[SP]program[SP]before[SP]it[SP]bites[SP]me[SP]in[SP]the[SP]ass.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Attends... Avec des\ndémons partout, pourquoi\nje serais surpris qu'elle soit réelle?[1205][001E] Faut\nm'adapter avant que ça me retombe dessus."
+    "texte_fr": "Attends... Avec des\ndémons partout, pourquoi\nje serais surpris qu'elle soit réelle?[001E][1205] Faut\nm'adapter avant que ça me retombe dessus."
   },
   {
     "id": 2,
@@ -87,7 +87,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Hey,[SP][1113]...[1205][001E][SP]Maybe[SP]Hanako[SP]really[SP]will\nshow[SP]up[SP]if[SP]this[SP]rumor[SP]spreads[SP]wide[SP]enough.",
     "nom_fr": "Lisa",
-    "texte_fr": "Hé, [1113]...[1205][001E] Hanako se manifestera\nsi la rumeur se répand assez."
+    "texte_fr": "Hé, [1113]...[001E][1205] Hanako se manifestera\nsi la rumeur se répand assez."
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP][1113]...[1205][001E][SP]Maybe[SP]Hanako[SP]really[SP]will\nshow[SP]up[SP]if[SP]this[SP]rumor[SP]spreads[SP]wide[SP]enough.",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, [1113]...[1205][001E] Hanako se manifestera\nsi la rumeur se répand assez."
+    "texte_fr": "Hé, [1113]...[001E][1205] Hanako se manifestera\nsi la rumeur se répand assez."
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "We're[SP]ready[SP]to[SP]go![1205][000F][SP]All[SP]that's[SP]left[SP]is[SP]to\nbeat[SP]Hanako![SP]Let's[SP]do[SP]this,[SP]Chinyan!",
     "nom_fr": "Lisa",
-    "texte_fr": "On est prêts! [1205][000F]Il ne reste plus qu'à\nvaincre Hanako! Allons-y, Chinyan!"
+    "texte_fr": "On est prêts! [000F][1205]Il ne reste plus qu'à\nvaincre Hanako! Allons-y, Chinyan!"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We're[SP]ready[SP]to[SP]go![1205][000F][SP]All[SP]that's[SP]left[SP]is[SP]to\nbeat[SP]Hanako![SP]Let's[SP]do[SP]this,[SP]Chinyan!",
     "nom_fr": "Ginko",
-    "texte_fr": "On est prêts! [1205][000F]Il ne reste plus qu'à\nvaincre Hanako! Allons-y, Chinyan!"
+    "texte_fr": "On est prêts! [000F][1205]Il ne reste plus qu'à\nvaincre Hanako! Allons-y, Chinyan!"
   },
   {
     "id": 11,
@@ -237,7 +237,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Hanako,[SP]huh?[1205][000F][SP]She's[SP]a[SP]tough[SP]nut[SP]to[SP]crack...[1205][000F]\nShe's[SP]resistant[SP]to[SP]fire[SP]and[SP]physical[SP]attacks.",
     "nom_fr": "Yukino",
-    "texte_fr": "Hanako, hein? [1205][000F][1205][000F]Elle n'est pas facile... Elle\nrésiste au feu et aux attaques physiques."
+    "texte_fr": "Hanako, hein? [000F][1205][000F][1205]Elle n'est pas facile... Elle\nrésiste au feu et aux attaques physiques."
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Noriko",
     "texte_orig": "I[SP]wonder[SP]what[SP]happened[SP]to[SP]today's[SP]club\nmeeting...[1205][001E][SP]I[SP]can't[SP]go[SP]home[SP]until[SP]it's[SP]over,\nbut[SP]I[SP]haven't[SP]heard[SP]from[SP]any[SP]of[SP]them[SP]yet.",
     "nom_fr": "Noriko",
-    "texte_fr": "Je me demande ce qu'il est arrivé à la\nréunion du club...[1205][001E] Je peux pas rentrer\navant, et personne m'a prévenu."
+    "texte_fr": "Je me demande ce qu'il est arrivé à la\nréunion du club...[001E][1205] Je peux pas rentrer\navant, et personne m'a prévenu."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Noriko",
     "texte_orig": "I[SP]want[SP]to[SP]hurry[SP]and[SP]pick[SP]up[SP]the[SP]search[SP]for\nSister![1205][001E][SP]She[SP]hasn't[SP]given[SP]up[SP]on[SP]her[SP]dream[SP]yet!\nShe[SP]needs[SP]these[SP]shoes!",
     "nom_fr": "Noriko",
-    "texte_fr": "Je veux vite chercher la grande sœur![1205][001E]\nElle n'a pas abandonné son rêve! Elle\na besoin de ces chaussures!"
+    "texte_fr": "Je veux vite chercher la grande sœur![001E][1205]\nElle n'a pas abandonné son rêve! Elle\na besoin de ces chaussures!"
   },
   {
     "id": 19,
@@ -342,7 +342,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Thanks[SP]for[SP]your[SP]help.[SP]All[SP]the[SP]emblems[SP]in[SP]this\nclassroom[SP]should[SP]be[SP]destroyed.[SP]I[SP]hope[SP]that\nputs[SP]an[SP]end[SP]to[SP]this[SP]madness...",
     "nom_fr": "Lycéen",
-    "texte_fr": "Merci pour ton aide. Tous les emblèmes de\ncette salle devraient être détruits.\nJ'espère que ça mettra\nfin à cette folie..."
+    "texte_fr": "Merci pour ton aide. Tous les emblèmes de\ncette salle devraient être détruits.\nJ'espère que ça mettra fin à cette folie..."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "As[SP]far[SP]as[SP]I[SP]know,[SP]the[SP]emblem[SP]here[SP]is[SP]the[SP]last\none...[1205][000F][SP]Oh,[SP]wait,[SP]no[SP]it[SP]wasn't![1205][000F][SP]There's\nsome[SP]emblems[SP]in[SP]the[SP]teachers'[SP]lounge[SP]too!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Pour autant que je sache, cet emblème est\n[1205]le dernier.[1205][000F][000F].. Oh, attendez, non! Il y a des\nemblèmes dans la salle des profs aussi!"
+    "texte_fr": "Pour autant que je sache, cet emblème est\n[1205]le dernier.[000F][1205][000F].. Oh, attendez, non! Il y a des\nemblèmes dans la salle des profs aussi!"
   },
   {
     "id": 24,
@@ -432,7 +432,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "I-I[SP]saw[SP]her![SP]It[SP]was[SP]really[SP][E4][NULL][NULL][0006]Hanako[E4][NULL][NULL][0002]![1205][001E][SP]I[SP]always\nheard[SP]rumors,[SP]but...[SP]They're[SP]true![SP]Why[SP]won't\nanyone[SP]believe[SP]me!?",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "J-Je l'ai vue! C'était [E4][NULL][NULL][0006]Hanako[E4][NULL][NULL][0002]![1205][001E] J'avais\nentendu des rumeurs, mais... C'est\nvrai! Pourquoi personne me croit!?"
+    "texte_fr": "J-Je l'ai vue! C'était [E4][NULL][NULL][0006]Hanako[E4][NULL][NULL][0002]![001E][1205] J'avais\nentendu des rumeurs, mais... C'est\nvrai! Pourquoi personne me croit!?"
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "Please,[SP]Senpai![SP]Defeat[SP]Hanako[SP]and[SP]bring[SP]back\nproof[SP]she[SP]really[SP]exists,[SP]and[SP]I'll[SP]make[SP]sure\nto[SP]reward[SP]you[SP]with[SP]a[SP]little[SP]something!",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "S'il vous plaît, senpai! Battez Hanako et\nramenez la preuve qu'elle existe vraiment,\net je vous\nrécompenserai avec quelque chose!"
+    "texte_fr": "S'il vous plaît, senpai! Battez Hanako et\nramenez la preuve qu'elle existe vraiment,\net je vous récompenserai avec quelque chose!"
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I-I[SP]saw[SP]her![SP]It[SP]was[SP]really[SP][E4][NULL][NULL][0006]Hanako[E4][NULL][NULL][0002]![1205][001E][SP]I[SP]always\nheard[SP]rumors,[SP]but...[SP]They're[SP]true![SP]Why[SP]won't\nanyone[SP]believe[SP]me!?",
     "nom_fr": "Lycéen",
-    "texte_fr": "J-Je l'ai vue! C'était [E4][NULL][NULL][0006]Hanako[E4][NULL][NULL][0002]![1205][001E] J'avais\nentendu des rumeurs, mais... C'est\nvrai! Pourquoi personne me croit!?"
+    "texte_fr": "J-Je l'ai vue! C'était [E4][NULL][NULL][0006]Hanako[E4][NULL][NULL][0002]![001E][1205] J'avais\nentendu des rumeurs, mais... C'est\nvrai! Pourquoi personne me croit!?"
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Please,[SP]Senpai![SP]Defeat[SP]Hanako[SP]and[SP]bring[SP]back\nproof[SP]she[SP]really[SP]exists,[SP]and[SP]I'll[SP]make[SP]sure\nto[SP]reward[SP]you[SP]with[SP]a[SP]little[SP]something!",
     "nom_fr": "Lycéen",
-    "texte_fr": "S'il vous plaît, senpai! Battez Hanako et\nramenez la preuve qu'elle existe vraiment,\net je vous\nrécompenserai avec quelque chose!"
+    "texte_fr": "S'il vous plaît, senpai! Battez Hanako et\nramenez la preuve qu'elle existe vraiment,\net je vous récompenserai avec quelque chose!"
   },
   {
     "id": 32,
@@ -522,7 +522,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "Whoa![SP]This[SP]is[SP]great,[SP]Senpai![SP]S-So[SP]you[SP]brought\nback[SP][E4][NULL][NULL][0006]Hanako's[SP]Nametag[E4][NULL][NULL][0002],[SP]huh?[SP]I-I'm[SP]gonna[SP]show\nthis[SP]to[SP]all[SP]those[SP]doubters[SP]right[SP]now!",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "Ouah! C'est super,\nsenpai! V-Vous avez ramené\nle [E4][NULL][NULL][0006]Badge de Hanako[E4][NULL][NULL][0002], hein? J-Je vais montrer\nça à tous ces incrédules tout de suite!"
+    "texte_fr": "Ouah! C'est super,\nsenpai! V-Vous avez ramené\nle [E4][NULL][NULL][0006]Badge de Hanako[E4][NULL][NULL][0002], hein? J-Je vais montrer ça à tous ces incrédules tout de suite!"
   },
   {
     "id": 35,
@@ -552,7 +552,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Whoa![SP]This[SP]is[SP]great,[SP]Senpai![SP]S-So[SP]you[SP]brought\nback[SP][E4][NULL][NULL][0006]Hanako's[SP]Nametag[E4][NULL][NULL][0002],[SP]huh?[SP]I-I'm[SP]gonna[SP]show\nthis[SP]to[SP]all[SP]those[SP]doubters[SP]right[SP]now!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Ouah! C'est super,\nsenpai! V-Vous avez ramené\nle [E4][NULL][NULL][0006]Badge de Hanako[E4][NULL][NULL][0002], hein? J-Je vais montrer\nça à tous ces incrédules tout de suite!"
+    "texte_fr": "Ouah! C'est super,\nsenpai! V-Vous avez ramené\nle [E4][NULL][NULL][0006]Badge de Hanako[E4][NULL][NULL][0002], hein? J-Je vais montrer ça à tous ces incrédules tout de suite!"
   },
   {
     "id": 37,
@@ -672,7 +672,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "That[SP]guy's[SP]a[SP]riot.[SP]He's[SP]showing[SP]everyone[SP]an\nelementary[SP]school[SP]nametag[SP]that[SP]says[SP][1432][NULL][NULL][0014]Hanako[1432][NULL][NULL][0014]\nand[SP]insisting[SP]it's[SP]proof[SP]that[SP]she[SP]exists.",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Ce gars est vraiment comique. Il montre à\ntout le monde un badge d'école primaire qui\ndit [1432][NULL][NULL][0014]Hanako[1432][NULL][NULL][0014] en insistant\nque c'est la preuve."
+    "texte_fr": "Ce gars est vraiment comique. Il montre à\ntout le monde un badge d'école primaire qui\ndit [1432][NULL][NULL][0014]Hanako[1432][NULL][NULL][0014] en insistant que c'est la preuve."
   },
   {
     "id": 45,
@@ -687,7 +687,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Thanks[SP]for[SP]your[SP]help.[SP]All[SP]the[SP]emblems[SP]in[SP]this\nclassroom[SP]should[SP]be[SP]destroyed.[SP]I[SP]hope[SP]that\nputs[SP]an[SP]end[SP]to[SP]this[SP]madness...",
     "nom_fr": "Lycéen",
-    "texte_fr": "Merci pour ton aide. Tous les emblèmes de\ncette salle devraient être détruits.\nJ'espère que ça mettra\nfin à cette folie..."
+    "texte_fr": "Merci pour ton aide. Tous les emblèmes de\ncette salle devraient être détruits.\nJ'espère que ça mettra fin à cette folie..."
   },
   {
     "id": 46,
@@ -702,7 +702,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "As[SP]far[SP]as[SP]I[SP]know,[SP]the[SP]emblem[SP]here[SP]is[SP]the[SP]last\none...[1205][000F][SP]Oh,[SP]wait,[SP]no[SP]it[SP]wasn't![1205][000F][SP]There's\nsome[SP]emblems[SP]in[SP]the[SP]teachers'[SP]lounge[SP]too!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Pour autant que je sache, cet emblème est\n[1205]le dernier.[1205][000F][000F].. Oh, attendez, non! Il y a des\nemblèmes dans la salle des profs aussi!"
+    "texte_fr": "Pour autant que je sache, cet emblème est\n[1205]le dernier.[000F][1205][000F].. Oh, attendez, non! Il y a des\nemblèmes dans la salle des profs aussi!"
   },
   {
     "id": 47,
@@ -732,7 +732,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "You[SP]destroyed[SP]that[SP]one,[SP][1112]-senpai.\nNow[SP]go[SP]and[SP]take[SP]care[SP]of[SP]the[SP]others!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Tu as détruit celui-là, [1112]-senpai.\nMaintenant va t'occuper des autres! Ce\nsont les restes d'une horloge qui était\nau mur...  Il y a une horloge au mur\navec l'emblème de l'école dessus."
+    "texte_fr": "Tu as détruit celui-là, [1112]-senpai.\nMaintenant va t'occuper des autres! Ce\nsont les restes d'une horloge qui était au mur...  Il y a une horloge au mur avec l'emblème de l'école dessus."
   },
   {
     "id": 49,
@@ -747,7 +747,7 @@
     "nom_orig": "Noriko",
     "texte_orig": "I'm[SP]about[SP]to[SP]go[SP]look[SP]for[SP]Sister.[1205][001E][SP]If[SP]you[SP]find\nher,[SP]let[SP]me[SP]know[SP]at[SP]once![SP]Alright[SP]then,[SP]please\nexcuse[SP]me!",
     "nom_fr": "Noriko",
-    "texte_fr": "Je pars chercher la grande sœur.[1205][001E] Si tu la\ntrouves, avertis-moi! Bien, veuillez\nm'excuser!"
+    "texte_fr": "Je pars chercher la grande sœur.[001E][1205] Si tu la\ntrouves, avertis-moi! Bien, veuillez\nm'excuser!"
   },
   {
     "id": 50,
@@ -762,6 +762,6 @@
     "nom_orig": "Noriko",
     "texte_orig": "I'm[SP]about[SP]to[SP]go[SP]look[SP]for[SP]Sister.[1205][001E][SP]If[SP]you[SP]find\nher,[SP]let[SP]me[SP]know[SP]at[SP]once![SP]Alright[SP]then,[SP]please\nexcuse[SP]me!",
     "nom_fr": "Noriko",
-    "texte_fr": "Je pars chercher la grande sœur.[1205][001E] Si tu la\ntrouves, avertis-moi! Bien, veuillez\nm'excuser!"
+    "texte_fr": "Je pars chercher la grande sœur.[001E][1205] Si tu la\ntrouves, avertis-moi! Bien, veuillez\nm'excuser!"
   }
 ]

--- a/traduction/event_scripts/script_266.json
+++ b/traduction/event_scripts/script_266.json
@@ -12,7 +12,7 @@
     "nom_orig": "???",
     "texte_orig": "Hm?[SP][1112]-senpai...[1205][001E][SP]Have[SP]you[SP]seen[SP]Lisa?[1205][001E]\nShe[SP]was[SP]looking[SP]for[SP]you[SP]with[SP]a[SP]letter[SP]in\nher[SP]hand.[1205][001E][SP]You[SP]get[SP]the[SP]picture,[SP]I[SP]hope?",
     "nom_fr": "???",
-    "texte_fr": "Hm?[1112] senpai..[1205][001E] Tu as vu Lisa?[1205][001E]\nElle est partie te chercher avec une lettre.[1205][001E]\nTu comprends ce qu'elle veut, j'espère?"
+    "texte_fr": "Hm?[1112] senpai..[001E][1205] Tu as vu Lisa?[001E][1205]\nElle est partie te chercher avec une lettre.[001E][1205]\nTu comprends ce qu'elle veut, j'espère?"
   },
   {
     "id": 1,
@@ -72,7 +72,7 @@
     "nom_orig": "???",
     "texte_orig": "Hm?[SP][1112]-senpai...[1205][001E][SP]Have[SP]you[SP]seen[SP]Lisa?[1205][001E]\nShe[SP]was[SP]looking[SP]for[SP]you[SP]with[SP]a[SP]letter[SP]in\nher[SP]hand.[1205][001E][SP]You[SP]get[SP]the[SP]picture,[SP]I[SP]hope?",
     "nom_fr": "",
-    "texte_fr": "Hm?[1112]-senpai...[1205][001E] T'as vu Lisa?[1205][001E]\nElle te cherchait, lettre en main.[1205][001E]\nTu vois ce que ça veut dire?"
+    "texte_fr": "Hm?[1112]-senpai...[001E][1205] T'as vu Lisa?[001E][1205]\nElle te cherchait, lettre en main.[001E][1205]\nTu vois ce que ça veut dire?"
   },
   {
     "id": 5,
@@ -177,7 +177,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "You'd[SP]take[SP]the[SP]time[SP]to[SP]talk[SP]to[SP]someone[SP]like[SP]me,\nSenpai?[SP]Glad[SP]I[SP]dragged[SP]myself[SP]to[SP]school[SP]today...[1205][001E]\nMs.[SP]Saeko?[SP]I[SP]saw[SP]her[SP]on[SP]the[SP]first[SP]floor.",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Tu viens vraiment\nme parler? Senpai? Contente\nd'avoir pu me tirer\nhors du lit aujourd'hui..[1205].\n[001E]Mme. Saeko? Je crois l'avoir vue\nau premier étage"
+    "texte_fr": "Tu viens vraiment\nme parler? Senpai? Contente\nd'avoir pu me tirer hors du lit aujourd'hui..[1205].[001E]Mme. Saeko? Je crois l'avoir vue\nau premier étage"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "Looking[SP]for[SP]Ms.[SP]Saeko,[SP]Senpai?[1205][000A][SP]I[SP]saw[SP]her[SP]going\ndown[SP]the[SP]hall[SP]on[SP]this[SP]floor[SP]a[SP]moment[SP]ago.[1205][000F]\nYou[SP]didn't[SP]see[SP]her?",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Tu cherches Mme. Saeko, Senpai?[1205][1205][000A] Je l'ai\nvu au bout du couloir de cet étage il y\n[000F]a un petit moment. Tu l'as pas vu?"
+    "texte_fr": "Tu cherches Mme. Saeko, Senpai?[1205][000A][1205] Je l'ai\nvu au bout du couloir de cet étage il y\n[000F]a un petit moment. Tu l'as pas vu?"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "Oh...![SP]I[SP]can't[SP]believe[SP]you're[SP]taking[SP]the[SP]time\nto[SP]talk[SP]to[SP]me...[1205][000F][SP]Huh?[SP]Ms.[SP]Saeko?[1205][000F][SP]Yeah,[SP]I[SP]saw\nher[SP]in[SP]the[SP]hall[SP]on[SP]the[SP]third[SP]floor.",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Oh...! Je peux pas croire que tu prends le\ntemps de me parler.[1205][000F][1205][000F].. Hein? MMe. SaekoOui,\nje l'ai vu dans le couloir au 3ème étage."
+    "texte_fr": "Oh...! Je peux pas croire que tu prends le\ntemps de me parler.[000F][1205][000F][1205].. Hein? MMe. SaekoOui,\nje l'ai vu dans le couloir au 3ème étage."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "Senpai,[SP]are[SP]you[SP]looking[SP]for[SP]Ms.[SP]Saeko?[1205][000F][SP]I[SP]think\nshe[SP]was[SP]in[SP]the[SP]courtyard[SP]a[SP]minute[SP]ago...[1205][000A][SP]Have\nyou[SP]tried[SP]there[SP]yet?",
     "nom_fr": "Lycéenne Blessée",
-    "texte_fr": "Senpai, tu cherches Mme. Saeko? Je crois\n[1205][000F]qu' elle était dans la cour il y a une\nminute...[1205][000A] T' as déja été voir là bas?"
+    "texte_fr": "Senpai, tu cherches Mme. Saeko? Je crois\n[000F][1205]qu' elle était dans la cour il y a une\nminute...[000A][1205] T' as déja été voir là bas?"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "I-I[SP]can't[SP]believe[SP]you're[SP]actually[SP]talking[SP]to\nme...![1205][001E][SP]Y-You're[SP]looking[SP]for[SP]Ms.[SP]Saeko,[SP]right?[1205][001E]\nShe's[SP]at[SP]the[SP]bike[SP]stands,[SP]I[SP]think.[E1][E2]\n[E3][E4][NULL][NULL]\"School[SP]paper[SP]writer\nOur[SP]editor,[SP]Kozy,[SP]hasn't[SP]come[SP]back.[SP]She[SP]ran\nout,[SP]saying[SP]she[SP]was[SP]investigating[SP]the[SP]curse\nrumor...[1205][001E][SP]Chikarin[SP]isn't[SP]around[SP]either.[SP]Hmm...",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "J-j'y crois pas, tu me parles..![1205][001E] Ah tu\n[001E][1205]cherches Mme. Saeko non?[1205][001E] Elle est à l'abri\nà vélos, je crois.[E1][E2]\n[E3][E4]Journaliste de l'école\net notre éditeur, Kozy, n'est toujours\npas revenue.\nElle a disparu alors qu'elle enquêtait\nsur la rumeur de la\nmalédiction...Chikarin est introuvable aussi. Hmm..[NULL][NULL]"
+    "texte_fr": "J-j'y crois pas, tu me parles..![001E][1205] Ah tu\n[001E][1205]cherches Mme. Saeko non?[001E][1205] Elle est à l'abri\nà vélos, je crois.[E1][E2]\n[E3][E4]Journaliste de l'école\net notre éditeur, Kozy, n'est toujours\npas revenue.\nElle a disparu alors qu'elle enquêtait\nsur la rumeur de la\nmalédiction...Chikarin est introuvable aussi. Hmm..[NULL][NULL]"
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "Argh...[1205][001E][SP]I[SP]should've[SP]hooked[SP]up[SP]with[SP]a[SP]Cuss[SP]High\nguy,[SP]even[SP]if[SP]he[SP]was[SP]ugly.[SP]Then[SP]I[SP]could've[SP]had\none[SP]of[SP]their[SP]evil-repelling[SP]emblems.",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Argh.[1205][001E] J'aurais du être en date avec un mec\nde Kakasu, même si il est moche.\nJ'aurais pu avoir une de leurs\nemblêmes exorcisants."
+    "texte_fr": "Argh.[001E][1205] J'aurais du être en date avec un mec\nde Kakasu, même si il est moche.\nJ'aurais pu avoir une de leurs emblêmes exorcisants."
   },
   {
     "id": 18,
@@ -282,6 +282,6 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "Huh?[SP]You[SP]don't[SP]know?[1205][001E][SP]Our[SP]emblem's[SP]cursed,[SP]but\nrumor[SP]has[SP]it[SP]Cuss[SP]High's[SP]wards[SP]off[SP]evil.[SP]Thanks\nto[SP]that,[SP]our[SP]reputations[SP]have[SP]been[SP]switched.",
     "nom_fr": "",
-    "texte_fr": "Hein ? Tu sais pas ?[1205][001E] Notre emblème est\nmaudit, mais la rumeur dit que Cuss High\nrepousse le mal. Du coup nos réputations s'inversent."
+    "texte_fr": "Hein ? Tu sais pas ?[001E][1205] Notre emblème est\nmaudit, mais la rumeur dit que Lycée Kasu\nrepousse le mal. Du coup nos réputations s'inversent."
   }
 ]

--- a/traduction/event_scripts/script_267.json
+++ b/traduction/event_scripts/script_267.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Is[SP]this[SP]because[SP]of[SP]the[SP]rumors[SP]too?[1205][000F][SP]Like,[SP]the\nrumor[SP]came[SP]true[SP]and[SP]brought[SP]that[SP]principal\nback[SP]to[SP]life?[1205][000F][SP]Seriously[SP]here?[SP]Seriously?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Est-ce que ça pourrait être à cause des\n[1205][000F][1205][000F]rumeurs? Genre la rumeur est devenu réalité\net a ramenée le\nprincipal à la vie? Sérieux?"
+    "texte_fr": "Est-ce que ça pourrait être à cause des\n[000F][1205][000F][1205]rumeurs? Genre la rumeur est devenu réalité\net a ramenée le principal à la vie? Sérieux?"
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That[SP]principal[SP]remembers[SP]our[SP]last[SP]fight,[SP]right?[1205][000F]\nI[SP]wasn't[SP]holding[SP]back[SP]at[SP]all...[SP]I[SP]wouldn't[SP]be\nsurprised[SP]if[SP]he[SP]held[SP]a[SP]grudge[SP]over[SP]it.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ce principal se\nrapelle notre dernier combat,\n[1205][000F]non? Je me suis donné\nà fond... Je serais pas\nsurpris si il m'en veut par rapport à ça."
+    "texte_fr": "Ce principal se\nrapelle notre dernier combat,\n[000F][1205]non? Je me suis donné à fond... Je serais pas surpris si il m'en veut par rapport à ça."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Principal[SP]Hanya...?[1205][000F][SP]What's[SP]going[SP]on?[1205][000F][SP]Was[SP]the\nprincipal[SP]the[SP]one[SP]who[SP]thrashed[SP]those[SP]Last\nBattalion[SP]goons[SP]on[SP]the[SP]floor[SP]there?",
     "nom_fr": "Ginko",
-    "texte_fr": "Proviseur Hanya.[1205][000F][1205][000F]. Qu'est ce qu'il se passe\nici?? C'est le principal celui qui a\nvaincus les sbires du Batailon à cet étage?"
+    "texte_fr": "Proviseur Hanya.[000F][1205][000F][1205]. Qu'est ce qu'il se passe\nici?? C'est le principal celui qui a\nvaincus les sbires du Batailon à cet étage?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh?[1205][000A][SP]Principal[SP]Hanya[SP]again...",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein?[1205][000A] le Proviseur Hanya.."
+    "texte_fr": "Hein?[000A][1205] le Proviseur Hanya.."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "It[SP]seemed[SP]like[SP]that[SP]Taurus[SP]guy[SP]got[SP]killed\ninstantly...[1205][000F][SP]We[SP]don't[SP]know[SP]what[SP]kind[SP]of[SP]traps\nthey[SP]have,[SP]so[SP]let's[SP]be[SP]careful,[SP]Chinyan.",
     "nom_fr": "Ginko",
-    "texte_fr": "On dirait que ce Taureau est mort d'un\ncoup.. [1205][000F]On ne sait pas quels pièges il peut\ny avoir, vaut mieux faire gaffe, Chinyan."
+    "texte_fr": "On dirait que ce Taureau est mort d'un\ncoup.. [000F][1205]On ne sait pas quels pièges il peut\ny avoir, vaut mieux faire gaffe, Chinyan."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm...[1205][000F][SP]That[SP]principal[SP]seems[SP]to[SP]have[SP]cleaned[SP]up\nhis[SP]act[SP]a[SP]lot...[1205][000F][SP]Oh![SP]You[SP]think[SP]it's[SP]because\nof[SP]the[SP]rumors?",
     "nom_fr": "Maya",
-    "texte_fr": "Hmmm.[1205][000F][1205][000F]. Ce principal a l'air d'avoir\nsoigner son apparence.. Oh! Tu penses\nque c'est à cause des rumeurs?."
+    "texte_fr": "Hmmm.[000F][1205][000F][1205]. Ce principal a l'air d'avoir\nsoigner son apparence.. Oh! Tu penses\nque c'est à cause des rumeurs?."
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "He's[SP]here[SP]too!?[1205][000F][SP]But[SP]he[SP]was[SP]in[SP]a[SP]different\nroom[SP]just[SP]a[SP]moment[SP]ago...[1205][000F][SP]Did[SP]he[SP]pass[SP]us\nsomewhere...?",
     "nom_fr": "Maya",
-    "texte_fr": "Il est là?[1205][000F][1205][000F]! Mais il était ailleurs il y a\nun instant... Est-ce qu'il nous a dépassés?"
+    "texte_fr": "Il est là?[000F][1205][000F][1205]! Mais il était ailleurs il y a\nun instant... Est-ce qu'il nous a dépassés?"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "There's[SP]no[SP]doubt[SP]they[SP]took[SP]Ms.[SP]Ideal[SP]to[SP]the\nSilver[SP]River[SP]from[SP]the[SP]courtyard.[1205][000F][SP]Let's[SP]leave\nSevens[SP]to[SP]the[SP]principal[SP]and[SP]hurry[SP]after[SP]her.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est sûr, ils ont emmené Mme Ideal\nà la Rivière d'Argent. [1205][000F]Laisse Seven\nau proviseur et fonce!"
+    "texte_fr": "C'est sûr, ils ont emmené Mme Ideal\nà la Rivière d'Argent. [000F][1205]Laisse Seven\nau proviseur et fonce!"
   },
   {
     "id": 11,
@@ -192,7 +192,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Granted,[SP]you're[SP]the[SP]one[SP]who[SP]decides[SP]your[SP]own\npath[SP]in[SP]life.[1205][000F][SP]But[SP]your[SP]journey[SP]down[SP]that[SP]path\nis[SP]supported[SP]by[SP]many[SP]other[SP]people.",
     "nom_fr": "Jun",
-    "texte_fr": "On décide seul de sa vie, mais d'autres\n[1205][000F]nous soutiennent tout au long du chemin."
+    "texte_fr": "On décide seul de sa vie, mais d'autres\n[000F][1205]nous soutiennent tout au long du chemin."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Don't[SP]you[SP]sense[SP]that[SP]when[SP]you[SP]see[SP]the[SP]principal\nand[SP]his[SP]students?[1205][000F][SP]I[SP]feel[SP]somewhat[SP]envious[SP]of\nthat[SP]man...",
     "nom_fr": "Jun",
-    "texte_fr": "Tu ne ressens pas ça quand tu vois\nle principal et ses élèvesJe suis\n[1205][000F]en partie envieux de cet homme.."
+    "texte_fr": "Tu ne ressens pas ça quand tu vois\nle principal et ses élèvesJe suis\n[000F][1205]en partie envieux de cet homme.."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Ah,[SP][1112]![1205][000F][SP]Your[SP]blows[SP]not[SP]long[SP]ago\ntruly[SP]hit[SP]home[SP]in[SP]my[SP]heart.",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Ah[1112]! [1205][000F]Tes coups on vraiment\ntouché leur cible: mon coeur."
+    "texte_fr": "Ah[1112]! [000F][1205]Tes coups on vraiment\ntouché leur cible: mon coeur."
   },
   {
     "id": 15,
@@ -252,7 +252,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "The[SP]students[SP]gave[SP]me[SP]the[SP]gist[SP]of[SP]what's\ngoing[SP]on.[1205][000F][SP]You[SP]hurry[SP]on[SP]and[SP]save[SP]Ms.[SP]Okamura.[1205][000F]\nDon't[SP]worry![SP]I'll[SP]keep[SP]the[SP]peace[SP]at[SP]Sevens!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Les élèves m'ont résumés la situation.\n[1205][000F][1205][000F]Vite, venez à mon secours Mme. Okamura. Ne\nvous inquiètez pas! Je vais protéger Seven"
+    "texte_fr": "Les élèves m'ont résumés la situation.\n[000F][1205][000F][1205]Vite, venez à mon secours Mme. Okamura. Ne\nvous inquiètez pas! Je vais protéger Seven"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "A[SP]pure[SP]body[SP]houses[SP]a[SP]pure[SP]mind,[SP]and[SP]a[SP]pure[SP]mind\nhouses[SP]a[SP]pure[SP]Persona![1205][000F][SP]You're[SP]ten[SP]years[SP]too\nearly[SP]to[SP]face[SP]me!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Un esprit pur dans un corps pur crée une\nPersona pure! [1205][000F]Tu n'es pas de taille face à\nmoi!"
+    "texte_fr": "Un esprit pur dans un corps pur crée une\nPersona pure! [000F][1205]Tu n'es pas de taille face à\nmoi!"
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "As[SP]long[SP]as[SP]I'm[SP]still[SP]standing,[SP]I[SP]won't[SP]let[SP]you\nlay[SP]a[SP]hand[SP]on[SP]my[SP]wonderful[SP]students![1205][000F][SP]Go[SP]back\nto[SP]your[SP]boss[SP]and[SP]tell[SP]him[SP]I[SP]said[SP]so!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Tant que je reste debout, je ne vous\nlaisserais pas toucher à un cheveu de mes\n[1205][000F]élèves! Retournez voir\nvotre chef et diteslui!"
+    "texte_fr": "Tant que je reste debout, je ne vous\nlaisserais pas toucher à un cheveu de mes\n[000F][1205]élèves! Retournez voir votre chef et diteslui!"
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Well?[1205][0008][SP]What[SP]are[SP]you[SP]waiting[SP]for?[1205][000A][SP]Don't[SP]worry\nabout[SP]Sevens.[SP]Hurry[SP]and[SP]save[SP]Ms.[SP]Okamura!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Alors? [1205][0008][1205]Qu'attendez-vous? [000A]Oubliez\nSeven et sauvez vite Mme Okamura!"
+    "texte_fr": "Alors? [0008][1205][1205]Qu'attendez-vous? [000A]Oubliez\nSeven et sauvez vite Mme Okamura!"
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I[SP]had[SP]no[SP]idea[SP]the[SP]principal[SP]was[SP]so[SP]strong...[1205][000F]\nH-He[SP]whomped[SP]the[SP]Last[SP]Battalion[SP]left[SP]and\nright...[1205][000F][SP]He[SP]might[SP]be[SP]the[SP]strongest[SP]man[SP]alive!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Je pensais pas que le principal était si\n[1205][1205]fort.[000F][000F].. I-Il a écrasé\nle Bataillon à droite et\nà gauche... C'est l'homme\nle plus fort dumonde!"
+    "texte_fr": "Je pensais pas que le principal était si\n[1205][1205]fort.[000F][000F].. I-Il a écrasé\nle Bataillon à droite et à gauche... C'est l'homme le plus fort dumonde!"
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "The[SP]Last[SP]Battalion's[SP]invasion[SP]and[SP]Principal\nHanya's[SP]miraculous[SP]return![1205][000F][SP]How[SP]could[SP]we[SP]call\nourselves[SP]journalists[SP]and[SP]not[SP]write[SP]this[SP]up!?",
     "nom_fr": "Lycéen",
-    "texte_fr": "L'invasion du Bataillon et le retour\nmiraculeux du Principal\n[1205]Hanya! [000F]Comment peut-on\ns'appeler des journalistes et\nne peux pasécrire ça!?"
+    "texte_fr": "L'invasion du Bataillon et le retour\nmiraculeux du Principal\n[1205]Hanya! [000F]Comment peut-on s'appeler des journalistes et ne peux pasécrire ça!?"
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "The[SP]next[SP]issue[SP]of[SP]the[SP]Seven[SP]Sisters[SP]Times[SP]will\nbe[SP]about[SP]Hanya's[SP]resurrection[SP]and[SP]the[SP]utter\ndefeat[SP]of[SP]the[SP]Last[SP]Battalion![1205][000F][SP]This[SP]is[SP]GOLD!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Le prochain numéro du\nTimes de Seven Sisters\nsera sur la ressurection\nd'Hanya et la défaite\nécrasante du BataillonC'est\n[1205][000F]du DIAMANT BRUT!"
+    "texte_fr": "Le prochain numéro du\nTimes de Seven Sisters\nsera sur la ressurection d'Hanya et la défaite écrasante du BataillonC'est [000F][1205]du DIAMANT BRUT!"
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Oh![1205][000A][SP]You[SP]found[SP]Kozy-senpai?[1205][000F][SP]That's[SP]great[SP]news.\nWe[SP]were[SP]getting[SP]worried,[SP]since[SP]none[SP]of[SP]us\ncould[SP]reach[SP]her.",
     "nom_fr": "Lycéen",
-    "texte_fr": "Oh![1205][000A] Vous avez trouvés Kozy?[1205][000F] C'est une\nbonne nouvelle. On commençait à\ns'inquièter, on n'arrivait à la joindre."
+    "texte_fr": "Oh![000A][1205] Vous avez trouvés Kozy?[000F][1205] C'est une\nbonne nouvelle. On commençait à\ns'inquièter, on n'arrivait à la joindre."
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "*sniff*[1205][000A][SP]I[SP]can[SP]hardly[SP]see[SP]through[SP]my[SP]tears...[1205][000F]\nI[SP]can't[SP]believe[SP]the[SP]principal[SP]saved[SP]us[SP]again![1205][000F]\nOh,[SP]Principal...[SP]I'm[SP]so[SP]glad[SP]you're[SP]safe...!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "*snif*[1205][000A]Mes larmes me troublent la vue.[000F][1205][000F][1205]..\nLe proviseur nous a sauvés! Monsieur,\nje suis ravie que vous soyez en vie!"
+    "texte_fr": "*snif*[000A][1205]Mes larmes me troublent la vue.[000F][000F][1205][1205]..\nLe proviseur nous a sauvés! Monsieur,\nje suis ravie que vous soyez en vie!"
   },
   {
     "id": 25,
@@ -387,6 +387,6 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "That[SP]reminds[SP]me,[SP]I[SP]saw[SP]Ms.[SP]Ideal[SP]in[SP]the\ncourtyard[SP]with[SP]a[SP]guy[SP]wearing[SP]a[SP]mask.[1205][000A][SP]The[SP]two\nof[SP]them[SP]disappeared[SP]into[SP]the[SP]light[SP]there.",
     "nom_fr": "",
-    "texte_fr": "Ça me rappelle, j'ai vu Mme Idéale\ndans la cour avec un gars portant un masque.[1205][000A]\nIls ont tous les deux disparu dans la lumière."
+    "texte_fr": "Ça me rappelle, j'ai vu Mme Idéale\ndans la cour avec un gars portant un masque.[000A][1205]\nIls ont tous les deux disparu dans la lumière."
   }
 ]

--- a/traduction/event_scripts/script_268.json
+++ b/traduction/event_scripts/script_268.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "So[SP]Elly-san's[SP]the[SP]reason[SP]that[SP]Last[SP]Battalion\nsoldier's[SP]on[SP]the[SP]floor[SP]over[SP]there?[1205][000F][SP]W-Wow...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Donc Elly est la raison pour laquelle les\nsoldats du Bataillon sont au sol? [1205][000F]W-Wow.."
+    "texte_fr": "Donc Elly est la raison pour laquelle les\nsoldats du Bataillon sont au sol? [000F][1205]W-Wow.."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Elly-san[SP]must[SP]be[SP]what[SP]they[SP]mean[SP]when[SP]they\ntalk[SP]about[SP][1432][NULL][NULL][0014]the[SP]whole[SP]package.[1432][NULL][NULL][0014][1205][000F][SP]Though[SP]of\ncourse,[SP]the[SP]same[SP]could[SP]be[SP]said[SP]about[SP]me.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Elly doit être celle à qui ils font\nréférence lorsqu' il parle de[1432][NULL][NULL][0014]l'idéale.[1205][000F][1432][NULL][NULL][0014]\nMême si on peut dire la même chose de moi."
+    "texte_fr": "Elly doit être celle à qui ils font\nréférence lorsqu' il parle de[1432][NULL][NULL][0014]l'idéale.[000F][1205][1432][NULL][NULL][0014]\nMême si on peut dire la même chose de moi."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh!?[1205][000A][SP]Elly-san?[1205][000F][SP]What's[SP]she[SP]doing[SP]here?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein?[1205][1205][000A] Elly? [000F]Qu'est ce qu'elle fait ici?"
+    "texte_fr": "Hein?[1205][000A][1205] Elly? [000F]Qu'est ce qu'elle fait ici?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Oh![1205][000A][SP]Elly-san[SP]came[SP]too...[E1][E2]\n[E3][E4][NULL][NULL]\"Ginko\nElly-san's[SP]the[SP]best.[SP]She's[SP]so[SP]pretty,[SP]and\nstrong,[SP]and[SP]smart...[1205][000F][SP]I[SP]want[SP]to[SP]be[SP]like[SP]her.",
     "nom_fr": "Ginko",
-    "texte_fr": "Oh![1205][1205][000A] Elly est venue...[E1][E2] [E3][E4][NULL][NULL]\"Ginko\nElly est\nla meilleure. Elle est belle, forte\n[000F]etintelligente.. Je veux être comme elle."
+    "texte_fr": "Oh![1205][000A][1205] Elly est venue...[E1][E2] [E3][E4][NULL][NULL]\"Ginko\nElly est\nla meilleure. Elle est belle, forte\n[000F]etintelligente.. Je veux être comme elle."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Ah,[SP]she[SP]must've[SP]come[SP]to[SP]save[SP]the[SP]students[SP]at\nSevens.[1205][000F][SP]Thank[SP]goodness...[SP]Everyone[SP]seems[SP]to\nbe[SP]okay[SP]here.",
     "nom_fr": "Maya",
-    "texte_fr": "Ah, elle a du venir sauver les\nélèves de Seven. [1205][000F]Dieu merci.. Tout\nle monde semble aller bien là-bas."
+    "texte_fr": "Ah, elle a du venir sauver les\nélèves de Seven. [000F][1205]Dieu merci.. Tout\nle monde semble aller bien là-bas."
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Elly-san's[SP]as[SP]strong[SP]as[SP]I[SP]thought[SP]she'd[SP]be.[1205][000A]\nShe[SP]took[SP]out[SP]five[SP]of[SP]the[SP]Last[SP]Battalion\nwithout[SP]breaking[SP]a[SP]sweat.[1205][000A][SP]Amazing...",
     "nom_fr": "Maya",
-    "texte_fr": "Elly est aussi forte que ce que je pensais.[1205][000A]\nElle a battue cinq membres du Bataillon \nsans le moindre effort.[1205][000A] Génial..."
+    "texte_fr": "Elly est aussi forte que ce que je pensais.[000A][1205]\nElle a battue cinq membres du Bataillon \nsans le moindre effort.[000A][1205] Génial..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Jun",
     "texte_orig": "How[SP]strange...[1205][000F][SP]I[SP]feel[SP]like[SP]I[SP]know[SP]her[SP]very\nwell[SP]already.[1205][000F][SP]Could[SP]this[SP]be[SP]another[SP]effect\nof[SP]Yukino-san's[SP]Persona...?",
     "nom_fr": "Jun",
-    "texte_fr": "C'est bizzare.[1205][000F][1205][000F]. J'ai l'impression de\ndéjà la connaître. Est ce que cela\npeut être lié à la Persona de Yukino?"
+    "texte_fr": "C'est bizzare.[000F][1205][000F][1205]. J'ai l'impression de\ndéjà la connaître. Est ce que cela\npeut être lié à la Persona de Yukino?"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Elly",
     "texte_orig": "You're[SP]all[SP]safe![1205][000A][SP]I[SP]had[SP]heard[SP]that[SP]the[SP]Last\nBattalion[SP]invaded[SP]this[SP]school,[SP]so[SP]I[SP]rushed\nhere[SP]straight[SP]away.",
     "nom_fr": "Elly",
-    "texte_fr": "Vous êtes tous en vie![1205][000A] J'ai compris\nque le Bataillon a envahi l'école,\ndonc j'ai foncé ici au plus vite."
+    "texte_fr": "Vous êtes tous en vie![000A][1205] J'ai compris\nque le Bataillon a envahi l'école,\ndonc j'ai foncé ici au plus vite."
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Elly",
     "texte_orig": "Whew...[SP]It's[SP]been[SP]some[SP]time[SP]since[SP]a[SP]battle[SP]made\nme[SP]sweat[SP]that[SP]way.[1205][000A][SP]It's[SP]fortunate[SP]I[SP]stopped[SP]by\nthe[SP]Velvet[SP]Room[SP]beforehand.[1205][000F][SP]Are[SP]you[SP]all[SP]okay?",
     "nom_fr": "Elly",
-    "texte_fr": "Fiou.. ça faisait longtemp qu'un\ncombat m'a fait transpirer autant.[1205][1205][000A]\nHereusement, j'ai été à la chambre\ndevelours avant. [000F]Tout le monde va bien?"
+    "texte_fr": "Fiou.. ça faisait longtemp qu'un\ncombat m'a fait transpirer autant.[1205][000A][1205]\nHereusement, j'ai été à la chambre develours avant. [000F]Tout le monde va bien?"
   },
   {
     "id": 12,
@@ -222,7 +222,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "If...[1205][0008][SP]If[SP]that[SP]lady[SP]hadn't[SP]come,[SP]wh-who[SP]knows\nwhat[SP]would've[SP]happened[SP]to[SP]us...[1205][000F][SP]Y-You[SP]have[SP]no\nidea[SP]how[SP]grateful[SP]I[SP]am[SP]for[SP]her!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Si.[1205].[1205][0008] Si cette femme n'était pas venue,\nq-qui sait ce qui aurait pu nous arriver.[000F].\nVous n'avez pas idée, je lui dois la vie"
+    "texte_fr": "Si.[1205].[0008][1205] Si cette femme n'était pas venue,\nq-qui sait ce qui aurait pu nous arriver.[000F].\nVous n'avez pas idée, je lui dois la vie"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "The[SP]Last[SP]Battalion's[SP]invasion[SP]and[SP]a[SP]graceful\nbeauty's[SP]sudden[SP]intervention![1205][000F][SP]How[SP]could[SP]we[SP]call\nourselves[SP]journalists[SP]and[SP]not[SP]write[SP]this[SP]up!?",
     "nom_fr": "Lycéen",
-    "texte_fr": "L'invasion du Bataillon et\nl'intervention de cette bombe grâcieuse!\n[1205][000F]Comment peut-on toujours prétendre êtrejournalistes\net ne pas écrire ceci!"
+    "texte_fr": "L'invasion du Bataillon et\nl'intervention de cette bombe grâcieuse!\n[000F][1205]Comment peut-on toujours prétendre êtrejournalistes et ne pas écrire ceci!"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "The[SP]next[SP]issue[SP]of[SP]the[SP]Seven[SP]Sisters[SP]Times[SP]will\nbe[SP]about[SP]the[SP]mysterious[SP]beauty[SP]who[SP]drove[SP]off\nthe[SP]evil[SP]Last[SP]Battalion![1205][000F][SP]This[SP]is[SP]GOLD!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Le prochain numéro du\nTimes des Seven Sisters\naura pour sujet la mystérieuse beauté qui a\nfait fuir le Bataillon. [1205][000F]C'est de l'OR!"
+    "texte_fr": "Le prochain numéro du\nTimes des Seven Sisters\naura pour sujet la mystérieuse beauté qui a fait fuir le Bataillon. [000F][1205]C'est de l'OR!"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Oh![1205][000A][SP]You[SP]found[SP]Kozy-senpai?[1205][000F][SP]That's[SP]great[SP]news.\nWe[SP]were[SP]getting[SP]worried,[SP]since[SP]none[SP]of[SP]us\ncould[SP]reach[SP]her.",
     "nom_fr": "Lycéen",
-    "texte_fr": "Oh![1205][1205][000A] Vous avez trouvé Kozy? [000F]Tant mieux. On\ns'inquiétait, on n'arrivait\npas à la joindre."
+    "texte_fr": "Oh![1205][000A][1205] Vous avez trouvé Kozy? [000F]Tant mieux. On\ns'inquiétait, on n'arrivait\npas à la joindre."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "She's...[SP]She's[SP]amazing![1205][000A][SP]I'm[SP]moved[SP]to[SP]tears...[1205][000F]\nShe[SP]defeated[SP]all[SP]those[SP]hooligans[SP]with[SP]one\nyell[SP]of[SP][1432][NULL][NULL][0014]Persona![1432][NULL][NULL][0014][1205][000F][SP]But[SP]what's[SP]a[SP]Persona?",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Elle est géniale![1205][1205][1205][000A] Je suis émue..[000F][000F]. Elle\na vaincu tous ces voyous d'un cri de\n[1432][NULL][NULL][0014]Persona![1432][NULL][NULL][0014] Mais c'est quoi, une Persona?"
+    "texte_fr": "Elle est géniale![1205][1205][000A][1205] Je suis émue..[000F][000F]. Elle\na vaincu tous ces voyous d'un cri de\n[1432][NULL][NULL][0014]Persona![1432][NULL][NULL][0014] Mais c'est quoi, une Persona?"
   },
   {
     "id": 19,
@@ -297,6 +297,6 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "That[SP]reminds[SP]me,[SP]I[SP]saw[SP]Ms.[SP]Ideal[SP]in[SP]the\ncourtyard[SP]with[SP]a[SP]guy[SP]wearing[SP]a[SP]mask.[1205][000A][SP]The[SP]two\nof[SP]them[SP]disappeared[SP]into[SP]the[SP]light[SP]there.",
     "nom_fr": "",
-    "texte_fr": "Ça me rappelle, j'ai vu Mme Idéale\ndans la cour avec un gars portant un masque.[1205][000A]\nIls ont tous les deux disparu dans la lumière."
+    "texte_fr": "Ça me rappelle, j'ai vu Mme Idéale\ndans la cour avec un gars portant un masque.[000A][1205]\nIls ont tous les deux disparu dans la lumière."
   }
 ]

--- a/traduction/event_scripts/script_269.json
+++ b/traduction/event_scripts/script_269.json
@@ -12,7 +12,7 @@
     "nom_orig": "Mr.[SP]Aishi",
     "texte_orig": "What's[SP]up,[SP][1112]?[1205][001E][SP]Looking[SP]for[SP]Ms.[SP]Saeko?\nI[SP]see![SP]I'm[SP]glad[SP]to[SP]hear[SP]it![SP]So[SP]you're[SP]finally\nready[SP]to[SP]do[SP]guidance[SP]counseling!",
     "nom_fr": "M. Aishi",
-    "texte_fr": "Salut, [1112]![1205][001E] Tu cherches Mme. Saeko? T'es\nprêt pour le conseil d'orientation? Enfin!"
+    "texte_fr": "Salut, [1112]![001E][1205] Tu cherches Mme. Saeko? T'es\nprêt pour le conseil d'orientation? Enfin!"
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Mr.[SP]Aishi",
     "texte_orig": "I[SP]saw[SP]Ms.[SP]Saeko[SP]heading[SP]up[SP]to[SP]the[SP]third[SP]floor.\nMaybe[SP]she[SP]went[SP]to[SP]check[SP]your[SP]classroom.[SP]You're\nfinally[SP]doing[SP]guidance[SP]counseling,[SP]eh?[SP]I[SP]see!",
     "nom_fr": "M. Aishi",
-    "texte_fr": "J'ai vu Mme. Saeko\naller au troisième étage.\nElle est peut-être dans ta classe. Tu fais\nenfin de l'orientation scolaire? Je vois!"
+    "texte_fr": "J'ai vu Mme. Saeko\naller au troisième étage.\nElle est peut-être dans ta classe. Tu fais enfin de l'orientation scolaire? Je vois!"
   },
   {
     "id": 4,
@@ -102,7 +102,7 @@
     "nom_orig": "Mr.[SP]Oriri",
     "texte_orig": "Oh,[SP]really?[SP]You[SP]had[SP]this[SP]Joker[SP]smarten[SP]you[SP]up,\nso[SP]it's[SP]not[SP]really[SP]cheating?[SP]Oh,[SP]really...[1205][001E]\nThen[SP]how[SP]did[SP]you[SP]cheat?",
     "nom_fr": "M. Oriri",
-    "texte_fr": "Oh, vraiment? Ce Joker t'as rendu\nfuté, donc t'as pas triché? Oh,\nvraiment...[1205][001E] Bref, comment t'as triché?"
+    "texte_fr": "Oh, vraiment? Ce Joker t'as rendu\nfuté, donc t'as pas triché? Oh,\nvraiment...[001E][1205] Bref, comment t'as triché?"
   },
   {
     "id": 7,
@@ -162,7 +162,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Hah![SP]Here[SP]goes![SP]Pi[SP]attack![1205][001E]\n3.14159265358979323846!\n2643383279502884197169!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Hah! Vas-y! Attaque de pi! [1205][001E]\n3.14159265358979323846!\n2643383279502884197169!"
+    "texte_fr": "Hah! Vas-y! Attaque de pi! [001E][1205]\n3.14159265358979323846!\n2643383279502884197169!"
   },
   {
     "id": 11,
@@ -222,7 +222,7 @@
     "nom_orig": "Vein-throbbing[SP]male[SP]student",
     "texte_orig": "9...[SP]9644288!!!!!!!!!!\n10197566593344612847!!\n*pant*[SP]*pant*[1205][001E][SP]N-No[SP]more...",
     "nom_fr": "Lycéen exténué",
-    "texte_fr": "9...\n9644288!!!!!!!!!! 10197566593344612847!!\n*souffle* *souffle*[1205][001E] J'en peux plus..."
+    "texte_fr": "9...\n9644288!!!!!!!!!! 10197566593344612847!!\n*souffle* *souffle*[001E][1205] J'en peux plus..."
   },
   {
     "id": 15,
@@ -312,7 +312,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Hah![SP]Here[SP]goes![SP]Pi[SP]attack![1205][001E]\n3.14159265358979323846!\n2643383279502884197169!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Hah! Vas-y! Attaque de pi! [1205][001E]\n3.14159265358979323846!\n2643383279502884197169!"
+    "texte_fr": "Hah! Vas-y! Attaque de pi! [001E][1205]\n3.14159265358979323846!\n2643383279502884197169!"
   },
   {
     "id": 21,
@@ -372,7 +372,7 @@
     "nom_orig": "Vein-throbbing[SP]male[SP]student",
     "texte_orig": "9...[SP]9644288!!!!!!!!!!\n10197566593344612847!!\n*pant*[SP]*pant*[1205][001E][SP]N-No[SP]more...",
     "nom_fr": "Lycéen exténué",
-    "texte_fr": "9...\n9644288!!!!!!!!!! 10197566593344612847!!\n*souffle* *souffle*[1205][001E] J'en peux plus..."
+    "texte_fr": "9...\n9644288!!!!!!!!!! 10197566593344612847!!\n*souffle* *souffle*[001E][1205] J'en peux plus..."
   },
   {
     "id": 25,
@@ -387,6 +387,6 @@
     "nom_orig": "Exhausted[SP]male[SP]student",
     "texte_orig": "*pant*[SP]*pant*[1205][001E][SP]That's[SP]Mr.[SP]Oriri,[SP]all[SP]right...\nIt's[SP]like[SP]shouting[SP]at[SP]a[SP]wall![SP]He's[SP]so[SP]tough...[1205][001E]\nHmph,[SP]fine.[SP]Joker[SP]really[SP]does[SP]exist.",
     "nom_fr": "",
-    "texte_fr": "*han* *han*[1205][001E] C'est bien M. Oriri...\nC'est comme crier contre un mur ! Il est coriace...[1205][001E]\nHmpf, bon. Le Joker existe vraiment."
+    "texte_fr": "*han* *han*[001E][1205] C'est bien M. Oriri...\nC'est comme crier contre un mur ! Il est coriace...[001E][1205]\nHmpf, bon. Le Joker existe vraiment."
   }
 ]

--- a/traduction/event_scripts/script_270.json
+++ b/traduction/event_scripts/script_270.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "*sigh*[SP]I[SP]can't[SP]stand[SP]girls[SP]who[SP]don't[SP]know\ntheir[SP]place.[1205][001E][SP]The[SP]best[SP]Ginko[SP]could[SP]hope[SP]for\nis[SP]to[SP]win[SP]Miss[SP]Garbage[SP]Dump.",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'supporte pas les filles qui connaissent\npas leur place.[1205][001E] Ginko pourrait au mieux \nespérer gagner Miss Poubelle."
+    "texte_fr": "J'supporte pas les filles qui connaissent\npas leur place.[001E][1205] Ginko pourrait au mieux \nespérer gagner Miss Poubelle."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]most[SP]beautiful[SP]woman[SP]in[SP]Sumaru[SP]City[SP]and[SP]the\nreal[SP]Miss[SP]Sevens?[1205][001E][SP]Hanakouji-san,[SP]hands[SP]down!",
     "nom_fr": "Eikichi",
-    "texte_fr": "La plus belle femme à Sumaru et la vraie\nMiss Seven?[1205][001E] Hanakouji-san, sans hésiter!"
+    "texte_fr": "La plus belle femme à Sumaru et la vraie\nMiss Seven?[001E][1205] Hanakouji-san, sans hésiter!"
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#6![1205][001E][SP][1432][NULL][NULL][0014]Touche[1432][NULL][NULL][0014][SP]means\n[1432][NULL][NULL][0014]thank[SP]you.[1432][NULL][NULL][0014][SP]I[SP]guess[SP]it's[SP]kind[SP]of[SP]more[SP]like,\n[1432][NULL][NULL][0014]thanks[SP]a[SP]lot[1432][NULL][NULL][0014]?",
     "nom_fr": "Ginko",
-    "texte_fr": "La leçon Cantonaise de Lisa #6![1205][001E] [1432][NULL][NULL][0014]Touche[1432][NULL][NULL][0014]veut\ndire [1432][NULL][NULL][0014]merci.[1432][NULL][NULL][0014] Je pense\nque c'est, [1432][NULL][NULL][0014]merci beaucoup\n[1432][NULL][NULL][0014]?"
+    "texte_fr": "La leçon Cantonaise de Lisa #6![001E][1205] [1432][NULL][NULL][0014]Touche[1432][NULL][NULL][0014]veut\ndire [1432][NULL][NULL][0014]merci.[1432][NULL][NULL][0014] Je pense\nque c'est, [1432][NULL][NULL][0014]merci beaucoup [1432][NULL][NULL][0014]?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![SP]Now[SP]I'm[SP]pissed![1205][001E][SP]If[SP]the[SP]school[SP]festival\nis[SP]canceled[SP]because[SP]of[SP]stupid[SP]Hanya...!",
     "nom_fr": "Ginko",
-    "texte_fr": "Maintenant je suis furax![1205][001E] Si le festival\ndu lycée est annulé à cause de Hanya...!"
+    "texte_fr": "Maintenant je suis furax![001E][1205] Si le festival\ndu lycée est annulé à cause de Hanya...!"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP]I[SP]was[SP]a[SP]candidate[SP]for[SP]Miss[SP]Sevens[SP]too![1205][001E]\nAnd[SP]I'd[SP]have[SP]won,[SP]at[SP]that![1205][001E][SP]Sheesh...[SP]Way[SP]to\nkill[SP]my[SP]good[SP]mood!",
     "nom_fr": "Ginko",
-    "texte_fr": "J'étais candidate à Miss Seven aussi![1205][001E]\nJ'aurais gagné, en plus![1205][001E] Pff... Voila\nqui ruine ma bonne humeur!"
+    "texte_fr": "J'étais candidate à Miss Seven aussi![001E][1205]\nJ'aurais gagné, en plus![001E][1205] Pff... Voila\nqui ruine ma bonne humeur!"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Looks[SP]like[SP]the[SP]principal's[SP]making[SP]his\nmove,[SP]right[SP]on[SP]cue![1205][001E][SP]Let's[SP]hurry[SP]and[SP]find\nthe[SP]key[SP]to[SP]the[SP]clock[SP]tower!",
     "nom_fr": "Maya",
-    "texte_fr": "Le principal agit enfin![1205][001E] Dépêchons-nous et\ntrouvons la clé de la tour de l'horloge!"
+    "texte_fr": "Le principal agit enfin![001E][1205] Dépêchons-nous et\ntrouvons la clé de la tour de l'horloge!"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]announcement[SP]just[SP]now...[1205][000F][SP]If[SP]he's[SP]trying\nto[SP]protect[SP]the[SP]last[SP]emblem,[SP]the[SP]principal[SP]might\nbe[SP]right[SP]there[SP]with[SP]it...",
     "nom_fr": "Maya",
-    "texte_fr": "Cette annonce maintenant...[1205][000F][0+000F] S'il\nprotège le dernier emblème, le\nprincipal est peut-être avec lui..."
+    "texte_fr": "Cette annonce maintenant...[000F][1205][0+000F] S'il\nprotège le dernier emblème, le\nprincipal est peut-être avec lui..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]thought[SP]Yukki[SP]would[SP]be[SP]happy[SP]that[SP]Ms.[SP]Saeko\nis[SP]back[SP]to[SP]normal.[1205][001E][SP]But[SP]it[SP]looks[SP]like[SP]something\nelse[SP]is[SP]bugging[SP]her...",
     "nom_fr": "Maya",
-    "texte_fr": "Je pensais que Yukki serait contente\nque Mme Saeko redevienne normale.[1205][001E]\nMais quelque chose la dérange..."
+    "texte_fr": "Je pensais que Yukki serait contente\nque Mme Saeko redevienne normale.[001E][1205]\nMais quelque chose la dérange..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "That[SP]goddamn[SP]Hamya...[SP]How[SP]dare[SP]he\nbrainwash[SP]my[SP]Ms.[SP]Saeko![SP][1205][001E][SP]Now[SP]how[SP]should\nI[SP]settle[SP]the[SP]score...?",
     "nom_fr": "Yukino",
-    "texte_fr": "Ce foutu Hamya...\nComment ose-t-il manipuler\nMme Saeko! [1205][001E] Maintenant comment régler ca?"
+    "texte_fr": "Ce foutu Hamya...\nComment ose-t-il manipuler\nMme Saeko! [001E][1205] Maintenant comment régler ca?"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Ms.[SP]Saeko[SP]would[SP]never[SP]blindly[SP]obey[SP]like\nthis.[1205][001E][SP]She's[SP]the[SP]kind[SP]of[SP]lady[SP]who'd[SP]punch\na[SP]minister[SP]if[SP]she[SP]thought[SP]she[SP]had[SP]to.",
     "nom_fr": "Yukino",
-    "texte_fr": "Mme Saeko n'obéirait jamais aveuglement\n.[1205][001E] Elle frapperait un ministre si elle\npensait qu'elle devait."
+    "texte_fr": "Mme Saeko n'obéirait jamais aveuglement\n.[001E][1205] Elle frapperait un ministre si elle\npensait qu'elle devait."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "A[SP]teacher,[SP]huh?[1205][001E][SP]It's[SP]no[SP]use...[SP]There's[SP]no[SP]way\nI'd[SP]be[SP]smart[SP]enough...",
     "nom_fr": "Yukino",
-    "texte_fr": "Un professeur?[1205][001E] Non.. Je serai\njamais assez intelligente."
+    "texte_fr": "Un professeur?[001E][1205] Non.. Je serai\njamais assez intelligente."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Hm?[1205][001E][SP]Ah,[SP]it's[SP]nothing.[SP]Nothing[SP]at[SP]all...[1205][001E]\nI[SP]should[SP]get[SP]a[SP]shot[SP]of[SP]Ms.[SP]Saeko[SP]for[SP]our[SP]file!",
     "nom_fr": "Yukino",
-    "texte_fr": "Hm?[1205][001E] Ah, c'est rien...[1205][001E] Je devrais\nprendre une photo de Mme Saeko!"
+    "texte_fr": "Hm?[001E][1205] Ah, c'est rien...[001E][1205] Je devrais\nprendre une photo de Mme Saeko!"
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "The[SP]clock[SP]tower?[SP]Why[SP]would[SP]you[SP]go[SP]there?\nIf[SP]you[SP]have[SP]time,[SP]you[SP]should[SP]be[SP]cleaning![1205][001E]\nWe[SP]must[SP]obey[SP]our[SP]principal.",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "La tour de l'horloge? Pourquoi y\naller? Si tu as du temps, tu devrais\nnettoyer![1205][001E] On doit obéir au principal."
+    "texte_fr": "La tour de l'horloge? Pourquoi y\naller? Si tu as du temps, tu devrais\nnettoyer![001E][1205] On doit obéir au principal."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "It[SP]really[SP]makes[SP]me[SP]mad[SP]for[SP]some[SP]reason,\nbut[SP]that[SP]bald[SP]buf--[1205][001E]I[SP]mean,[SP]errr...[1205][001E][SP]Y-You\nlike[SP]Principal[SP]Hanya[SP]too,[SP]right,[SP][1113]?",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Ça me met hors de moi mais ce\nbouff-[1205][001E] Eum...[1205][001E] Tu aimes le Proviseur\nHanya, toi aussi pas vrai, [1113]"
+    "texte_fr": "Ça me met hors de moi mais ce\nbouff-[001E][1205] Eum...[001E][1205] Tu aimes le Proviseur\nHanya, toi aussi pas vrai, [1113]"
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "Thank[SP]you,[SP][1113]...[1205][001E][SP]You[SP]really[SP]are[SP]the\nperson[SP]I[SP]thought[SP]you[SP]were.",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Merci, [1113]...[1205][001E] T'es vraiment\nexactement comme je le pensais."
+    "texte_fr": "Merci, [1113]...[001E][1205] T'es vraiment\nexactement comme je le pensais."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "I'll[SP]do[SP]something[SP]about[SP]the[SP]school[SP]festival,\nso[SP]off[SP]you[SP]go![1205][001E][SP]You[SP]still[SP]have[SP]work[SP]to[SP]do,\ndon't[SP]you?[1205][001E][SP]I'm[SP]sure[SP]you[SP]can[SP]handle[SP]it!",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Je m'occupe du festival du lycée, donc\nvas-y![1205][001E] Mais t'as toujours du boulot, pas\nvrai?[1205][001E] Je suis sûr que tu peux le faire!"
+    "texte_fr": "Je m'occupe du festival du lycée, donc\nvas-y![001E][1205] Mais t'as toujours du boulot, pas\nvrai?[001E][1205] Je suis sûr que tu peux le faire!"
   },
   {
     "id": 19,
@@ -402,7 +402,7 @@
     "nom_orig": "Mr.[SP]Oriri",
     "texte_orig": "Since[SP]Lisa's[SP]with[SP]you...[SP]Tell[SP]her[SP]she[SP]needs\nto[SP]take[SP]English[SP]more[SP]seriously![SP]Her[SP]grades\nare[SP]horrible!",
     "nom_fr": "M. Oriri",
-    "texte_fr": "Puisque Lisa est avec\ntoi... Dis lui qu'elle\ndoit s'améliorer en\nanglais! Elle est nulle!"
+    "texte_fr": "Puisque Lisa est avec\ntoi... Dis lui qu'elle\ndoit s'améliorer en anglais! Elle est nulle!"
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Deeply[SP]emotional[SP]Mr.[SP]Oriri",
     "texte_orig": "Oh,[SP]by[SP]the[SP]way,[SP]the[SP]school[SP]festival[SP]is[SP]called\noff[SP]as[SP]a[SP]result[SP]of[SP]this.[SP]It[SP]had[SP]to[SP]happen.\nReally.[SP]But[SP]it's[SP]not[SP]the[SP]principal's[SP]fault.",
     "nom_fr": "Mr. Oriri ému",
-    "texte_fr": "Oh, et d'ailleurs, le festival du\nlycée est annulé à cause de ça.\nC'était obligé d'arriver. Vraiment.Mais\nc'est pas la faute du principal."
+    "texte_fr": "Oh, et d'ailleurs, le festival du\nlycée est annulé à cause de ça.\nC'était obligé d'arriver. Vraiment.Mais c'est pas la faute du principal."
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Ill[SP]male[SP]student",
     "texte_orig": "Th-This[SP]is[SP]tough...[SP]I[SP]shouldn't[SP]have[SP]been\nso[SP]sloppy...[1205][001E][SP]Not[SP]even[SP]I[SP]could[SP]have\npredicted[SP]this[SP]turn[SP]of[SP]events!",
     "nom_fr": "Lycéen malade",
-    "texte_fr": "C-C'est dur... J'aurais pas du être si\nnégligeant...[1205][001E] Même moi\nj'aurais pas pu prédire\nça!"
+    "texte_fr": "C-C'est dur... J'aurais pas du être si\nnégligeant...[001E][1205] Même moi\nj'aurais pas pu prédire\nça!"
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I-It's[SP]tough[SP]with[SP]the[SP]principal[SP]gone...[SP]Not\neven[SP]I[SP]could've[SP]predicted[SP]this[SP]turn[SP]of[SP]events!\nBut[SP]it's[SP]fine.[SP]I'm[SP]sure[SP]he'll[SP]be[SP]back.",
     "nom_fr": "Lycéen",
-    "texte_fr": "C'est dur depuis que\nle principal est parti...\nMême moi j'aurais pas pu prédire ça! Mais\nc'est pas grave. Je\nsuis sûr qu'il reviendra."
+    "texte_fr": "C'est dur depuis que\nle principal est parti...\nMême moi j'aurais pas pu prédire ça! Mais c'est pas grave. Je suis sûr qu'il reviendra."
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I-It'll[SP]be[SP]tough[SP]with[SP]the[SP]principal[SP]dead...[SP]Not\neven[SP]I[SP]could've[SP]predicted[SP]this[SP]turn[SP]of[SP]events!\nBut[SP]it's[SP]fine.[SP]I'm[SP]sure[SP]he's[SP]in[SP]heaven[SP]now.",
     "nom_fr": "Lycéen",
-    "texte_fr": "Ça va être dur avec la mort du principal...\nMême moi j'aurais pas pu prédire ça! Mais\nc'est pas grave. Je\nsuis sûr qu'il repose enpaix."
+    "texte_fr": "Ça va être dur avec la mort du principal...\nMême moi j'aurais pas pu prédire ça! Mais\nc'est pas grave. Je suis sûr qu'il repose enpaix."
   },
   {
     "id": 31,
@@ -537,6 +537,6 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "*squeal*[1205][0008][SP]The[SP]curse[SP]is[SP]lifted![SP]I'm[SP]soooo\nlucky![1205][000F][SP]And[SP]the[SP]principal's[SP]gone,[SP]too,[SP]so\nI'll[SP]get[SP]to[SP]stay[SP]out[SP]late[SP]again!",
     "nom_fr": "",
-    "texte_fr": "*cri de joie*[1205][0008] La malédiction est levée !\nJe suis trop de chance ![1205][000F] Et le proviseur\npartit, je vais pouvoir rentrer tard le soir !"
+    "texte_fr": "*cri de joie*[0008][1205] La malédiction est levée !\nJe suis trop de chance ![000F][1205] Et le proviseur\npartit, je vais pouvoir rentrer tard le soir !"
   }
 ]

--- a/traduction/event_scripts/script_271.json
+++ b/traduction/event_scripts/script_271.json
@@ -42,7 +42,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "What[SP]exactly[SP]happened[SP]here!?[SP]I'm[SP]all[SP]stressed\nout[SP]because[SP]of[SP]the[SP]curse,[SP]but[SP]look[SP]at[SP]Yoko!\nYou[SP]remember,[SP]the[SP]girl[SP]you[SP]rejected?",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Il s'est passé quoi\nici!? Je suis stressée à\ncause de la malédiction,\nmais regarde Yoko!\nTu te souviens, celle que t'as rejeté?"
+    "texte_fr": "Il s'est passé quoi\nici!? Je suis stressée à\ncause de la malédiction, mais regarde Yoko! Tu te souviens, celle que t'as rejeté?"
   },
   {
     "id": 3,
@@ -147,7 +147,7 @@
     "nom_orig": "Yoko",
     "texte_orig": "Hohoho...[1205][001E][SP]Well?[SP]Aren't[SP]I[SP]gorgeous?[SP]There's[SP]no\nway[SP]I'm[SP]not[SP]chosen[SP]as[SP]Miss[SP]Sevens[SP]this[SP]year.\nI[SP]won't[SP]let[SP]that[SP]foreign[SP]bitch[SP]Lisa[SP]beat[SP]me!",
     "nom_fr": "Yoko",
-    "texte_fr": "Hoho...[1205][001E] Je suis pas magnifique? Aucune\nchance que cette putain d'étrangère de\nLisa me batte au concours Miss Seven!"
+    "texte_fr": "Hoho...[001E][1205] Je suis pas magnifique? Aucune\nchance que cette putain d'étrangère de\nLisa me batte au concours Miss Seven!"
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Hey[SP]there,[SP][1113].[SP]You[SP]know[SP]that[SP]blonde[SP]girl\nLisa[SP]in[SP]2-C[SP]who[SP]follows[SP]you[SP]around?[SP]She[SP]was\nlooking[SP]for[SP]you.[SP]Hey,[SP]is[SP]she[SP]really[SP]American?",
     "nom_fr": "Lycéen",
-    "texte_fr": "Hey toi, [1113]. Tu sais, cette Lisa blonde\nen 2-C qui te\nsuit partout? Elle te cherchait.\nHey, elle est vraiment américaine?"
+    "texte_fr": "Hey toi, [1113]. Tu sais, cette Lisa blonde\nen 2-C qui te\nsuit partout? Elle te cherchait. Hey, elle est vraiment américaine?"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "She[SP]yells[SP]random[SP]Chinese[SP]and[SP]she's[SP]kinda[SP]weird,\nbut[SP]man,[SP]it'd[SP]be[SP]awesome[SP]having[SP]a[SP]real[SP]blonde[SP]as\na[SP]girlfriend.[SP]I'd[SP]go[SP]after[SP]her[SP]if[SP]I[SP]were[SP]you.",
     "nom_fr": "Lycéen",
-    "texte_fr": "Elle crie des mots chinois et elle est\nbizarre, mais ça serait trop bien\nd'avoir une copine vraiment blonde.Je\ntenterais ma chance si j'étais toi."
+    "texte_fr": "Elle crie des mots chinois et elle est\nbizarre, mais ça serait trop bien\nd'avoir une copine vraiment blonde.Je tenterais ma chance si j'étais toi."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "You[SP]remember[SP]that[SP]girl[SP]Anna[SP]Yoshizaka[SP]who\ndropped[SP]out?[SP]I[SP]saw[SP]her[SP]near[SP]a[SP]club[SP]the[SP]other\nday.[SP]She[SP]was[SP]with[SP]a[SP]baaaaaaaad[SP]crowd.",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "Tu te souviens d'Anna\nYoshikaza? Je l'ai vue\nprès d'un club,\navec de mauvaises personnes."
+    "texte_fr": "Tu te souviens d'Anna\nYoshikaza? Je l'ai vue\nprès d'un club, avec de mauvaises personnes."
   },
   {
     "id": 14,

--- a/traduction/event_scripts/script_272.json
+++ b/traduction/event_scripts/script_272.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Whoa,[SP]wait[SP]a[SP]sec![1205][001E][SP]There's[SP]people[SP]from[SP]Coolest\nhere!?[1205][001E][SP]To[SP]interview[SP]YOU!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, attendez![1205][001E] Des gens de Coolest\nici!?[1205][001E] Pour t'interviewer, TOI!?"
+    "texte_fr": "Hé, attendez![001E][1205] Des gens de Coolest\nici!?[001E][1205] Pour t'interviewer, TOI!?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Whaaaaaat!?[1205][001E][SP]Why[SP]not[SP]me!?[1205][001E][SP]How[SP]could[SP]they[SP]write\na[SP]story[SP]without[SP]interviewing[SP]the[SP]handsomest,\nmost[SP]beautiful[SP]guy[SP]around!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Quoooooi!?[1205][001E] Pourquoi pas moi!?[1205][001E]\nComment écrire un article sans\ninterviewer le plus beau du coin!?"
+    "texte_fr": "Quoooooi!?[001E][1205] Pourquoi pas moi!?[001E][1205]\nComment écrire un article sans\ninterviewer le plus beau du coin!?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ooooh![1205][001E][SP]Ginko's[SP]all[SP]mad[SP]now![SP]One[SP]girl's[SP]vault\nis[SP]another[SP]man's[SP]lesson![E1][E2]\n\n\n[E3][E4][NULL][NULL]\"Ginko\nShut[SP]your[SP]face,[SP]Undie[SP]Bastard!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ooooh![1205][001E] Ginko pète un câble! Ce\nqui choque une fille instruit un\nhomme ![E1][E2]\n[E3][E4][NULL][NULL]\"Ginko\n Ferme-la, minus!"
+    "texte_fr": "Ooooh![001E][1205] Ginko pète un câble! Ce\nqui choque une fille instruit un\nhomme ![E1][E2]\n[E3][E4][NULL][NULL]\"Ginko\n Ferme-la, minus!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yeesh,[SP]she's[SP]scary...[1205][001E][SP]She's[SP]not[SP]really[SP]one[SP]to\ntalk[SP]when[SP]it[SP]comes[SP]to[SP]girls'[SP]personalities.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pfff, elle fait peur...[1205][001E] Elle est mal placée\npour parler du caractère des filles."
+    "texte_fr": "Pfff, elle fait peur...[001E][1205] Elle est mal placée\npour parler du caractère des filles."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ooooh!?[1205][001E][SP]Ginko's[SP]pissed[SP]again![SP]One[SP]girl's[SP]colt\nis[SP]another[SP]man's[SP]lesson!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ooooh!?[1205][001E] Ginko s'énerve! Ce qui\nchoque une fille instruit un homme !"
+    "texte_fr": "Ooooh!?[001E][1205] Ginko s'énerve! Ce qui\nchoque une fille instruit un homme !"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yeesh,[SP]she's[SP]terrifying...[1205][001E][SP]Seriously,[SP]she's\nin[SP]no[SP]position[SP]to[SP]make[SP]snarky[SP]remarks[SP]about\nother[SP]girls'[SP]personalities.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pfff, terrifiante...[1205][001E] Sérieux, elle\nest mal placée pour critiquer le\ncaractère des autres filles."
+    "texte_fr": "Pfff, terrifiante...[001E][1205] Sérieux, elle\nest mal placée pour critiquer le\ncaractère des autres filles."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "A[SP]contest,[SP]huh...?[1205][001E][SP]Just[SP]better[SP]hope[SP]the[SP]school\nfestival[SP]isn't[SP]canceled[SP]because[SP]of[SP]all[SP]this!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Un concours, hein...?[1205][001E] Espérons que la fête\nscolaire ne soit pas annulée à cause de ça!"
+    "texte_fr": "Un concours, hein...?[001E][1205] Espérons que la fête\nscolaire ne soit pas annulée à cause de ça!"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Huh!?[SP]What're[SP]you[SP]talking[SP]about!?[1205][001E][SP][1113]\ndeserves[SP]it[SP]because[SP]he[SP]IS[SP]the[SP]coolest![1205][001E][SP]Who'd\nwant[SP]to[SP]read[SP]about[SP]an[SP]Undie[SP]Boss[SP]like[SP]you!?",
     "nom_fr": "Lisa",
-    "texte_fr": "Hein!? De quoi tu parles!?[1205][001E] [1113] le\nmérite car il EST le plus cool![1205][001E] Qui\nvoudrait lire un article sur toi?"
+    "texte_fr": "Hein!? De quoi tu parles!?[001E][1205] [1113] le\nmérite car il EST le plus cool![001E][1205] Qui\nvoudrait lire un article sur toi?"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh!?[SP]What're[SP]you[SP]talking[SP]about!?[1205][001E][SP]I[SP]don't[SP]need\nJoker[SP]to[SP]whip[SP]you[SP]in[SP]a[SP]beauty[SP]contest!",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein!? De quoi tu parles!?[1205][001E] J'ai pas\nbesoin du Joker pour te battre en beauté!"
+    "texte_fr": "Hein!? De quoi tu parles!?[001E][1205] J'ai pas\nbesoin du Joker pour te battre en beauté!"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "It[SP]was[SP]your[SP]personality[SP]that[SP]got[SP]you[SP]rejected\nby[SP][1113],[SP]anyway![1205][001E][SP]Honestly,[SP]everyone's[SP]like\nyou[SP]at[SP]this[SP]school![SP]I[SP]hope[SP]they[SP]all[SP]get[SP]cursed!",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est ton caractère qui t'a valu d'être\nrejetée par [1113]![1205][001E] Toute cette école est\npareille! J'espère qu'ils\nsoient tous maudits!"
+    "texte_fr": "C'est ton caractère qui t'a valu d'être\nrejetée par [1113]![001E][1205] Toute cette école est\npareille! J'espère qu'ils\nsoient tous maudits!"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh!?[SP]Are[SP]you[SP]still[SP]bitching[SP]about[SP]that!?[1205][001E]\nI've[SP]told[SP]you[SP]a[SP]million[SP]times,[SP]you're[SP]not\nworthy[SP]to[SP]carry[SP]my[SP]makeup[SP]kit!",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein!? Tu en es encore là!?[1205][001E] Je te l'ai\ndit mille fois, t'es même pas digne de\nporter ma trousse de maquillage!"
+    "texte_fr": "Hein!? Tu en es encore là!?[001E][1205] Je te l'ai\ndit mille fois, t'es même pas digne de\nporter ma trousse de maquillage!"
   },
   {
     "id": 12,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Is[SP]Lisa[SP]this[SP]cold[SP]to[SP]everyone...?[1205][001E][SP]She's[SP]so\nopen[SP]around[SP][1113]-kun,[SP]though...",
     "nom_fr": "Maya",
-    "texte_fr": "Lisa est froide avec tout le monde?[1205][001E]\nPourtant si ouverte avec [1113]-kun..."
+    "texte_fr": "Lisa est froide avec tout le monde?[001E][1205]\nPourtant si ouverte avec [1113]-kun..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm...[SP]It's[SP]not[SP]coldness,[SP]really...[1205][001E][SP]And[SP]it\ndoesn't[SP]seem[SP]specifically[SP]directed[SP]toward[SP]that\nYoko[SP]girl...[1205][001E][SP]She's[SP]not[SP]bullied[SP]here,[SP]right?",
     "nom_fr": "Maya",
-    "texte_fr": "Hmm... C'est pas vraiment de la froideur...[1205][001E]\nEt c'est pas dirigé spécifiquement contre\nYoko...[1205][001E] Elle n'est pas harcelée, si ?"
+    "texte_fr": "Hmm... C'est pas vraiment de la froideur...[001E][1205]\nEt c'est pas dirigé spécifiquement contre\nYoko...[001E][1205] Elle n'est pas harcelée, si ?"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Lisa...[SP]I[SP]don't[SP]think[SP]she[SP]actually[SP]means[SP]that.[1205][001E]\nShe[SP]must[SP]be[SP]hiding[SP]some[SP]kind[SP]of[SP]trauma...",
     "nom_fr": "Maya",
-    "texte_fr": "Lisa... je crois pas qu'elle le pense.[1205][001E]\nElle doit cacher un traumatisme..."
+    "texte_fr": "Lisa... je crois pas qu'elle le pense.[001E][1205]\nElle doit cacher un traumatisme..."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]mean,[SP]she's[SP]so[SP]nice[SP]to[SP]you,[SP][1113]-kun![1205][001E]\nSure,[SP]she[SP]seems[SP]a[SP]little[SP]cold[SP]at[SP]times,[SP]but\ndeep[SP]down,[SP]I[SP]think[SP]she's[SP]a[SP]considerate[SP]girl.",
     "nom_fr": "Maya",
-    "texte_fr": "Je veux dire, elle est si gentille avec\ntoi, [1113]-kun![1205][001E] Certes froide parfois,\nmais au fond c'est une fille attentionnée."
+    "texte_fr": "Je veux dire, elle est si gentille avec\ntoi, [1113]-kun![001E][1205] Certes froide parfois,\nmais au fond c'est une fille attentionnée."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Cripes,[SP]Lisa's[SP]being[SP]pretty[SP]harsh.[1205][001E][SP]I[SP]don't\nblame[SP]her[SP]for[SP]being[SP]upset[SP]at[SP]someone[SP]who\ntalks[SP]to[SP]her[SP]like[SP]that,[SP]but...",
     "nom_fr": "Yukino",
-    "texte_fr": "Bon sang, Lisa est vraiment dure.[1205][001E]\nJe la comprends d'être contrariée,\nmais c'est quand même trop loin..."
+    "texte_fr": "Bon sang, Lisa est vraiment dure.[001E][1205]\nJe la comprends d'être contrariée,\nmais c'est quand même trop loin..."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Is[SP]Lisa[SP]still[SP]at[SP]it?[1205][001E][SP]She's[SP]definitely[SP]going\ntoo[SP]far[SP]here.[SP]She[SP]makes[SP]it[SP]sound[SP]like[SP]she\ndoesn't[SP]trust[SP]anyone...",
     "nom_fr": "Yukino",
-    "texte_fr": "Lisa en est encore là?[1205][001E] Elle va\nvraiment trop loin. On dirait qu'elle\nne fait confiance à personne..."
+    "texte_fr": "Lisa en est encore là?[001E][1205] Elle va\nvraiment trop loin. On dirait qu'elle\nne fait confiance à personne..."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "It[SP]must[SP]be[SP]tough[SP]for[SP]a[SP]girl[SP]with[SP]no[SP]confidence\nin[SP]her[SP]looks.[1205][001E][SP]Good[SP]thing[SP]that's[SP]a[SP]world[SP]I'll\nnever[SP]have[SP]anything[SP]to[SP]do[SP]with.",
     "nom_fr": "Yukino",
-    "texte_fr": "Ça doit être dur pour une fille sans\nconfiance en son apparence.[1205][001E] Heureusement,\nje n'ai rien à voir avec ça."
+    "texte_fr": "Ça doit être dur pour une fille sans\nconfiance en son apparence.[001E][1205] Heureusement,\nje n'ai rien à voir avec ça."
   },
   {
     "id": 21,
@@ -387,7 +387,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "Oh[SP]man![SP]Did[SP]you[SP]already[SP]score[SP]with[SP]one[SP]of\nthem[SP]at[SP]school!?[SP]Geez,[SP]you're[SP]so[SP]lucky...\nCan't[SP]you[SP]share[SP]at[SP]least[SP]one[SP]of[SP]them?",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "Oh là là! T'as\ndéjà flirté avec l'une d'elles\nà l'école!? Pfff, t'as de la chance... Tu\npeux pas m'en présenter une au moins?"
+    "texte_fr": "Oh là là! T'as\ndéjà flirté avec l'une d'elles\nà l'école!? Pfff, t'as de la chance... Tu peux pas m'en présenter une au moins?"
   },
   {
     "id": 26,
@@ -447,7 +447,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "I[SP]heard[SP]Junko[SP]Kurosu[SP]is[SP]a[SP]Sevens[SP]graduate!\nShe[SP]was[SP]a[SP]big[SP]deal[SP]about[SP]ten[SP]years[SP]ago[SP]before\ndisappearing,[SP]but[SP]she's[SP]making[SP]a[SP]comeback[SP]now.",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "J'ai entendu que Junko Kurosu est une\nancienne élève de Seven! Célèbre il y a dix\nans, elle a disparu\nmais revient maintenant."
+    "texte_fr": "J'ai entendu que Junko Kurosu est une\nancienne élève de Seven! Célèbre il y a dix\nans, elle a disparu mais revient maintenant."
   },
   {
     "id": 30,
@@ -492,7 +492,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "Oh[SP]yeah,[SP]there[SP]were[SP]some[SP]emblems[SP]in[SP]the[SP]teachers'\nlounge[SP]on[SP]the[SP]second[SP]floor...[1205][000F][SP]But[SP]our[SP]teachers\nare[SP]there.[SP]I[SP]don't[SP]want[SP]them[SP]catching[SP]on!",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Ah oui, il y avait des emblèmes dans\nla salle des profs au deuxième\nétage.[1205].[000F]. Mais nos profs sont là.\nJeveux pas qu'ils s'en rendent compte!"
+    "texte_fr": "Ah oui, il y avait des emblèmes dans\nla salle des profs au deuxième\nétage.[1205].[000F]. Mais nos profs sont là. Jeveux pas qu'ils s'en rendent compte!"
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "So[SP]how[SP]about[SP]you[SP]go[SP]destroy[SP]the[SP]ones[SP]in[SP]the\nteachers'[SP]lounge,[SP][1113].[1205][000F][SP]Sound[SP]good?\nI'm[SP]counting[SP]on[SP]you!",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Alors, et si tu allais détruire ceux\ndans la salle des profs, [1113]? [1205][000F]Ça\nte va? Je compte sur toi!"
+    "texte_fr": "Alors, et si tu allais détruire ceux\ndans la salle des profs, [1113]? [000F][1205]Ça\nte va? Je compte sur toi!"
   },
   {
     "id": 34,
@@ -732,7 +732,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "Oh[SP]yeah,[SP]there[SP]were[SP]some[SP]emblems[SP]in[SP]the[SP]teachers'\nlounge[SP]on[SP]the[SP]second[SP]floor...[1205][000F][SP]But[SP]our[SP]teachers\nare[SP]there.[SP]I[SP]don't[SP]want[SP]them[SP]catching[SP]on!",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Ah oui, il y avait des emblèmes dans\nla salle des profs au deuxième\nétage.[1205].[000F]. Mais nos profs sont là.\nJeveux pas qu'ils s'en rendent compte!"
+    "texte_fr": "Ah oui, il y avait des emblèmes dans\nla salle des profs au deuxième\nétage.[1205].[000F]. Mais nos profs sont là. Jeveux pas qu'ils s'en rendent compte!"
   },
   {
     "id": 49,
@@ -747,7 +747,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "So[SP]how[SP]about[SP]you[SP]go[SP]destroy[SP]the[SP]ones[SP]in[SP]the\nteachers'[SP]lounge,[SP][1113].[1205][000F][SP]Sound[SP]good?\nI'm[SP]counting[SP]on[SP]you!",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Alors, et si tu allais détruire ceux\ndans la salle des profs, [1113]? [1205][000F]Ça\nte va? Je compte sur toi!"
+    "texte_fr": "Alors, et si tu allais détruire ceux\ndans la salle des profs, [1113]? [000F][1205]Ça\nte va? Je compte sur toi!"
   },
   {
     "id": 50,

--- a/traduction/event_scripts/script_273.json
+++ b/traduction/event_scripts/script_273.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Is[SP]this[SP]because[SP]of[SP]the[SP]rumors[SP]too?[1205][000F][SP]Like,[SP]the\nrumor[SP]came[SP]true[SP]and[SP]brought[SP]that[SP]principal\nback[SP]to[SP]life?[1205][000F][SP]Seriously[SP]here?[SP]Seriously?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est encore à cause des rumeurs? [1205][000F][1205][000F]Genre,\nune rumeur s'est réalisée et a ramené le\nproviseur à la vie? Sérieusement?"
+    "texte_fr": "C'est encore à cause des rumeurs? [000F][1205][000F][1205]Genre,\nune rumeur s'est réalisée et a ramené le\nproviseur à la vie? Sérieusement?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Does[SP]that[SP]principal[SP]have[SP]super[SP]speed[SP]or\nsomething?[SP]Looks[SP]like[SP]he[SP]has[SP]his[SP]powers[SP]from\nwhen[SP]we[SP]fought[SP]him...[SP]He's[SP]really[SP]shaped[SP]up!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Il a la super\nvitesse ou quoi, ce proviseur?\nOn dirait qu'il a gardé ses pouvoirs du \ncombat... Il s'est vraiment mis en forme!"
+    "texte_fr": "Il a la super\nvitesse ou quoi, ce proviseur?\nOn dirait qu'il a gardé ses pouvoirs du combat... Il s'est vraiment mis en forme!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Man,[SP]that[SP]teacher[SP]of[SP]yours...[1205][000A][SP]She's[SP]almost\nmore[SP]like[SP]a[SP]sister[SP]than[SP]a[SP]teacher.[1205][000F][SP]Heheh,\nshe[SP]reminds[SP]me[SP]a[SP]lot[SP]of[SP]Yukino-san.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Dis donc, ton prof...[1205][1205][000A] Elle ressemble plus\nà une grande sœur qu'à un prof. [000F]Heheh, ça\nme rappelle beaucoup Yukino-san."
+    "texte_fr": "Dis donc, ton prof...[1205][000A][1205] Elle ressemble plus\nà une grande sœur qu'à un prof. [000F]Heheh, ça\nme rappelle beaucoup Yukino-san."
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Principal[SP]Hanya...?[1205][000F][SP]What's[SP]going[SP]on?[1205][000F][SP]Was[SP]the\nprincipal[SP]the[SP]one[SP]who[SP]thrashed[SP]those[SP]Last\nBattalion[SP]goons[SP]on[SP]the[SP]floor[SP]there?",
     "nom_fr": "Ginko",
-    "texte_fr": "Le Proviseur Hanya.[1205][000F][1205][000F]..? Qu'est-ce qui\nse passe? C'est le proviseur qui a\nmis à terre ces types du Bataillon?"
+    "texte_fr": "Le Proviseur Hanya.[000F][1205][000F][1205]..? Qu'est-ce qui\nse passe? C'est le proviseur qui a\nmis à terre ces types du Bataillon?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh?[1205][000A][SP]Principal[SP]Hanya[SP]again...",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein?[1205][000A] Hanya encore..."
+    "texte_fr": "Hein?[000A][1205] Hanya encore..."
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "[1113]...[1205][000A][SP]She's...",
     "nom_fr": "Ginko",
-    "texte_fr": "[1113]...[1205][000A] Elle..."
+    "texte_fr": "[1113]...[000A][1205] Elle..."
   },
   {
     "id": 8,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I'm[SP]not[SP]giving[SP]up,[SP][1113]-kun.[1205][000F][SP]I'm[SP]positive\nwe[SP]can[SP]return[SP]Yukki[SP]to[SP]normal[SP]too.[1205][000F][SP]There's[SP]no\nreason[SP]to[SP]be[SP]sad!",
     "nom_fr": "Maya",
-    "texte_fr": "J'abandonne pas, [1113]-kun. [1205][000F][1205][000F]Je\nsuis certaine qu'on peut ramener\nYukki. Aucune raison d'être triste!"
+    "texte_fr": "J'abandonne pas, [1113]-kun. [000F][1205][000F][1205]Je\nsuis certaine qu'on peut ramener\nYukki. Aucune raison d'être triste!"
   },
   {
     "id": 11,
@@ -207,7 +207,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Ah,[SP][1112]![1205][000F][SP]Your[SP]blows[SP]not[SP]long[SP]ago\ntruly[SP]hit[SP]home[SP]in[SP]my[SP]heart.",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Ah, [1112]! [1205][000F]Tes coups m'ont\ntouché en plein cœur."
+    "texte_fr": "Ah, [1112]! [000F][1205]Tes coups m'ont\ntouché en plein cœur."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "It's[SP]because[SP]of[SP]you[SP]kids[SP]that[SP]I[SP]was[SP]able[SP]to\nreturn[SP]like[SP]this.[1205][000F][SP]I[SP]have[SP]to[SP]thank[SP]you.",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "C'est grâce à vous que j'ai pu revenir\nainsi. [1205][000F]Je dois vous remercier."
+    "texte_fr": "C'est grâce à vous que j'ai pu revenir\nainsi. [000F][1205]Je dois vous remercier."
   },
   {
     "id": 15,
@@ -252,7 +252,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "You[SP]cretins![1205][000F][SP]Not[SP]only[SP]have[SP]you[SP]forced[SP]your[SP]way\ninto[SP]this[SP]sacred[SP]place[SP]of[SP]education...[1205][000F][SP]You[SP]have\nthreatened[SP]its[SP]students[SP]with[SP]violence!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Bande de crétins! [1205][000F][1205][000F]Non seulement vous\nforcez ce lieu sacré d'éducation... Mais\nvous menacez les élèves par la violence!"
+    "texte_fr": "Bande de crétins! [000F][1205][000F][1205]Non seulement vous\nforcez ce lieu sacré d'éducation... Mais\nvous menacez les élèves par la violence!"
   },
   {
     "id": 17,
@@ -282,7 +282,7 @@
     "nom_orig": "Principal[SP]Hanya",
     "texte_orig": "Well?[1205][0008][SP]What[SP]are[SP]you[SP]waiting[SP]for?[1205][000A][SP]Don't[SP]worry\nabout[SP]Sevens.[SP]Hurry[SP]and[SP]save[SP]Ms.[SP]Okamura!",
     "nom_fr": "Proviseur Hanya",
-    "texte_fr": "Alors?[1205][0008] Qu'attendez-vous?[1205][000A] N'inquiétez pas\npour Seven. Vite, sauvez Mme Okamura!"
+    "texte_fr": "Alors?[0008][1205] Qu'attendez-vous?[000A][1205] N'inquiétez pas\npour Seven. Vite, sauvez Mme Okamura!"
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Ms.[SP]Saeko[SP]was[SP]protecting[SP]us[SP]all[SP]before[SP]the\nprincipal[SP]got[SP]here.[1205][000F][SP]We're[SP]lucky[SP]to[SP]be\nsurrounded[SP]by[SP]such[SP]wonderful[SP]teachers!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Mme Saeko nous protégeait tous avant\nque le proviseur arrive. [1205][000F]On a de la\nchance d'avoir de si bons professeurs!"
+    "texte_fr": "Mme Saeko nous protégeait tous avant\nque le proviseur arrive. [000F][1205]On a de la\nchance d'avoir de si bons professeurs!"
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "That[SP]reminds[SP]me--I[SP]saw[SP]her[SP]in[SP]town![1205][000F][SP]Who?\nAnna,[SP]of[SP]course![1205][000A][SP]I[SP]saw[SP]her!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Tiens, je l'ai vue en ville! [1205]Qui\n[000F]ça? Anna, bien sûr![1205][000A] Je l'ai vue!"
+    "texte_fr": "Tiens, je l'ai vue en ville! [1205]Qui\n[000F]ça? Anna, bien sûr![000A][1205] Je l'ai vue!"
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "She[SP]was[SP]helping[SP]rescue[SP]people[SP]with[SP]some[SP]other\nlady[SP]I[SP]didn't[SP]know.[1205][000A][SP]She[SP]looked[SP]so[SP]fierce...[1205][000F]\nLike[SP]she's[SP]finally[SP]back...[1205][000A][SP]I'm[SP]so[SP]glad!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Elle aidait à secourir\ndes gens avec une dame\nque je connaissais pas.[1205][1205][000A] L'air déterminé.[000F]..\nEnfin de retour...[1205][000A] Trop content!"
+    "texte_fr": "Elle aidait à secourir\ndes gens avec une dame\nque je connaissais pas.[1205][000A][1205] L'air déterminé.[000F].. Enfin de retour...[000A][1205] Trop content!"
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I[SP]used[SP]to[SP]think[SP]the[SP]teachers[SP]were[SP]a[SP]pain,[SP]but\nnow[SP]I[SP]regret[SP]that[SP]a[SP]little.[1205][000F][SP]They[SP]always\nlooked[SP]out[SP]for[SP]us[SP]in[SP]one[SP]way[SP]or[SP]another...",
     "nom_fr": "Lycéen",
-    "texte_fr": "Je trouvais les profs relous avant, mais\nmaintenant je le regrette. [1205][000F]Ils ont toujours\nveillé sur nous d'une\nfaçon ou d'une autre..."
+    "texte_fr": "Je trouvais les profs relous avant, mais\nmaintenant je le regrette. [000F][1205]Ils ont toujours\nveillé sur nous d'une façon ou d'une autre..."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "By[SP]the[SP]way,[SP][1113]-kun,[SP]did[SP]you[SP]see[SP]the[SP]light\nin[SP]the[SP]courtyard?[1205][000A][SP]I[SP]don't[SP]know[SP]how,[SP]but[SP]it\nlooks[SP]like[SP]the[SP]Narurato[SP]Stone[SP]is[SP]shining.",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Au fait, [1113]-kun, t'as vu la lumière\ndans la cour?[1205][000A] Je sais pas comment, mais\non dirait que la Pierre Narurato brille."
+    "texte_fr": "Au fait, [1113]-kun, t'as vu la lumière\ndans la cour?[000A][1205] Je sais pas comment, mais\non dirait que la Pierre Narurato brille."
   },
   {
     "id": 24,
@@ -387,7 +387,7 @@
     "nom_orig": "Yoko",
     "texte_orig": "Huh...?[SP][1113]-kun?[1205][000A][SP]Geez...[SP]Where've[SP]you\nbeen[SP]all[SP]this[SP]time?[1205][000F][SP]I[SP]wanted[SP]so[SP]much[SP]to[SP]apologize...[1205][000F]\nI'm[SP]sorry[SP]I[SP]said[SP]such[SP]horrible[SP]things...",
     "nom_fr": "Yoko",
-    "texte_fr": "Hein...? [1205][1205][1113]-kun?[1205][000A] Alors là... Tu étais\n[000F][000F]où tout ce temps? Je voulais tellement\nm'excuser... Pardon pour ce que j'ai dit..."
+    "texte_fr": "Hein...? [1205][1205][1113]-kun?[000A][1205] Alors là... Tu étais\n[000F][000F]où tout ce temps? Je voulais tellement\nm'excuser... Pardon pour ce que j'ai dit..."
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Yoko",
     "texte_orig": "I...[SP]I[SP]had[SP]Joker...[SP]grant[SP]my[SP]ideals...[1205][000F]\nI[SP]had[SP]him[SP]make[SP]me[SP]beautiful...[1205][000F][SP]because[SP]I\nwanted[SP]you[SP]to[SP]notice[SP]me...",
     "nom_fr": "Yoko",
-    "texte_fr": "J'ai demandé au Joker de réaliser\n[1205][000F][1205][000F]mes idéaux... Me rendre belle...\ncar je voulais que tu me voies..."
+    "texte_fr": "J'ai demandé au Joker de réaliser\n[000F][1205][000F][1205]mes idéaux... Me rendre belle...\ncar je voulais que tu me voies..."
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Yoko",
     "texte_orig": "But[SP]it's[SP]okay[SP]now...[1205][000A][SP]Just[SP]forget[SP]about[SP]me...[1205][000A]\nLike[SP]everyone[SP]else[SP]did.[1205][000F][SP]I[SP]don't[SP]want[SP]you[SP]to\nlook[SP]at[SP]such[SP]a[SP]pitiful[SP]sight...",
     "nom_fr": "Yoko",
-    "texte_fr": "C'est bon maintenant.[1205]..[1205][000A] Oublie-moi...[1205][000A]\nComme tout le monde. [000F]Je veux pas que\ntu voies un truc aussi pitoyable..."
+    "texte_fr": "C'est bon maintenant.[1205]..[000A][1205] Oublie-moi...[000A][1205]\nComme tout le monde. [000F]Je veux pas que\ntu voies un truc aussi pitoyable..."
   },
   {
     "id": 28,
@@ -447,7 +447,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "I[SP]see...[1205][0008][SP]Yukino's[SP]fighting[SP]elsewhere[SP]in[SP]town\ntoo,[SP]haha.[1205][000A][SP]Don't[SP]let[SP]your[SP]senpai[SP]outdo[SP]you,\n[1113]![1205][000F][SP]And[SP]stay[SP]true[SP]to[SP]yourself...",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Je vois.[1205]..[1205][0008] Yukino se bat en ville aussi,\nhaha.[1205][000A] Laisse pas ta senpai te dépasser,\n[000F][1113]! Reste fidèle à toi-même..."
+    "texte_fr": "Je vois.[1205]..[0008][1205] Yukino se bat en ville aussi,\nhaha.[000A][1205] Laisse pas ta senpai te dépasser,\n[000F][1113]! Reste fidèle à toi-même..."
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "After[SP]all...[1205][0008][SP]You[SP]only[SP]live[SP]once.[1205][000A][SP]You[SP]can't\nwaste[SP]your[SP]only[SP]shot[SP]at[SP]life[SP]on[SP]indecision.",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Après tout...[1205][0008] On ne vit qu'une fois.[1205][000A]\nFaut pas gâcher sa seule vie à hésiter."
+    "texte_fr": "Après tout...[0008][1205] On ne vit qu'une fois.[000A][1205]\nFaut pas gâcher sa seule vie à hésiter."
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "I...[SP]I[SP]refuse[SP]to[SP]believe[SP]it.[1205][000A][SP]Yukino[SP]can't[SP]be...[1205][000F]\nIt[SP]just[SP]can't[SP]be[SP]true!",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Je... je refuse d'y croire.[1205][1205][000A] Yukino\n[000F]ne peut pas... C'est pas vrai!"
+    "texte_fr": "Je... je refuse d'y croire.[1205][000A][1205] Yukino\n[000F]ne peut pas... C'est pas vrai!"
   },
   {
     "id": 32,
@@ -492,6 +492,6 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "I'm[SP]sorry...[1205][000A][SP]Could[SP]you[SP]leave[SP]me[SP]alone[SP]for\na[SP]little[SP]while...?",
     "nom_fr": "",
-    "texte_fr": "Je suis désolée...[1205][000A] Pourriez-vous\nme laisser seule un moment...?"
+    "texte_fr": "Je suis désolée...[000A][1205] Pourriez-vous\nme laisser seule un moment...?"
   }
 ]

--- a/traduction/event_scripts/script_274.json
+++ b/traduction/event_scripts/script_274.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Big[SP]Maya's[SP]right.[SP]My[SP]Persona's[SP]resonating...[1205][000F]\nSo[SP]that's[SP]how[SP]she[SP]was[SP]able[SP]to[SP]defeat[SP]them.[1205][000F]\nBut[SP]who[SP]is[SP]this[SP]minx,[SP]anyway?",
     "nom_fr": "Eikichi",
-    "texte_fr": "La Grande Maya a raison. Ma Persona\n[1205][000F][1205][000F]résonne... C'est comme ça qu'elle a pu\nles vaincre. Mais qui est cette nana?"
+    "texte_fr": "La Grande Maya a raison. Ma Persona\n[000F][1205][000F][1205]résonne... C'est comme ça qu'elle a pu\nles vaincre. Mais qui est cette nana?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Maki-san[SP]beat[SP]them?[1205][000F][SP]She[SP]beat[SP]three[SP]Last\nBattalion[SP]troops[SP]by[SP]herself?[1205][000F][SP]Wow...\nI'm[SP]speechless...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Maki-san les a battus? [1205][000F][1205][000F]Trois soldats du\nBataillon toute seule? Wow... Sans voix..."
+    "texte_fr": "Maki-san les a battus? [000F][1205][000F][1205]Trois soldats du\nBataillon toute seule? Wow... Sans voix..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "She's[SP]one[SP]of[SP]Yukino-san's[SP]old[SP]friends,[SP]right?\nShe[SP]beat[SP]three[SP]Last[SP]Battalion[SP]troops[SP]on[SP]her\nown...[1205][000F][SP]She's[SP]no[SP]ordinary[SP]Persona-user.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ancienne amie de Yukino-san, non? Elle a\nbattu trois soldats du Bataillon seule...\n[1205][000F]Pas une utilisatrice de Persona ordinaire."
+    "texte_fr": "Ancienne amie de Yukino-san, non? Elle a\nbattu trois soldats du Bataillon seule...\n[000F][1205]Pas une utilisatrice de Persona ordinaire."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ah...[1205][000A][SP]Even[SP]a[SP]beautiful[SP]rose[SP]has[SP]its[SP]thorns...[1205][000F]\nI'm[SP]astonished[SP]that[SP]she[SP]beat[SP]three[SP]Last\nBattalion[SP]members[SP]by[SP]herself.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ah.[1205]..[1205][000A] Même la plus belle rose a ses\n[000F]épines... Stupéfait qu'elle ait battu\ntrois membres du Bataillon seule."
+    "texte_fr": "Ah.[1205]..[000A][1205] Même la plus belle rose a ses\n[000F]épines... Stupéfait qu'elle ait battu\ntrois membres du Bataillon seule."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Man,[SP]that[SP]teacher[SP]of[SP]yours...[1205][000A][SP]She's[SP]almost\nmore[SP]like[SP]a[SP]sister[SP]than[SP]a[SP]teacher.[1205][000F][SP]Heheh,\nshe[SP]reminds[SP]me[SP]a[SP]lot[SP]of[SP]Yukino-san.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Dis donc, ton prof...[1205][1205][000A] Elle ressemble plus\nà une grande sœur qu'à un prof. [000F]Heheh, ça\nme rappelle beaucoup Yukino-san."
+    "texte_fr": "Dis donc, ton prof...[1205][000A][1205] Elle ressemble plus\nà une grande sœur qu'à un prof. [000F]Heheh, ça\nme rappelle beaucoup Yukino-san."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah...![1205][000F][SP]Looks[SP]like[SP]that[SP]lady[SP]beat[SP]up[SP]the\nLast[SP]Battalion[SP]guys...",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiyah.[1205][000F]..! Cette dame a battu\nles types du Bataillon..."
+    "texte_fr": "Aiyah.[000F][1205]..! Cette dame a battu\nles types du Bataillon..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh!?[1205][000A][SP]Maki-san...?[1205][000F][SP]What's[SP]she[SP]doing[SP]here?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein![1205]?[1205][000A] Maki-san.[000F]..? Que fait-elle?"
+    "texte_fr": "Hein![1205]?[000A][1205] Maki-san.[000F]..? Que fait-elle?"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah...![1205][000F][SP]The[SP]Last[SP]Battalion[SP]guys[SP]here[SP]are\ndown,[SP]too!",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiyah.[1205][000F]..! Le Bataillon ici aussi à terre!"
+    "texte_fr": "Aiyah.[000F][1205]..! Le Bataillon ici aussi à terre!"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hoisamuro![1205][000F][SP]Maki-san[SP]came[SP]too!",
     "nom_fr": "Ginko",
-    "texte_fr": "Hoisamuro! [1205][000F]Maki-san aussi!"
+    "texte_fr": "Hoisamuro! [000F][1205]Maki-san aussi!"
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "[1113]...[1205][000A][SP]She's...",
     "nom_fr": "Ginko",
-    "texte_fr": "[1113]...[1205][000A] Elle..."
+    "texte_fr": "[1113]...[000A][1205] Elle..."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]resonance...[1205][000F][SP]I[SP]sense[SP]a[SP]Persona[SP]in[SP]that\nwoman...[1205][000F][SP]Does[SP]this[SP]mean[SP]she's[SP]a[SP]Persona-user?",
     "nom_fr": "Maya",
-    "texte_fr": "Cette résonance.[1205][000F][1205][000F].. Je sens une Persona\nen elle... Serait-elle une utilisatrice?"
+    "texte_fr": "Cette résonance.[000F][1205][000F][1205].. Je sens une Persona\nen elle... Serait-elle une utilisatrice?"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I'm[SP]sure[SP]she[SP]came[SP]to[SP]rescue[SP]the[SP]students[SP]at\nSevens.[1205][000F][SP]Thank[SP]goodness...[SP]It[SP]seems[SP]everyone\nis[SP]safe.",
     "nom_fr": "Maya",
-    "texte_fr": "Elle est venue secourir les élèves\nde Seven. [1205][000F]Dieu merci... Tout le\nmonde semble sain et sauf."
+    "texte_fr": "Elle est venue secourir les élèves\nde Seven. [000F][1205]Dieu merci... Tout le\nmonde semble sain et sauf."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Is[SP]your[SP]Persona[SP]resonating[SP]too...?[1205][000F][SP]I[SP]bet[SP]that\nwoman[SP]is[SP]one[SP]of[SP]Yukki's[SP]friends.[SP]She[SP]must[SP]have\ncome[SP]with[SP]the[SP]others[SP]to[SP]save[SP]this[SP]school.",
     "nom_fr": "Maya",
-    "texte_fr": "Ta Persona résonne aussi...[1205]? [000F]Je parie que\ncette femme est une amie\nde Yukki. Elle a dû\nvenir avec les autres pour sauver l'école."
+    "texte_fr": "Ta Persona résonne aussi...[1205]? [000F]Je parie que\ncette femme est une amie\nde Yukki. Elle a dû venir avec les autres pour sauver l'école."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Maya",
     "texte_orig": "With[SP]those[SP]guys[SP]on[SP]our[SP]side,[SP]there's[SP]nothing\nto[SP]worry[SP]about![SP]We[SP]can[SP]head[SP]to[SP]Xibalba[SP]without\nany[SP]fear.",
     "nom_fr": "Maya",
-    "texte_fr": "Avec eux de notre côté, il n'y a rien à\ncraindre! On peut aller\nà Xibalba sans aucune\npeur."
+    "texte_fr": "Avec eux de notre côté, il n'y a rien à\ncraindre! On peut aller\nà Xibalba sans aucune peur."
   },
   {
     "id": 16,
@@ -282,7 +282,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I'm[SP]not[SP]giving[SP]up,[SP][1113]-kun.[1205][000F][SP]I'm[SP]positive\nwe[SP]can[SP]return[SP]Yukki[SP]to[SP]normal[SP]too.[1205][000F][SP]There's[SP]no\nreason[SP]to[SP]be[SP]sad!",
     "nom_fr": "Maya",
-    "texte_fr": "J'abandonne pas, [1113]-kun. [1205][000F][1205][000F]Je\nsuis certaine qu'on peut ramener\nYukki. Aucune raison d'être triste!"
+    "texte_fr": "J'abandonne pas, [1113]-kun. [000F][1205][000F][1205]Je\nsuis certaine qu'on peut ramener\nYukki. Aucune raison d'être triste!"
   },
   {
     "id": 19,
@@ -327,7 +327,7 @@
     "nom_orig": "???",
     "texte_orig": "Oh,[SP]are[SP]you[SP]the[SP][1113]-kun[SP]Elly[SP]told[SP]us\nabout?[1205][000F][SP]It's[SP]nice[SP]to[SP]meet[SP]you.[SP]I'm[SP]Maki,\nMaki[SP]Sonomura.",
     "nom_fr": "???",
-    "texte_fr": "Oh, tu es le [1113]-kun dont Elly nous a\n[1205][000F]parlé? Enchantée. Je suis Maki Sonomura."
+    "texte_fr": "Oh, tu es le [1113]-kun dont Elly nous a\n[000F][1205]parlé? Enchantée. Je suis Maki Sonomura."
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Maki",
     "texte_orig": "She's[SP]right...[1205][000F][SP]You[SP]do[SP]remind[SP]me[SP]of[SP]someone\nI[SP]know.[1205][000F][SP]I[SP]feel[SP]like[SP]we've[SP]met[SP]before.[1205][000F][SP]Anyway,\nwe[SP]came[SP]because[SP]Elly[SP]called[SP]us.",
     "nom_fr": "Maki",
-    "texte_fr": "Elle a raison.[1205][000F][1205][000F][1205][000F].. Tu me rappelles\nquelqu'un. On se serait déjà vus?\nEn tout cas, Elly nous a appelées."
+    "texte_fr": "Elle a raison.[000F][1205][000F][1205][000F][1205].. Tu me rappelles\nquelqu'un. On se serait déjà vus?\nEn tout cas, Elly nous a appelées."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Maki",
     "texte_orig": "She[SP]gave[SP]us[SP]the[SP]short[SP]version[SP]of[SP]what's\ngoing[SP]on.[1205][000F][SP]Don't[SP]worry,[SP]you[SP]can[SP]leave[SP]Sumaru\nCity[SP]to[SP]us![SP]You[SP]need[SP]to[SP]get[SP]to[SP]Xibalba!",
     "nom_fr": "Maki",
-    "texte_fr": "Elle nous a résumé la situation. Ne\n[1205][000F]t'inquiète pas, laisse Sumaru entre\nnos mains! Tu dois aller à Xibalba !"
+    "texte_fr": "Elle nous a résumé la situation. Ne\n[000F][1205]t'inquiète pas, laisse Sumaru entre\nnos mains! Tu dois aller à Xibalba !"
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Maki",
     "texte_orig": "Ah,[SP][1113]-kun.[1205][000A][SP]Are[SP]you[SP]okay?[1205][000F][SP]Elly[SP]told[SP]us\nthe[SP]Last[SP]Battalion[SP]was[SP]headed[SP]here.",
     "nom_fr": "Maki",
-    "texte_fr": "Ah, [1113]-kun.[1205][1205][000A] Tu vas bien? [000F]Elly\nnous a dit que le Bataillon venait."
+    "texte_fr": "Ah, [1113]-kun.[1205][000A][1205] Tu vas bien? [000F]Elly\nnous a dit que le Bataillon venait."
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Maki",
     "texte_orig": "She[SP]gave[SP]us[SP]the[SP]short[SP]version[SP]of[SP]what's\ngoing[SP]on.[1205][000F][SP]Don't[SP]worry,[SP]you[SP]can[SP]leave[SP]Sumaru\nCity[SP]to[SP]us![SP]You[SP]need[SP]to[SP]get[SP]to[SP]Xibalba!",
     "nom_fr": "Maki",
-    "texte_fr": "Elle nous a résumé la situation. Ne\n[1205][000F]t'inquiète pas, laisse Sumaru entre\nnos mains! Tu dois aller à Xibalba !"
+    "texte_fr": "Elle nous a résumé la situation. Ne\n[000F][1205]t'inquiète pas, laisse Sumaru entre\nnos mains! Tu dois aller à Xibalba !"
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Maki",
     "texte_orig": "Hm?[SP]This[SP]flower?[1205][000F][SP]The[SP]Count[SP]at[SP]Time[SP]Castle\ngave[SP]it[SP]to[SP]me.[1205][000F][SP]He[SP]said[SP]it[SP]was[SP]a[SP]symbol[SP]of\ndestiny[SP]to[SP]be[SP]passed[SP]on...",
     "nom_fr": "Maki",
-    "texte_fr": "Hm? [1205][000F][1205]Cette fleur? [000F]Le Comte du\nChâteau du Temps me l'a donnée. Un\nsymbole du destin à transmettre..."
+    "texte_fr": "Hm? [000F][1205][1205]Cette fleur? [000F]Le Comte du\nChâteau du Temps me l'a donnée. Un\nsymbole du destin à transmettre..."
   },
   {
     "id": 27,
@@ -442,7 +442,7 @@
     "nom_orig": "Maki",
     "texte_orig": "A[SP]legendary[SP]flower?[1205][000F][SP]This?[1205][000F][SP]Huh...[SP]It[SP]doesn't\nlook[SP]like[SP]it...[1205][000F][SP]But[SP]stranger[SP]things[SP]have\nhappened.",
     "nom_fr": "Maki",
-    "texte_fr": "Une fleur légendaire? [1205][000F][1205][000F][1205][000F]Ça? Hmm... Ça n'en\na pas l'air... Mais pire s'est déjà vu."
+    "texte_fr": "Une fleur légendaire? [000F][1205][000F][1205][000F][1205]Ça? Hmm... Ça n'en\na pas l'air... Mais pire s'est déjà vu."
   },
   {
     "id": 29,
@@ -472,7 +472,7 @@
     "nom_orig": "Maki",
     "texte_orig": "But...[SP]I[SP]wonder[SP]what[SP]he[SP]meant[SP]about[SP]it[SP]being\na[SP]symbol[SP]of[SP]destiny[SP]to[SP]be[SP]passed[SP]on...[1205][000F][SP]Well,\nlet's[SP]just[SP]give[SP]thanks[SP]and[SP]put[SP]it[SP]to[SP]good[SP]use.",
     "nom_fr": "Maki",
-    "texte_fr": "Mais... je me demande ce qu'il voulait dire\npar symbole du destin à transmettre.[1205][000F].. Bah,\nremercions-le et mettons-la à bon usage."
+    "texte_fr": "Mais... je me demande ce qu'il voulait dire\npar symbole du destin à transmettre.[000F][1205].. Bah,\nremercions-le et mettons-la à bon usage."
   },
   {
     "id": 31,
@@ -487,7 +487,7 @@
     "nom_orig": "Maki",
     "texte_orig": "I[SP]didn't[SP]know[SP]Ms.[SP]Saeko[SP]taught[SP]here,[SP]though!\nThat[SP]was[SP]a[SP]surprise.[1205][000F][SP]She[SP]hasn't[SP]changed[SP]one\nbit...[1205][000F][SP]Seeing[SP]her[SP]brings[SP]back[SP]memories.",
     "nom_fr": "Maki",
-    "texte_fr": "Je savais pas que Mme Saeko enseignait ici\n! Quelle surprise. [1205][000F][1205][000F]Elle n'a pas changé\nd'un poil... Ça me rappelle des souvenirs."
+    "texte_fr": "Je savais pas que Mme Saeko enseignait ici\n! Quelle surprise. [000F][1205][000F][1205]Elle n'a pas changé\nd'un poil... Ça me rappelle des souvenirs."
   },
   {
     "id": 32,
@@ -517,7 +517,7 @@
     "nom_orig": "Maki",
     "texte_orig": "Give[SP]Ms.[SP]Saeko[SP]some[SP]space[SP]for[SP]now.[1205][000F][SP]I'll[SP]keep\nthis[SP]place[SP]safe.",
     "nom_fr": "Maki",
-    "texte_fr": "Laisse Mme Saeko un moment.\n[1205][000F]Je veillerai sur cet endroit."
+    "texte_fr": "Laisse Mme Saeko un moment.\n[000F][1205]Je veillerai sur cet endroit."
   },
   {
     "id": 34,
@@ -532,7 +532,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Ms.[SP]Saeko[SP]was[SP]protecting[SP]us[SP]until[SP]that[SP]lady\narrived.[1205][000F][SP]I[SP]owe[SP]them[SP]both[SP]big-time.",
     "nom_fr": "Lycéen",
-    "texte_fr": "Mme Saeko nous protégeait jusqu'à cette\ndame. [1205][000F]Je leur dois beaucoup à toutes!"
+    "texte_fr": "Mme Saeko nous protégeait jusqu'à cette\ndame. [000F][1205]Je leur dois beaucoup à toutes!"
   },
   {
     "id": 35,
@@ -547,7 +547,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "That[SP]reminds[SP]me--I[SP]saw[SP]her[SP]in[SP]town![1205][000F][SP]Who?\nAnna,[SP]of[SP]course![1205][000A][SP]I[SP]saw[SP]her!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Tiens, je l'ai vue en ville! [1205]Qui\n[000F]ça? Anna, bien sûr![1205][000A] Je l'ai vue!"
+    "texte_fr": "Tiens, je l'ai vue en ville! [1205]Qui\n[000F]ça? Anna, bien sûr![000A][1205] Je l'ai vue!"
   },
   {
     "id": 36,
@@ -562,7 +562,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "She[SP]was[SP]helping[SP]rescue[SP]people[SP]with[SP]some[SP]other\nlady[SP]I[SP]didn't[SP]know.[1205][000A][SP]She[SP]looked[SP]so[SP]fierce...[1205][000F]\nLike[SP]she's[SP]finally[SP]back...[1205][000A][SP]I'm[SP]so[SP]glad!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Elle aidait à secourir\ndes gens avec une dame\nque je connaissais pas.[1205][1205][000A] L'air déterminé.[000F]..\nEnfin de retour...[1205][000A] Trop content!"
+    "texte_fr": "Elle aidait à secourir\ndes gens avec une dame\nque je connaissais pas.[1205][000A][1205] L'air déterminé.[000F].. Enfin de retour...[000A][1205] Trop content!"
   },
   {
     "id": 37,
@@ -577,7 +577,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I[SP]used[SP]to[SP]think[SP]the[SP]teachers[SP]were[SP]a[SP]pain,[SP]but\nnow[SP]I[SP]regret[SP]that[SP]a[SP]little.[1205][000F][SP]They[SP]always\nlooked[SP]out[SP]for[SP]us[SP]in[SP]one[SP]way[SP]or[SP]another...",
     "nom_fr": "Lycéen",
-    "texte_fr": "Je trouvais les profs relous avant, mais\nmaintenant je le regrette. [1205][000F]Ils ont toujours\nveillé sur nous d'une\nfaçon ou d'une autre..."
+    "texte_fr": "Je trouvais les profs relous avant, mais\nmaintenant je le regrette. [000F][1205]Ils ont toujours\nveillé sur nous d'une façon ou d'une autre..."
   },
   {
     "id": 38,
@@ -592,7 +592,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "By[SP]the[SP]way,[SP][1113]-kun,[SP]did[SP]you[SP]see[SP]the[SP]light\nin[SP]the[SP]courtyard?[1205][000A][SP]I[SP]don't[SP]know[SP]how,[SP]but[SP]it\nlooks[SP]like[SP]the[SP]Narurato[SP]Stone[SP]is[SP]shining.",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Au fait, [1113]-kun, t'as vu la lumière\ndans la cour?[1205][000A] Je sais pas comment, mais\non dirait que la Pierre Narurato brille."
+    "texte_fr": "Au fait, [1113]-kun, t'as vu la lumière\ndans la cour?[000A][1205] Je sais pas comment, mais\non dirait que la Pierre Narurato brille."
   },
   {
     "id": 39,
@@ -622,7 +622,7 @@
     "nom_orig": "Yoko",
     "texte_orig": "Huh...?[SP][1113]-kun?[1205][000A][SP]Geez...[SP]Where've[SP]you\nbeen[SP]all[SP]this[SP]time?[1205][000F][SP]I[SP]wanted[SP]so[SP]much[SP]to[SP]apologize...[1205][000F]\nI'm[SP]sorry[SP]I[SP]said[SP]such[SP]horrible[SP]things...",
     "nom_fr": "Yoko",
-    "texte_fr": "Hein...? [1205][1205][1113]-kun?[1205][000A] Alors là... Tu étais\n[000F][000F]où tout ce temps? Je voulais tellement\nm'excuser... Pardon pour ce que j'ai dit..."
+    "texte_fr": "Hein...? [1205][1205][1113]-kun?[000A][1205] Alors là... Tu étais\n[000F][000F]où tout ce temps? Je voulais tellement\nm'excuser... Pardon pour ce que j'ai dit..."
   },
   {
     "id": 41,
@@ -637,7 +637,7 @@
     "nom_orig": "Yoko",
     "texte_orig": "I...[SP]I[SP]had[SP]Joker...[SP]grant[SP]my[SP]ideals...[1205][000F]\nI[SP]had[SP]him[SP]make[SP]me[SP]beautiful...[1205][000F][SP]because[SP]I\nwanted[SP]you[SP]to[SP]notice[SP]me...",
     "nom_fr": "Yoko",
-    "texte_fr": "J'ai demandé au Joker de réaliser\n[1205][000F][1205][000F]mes idéaux... Me rendre belle...\ncar je voulais que tu me voies..."
+    "texte_fr": "J'ai demandé au Joker de réaliser\n[000F][1205][000F][1205]mes idéaux... Me rendre belle...\ncar je voulais que tu me voies..."
   },
   {
     "id": 42,
@@ -652,7 +652,7 @@
     "nom_orig": "Yoko",
     "texte_orig": "But[SP]it's[SP]okay[SP]now...[1205][000A][SP]Just[SP]forget[SP]about[SP]me...[1205][000A]\nLike[SP]everyone[SP]else[SP]did.[1205][000F][SP]I[SP]don't[SP]want[SP]you[SP]to\nlook[SP]at[SP]such[SP]a[SP]pitiful[SP]sight...",
     "nom_fr": "Yoko",
-    "texte_fr": "C'est bon maintenant.[1205]..[1205][000A] Oublie-moi...[1205][000A]\nComme tout le monde. [000F]Je veux pas que\ntu voies un truc aussi pitoyable..."
+    "texte_fr": "C'est bon maintenant.[1205]..[000A][1205] Oublie-moi...[000A][1205]\nComme tout le monde. [000F]Je veux pas que\ntu voies un truc aussi pitoyable..."
   },
   {
     "id": 43,
@@ -682,7 +682,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "I[SP]see...[1205][0008][SP]Yukino's[SP]fighting[SP]elsewhere[SP]in[SP]town\ntoo,[SP]haha.[1205][000A][SP]Don't[SP]let[SP]your[SP]senpai[SP]outdo[SP]you,\n[1113]![1205][000F][SP]And[SP]stay[SP]true[SP]to[SP]yourself...",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Je vois.[1205]..[1205][0008] Yukino se bat en ville aussi,\nhaha.[1205][000A] Laisse pas ta senpai te dépasser,\n[000F][1113]! Reste fidèle à toi-même..."
+    "texte_fr": "Je vois.[1205]..[0008][1205] Yukino se bat en ville aussi,\nhaha.[000A][1205] Laisse pas ta senpai te dépasser,\n[000F][1113]! Reste fidèle à toi-même..."
   },
   {
     "id": 45,
@@ -697,7 +697,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "After[SP]all...[1205][0008][SP]You[SP]only[SP]live[SP]once.[1205][000A][SP]You[SP]can't\nwaste[SP]your[SP]only[SP]shot[SP]at[SP]life[SP]on[SP]indecision.",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Après tout...[1205][0008] On ne vit qu'une fois.[1205][000A]\nFaut pas gâcher sa seule vie à hésiter."
+    "texte_fr": "Après tout...[0008][1205] On ne vit qu'une fois.[000A][1205]\nFaut pas gâcher sa seule vie à hésiter."
   },
   {
     "id": 46,
@@ -712,7 +712,7 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "I...[SP]I[SP]refuse[SP]to[SP]believe[SP]it.[1205][000A][SP]Yukino[SP]can't[SP]be...[1205][000F]\nIt[SP]just[SP]can't[SP]be[SP]true!",
     "nom_fr": "Mme Saeko",
-    "texte_fr": "Je... je refuse d'y croire.[1205][1205][000A] Yukino\n[000F]ne peut pas... C'est pas vrai!"
+    "texte_fr": "Je... je refuse d'y croire.[1205][000A][1205] Yukino\n[000F]ne peut pas... C'est pas vrai!"
   },
   {
     "id": 47,
@@ -727,6 +727,6 @@
     "nom_orig": "Ms.[SP]Saeko",
     "texte_orig": "I'm[SP]sorry...[1205][000A][SP]Could[SP]you[SP]leave[SP]me[SP]alone[SP]for\na[SP]little[SP]while...?",
     "nom_fr": "",
-    "texte_fr": "Je suis désolée...[1205][000A] Pourriez-vous\nme laisser seule un moment...?"
+    "texte_fr": "Je suis désolée...[000A][1205] Pourriez-vous\nme laisser seule un moment...?"
   }
 ]

--- a/traduction/event_scripts/script_275.json
+++ b/traduction/event_scripts/script_275.json
@@ -12,7 +12,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "You[SP]know[SP]that[SP]Joker[SP]Game[SP]thing?[SP]I[SP]wonder[SP]if\nit's[SP]real...[1205][001E][SP]Oh,[SP]I[SP]just[SP]heard[SP]a[SP]rumor,[SP]is[SP]all.\nYour[SP]dreams[SP]come[SP]true,[SP]eh?[SP]Has[SP]that[SP]happened?",
     "nom_fr": "Lycéen",
-    "texte_fr": "T'as entendu parler du Jeu du Joker? C'est\nvrai tout ça...[1205][001E] Bah, j'ai juste entendu\nune rumeur. Tes rêves se réalisent, non?"
+    "texte_fr": "T'as entendu parler du Jeu du Joker? C'est\nvrai tout ça...[001E][1205] Bah, j'ai juste entendu\nune rumeur. Tes rêves se réalisent, non?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Horror-loving[SP]girl",
     "texte_orig": "Bleheheh...[SP]I'm[SP]gathering[SP]scaaary[SP]stories,\njust[SP]for[SP]you.[SP]The[SP]one[SP]I've[SP]got[SP]today[SP]is\nespecially[SP]spooktacular.[1205][001E][SP]Listen[SP]to[SP]this...",
     "nom_fr": "Fille amateur d'horreur",
-    "texte_fr": "Bleheheh... Je collecte des histoires\neffrayantes pour toi. Celle d'aujourd'hui\nest vraiment terrifiante.[1205][001E] Écoute..."
+    "texte_fr": "Bleheheh... Je collecte des histoires\neffrayantes pour toi. Celle d'aujourd'hui\nest vraiment terrifiante.[001E][1205] Écoute..."
   },
   {
     "id": 2,
@@ -101,7 +101,7 @@
     "nom_orig": "Horror-loving[SP]girl",
     "texte_orig": "Bleheheh![SP]Even[SP]the[SP]fearless[SP][1113]-kun[SP]got\nfreaked[SP]out[SP]by[SP]that[SP]one![1205][001E][SP]Such[SP]an[SP]exquisite[1205][000A]\nfrisson...[1205][001E][SP]Don't[SP]worry...[1205][001E][SP]It's[SP]only[1205][000A][SP]a[SP]rumor...",
     "nom_fr": "Fille amateur d'horreur",
-    "texte_fr": "Bleheheh! Même l'intrépide [1113]-kun a eu\npeur![1205][001E] Quel frisson exquis...[1205][000A] [1205][001E] T'inquiète\npas...[1205][001E] C'est juste[1205][000A] une rumeur..."
+    "texte_fr": "Bleheheh! Même l'intrépide [1113]-kun a eu\npeur![001E][1205] Quel frisson exquis...[000A][1205] [001E][1205] T'inquiète\npas...[001E][1205] C'est juste[000A][1205] une rumeur..."
   },
   {
     "id": 6,
@@ -116,7 +116,7 @@
     "nom_orig": "Horror-loving[SP]girl",
     "texte_orig": "Gosh![SP]I'm[SP]scary!?[SP]Really!?[SP]Now[SP]memories[SP]of[SP]me\nwill[SP]be[SP]burned[SP]into[SP]your[SP]brain...[SP]Bleheheh!\nBleheheheheh![1205][001E][SP]Such[SP]an[SP]exquisite[1205][000A][SP]frisson!",
     "nom_fr": "Fille amateur d'horreur",
-    "texte_fr": "Oh! Je suis effrayante!? Vraiment!?\nGravée dans ta mémoire... Bleheheh!\nBleheheheheh![1205][001E] Quel frisson[1205][000A] exquis!"
+    "texte_fr": "Oh! Je suis effrayante!? Vraiment!?\nGravée dans ta mémoire... Bleheheh!\nBleheheheheh![001E][1205] Quel frisson[000A][1205] exquis!"
   },
   {
     "id": 7,

--- a/traduction/event_scripts/script_276.json
+++ b/traduction/event_scripts/script_276.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "So[SP]you've[SP]had[SP]trouble[SP]because[SP]of[SP]your[SP]dad...[1205][001E]\nWell,[SP]uh,[SP]you[SP]know...[1205][001E][SP]Let's[SP]not[SP]let[SP]it[SP]get\neither[SP]of[SP]us[SP]down![SP]Right?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Donc t'as eu des soucis à cause\nde ton père...[1205][001E] Eh bien...[1205][001E] On va\npas se laisser abattre! D'accord?"
+    "texte_fr": "Donc t'as eu des soucis à cause\nde ton père...[001E][1205] Eh bien...[001E][1205] On va\npas se laisser abattre! D'accord?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What!?[SP]You[SP]were[SP]stabbed?[1205][001E][SP]Geez.[SP]I[SP]dunno[SP]who\ndid[SP]it,[SP]but[SP]whoever[SP]it[SP]was[SP]is[SP]pathetic[SP]for\npulling[SP]a[SP]knife.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Quoi!? T'as été poignardé?[1205][001E] Pfff.\nSais pas qui a fait ça, mais c'est\nminable de sortir un couteau."
+    "texte_fr": "Quoi!? T'as été poignardé?[001E][1205] Pfff.\nSais pas qui a fait ça, mais c'est\nminable de sortir un couteau."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Huh?[SP]What[SP]do[SP]you[SP]mean,[SP][1432][NULL][NULL][0014]What[SP]about[SP]Personas[1432][NULL][NULL][0014]?[1205][001E]\nSh-Shut[SP]up...[SP]Personas[SP]are[SP]kosher![SP]Nothing\nwrong[SP]with[SP]that!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hein? Quoi par\n[1432][NULL][NULL][0014]Et les Personae?[1432][NULL][NULL][0014][1205][001E] F-Ferme-la...\nLes Personae c'est bien! Y'a rien de mal!"
+    "texte_fr": "Hein? Quoi par\n[1432][NULL][NULL][0014]Et les Personae?[1432][NULL][NULL][0014][001E][1205] F-Ferme-la...\nLes Personae c'est bien! Y'a rien de mal!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Heheh...[SP]Hey,[SP][1113]...[1205][001E][SP]That[SP]guy[SP]by[SP]the\nwindow's[SP]getting[SP]on[SP]my[SP]nerves.[SP]Mind[SP]if[SP]I[SP]mess\nup[SP]his[SP]face[SP]again?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Heheh... Hé, [1113]...[1205][001E] Ce gars\nprès de la fenêtre m'énerve. Tu\nm'laisses lui refaire le portrait?"
+    "texte_fr": "Heheh... Hé, [1113]...[001E][1205] Ce gars\nprès de la fenêtre m'énerve. Tu\nm'laisses lui refaire le portrait?"
   },
   {
     "id": 4,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Geez,[SP]you're[SP]always[SP]like[SP]this,[SP][1113].\nI[SP]just[SP]worry[SP]about[SP]you,[SP]you[SP]know?[1205][001E][SP]Holeen...\nPoor[SP]me...",
     "nom_fr": "Ginko",
-    "texte_fr": "T'es toujours comme ça, [1113]. Je m'inquiète\npour toi, tu sais?[1205][001E]\nHoleen... Pauvre de moi..."
+    "texte_fr": "T'es toujours comme ça, [1113]. Je m'inquiète\npour toi, tu sais?[001E][1205]\nHoleen... Pauvre de moi..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#9![1205][001E][SP]You[SP]use[SP][1432][NULL][NULL][0014]Aiyah[1432][NULL][NULL][0014]\nwhen[SP]you're[SP]surprised.[SP]It's[SP]kind[SP]of[SP]like\n[1432][NULL][NULL][0014]Whoa[1432][NULL][NULL][0014][SP]or[SP][1432][NULL][NULL][0014]Whaaat.[1432][NULL][NULL][0014]",
     "nom_fr": "Ginko",
-    "texte_fr": "Leçon cantonais Lisa n°9![1205][001E] On dit\n[1432][NULL][NULL][0014]Aiyah[1432][NULL][NULL][0014] quand on est surpris. C'est\nun peu comme [1432][NULL][NULL][0014]Ouah[1432][NULL][NULL][0014] ou [1432][NULL][NULL][0014]Quoooi.[1432][NULL][NULL][0014]"
+    "texte_fr": "Leçon cantonais Lisa n°9![001E][1205] On dit\n[1432][NULL][NULL][0014]Aiyah[1432][NULL][NULL][0014] quand on est surpris. C'est\nun peu comme [1432][NULL][NULL][0014]Ouah[1432][NULL][NULL][0014] ou [1432][NULL][NULL][0014]Quoooi.[1432][NULL][NULL][0014]"
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Oof...[1205][001E][SP]N-No,[SP]I'm[SP]okay.[1205][001E][SP]I[SP]just[SP]felt[SP]lightheaded\nfor[SP]a[SP]moment...",
     "nom_fr": "Maya",
-    "texte_fr": "Ouf...[1205][001E] N-Non, ça va.[1205][001E] J'ai\njuste eu un petit vertige..."
+    "texte_fr": "Ouf...[001E][1205] N-Non, ça va.[001E][1205] J'ai\njuste eu un petit vertige..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Th-The[SP]student[SP]she's[SP]talking[SP]about...[1205][001E]\nNo...",
     "nom_fr": "Maya",
-    "texte_fr": "C-Cet élève dont elle parle...[1205][001E] Non..."
+    "texte_fr": "C-Cet élève dont elle parle...[001E][1205] Non..."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "A[SP]rumor[SP]fiend[SP]in[SP]Honmaru[SP]Park?[1205][001E][SP]She's[SP]probably\ntalking[SP]about[SP]Toku-san.[SP]He's[SP]a[SP]homeless[SP]man\nwho[SP]lives[SP]there.",
     "nom_fr": "Maya",
-    "texte_fr": "Un propagateur à Honmaru Park?[1205][001E] Elle\nparle probablement de Toku-san.\nC'est un sans-abri qui vit là-bas."
+    "texte_fr": "Un propagateur à Honmaru Park?[001E][1205] Elle\nparle probablement de Toku-san.\nC'est un sans-abri qui vit là-bas."
   },
   {
     "id": 13,
@@ -222,7 +222,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Did[SP]you[SP]hurt[SP]your[SP]arm,[SP]Maya-san?[1205][001E][SP]Oh,[SP]you[SP]were\njust[SP]feeling[SP]dizzy?[1205][001E][SP]It[SP]looked[SP]like[SP]you[SP]were\nrubbing[SP]your[SP]right[SP]arm,[SP]is[SP]all...",
     "nom_fr": "Yukino",
-    "texte_fr": "Tu t'es blessée au bras, Maya-san?[1205][001E] Ah,\ntu avais juste le vertige?[1205][001E] C'est que tu\nfrottais ton bras droit, c'est tout..."
+    "texte_fr": "Tu t'es blessée au bras, Maya-san?[001E][1205] Ah,\ntu avais juste le vertige?[001E][1205] C'est que tu\nfrottais ton bras droit, c'est tout..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]wonder[SP]what's[SP]gotten[SP]into[SP]Maya-san...[1205][001E]\nCould[SP]she[SP]be...[1205][001E][SP]scared...?",
     "nom_fr": "Yukino",
-    "texte_fr": "Mais qu'est-ce qui a pris Maya-san...[1205][001E]\nSerait-elle...[1205][001E] apeurée...?"
+    "texte_fr": "Mais qu'est-ce qui a pris Maya-san...[001E][1205]\nSerait-elle...[001E][1205] apeurée...?"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Nah,[SP]not[SP]her.[1205][001E][SP]She[SP]doesn't[SP]miss[SP]a[SP]beat[SP]even\nwhen[SP]interviewing[SP]demons,[SP]so[SP]kiddie-grade\nhorror[SP]stories[SP]wouldn't[SP]faze[SP]her.",
     "nom_fr": "Yukino",
-    "texte_fr": "Non, pas elle.[1205][001E] Elle garde son calme\nmême face aux démons. Des histoires\npour enfants ne la dérangeraient pas."
+    "texte_fr": "Non, pas elle.[001E][1205] Elle garde son calme\nmême face aux démons. Des histoires\npour enfants ne la dérangeraient pas."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Well,[SP]the[SP]emblem[SP]curse[SP]started[SP]with[SP]a[SP]rumor,\nafter[SP]all.[1205][001E][SP]If[SP]rumors[SP]are[SP]coming[SP]true,[SP]maybe\nthey[SP]really[SP]are[SP]selling[SP]weapons[SP]at[SP]the[SP]mall.",
     "nom_fr": "Yukino",
-    "texte_fr": "Enfin, la malédiction a commencé par une\nrumeur.[1205][001E] Si les rumeurs se réalisent,\npeut-être qu'ils vendent\nvraiment des armes."
+    "texte_fr": "Enfin, la malédiction a commencé par une\nrumeur.[001E][1205] Si les rumeurs se réalisent,\npeut-être qu'ils vendent\nvraiment des armes."
   },
   {
     "id": 18,
@@ -492,7 +492,7 @@
     "nom_orig": "Horror-loving[SP]girl",
     "texte_orig": "Awww...[SP]The[SP]curse[SP]is[SP]lifted[SP]already?[SP]It[SP]was\nso[SP]much[SP]fun,[SP]though...[1205][000F][SP]I[SP]hope[SP]something[SP]even\nbigger[SP]happens...[SP]Bleheheheheh!",
     "nom_fr": "Fille amateur d'horreur",
-    "texte_fr": "Awww... Malédiction levée déjà?\nC'était amusant... [1205][000F]J'espère qu'il se\npasse quelque chose de plus grand..."
+    "texte_fr": "Awww... Malédiction levée déjà?\nC'était amusant... [000F][1205]J'espère qu'il se\npasse quelque chose de plus grand..."
   },
   {
     "id": 33,
@@ -642,7 +642,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "By[SP]the[SP]way,[SP][1113]-kun,[SP]there's[SP]some[SP]emblems\nin[SP]the[SP]teachers'[SP]lounge[SP]too![1205][000F][SP]We'll[SP]clean[SP]up\nthe[SP]mess[SP]here[SP]if[SP]you[SP]go[SP]take[SP]care[SP]of[SP]it.",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Au fait, [1113]-kun, il y a des emblèmes\ndans la salle des profs aussi! [1205][000F]On nettoiera\nle désordre ici si tu t'en occupes."
+    "texte_fr": "Au fait, [1113]-kun, il y a des emblèmes\ndans la salle des profs aussi! [000F][1205]On nettoiera\nle désordre ici si tu t'en occupes."
   },
   {
     "id": 43,
@@ -672,7 +672,7 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "I[SP]wonder[SP]if[SP]we'll[SP]have[SP]to[SP]take[SP]our[SP]graduation\nphotos[SP]like[SP]this.[SP]No[SP]one[SP]will[SP]be[SP]able[SP]to[SP]tell\nwho's[SP]who...[SP]It'll[SP]be[SP]pretty[SP]stupid.",
     "nom_fr": "Lycéenne blessée",
-    "texte_fr": "Je me demande si\non devra prendre nos photos\nde promotion comme ça. Personne ne pourra\ndire qui est qui... Ce sera assez ridicule."
+    "texte_fr": "Je me demande si\non devra prendre nos photos\nde promotion comme ça. Personne ne pourra dire qui est qui... Ce sera assez ridicule."
   },
   {
     "id": 45,
@@ -747,6 +747,6 @@
     "nom_orig": "Bandaged[SP]female[SP]student",
     "texte_orig": "I[SP]think[SP]that[SP]was[SP]the[SP]last[SP]emblem[SP]in[SP]this\nclassroom.[1205][000A][SP]Don't[SP]waste[SP]any[SP]time[SP]destroying\nthe[SP]ones[SP]in[SP]the[SP]other[SP]classes[SP]too.",
     "nom_fr": "",
-    "texte_fr": "Je crois que c'était le dernier emblème\nde cette classe.[1205][000A] Ne perds pas de temps\net détruis aussi ceux des autres classes."
+    "texte_fr": "Je crois que c'était le dernier emblème\nde cette classe.[000A][1205] Ne perds pas de temps\net détruis aussi ceux des autres classes."
   }
 ]

--- a/traduction/event_scripts/script_277.json
+++ b/traduction/event_scripts/script_277.json
@@ -12,7 +12,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Gaaahhh![1205][000F][SP]Oh...[1205][0008][SP]It's[SP]just[SP]you.[SP]Don't[SP]scare[SP]me\nlike[SP]that.[1205][000A][SP]Hm?[1205][000A][SP]Oh,[SP]I'm[SP]looking[SP]for[SP]a[SP]mask.[1205][000F][SP]It\nmust[SP]be[SP]here[SP]somewhere...[SP]the[SP][1432][NULL][NULL][0014]talking[SP]mask.[1432][NULL][NULL][0014]",
     "nom_fr": "Lycéen",
-    "texte_fr": "Waaah! [1205][000F][1205][000F]Oh...[1205][0008] C'est juste toi. Tu m'as fait\npeur![1205][000A] Hm?[1205][000A] Je cherche un masque. Il doit\nêtre là quelque part... le [1432][NULL][NULL][0014]masque parlant.[1432][NULL][NULL][0014]"
+    "texte_fr": "Waaah! [000F][1205][000F][1205]Oh...[0008][1205] C'est juste toi. Tu m'as fait\npeur![000A][1205] Hm?[000A][1205] Je cherche un masque. Il doit\nêtre là quelque part... le [1432][NULL][NULL][0014]masque parlant.[1432][NULL][NULL][0014]"
   },
   {
     "id": 1,
@@ -27,6 +27,6 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Last[SP]time[SP]I[SP]came[SP]to[SP]clean[SP]this[SP]place[SP]up,[SP]the\nprincipal[SP]was[SP]like...[SP]muttering[SP]something[SP]to\nthis[SP]mask.[1205][000F][SP]I[SP]bet[SP]he's[SP]hiding[SP]something.",
     "nom_fr": "",
-    "texte_fr": "La dernière fois que je suis venu\nnettoyer ici, le proviseur... marmonnait quelque\nchose à ce masque.[1205][000F] Il cache forcément un truc."
+    "texte_fr": "La dernière fois que je suis venu\nnettoyer ici, le proviseur... marmonnait quelque\nchose à ce masque.[000F][1205] Il cache forcément un truc."
   }
 ]

--- a/traduction/event_scripts/script_278.json
+++ b/traduction/event_scripts/script_278.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]memories[SP]evoked[SP]by[SP]the[SP]lady[SP]Maya-san...[1205][001E]\nThey[SP]were[SP]warm,[SP]sad,[SP]and[SP]painful,[SP]all[SP]at\nonce...[1205][001E][SP]Like[SP]the[SP]wringing[SP]of[SP]my[SP]heart...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Les souvenirs évoqués par Maya-san...[1205][001E]\nChaleureux, tristes et douloureux à la\nfois...[1205][001E] Comme si mon cœur se serrait..."
+    "texte_fr": "Les souvenirs évoqués par Maya-san...[001E][1205]\nChaleureux, tristes et douloureux à la\nfois...[001E][1205] Comme si mon cœur se serrait..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]felt[SP]it[SP]too,[SP]right,[SP][1113]?[SP]And[SP]yet,\nthis[SP]is[SP]our[SP]first[SP]meeting...[1205][001E][SP]Is[SP]this[SP]a\nlove[SP]that's[SP]destined[SP]to[SP]be?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tu l'as ressenti aussi, [1113]? C'est\npourtant notre première rencontre...[1205][001E]\nSerait-ce un amour destiné?"
+    "texte_fr": "Tu l'as ressenti aussi, [1113]? C'est\npourtant notre première rencontre...[001E][1205]\nSerait-ce un amour destiné?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]got[SP]scolded[SP]for[SP]mouthing[SP]off[SP]to[SP]the[SP]principal:\n[1432][NULL][NULL][0014]What[SP]are[SP]you[SP]doing[SP]in[SP]the[SP]clock[SP]tower?[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]It's[SP]rock[SP]hour![1432][NULL][NULL][0014][SP]Heheh...[SP]I'm[SP]a[SP]genius.[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nNo[SP]use[SP]for[SP]this[SP]place[SP]anymore.[SP]Why[SP]not\nconvert[SP]it[SP]to[SP]a[SP]storage[SP]room?[1205][000F][SP]Hmmm...\nI[SP]guess[SP]you[SP]can't[SP]really[SP]do[SP]that...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Engueulé par le proviseur\n: [1432][NULL][NULL][0014]Que fais-tu dans le clocher?[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]C'est l'heure du rock![1432][NULL][NULL][0014]\nHéhé... suis ungénie.[E1][E2] [E3][E4][NULL][NULL]\"Eikichi\n Cet endroit ne sert plus à\nrien. Pourquoi pas en faire un\n[1205][000F]débarras?Hmm... Bon, c'est pas si simple..."
+    "texte_fr": "Engueulé par le proviseur\n: [1432][NULL][NULL][0014]Que fais-tu dans le clocher?[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]C'est l'heure du rock![1432][NULL][NULL][0014]\nHéhé... suis ungénie.[E1][E2] [E3][E4][NULL][NULL]\"Eikichi\n Cet endroit ne sert plus à\nrien. Pourquoi pas en faire un\n[000F][1205]débarras?Hmm... Bon, c'est pas si simple..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]get[SP]this[SP]weird,[SP]nostalgic[SP]feeling\nfrom[SP]her...[1205][001E][SP]Nah,[SP]that's[SP]impossible![1205][001E]\nWe've[SP]never[SP]even[SP]met[SP]before.",
     "nom_fr": "Ginko",
-    "texte_fr": "Elle me donne une étrange impression\nde nostalgie...[1205][001E] Non, impossible![1205][001E] On\nne s'est jamais vues."
+    "texte_fr": "Elle me donne une étrange impression\nde nostalgie...[001E][1205] Non, impossible![001E][1205] On\nne s'est jamais vues."
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]think[SP]it[SP]was[SP]when[SP]he[SP]sprouted[SP]all[SP]that[SP]hair.[1205][001E]\nHe's[SP]got[SP]such[SP]a[SP]punchable[SP]face...[SP]Arrrgh!\nWanna[SP]pound[SP]some[SP]nails[SP]in[SP]the[SP]photo's[SP]eyes?",
     "nom_fr": "Ginko",
-    "texte_fr": "Je crois que c'est depuis qu'il a eu cette\ntignasse.[1205][001E] Quelle tête à claques... Argh!\nVeux-tu enfoncer des clous sur la photo?"
+    "texte_fr": "Je crois que c'est depuis qu'il a eu cette\ntignasse.[001E][1205] Quelle tête à claques... Argh!\nVeux-tu enfoncer des clous sur la photo?"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#10![1205][001E][SP][1432][NULL][NULL][0014]Haime[1432][NULL][NULL][0014][SP]means\n[1432][NULL][NULL][0014]Really?[1432][NULL][NULL][0014][SP]or[SP][1432][NULL][NULL][0014]Seriously?[1432][NULL][NULL][0014][SP]Remember[SP]that!",
     "nom_fr": "Ginko",
-    "texte_fr": "Cours n°10 cantonais de Lisa![1205][001E][1432][NULL][NULL][0014] Haime[1432][NULL][NULL][0014]\nsignifie [1432][NULL][NULL][0014]Vraiment?[1432][NULL][NULL][0014]/[1432][NULL][NULL][0014]Sérieux?[1432][NULL][NULL][0014] Retenez!"
+    "texte_fr": "Cours n°10 cantonais de Lisa![001E][1205][1432][NULL][NULL][0014] Haime[1432][NULL][NULL][0014]\nsignifie [1432][NULL][NULL][0014]Vraiment?[1432][NULL][NULL][0014]/[1432][NULL][NULL][0014]Sérieux?[1432][NULL][NULL][0014] Retenez!"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "*staaa[1205][000F]a[1205][000F]a[1205][000F]a[1205][000F]a[1205][000F]re*[1205][001E]\nBut[SP]that[SP]aside,[SP][1113]-kun...[1205][001E]\nHave[SP]we[SP]met[SP]somewhere[SP]before?",
     "nom_fr": "Maya",
-    "texte_fr": "*fixefixefixefixefixe*[1205][001E] Bref.[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]..\n[1113]-kun...[1205][001E] On s'est déjà vus?"
+    "texte_fr": "*fixefixefixefixefixe*[001E][1205] Bref.[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]..\n[1113]-kun...[001E][1205] On s'est déjà vus?"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Nah,[SP]just[SP]kidding![1205][001E][SP]Like[SP]that'd[SP]even[SP]be\npossible![1205][001E][SP]You're[SP]just[SP]such[SP]a[SP]fine-lookin'\nguy[SP]that[SP]I[SP]had[SP]to[SP]get[SP]a[SP]good[SP]ogle[SP]in!",
     "nom_fr": "Maya",
-    "texte_fr": "Nan, je plaisante![1205][001E] Comme si c'était\npossible![1205][001E] T'es trop beau gosse, j'ai\npas pu m'empêcher de te reluquer!"
+    "texte_fr": "Nan, je plaisante![001E][1205] Comme si c'était\npossible![001E][1205] T'es trop beau gosse, j'ai\npas pu m'empêcher de te reluquer!"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "These[SP]photos[SP]lined[SP]up[SP]here...[1205][001E][SP]Are[SP]they[SP]ALL\nof[SP]the[SP]principal!?[1205][001E][SP]He's[SP]got[SP]guts,[SP]I'll[SP]give\nhim[SP]that.",
     "nom_fr": "Maya",
-    "texte_fr": "Ces photos...[1205][001E] Ce sont TOUTES celles du\nproviseur!?[1205][001E] Au moins il a du culot."
+    "texte_fr": "Ces photos...[001E][1205] Ce sont TOUTES celles du\nproviseur!?[001E][1205] Au moins il a du culot."
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]wonder[SP]if[SP]there's[SP]really[SP]any[SP]such[SP]thing[SP]as\ncoincidence...[1205][001E][SP]When[SP]so[SP]many[SP]of[SP]them[SP]happen\nlike[SP]this,[SP]I[SP]wonder[SP]if[SP]it's[SP]all[SP]a[SP]setup.",
     "nom_fr": "Yukino",
-    "texte_fr": "Est-ce que les coïncidences existent\nvraiment...[1205][001E] Quand il y\nen a autant d'un coup,\nje me demande si tout n'est pas orchestré."
+    "texte_fr": "Est-ce que les coïncidences existent\nvraiment...[001E][1205] Quand il y\nen a autant d'un coup,\nje me demande si tout n'est pas orchestré."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Oh,[SP]I[SP]was[SP]talking[SP]about[SP]Hamya.[1205][001E][SP]He[SP]was[SP]vice-\nprincipal[SP]at[SP]my[SP]high[SP]school.[1205][001E][SP]Looks[SP]like[SP]he's\nstill[SP]got[SP]rotten[SP]taste.",
     "nom_fr": "Yukino",
-    "texte_fr": "Oh, je parlais de Hamya.[1205][001E] Il était\nproviseur adjoint dans mon lycée.[1205][001E]\nToujours aussi mauvais goût."
+    "texte_fr": "Oh, je parlais de Hamya.[001E][1205] Il était\nproviseur adjoint dans mon lycée.[001E][1205]\nToujours aussi mauvais goût."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Yeah,[SP]there[SP]was[SP]a[SP]guy[SP]like[SP]him[SP]back[SP]then...\nA[SP]dork[SP]who'd[SP]say[SP]the[SP]dumbest[SP]shit...[1205][001E]\nI[SP]had[SP]a[SP]friend[SP]like[SP]him[SP]too!",
     "nom_fr": "Yukino",
-    "texte_fr": "Ouais, il y en avait un comme lui à\nl'époque... Un idiot qui sortait des\nâneries...[1205][001E] J'avais un ami pareil!"
+    "texte_fr": "Ouais, il y en avait un comme lui à\nl'époque... Un idiot qui sortait des\nâneries...[001E][1205] J'avais un ami pareil!"
   },
   {
     "id": 14,
@@ -263,7 +263,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]knew[SP]it...[1205][001E][SP]There[SP]was[SP]an[SP]antisocial[SP]guy[SP]like\nyou[SP]there,[SP]too...[1205][001E][SP]Am[SP]I[SP]cursed[SP]or[SP]something!?",
     "nom_fr": "Yukino",
-    "texte_fr": "Je m'en doutais...[1205][001E] Il y avait un asocial\ncomme toi là-bas aussi...[1205][001E]\nJe suis maudite !?"
+    "texte_fr": "Je m'en doutais...[001E][1205] Il y avait un asocial\ncomme toi là-bas aussi...[001E][1205]\nJe suis maudite !?"
   },
   {
     "id": 17,
@@ -278,7 +278,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]knew[SP]it...[1205][001E][SP]There[SP]was[SP]an[SP]antisocial[SP]guy[SP]like\nyou[SP]there,[SP]too...[1205][001E][SP]Am[SP]I[SP]cursed[SP]or[SP]something!?",
     "nom_fr": "Yukino",
-    "texte_fr": "Je m'en doutais...[1205][001E] Un asocial comme toi\nlà-bas aussi...[1205][001E] Je suis maudite ou quoi!?"
+    "texte_fr": "Je m'en doutais...[001E][1205] Un asocial comme toi\nlà-bas aussi...[001E][1205] Je suis maudite ou quoi!?"
   },
   {
     "id": 18,

--- a/traduction/event_scripts/script_279.json
+++ b/traduction/event_scripts/script_279.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Huh?[SP]This[SP]is[SP]the[SP]same[SP]tree,[SP]too...[1205][001E][SP]So[SP]weird.\nEverything[SP]about[SP]this[SP]place[SP]is[SP]just[SP]like[SP]it\nis[SP]in[SP]my[SP]dream...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hein? Cet arbre aussi est le\nmême...[1205][001E] C'est bizarre. Tout ici est\nexactement comme dans mon rêve..."
+    "texte_fr": "Hein? Cet arbre aussi est le\nmême...[001E][1205] C'est bizarre. Tout ici est\nexactement comme dans mon rêve..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]shrine[SP]from[SP]my[SP]dream...[1205][000F][SP]Why's[SP]it[SP]here?[1205][000F]\nOr,[SP]better[SP]question:[SP]Did[SP]I[SP]somehow[SP]know\nabout[SP]this[SP]shrine?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le sanctuaire de mon rêve.[1205][000F][1205][000F].. Que\nfait-il là? Ou... est-ce que je\nconnaissais déjà ce sanctuaire?"
+    "texte_fr": "Le sanctuaire de mon rêve.[000F][1205][000F][1205].. Que\nfait-il là? Ou... est-ce que je\nconnaissais déjà ce sanctuaire?"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Haha...[1205][000A][SP]This[SP]can't[SP]be[SP]right...[1205][000F][SP]Even[SP]that[SP]old\nlady[SP]is[SP]the[SP]same[SP]person[SP]I[SP]saw[SP]in[SP]my[SP]dreams...[1205][000F]\nWh-What's[SP]happening[SP]to[SP]me?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Haha.[1205][1205]..[1205][000A] C'est impossible.[000F][000F].. Même cette\nvieille dame est celle que j'ai vue en\nrêve... Q-Qu'est-ce qui m'arrive?"
+    "texte_fr": "Haha.[1205][1205]..[000A][1205] C'est impossible.[000F][000F].. Même cette\nvieille dame est celle que j'ai vue en\nrêve... Q-Qu'est-ce qui m'arrive?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That's[SP]right![1205][000F][SP]We[SP]did[SP]have[SP]a[SP]secret[SP]base!\nI[SP]can[SP]clearly[SP]remember[SP]it[SP]now.",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est vrai! [1205][000F]On avait une base\nsecrète! Je m'en souviens maintenant."
+    "texte_fr": "C'est vrai! [000F][1205]On avait une base\nsecrète! Je m'en souviens maintenant."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]feel[SP]bad[SP]about[SP]what[SP]we[SP]did[SP]to[SP]that[SP]girl.[1205][000F]\nIf[SP]we'd[SP]done[SP]this[SP]sooner,[SP]she[SP]wouldn't[SP]have\nended[SP]up[SP]in[SP]this[SP]state...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je me sens mal pour ce qu'on lui a\nfait. [1205][000F]Si on avait agi plus tôt, elle\nne se serait pas dans cet état..."
+    "texte_fr": "Je me sens mal pour ce qu'on lui a\nfait. [000F][1205]Si on avait agi plus tôt, elle\nne se serait pas dans cet état..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Fanna...[SP]I[SP]don't[SP]like[SP]it[SP]here.[1205][001E][SP]It's[SP]boring.\nLet's[SP]hurry[SP]back[SP]to[SP]Sevens.",
     "nom_fr": "Lisa",
-    "texte_fr": "Fanna... Cet endroit me déplaît.[1205][001E]\nC'est ennuyeux. Rentre vite à Seven."
+    "texte_fr": "Fanna... Cet endroit me déplaît.[001E][1205]\nC'est ennuyeux. Rentre vite à Seven."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Fanna...[SP]I[SP]don't[SP]like[SP]it[SP]here.[1205][001E][SP]It's[SP]boring.\nLet's[SP]hurry[SP]back[SP]to[SP]Sevens.",
     "nom_fr": "Ginko",
-    "texte_fr": "Fanna... Cet endroit me déplaît.[1205][001E]\nC'est ennuyeux. Rentre vite à Seven."
+    "texte_fr": "Fanna... Cet endroit me déplaît.[001E][1205]\nC'est ennuyeux. Rentre vite à Seven."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Fanna,[SP]no...[SP]Nuh-uh...[1205][000A][SP]I[SP]don't[SP]wanna[SP]be[SP]here.[1205][000F]\nLet's[SP]ditch[SP]this[SP]place,[SP]Chinyan...",
     "nom_fr": "Ginko",
-    "texte_fr": "Fanna, non... [1205]Non non...[1205][000A] Je veux pas\n[000F]rester ici. On s'en va, Chinyan..."
+    "texte_fr": "Fanna, non... [1205]Non non...[000A][1205] Je veux pas\n[000F]rester ici. On s'en va, Chinyan..."
   },
   {
     "id": 9,
@@ -192,7 +192,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "That[SP]summer[SP]ten[SP]years[SP]ago...[SP]Remember...?[1205][000F]\nIt's[SP]real...[1205][000F][SP]I'm[SP]scared,[SP][1113]...",
     "nom_fr": "Ginko",
-    "texte_fr": "Il y a dix ans... Tu t'en souviens?\n[1205][000F][1205][000F]C'est réel... J'ai peur, [1113]..."
+    "texte_fr": "Il y a dix ans... Tu t'en souviens?\n[000F][1205][000F][1205]C'est réel... J'ai peur, [1113]..."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Do[SP]you[SP]remember[SP]the[SP]secret[SP]base,[SP][1113]?\nThe[SP]one[SP]behind[SP]this[SP]shrine...[1205][000F][SP]Mt.[SP]Iwato...[1205][000F]\nOur[SP]secret[SP]headquarters...",
     "nom_fr": "Ginko",
-    "texte_fr": "Tu te rappelles la base secrète,\n[1113]? Derrière ce sanctuaire.[1205][000F][1205][000F]..\nMt. Iwato... Notre QG secret..."
+    "texte_fr": "Tu te rappelles la base secrète,\n[1113]? Derrière ce sanctuaire.[000F][1205][000F][1205]..\nMt. Iwato... Notre QG secret..."
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Ow...[1205][001E][SP]The[SP]moment[SP]I[SP]stepped[SP]in[SP]here,[SP]my[SP]scar--[1205][001E]\nMy[SP]head[SP]started[SP]hurting...",
     "nom_fr": "Maya",
-    "texte_fr": "Aïe...[1205][001E] En entrant ici, ma cicatrice--[1205][001E]\nMa tête s'est mise à faire mal..."
+    "texte_fr": "Aïe...[001E][1205] En entrant ici, ma cicatrice--[001E][1205]\nMa tête s'est mise à faire mal..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Oh,[SP]I'm[SP]okay.[SP]It'll[SP]go[SP]away[SP]soon...[1205][001E][SP]It[SP]just\nflares[SP]up[SP]from[SP]time[SP]to[SP]time.",
     "nom_fr": "Maya",
-    "texte_fr": "Oh, ça va. Ça va passer...[1205][001E] C'est\njuste une douleur passagère."
+    "texte_fr": "Oh, ça va. Ça va passer...[001E][1205] C'est\njuste une douleur passagère."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Masked[SP]Circle...[1205][000F][SP]Masked[SP]Circle...[1205][000F][SP]What[SP]could\nit[SP]be?[1205][000F][SP]I[SP]feel[SP]like[SP]I've[SP]heard[SP]that[SP]name[SP]before,\na[SP]long[SP]time[SP]ago...",
     "nom_fr": "Maya",
-    "texte_fr": "Cercle masqué.[1205][000F][1205][000F][1205][000F].. Cercle masqué...\nC'est quoi donc? J'ai l'impression\nd'avoir entendu ce nom quelque part..."
+    "texte_fr": "Cercle masqué.[000F][1205][000F][1205][000F][1205].. Cercle masqué...\nC'est quoi donc? J'ai l'impression\nd'avoir entendu ce nom quelque part..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I...[SP]prayed[SP]for[SP]something[SP]here[SP]once...[1205][000F][SP]And\nsomeone[SP]told[SP]me[SP]it[SP]would[SP]easily[SP]come[SP]true...[1205][000F]\nYes,[SP]I[SP]met[SP]someone[SP]here.[1205][000F][SP]Someone[SP]important...",
     "nom_fr": "Maya",
-    "texte_fr": "J'ai... prié ici autrefois pour quelque\n[1205][000F][1205][000F][1205][000F]chose... On m'a dit\nque ça se réaliserait...\nJ'ai rencontré\nquelqu'un ici. D'important..."
+    "texte_fr": "J'ai... prié ici autrefois pour quelque\n[000F][1205][000F][1205][000F][1205]chose... On m'a dit\nque ça se réaliserait... J'ai rencontré quelqu'un ici. D'important..."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Maya",
     "texte_orig": "No[SP]matter[SP]how[SP]much[SP]you[SP]try[SP]to[SP]seal[SP]off[SP]your\nmemories,[SP]they[SP]shine[SP]clearly[SP]in[SP]the[SP]mirror.[1205][000F]\nYou[SP]can't[SP]escape[SP]your[SP]sins.",
     "nom_fr": "Maya",
-    "texte_fr": "Peu importe tes efforts pour sceller\ntes souvenirs, ils brillent dans le\nmiroir. [1205][000F]On ne peut pas fuir ses péchés."
+    "texte_fr": "Peu importe tes efforts pour sceller\ntes souvenirs, ils brillent dans le\nmiroir. [000F][1205]On ne peut pas fuir ses péchés."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Am[SP]I...[SP]real...?[1205][000F][SP]It[SP]could[SP]be[SP]me[SP]who[SP]was[SP]born\nfrom[SP]a[SP]rumor,[SP]couldn't[SP]it?",
     "nom_fr": "Maya",
-    "texte_fr": "Suis-je réelle? [1205][000F]C'est peut-être moi\nqui suis née d'une rumeur, non?"
+    "texte_fr": "Suis-je réelle? [000F][1205]C'est peut-être moi\nqui suis née d'une rumeur, non?"
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Wow...[1205][001E][SP]Small[SP]world.[SP]There[SP]was[SP]an[SP]Alaya[SP]Shrine\nback[SP]in[SP]Mikage-cho,[SP]too.[SP]That's[SP]where[SP]we[SP]met\nPhilemon.",
     "nom_fr": "Yukino",
-    "texte_fr": "Oh![1205][001E] Petit monde! Un sanctuaire\nAlaya à Mikage-cho aussi. C'est\nlà qu'on a rencontré Philémon."
+    "texte_fr": "Oh![001E][1205] Petit monde! Un sanctuaire\nAlaya à Mikage-cho aussi. C'est\nlà qu'on a rencontré Philémon."
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Behind[SP]the[SP]shrine,[SP]huh...?[1205][000F][SP]In[SP]Mikage-cho,\nthe[SP]entrance[SP]to[SP]your[SP]soul[SP]was[SP]behind[SP]the\nAlaya[SP]Shrine.[1205][000F][SP]But[SP]that[SP]was[SP]a[SP]long[SP]time[SP]ago...",
     "nom_fr": "Yukino",
-    "texte_fr": "Derrière le sanctuaire, hein? [1205][000F][1205][000F]À Mikage-cho,\nl'entrée de ton âme était derrière le\nsanctuaire Alaya. Mais c'était si loin..."
+    "texte_fr": "Derrière le sanctuaire, hein? [000F][1205][000F][1205]À Mikage-cho,\nl'entrée de ton âme était derrière le\nsanctuaire Alaya. Mais c'était si loin..."
   },
   {
     "id": 23,
@@ -447,7 +447,7 @@
     "nom_orig": "Old[SP]lady",
     "texte_orig": "Terrible...[SP]Terrible...[1205][001E][SP]By[SP]the[SP]way,[SP]do[SP]you\nknow[SP]the[SP]rumor[SP]that[SP]a[SP]girl's[SP]ghost[SP]appears\nhere[SP]from[SP]time[SP]to[SP]time?",
     "nom_fr": "Vieille dame",
-    "texte_fr": "Terrible... Terrible...[1205][001E] Au fait,\nsavez-vous la rumeur du fantôme d'une\nfille qui apparaît ici parfois?"
+    "texte_fr": "Terrible... Terrible...[001E][1205] Au fait,\nsavez-vous la rumeur du fantôme d'une\nfille qui apparaît ici parfois?"
   },
   {
     "id": 30,
@@ -533,7 +533,7 @@
     "nom_orig": "Old[SP]lady",
     "texte_orig": "The[SP]girl's[SP]ghost[SP]always[SP]seems[SP]to[SP]disappear\ninto[SP]the[SP]shrine.[1205][000F][SP]Could[SP]it[SP]be[SP]connected[SP]to\nthe[SP]netherworld?",
     "nom_fr": "Vieille dame",
-    "texte_fr": "Le fantôme de la\nfille disparaît toujours dans\n[1205][000F]le sanctuaire. Serait-ce\nlié à l'autre monde?"
+    "texte_fr": "Le fantôme de la\nfille disparaît toujours dans\n[000F][1205]le sanctuaire. Serait-ce lié à l'autre monde?"
   },
   {
     "id": 35,
@@ -548,7 +548,7 @@
     "nom_orig": "Old[SP]lady",
     "texte_orig": "That[SP]was[SP]a[SP]surprise...[1205][000F][SP]I[SP]wonder[SP]how[SP]that\nblue[SP]person[SP]knew[SP]my[SP]name.",
     "nom_fr": "Vieille dame",
-    "texte_fr": "Surprise! [1205][000F]Comment cette\npersonne bleue connaît mon nom?"
+    "texte_fr": "Surprise! [000F][1205]Comment cette\npersonne bleue connaît mon nom?"
   },
   {
     "id": 36,
@@ -578,7 +578,7 @@
     "nom_orig": "Old[SP]lady",
     "texte_orig": "It[SP]was[SP]rumored[SP]that[SP]Kuchisake-onna[SP]dwelled[SP]in\nMt.[SP]Iwato.[1205][000F][SP]The[SP]local[SP]youth[SP]were[SP]too[SP]scared[SP]to\ngo[SP]near[SP]it.[1205][000F][SP]Some[SP]kids[SP]were[SP]fine,[SP]though...",
     "nom_fr": "Vieille dame",
-    "texte_fr": "La Kuchisake-onna vivait, dit-on, au Mt.\n[1205][000F][1205][000F]Iwato. Les locaux avaient trop peur d'en\napprocher. Sauf certains enfants..."
+    "texte_fr": "La Kuchisake-onna vivait, dit-on, au Mt.\n[000F][1205][000F][1205]Iwato. Les locaux avaient trop peur d'en\napprocher. Sauf certains enfants..."
   },
   {
     "id": 38,
@@ -623,7 +623,7 @@
     "nom_orig": "Sad-looking[SP]old[SP]lady",
     "texte_orig": "What's[SP]gotten[SP]into[SP]my[SP]old[SP]man?[1205][000F][SP]He's[SP]making\nsuch[SP]a[SP]fuss[SP]about[SP]seeing[SP]Kuchisake-onna.[1205][000F]\nEveryone[SP]knows[SP]she[SP]doesn't[SP]actually[SP]exist...",
     "nom_fr": "Vieille dame triste",
-    "texte_fr": "Qu'est-ce qui lui prend? [1205][000F][1205][000F]Il fait une telle\nhistoire pour la Kuchisake-onna. Tout le\nmonde sait qu'elle n'existe pas..."
+    "texte_fr": "Qu'est-ce qui lui prend? [000F][1205][000F][1205]Il fait une telle\nhistoire pour la Kuchisake-onna. Tout le\nmonde sait qu'elle n'existe pas..."
   },
   {
     "id": 41,

--- a/traduction/event_scripts/script_280.json
+++ b/traduction/event_scripts/script_280.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yellow[SP]Owl.[1205][000A][SP]Of[SP]course[SP]I[SP]remember.[1205][000F][SP]I[SP]might\nhave[SP]confused[SP]it[SP]for[SP]a[SP]dream,[SP]but[SP]I[SP]hadn't\nforgotten[SP]about[SP]you[SP]guys[SP]all[SP]these[SP]years.",
     "nom_fr": "Eikichi",
-    "texte_fr": "La Chouette Jaune.[1205][1205][000A] Je m'en souviens. [000F]J'ai\npu prendre ça pour un rêve, mais je ne\nvous ai pas oubliés toutes ces années."
+    "texte_fr": "La Chouette Jaune.[1205][000A][1205] Je m'en souviens. [000F]J'ai\npu prendre ça pour un rêve, mais je ne\nvous ai pas oubliés toutes ces années."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Sevens[SP]AGAIN?[1205][000F][SP]It's[SP]just[SP]one[SP]thing[SP]after\nanother[SP]with[SP]that[SP]place...[1205][000F][SP]*sigh*\nYour[SP]school's[SP]got[SP]problems,[SP]man.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Encore Seven? [1205][000F][1205][000F]C'est un problème après\nl'autre dans ce lycée...*soupir*\nVotre école craint, mec."
+    "texte_fr": "Encore Seven? [000F][1205][000F][1205]C'est un problème après\nl'autre dans ce lycée...*soupir*\nVotre école craint, mec."
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]don't[SP]have[SP]to[SP]worry[SP]about[SP]that[SP]at[SP]all,\nJun.[1205][000F][SP]Between[SP]a[SP]former[SP]Death[SP]Boss[SP]and[SP]the\nformer[SP]Joker,[SP]we[SP]got[SP]an[SP]unbeatable[SP]team.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ne t'en fais pas pour ça, Jun. Entre\n[1205][000F]un ex-Boss de la Mort et un ancien\nJoker, on forme une équipe imbattable."
+    "texte_fr": "Ne t'en fais pas pour ça, Jun. Entre\n[000F][1205]un ex-Boss de la Mort et un ancien\nJoker, on forme une équipe imbattable."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "The[SP]Masked[SP]Circle,[SP]huh...[1205][000F][SP]I[SP]was[SP]Pink[SP]Azas.[1205][000F]\nDo[SP]you[SP]remember[SP]your[SP]color,[SP]Eikichi?",
     "nom_fr": "Ginko",
-    "texte_fr": "Le Cercle Masqué, hein.[1205][000F][1205][000F].. J'étais Rose.\nTu te souviens de ta couleur, Eikichi?"
+    "texte_fr": "Le Cercle Masqué, hein.[000F][1205][000F][1205].. J'étais Rose.\nTu te souviens de ta couleur, Eikichi?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Oh[SP]yeah,[SP]there[SP]was[SP]a[SP]rumor[SP]going[SP]around[SP]about\nthere[SP]being[SP]a[SP]Silver[SP]River[SP]under[SP]Sevens.[1205][000F]\nDid[SP]that[SP]become[SP]reality[SP]along[SP]with[SP]Xibalba?",
     "nom_fr": "Ginko",
-    "texte_fr": "Oh ouais, une rumeur disait qu'une\nRivière d'Argent coulait sous Seven.\n[1205][000F]C'est devenu réalité avec Xibalba?"
+    "texte_fr": "Oh ouais, une rumeur disait qu'une\nRivière d'Argent coulait sous Seven.\n[000F][1205]C'est devenu réalité avec Xibalba?"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Former[SP]Death[SP]Boss?[1205][000A][SP]Doesn't[SP]he[SP]mean[SP]former\nUndie[SP]Boss?",
     "nom_fr": "Ginko",
-    "texte_fr": "Le Boss Mort?[1205][000A] Il veut pas\ndire le Boss des Caleçons?"
+    "texte_fr": "Le Boss Mort?[000A][1205] Il veut pas\ndire le Boss des Caleçons?"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Haha...[1205][000F][SP]It's[SP]been[SP]ten[SP]years[SP]since[SP]the[SP]original\nMasked[SP]Circle[SP]gathered[SP]here.[1205][000F][SP]Everyone[SP]was[SP]so\nclose...[SP]yet[SP]so[SP]far...",
     "nom_fr": "Maya",
-    "texte_fr": "Haha.[1205][000F][1205][000F].. Ça fait dix ans que le Cercle\nMasqué originel s'est réuni ici. On\nétait si proches... et pourtant..."
+    "texte_fr": "Haha.[000F][1205][000F][1205].. Ça fait dix ans que le Cercle\nMasqué originel s'est réuni ici. On\nétait si proches... et pourtant..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "But[SP]now[SP]we've[SP]finally[SP]reunited.[1205][000F][SP]There's[SP]nothing\nmore[SP]amazing[SP]than[SP]this,[SP]and[SP]I[SP]believe[SP]that\nfrom[SP]the[SP]bottom[SP]of[SP]my[SP]heart.",
     "nom_fr": "Maya",
-    "texte_fr": "Mais nous voilà enfin réunis. [1205][000F]Il n'y\na rien de plus merveilleux, j'en\nsuis convaincue du fond du cœur."
+    "texte_fr": "Mais nous voilà enfin réunis. [000F][1205]Il n'y\na rien de plus merveilleux, j'en\nsuis convaincue du fond du cœur."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "If[SP]the[SP]rumors[SP]are[SP]true,[SP]the[SP]Silver[SP]River\nshould[SP]be[SP]connected[SP]to[SP]Xibalba.[1205][000F][SP]Let's[SP]hurry.\nI'm[SP]worried[SP]about[SP]that[SP]teacher.",
     "nom_fr": "Maya",
-    "texte_fr": "Si les rumeurs disent vrai, la Rivière\nd'Argent doit être reliée au Xibalba.\n[1205][000F]Filons! Je m'inquiète pour cette prof."
+    "texte_fr": "Si les rumeurs disent vrai, la Rivière\nd'Argent doit être reliée au Xibalba.\n[000F][1205]Filons! Je m'inquiète pour cette prof."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Eikichi-kun's[SP]right.[SP]I'm[SP]sure[SP]we[SP]can[SP]beat\nwhoever[SP]stands[SP]against[SP]us[SP]now.[1205][000F][SP]There's\nnothing[SP]we[SP]can't[SP]do!",
     "nom_fr": "Maya",
-    "texte_fr": "Eikichi a raison. Sûre qu'on peut battre\nn'importe qui maintenant. [1205][000F]Rien ne nous\narrêtera!"
+    "texte_fr": "Eikichi a raison. Sûre qu'on peut battre\nn'importe qui maintenant. [000F][1205]Rien ne nous\narrêtera!"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "After[SP]all,[SP]we're[SP]not[SP]alone[SP]anymore.[1205][000F][SP]I[SP]believe\nin[SP]you[SP]guys,[SP]and[SP]that's[SP]why[SP]I[SP]know[SP]that[SP]we'll\nbe[SP]okay.",
     "nom_fr": "Maya",
-    "texte_fr": "Après tout, on n'est plus seuls. [1205][000F]Je crois\nen vous, je sais que tout ira bien."
+    "texte_fr": "Après tout, on n'est plus seuls. [000F][1205]Je crois\nen vous, je sais que tout ira bien."
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I,[SP]too,[SP]remember[SP]this[SP]place[SP]well...[1205][000F]\nI'll[SP]never[SP]be[SP]able[SP]to[SP]forget[SP]it.",
     "nom_fr": "Jun",
-    "texte_fr": "Je m'en souviens bien aussi.[1205][000F]..\nJe ne l'oublierai jamais."
+    "texte_fr": "Je m'en souviens bien aussi.[000F][1205]..\nJe ne l'oublierai jamais."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Jun",
     "texte_orig": "This[SP]was[SP]where[SP]we[SP]first[SP]met...[1205][000A][SP]And[SP]also\nwhere[SP]this[SP]terrible[SP]chain[SP]of[SP]events[SP]had\nits[SP]origin.",
     "nom_fr": "Jun",
-    "texte_fr": "C'est là qu'on s'est vus pour la première\nfois...[1205][000A] Et là où tout a commencé."
+    "texte_fr": "C'est là qu'on s'est vus pour la première\nfois...[000A][1205] Et là où tout a commencé."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Jun",
     "texte_orig": "But[SP]I[SP]felt[SP]the[SP]need[SP]to[SP]come[SP]here[SP]once[SP]before.[1205][000F]\nIf[SP]this[SP]was[SP]the[SP]origin[SP]of[SP]the[SP]sin,[SP]it[SP]should\nbe[SP]the[SP]origin[SP]of[SP]the[SP]atonement[SP]as[SP]well.",
     "nom_fr": "Jun",
-    "texte_fr": "Mais je ressentais le besoin de revenir ici\n[1205][000F]une fois. Si c'est ici qu'est né le péché,\nc'est ici que doit commencer l'expiation."
+    "texte_fr": "Mais je ressentais le besoin de revenir ici\n[000F][1205]une fois. Si c'est ici qu'est né le péché,\nc'est ici que doit commencer l'expiation."
   },
   {
     "id": 18,
@@ -342,7 +342,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]can't[SP]predict[SP]Father's[SP]strength.[1205][000F][SP]In[SP]truth,\nI'm[SP]scared.[SP]I'm[SP]not[SP]sure...[1205][000F][SP]if[SP]we'll[SP]really\nbe[SP]enough[SP]to[SP]stop[SP]him...",
     "nom_fr": "Jun",
-    "texte_fr": "La force de mon père m'effraie.\n[1205][000F][1205][000F]J'ai peur... Je ne sais pas si\non pourra vraiment l'arrêter..."
+    "texte_fr": "La force de mon père m'effraie.\n[000F][1205][000F][1205]J'ai peur... Je ne sais pas si\non pourra vraiment l'arrêter..."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Old[SP]lady",
     "texte_orig": "I[SP]see...[1205][000A][SP]That[SP]girl[SP]is[SP]finally[SP]at[SP]rest.[1205][000F]\nI[SP]can[SP]tell[SP]because[SP]the[SP]smell[SP]of[SP]the[SP]earth\nhas[SP]changed...[1205][000F][SP]It[SP]smells[SP]of[SP]the[SP]sun[SP]now.",
     "nom_fr": "Vieille Dame",
-    "texte_fr": "Je vois.[1205][1205]..[1205][000A] Cette petite repose enfin.\n[000F][000F]L'odeur de la terre a changé... Elle\nsent le soleil maintenant."
+    "texte_fr": "Je vois.[1205][1205]..[000A][1205] Cette petite repose enfin.\n[000F][000F]L'odeur de la terre a changé... Elle\nsent le soleil maintenant."
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Old[SP]lady",
     "texte_orig": "I'm[SP]so[SP]glad...[1205][000A][SP]My[SP]heart[SP]ached[SP]for[SP]such[SP]a\nsmall[SP]girl[SP]having[SP]to[SP]bear[SP]those[SP]regrets\nforever...[1205][000F][SP]It's[SP]better[SP]this[SP]way.",
     "nom_fr": "Vieille Dame",
-    "texte_fr": "Quelle joie.[1205]..[1205][000A] Ça m'attristait qu'une\nenfant si petite porte ses regrets à\n[000F]jamais... C'est mieux ainsi."
+    "texte_fr": "Quelle joie.[1205]..[000A][1205] Ça m'attristait qu'une\nenfant si petite porte ses regrets à\n[000F]jamais... C'est mieux ainsi."
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Old[SP]lady",
     "texte_orig": "What[SP]is[SP]that[SP]pillar[SP]of[SP]light[SP]rising[SP]from\nSevens?[1205][000F][SP]Has[SP]Buddha[SP]descended[SP]to[SP]Heaven's\nShores?[1205][000F][SP]Aaah,[SP]it's[SP]a[SP]terrible[SP]omen...",
     "nom_fr": "Vieille Dame",
-    "texte_fr": "Ce pilier de lumière à Seven?\n[1205][000F][1205][000F]Bouddha serait-il sur les Rives\nCélestes? C'est un terrible présage."
+    "texte_fr": "Ce pilier de lumière à Seven?\n[000F][1205][000F][1205]Bouddha serait-il sur les Rives\nCélestes? C'est un terrible présage."
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Old[SP]lady",
     "texte_orig": "I'll[SP]gaze[SP]down[SP]at[SP]the[SP]city[SP]to[SP]the[SP]last...[1205][000F]\nI've[SP]watched[SP]over[SP]it[SP]since[SP]I[SP]was[SP]born[SP]and[SP]I\nwant[SP]to[SP]do[SP]the[SP]same[SP]until[SP]the[SP]very[SP]end.",
     "nom_fr": "Vieille Dame",
-    "texte_fr": "Je contemplerai la ville enfin.[1205][000F]..\nJe veille sur elle depuis toujours\net je le ferai jusqu'au bout."
+    "texte_fr": "Je contemplerai la ville enfin.[000F][1205]..\nJe veille sur elle depuis toujours\net je le ferai jusqu'au bout."
   },
   {
     "id": 27,

--- a/traduction/event_scripts/script_281.json
+++ b/traduction/event_scripts/script_281.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]just[SP]like[SP]Ken[SP]and[SP]the[SP]others.[SP]He's[SP]turned\nblack[SP]as[SP]a[SP]shadow...[1205][001E][SP]That[SP]Joker...[SP]I'm[SP]gonna\ncatch[SP]him,[SP]you[SP]just[SP]watch[SP]me...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Comme Ken et les autres, il est devenu\nnoir comme une Ombre...[1205][001E] Ce Joker... je\nvais l'attraper, vous pouvez me croire!"
+    "texte_fr": "Comme Ken et les autres, il est devenu\nnoir comme une Ombre...[001E][1205] Ce Joker... je\nvais l'attraper, vous pouvez me croire!"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Stupid[SP]Ginko,[SP]going[SP]on[SP]and[SP]on[SP]about[SP]undies...[1205][000F]\nAlright,[SP]bring[SP]it[SP]on![1205][000A][SP]I'll[SP]spend[SP]a[SP]whole[SP]day\nhere[SP]with[SP]you[SP]if[SP]that's[SP]what[SP]it[SP]takes!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Idiote de Ginko avec ses histoires de\n[1205][000F]slips... Bon, j'accepte![1205][000A] Je passerai\nla journée ici avec toi s'il le faut!"
+    "texte_fr": "Idiote de Ginko avec ses histoires de\n[000F][1205]slips... Bon, j'accepte![000A][1205] Je passerai\nla journée ici avec toi s'il le faut!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Whoa,[SP]whoa...[SP]Don't[SP]tell[SP]me[SP]this[SP]is[SP]because\nof[SP]a[SP]rumor[SP]too![1205][000F][SP]When[SP]the[SP]rumor[SP]spread[SP]at[SP]Sevens\nthat[SP]the[SP]principal[SP]died,[SP]he[SP]really[SP]did!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ne me dis pas que c'est aussi une rumeur!\n[1205][000F]Quand la rumeur que le directeur de Seven\nétait mort s'est répandue, c'était vrai!?"
+    "texte_fr": "Ne me dis pas que c'est aussi une rumeur!\n[000F][1205]Quand la rumeur que le directeur de Seven\nétait mort s'est répandue, c'était vrai!?"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "This[SP]is[SP]a[SP]joke,[SP]right?[1205][000F][SP]Are[SP]rumors[SP]deciding\nwhether[SP]people[SP]live[SP]or[SP]die!?[SP]That's[SP]just\ncompletely[SP]ridiculous...",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est une blague, non? [1205][000F]Les rumeurs\ndécident si les gens vivent ou\nmeurent!? C'est complètement absurde..."
+    "texte_fr": "C'est une blague, non? [000F][1205]Les rumeurs\ndécident si les gens vivent ou\nmeurent!? C'est complètement absurde..."
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey,maybe[SP]Hanakouji-san[SP]went[SP]back[SP]to[SP]her[SP]\nunderclassman's[SP]place.[1205][000F]\nLet's[SP]try[SP]going[SP]to[SP]Peace[SP]Diner.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, Hanakouji-san est\npeut-être retournée chez\nson cadet. [1205][000F]Essayons d'aller au Peace Diner."
+    "texte_fr": "Hé, Hanakouji-san est\npeut-être retournée chez\nson cadet. [000F][1205]Essayons d'aller au Peace Diner."
   },
   {
     "id": 6,
@@ -147,7 +147,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "If[SP]the[SP]Masked[SP]Circle[SP]is[SP]behind[SP]this,[SP]they\ndon't[SP]have[SP]very[SP]good[SP]taste.[1205][000F][SP]It[SP]would[SP]have\nbeen[SP]so[SP]much[SP]easier[SP]to[SP]sponsor[SP]my[SP]debut!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Si le Cercle masqué est derrière ça, ils\nont vraiment mauvais goût. [1205][000F]Il aurait été\nplus simple de sponsoriser mes débuts!"
+    "texte_fr": "Si le Cercle masqué est derrière ça, ils\nont vraiment mauvais goût. [000F][1205]Il aurait été\nplus simple de sponsoriser mes débuts!"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Are[SP]you[SP]worried[SP]about[SP]Ginko?[SP]Relax,[SP]she'll[SP]be\nfine.[SP]I[SP]mean,[SP]she[SP]knows[SP]kung[SP]fu,[SP]she's[SP]a\nPersona-user,[SP]and[SP]she's[SP]got[SP]that[SP]temper...",
     "nom_fr": "Eikichi",
-    "texte_fr": "T'inquiètes pour Ginko? Elle s'en sortira.\nElle connaît le kung fu, c'est une\nutilisatrice de Persona\navec ce caractère..."
+    "texte_fr": "T'inquiètes pour Ginko? Elle s'en sortira.\nElle connaît le kung fu, c'est une\nutilisatrice de Persona avec ce caractère..."
   },
   {
     "id": 11,
@@ -192,7 +192,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]too[SP]bad[SP]the[SP]concert[SP]hall[SP]had[SP]to[SP]burn\ndown...[1205][000F][SP]I[SP]dreamed[SP]of[SP]having[SP]my[SP]own[SP]concert\nthere[SP]someday.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Dommage que la salle de concerts ait dû\n[1205]brûler.[000F].. Je rêvais d'y\ndonner un concert un\njour."
+    "texte_fr": "Dommage que la salle de concerts ait dû\n[1205]brûler.[000F].. Je rêvais d'y\ndonner un concert un jour."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]think[SP]the[SP]Sakanoue[SP]Building[SP]will[SP]be[SP]the[SP]next\ntarget.[1205][000A][SP]Why?[1205][000A][SP]My[SP]sixth[SP]sense[SP]says[SP]so![1205][000F][SP]You[SP]can\nalways[SP]trust[SP]the[SP]instinct[SP]of[SP]a[SP]beautiful[SP]man.",
     "nom_fr": "Eikichi",
-    "texte_fr": "L'immeuble Sakanoue sera la prochaine\ncible.[1205][1205][000A] Pourquoi?[1205][000A] Mon sixième sens! [000F]On\npeut se fier à l'instinct d'un beau mec."
+    "texte_fr": "L'immeuble Sakanoue sera la prochaine\ncible.[1205][000A][1205] Pourquoi?[000A][1205] Mon sixième sens! [000F]On\npeut se fier à l'instinct d'un beau mec."
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]Aerospace[SP]Museum,[SP]huh?[1205][000F][SP]That[SP]bastard[SP]is\nthere[SP]too!?[1205][000A][SP]I'll[SP]rip[SP]that[SP]mask[SP]off[SP]and[SP]beat\nhis[SP]face[SP]in[SP]this[SP]time[SP]for[SP]sure!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le Musée de l'espace, hein? [1205][000F]Ce salaud\nlà-bas aussi!?[1205][000A] Cette fois je lui arrache\nle masque et lui défonce la tête!"
+    "texte_fr": "Le Musée de l'espace, hein? [000F][1205]Ce salaud\nlà-bas aussi!?[000A][1205] Cette fois je lui arrache\nle masque et lui défonce la tête!"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Tch...[1205][000A][SP]Even[SP]here,[SP]they're[SP]talking[SP]about[SP]the\nIn[SP]Lak'ech...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tss...[1205][000A] Même ici, ils\nparlent de l'In Lak'ech..."
+    "texte_fr": "Tss...[000A][1205] Même ici, ils\nparlent de l'In Lak'ech..."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "But...[1205][000A][SP]if[SP]Jun[SP]ordered[SP]them[SP]to[SP]protect[SP]the\npeople[SP]of[SP]the[SP]city...[SP]He's[SP]still...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mais...[1205][000A] si Jun a ordonné de protéger\nla population... Il est toujours..."
+    "texte_fr": "Mais...[000A][1205] si Jun a ordonné de protéger\nla population... Il est toujours..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Ack![SP]No,[SP]stay[SP]away![1205][001E][SP]Rumor[SP]is[SP]that[SP]couples[SP]who\ngo[SP]on[SP]dates[SP]in[SP]this[SP]park[SP]always[SP]have[SP]messy\nbreakups!",
     "nom_fr": "Lisa",
-    "texte_fr": "Aïe! Non, restez loin![1205][001E]\nOn dit que les couples\nqui sortent dans ce\nparc se séparent toujours!"
+    "texte_fr": "Aïe! Non, restez loin![001E][1205]\nOn dit que les couples\nqui sortent dans ce parc se séparent toujours!"
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Ack![SP]No,[SP]stay[SP]away![1205][001E][SP]Rumor[SP]is[SP]that[SP]couples[SP]who\ngo[SP]on[SP]dates[SP]in[SP]this[SP]park[SP]always[SP]have[SP]messy\nbreakups!",
     "nom_fr": "Ginko",
-    "texte_fr": "Aïe! Non, restez loin![1205][001E]\nOn dit que les couples\nqui sortent dans ce\nparc se séparent toujours!"
+    "texte_fr": "Aïe! Non, restez loin![001E][1205]\nOn dit que les couples\nqui sortent dans ce parc se séparent toujours!"
   },
   {
     "id": 20,
@@ -327,7 +327,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Well,[SP]if[SP]that's[SP]the[SP]rumor,[SP]then[SP]it's[SP]probably\ntrue[SP]now.[1205][000F][SP]Hey,[SP]I[SP]should[SP]go[SP]on[SP]a[SP]date[SP]with\nUndie[SP]Boss[SP]here!",
     "nom_fr": "Ginko",
-    "texte_fr": "Bon, si c'est la rumeur, c'est\nvrai maintenant. [1205][000F]Hé, je devrais\nsortir avec le Boss des Slips!"
+    "texte_fr": "Bon, si c'est la rumeur, c'est\nvrai maintenant. [000F][1205]Hé, je devrais\nsortir avec le Boss des Slips!"
   },
   {
     "id": 22,
@@ -357,7 +357,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![SP]We[SP]heard[SP]it[SP]from[SP]Hanya,[SP]but[SP]Cuss[SP]High\nreally[SP]was[SP]behind[SP]the[SP]emblem[SP]curse![SP]I[SP]should've\nexpected[SP]a[SP]dirty[SP]trick[SP]like[SP]that[SP]from[SP]them!",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei! On l'a appris de Hanya, le Lycée\nKakasu était vraiment\nderrière la malédiction!\nJ'aurais dû m'attendre à un coup aussi bas!"
+    "texte_fr": "Kehhei! On l'a appris de Hanya, le Lycée\nKakasu était vraiment\nderrière la malédiction! J'aurais dû m'attendre à un coup aussi bas!"
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Undie[SP]Boss[SP]swore[SP]it[SP]wasn't[SP]true,[SP]but[SP]it[SP]really\nwas[SP]Cuss[SP]High[SP]who[SP]spread[SP]that[SP]rumor.[1205][000F][SP]He[SP]talks\na[SP]good[SP]game,[SP]but[SP]he's[SP]just[SP]an[SP]idiot.",
     "nom_fr": "Ginko",
-    "texte_fr": "Le Boss des Slips jurait que non, mais\nc'est bien le Lycée Kakasu qui a répandu la\n[1205][000F]rumeur. Il se vante, c'est juste un idiot."
+    "texte_fr": "Le Boss des Slips jurait que non, mais\nc'est bien le Lycée Kakasu qui a répandu la\n[000F][1205]rumeur. Il se vante, c'est juste un idiot."
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Things[SP]are[SP]getting[SP]serious.[SP]If[SP]it[SP]had[SP]been[SP]the\nwork[SP]of[SP]some[SP]yahoos,[SP]that's[SP]fine,[SP]but[SP]this[SP]went\nall[SP]the[SP]way[SP]to[SP]the[SP]student[SP]council[SP]president...",
     "nom_fr": "Ginko",
-    "texte_fr": "Ça devient grave. Si c'était l'œuvre de\nquelques idiots, passe\nencore, mais ça remonte\njusqu'au président du conseil des élèves..."
+    "texte_fr": "Ça devient grave. Si c'était l'œuvre de\nquelques idiots, passe\nencore, mais ça remonte jusqu'au président du conseil des élèves..."
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What[SP]do[SP]you[SP]mean,[SP]third[SP]member?[1205][000F][SP]Wait,[SP]really,\nI[SP]don't[SP]understand[SP]what[SP]you're[SP]talking[SP]about\nat[SP]all!",
     "nom_fr": "Ginko",
-    "texte_fr": "Un troisième membre? [1205][000F]Attends, serieusement,\nje ne comprends pas de quoi tu parles!"
+    "texte_fr": "Un troisième membre? [000F][1205]Attends, serieusement,\nje ne comprends pas de quoi tu parles!"
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Why'd[SP]everyone[SP]think[SP]I[SP]was[SP]going[SP]to[SP]debut?[1205][000F]\nWould[SP]Tamaki-san[SP]and[SP]the[SP]others[SP]know?",
     "nom_fr": "Ginko",
-    "texte_fr": "Pourquoi croire que je vais débuter?\n[1205][000F]Tamaki-san et les autres sauraient-ils?"
+    "texte_fr": "Pourquoi croire que je vais débuter?\n[000F][1205]Tamaki-san et les autres sauraient-ils?"
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]told[SP]you[SP]already,[SP]it's[SP]just[SP]Sheba[SP]and[SP]Mee-ho\nin[SP]this[SP]group![SP]It's[SP]got[SP]nothing[SP]to[SP]do[SP]with[SP]me![1205][000F]\nYou[SP]better[SP]tell[SP]the[SP]guys[SP]at[SP]school[SP]that!",
     "nom_fr": "Ginko",
-    "texte_fr": "Je t'ai déjà dit, ce groupe c'est juste\nSheba et Mee-ho! Ça n'a rien à voir\n[1205][000F]avec moi! Dis-le aux gars à l'école!"
+    "texte_fr": "Je t'ai déjà dit, ce groupe c'est juste\nSheba et Mee-ho! Ça n'a rien à voir\n[000F][1205]avec moi! Dis-le aux gars à l'école!"
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Sheba...[1205][000F][SP]Mee-ho...[SP]Hang[SP]in[SP]there.[1205][000F][SP]I'll...[1205][000F]\nI'll[SP]make[SP]sure[SP]to[SP]get[SP]your[SP]dreams[SP]back...",
     "nom_fr": "Ginko",
-    "texte_fr": "Sheba.[1205][000F][1205][000F][1205][000F].. Mee-ho... Tenez bon. Je... Je\nveillerai à vous rendre vos rêves..."
+    "texte_fr": "Sheba.[000F][1205][000F][1205][000F][1205].. Mee-ho... Tenez bon. Je... Je\nveillerai à vous rendre vos rêves..."
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]think[SP]Smile[SP]Hirasaka[SP]is[SP]the[SP]next[SP]target.[1205][000A]\nI-I[SP]don't[SP]have[SP]any[SP]reason[SP]for[SP]thinking[SP]that,\nthough...[1205][000F][SP]It's[SP]just[SP]a[SP]hunch.",
     "nom_fr": "Ginko",
-    "texte_fr": "Smile Hirasaka est sûrement la prochaine\n[1205]cible.[1205][000A] J-Je n'ai pas de raison de penser\nça... [000F]C'est juste une intuition."
+    "texte_fr": "Smile Hirasaka est sûrement la prochaine\n[1205]cible.[000A][1205] J-Je n'ai pas de raison de penser\nça... [000F]C'est juste une intuition."
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Umm...[1205][000A][SP]Maybe[SP]the[SP]next[SP]target[SP]is[SP]Pachinko\nSilver?[1205][000F][SP]I'm[SP]just[SP]throwing[SP]out[SP]ideas...",
     "nom_fr": "Ginko",
-    "texte_fr": "Euh.[1205]..[1205][000A] La prochaine cible serait le\n[000F]Pachinko Silver? Je lance des idées..."
+    "texte_fr": "Euh.[1205]..[000A][1205] La prochaine cible serait le\n[000F]Pachinko Silver? Je lance des idées..."
   },
   {
     "id": 32,
@@ -507,7 +507,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh!?[1205][000F][SP]Wasn't[SP]there[SP]a[SP]shadowman[SP]over[SP]there\nbefore?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein![1205][000F]? Il n'y avait pas\nune Ombre là-bas avant?"
+    "texte_fr": "Hein![000F][1205]? Il n'y avait pas\nune Ombre là-bas avant?"
   },
   {
     "id": 34,
@@ -552,7 +552,7 @@
     "nom_orig": "Maya",
     "texte_orig": "No[SP]one[SP]notices[SP]or[SP]recognizes[SP]him.[1205][001E][SP]To[SP]be\nsuddenly[SP]forgotten[SP]by[SP]everyone[SP]like[SP]this...[1205][001E]\nIn[SP]a[SP]way,[SP]it's[SP]worse[SP]than[SP]death.",
     "nom_fr": "Maya",
-    "texte_fr": "Personne ne le remarque ni\nreconnaît.[1205][001E] Être oublié de tous...[1205][001E]\nD'une façon, c'est pire que la mort."
+    "texte_fr": "Personne ne le remarque ni\nreconnaît.[001E][1205] Être oublié de tous...[001E][1205]\nD'une façon, c'est pire que la mort."
   },
   {
     "id": 37,
@@ -582,7 +582,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Th-The[SP]principal[SP]really[SP]died!?[1205][001E][SP]Yikes...\nI[SP]guess[SP]this[SP]has[SP]gone[SP]beyond[SP]a[SP]prank...",
     "nom_fr": "Maya",
-    "texte_fr": "L-Le directeur est vraiment mort!?[1205][001E]\nAïe... Ça dépasse la simple farce..."
+    "texte_fr": "L-Le directeur est vraiment mort!?[001E][1205]\nAïe... Ça dépasse la simple farce..."
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Well,[SP]it'll[SP]be[SP]fine,[SP]right?[1205][001E][SP]He[SP]died[SP]because[SP]of\na[SP]rumor,[SP]so[SP]one[SP]can[SP]probably[SP]bring[SP]him[SP]back[SP]to\nlife![SP]Let's[SP]spread[SP]that[SP]rumor[SP]at[SP]Sevens!",
     "nom_fr": "Maya",
-    "texte_fr": "Ça va aller, non?[1205][001E] Il est mort à cause d'une\nrumeur, donc on peut sûrement le ramener à\nla vie! Répandons cette rumeur à Seven!"
+    "texte_fr": "Ça va aller, non?[001E][1205] Il est mort à cause d'une\nrumeur, donc on peut sûrement le ramener à\nla vie! Répandons cette rumeur à Seven!"
   },
   {
     "id": 40,
@@ -627,7 +627,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Eikichi-kun[SP]didn't[SP]know[SP]what[SP]that[SP]new[SP]Leader\nSugimoto[SP]was[SP]doing,[SP]right?[1205][000F][SP]Then[SP]it's[SP]not\nhis[SP]fault!",
     "nom_fr": "Maya",
-    "texte_fr": "Eikichi-kun ignorait ce\nque le nouveau Leader\nSugimoto faisait, non? [1205][000F]Ce\nn'est pas sa faute!"
+    "texte_fr": "Eikichi-kun ignorait ce\nque le nouveau Leader\nSugimoto faisait, non? [000F][1205]Ce n'est pas sa faute!"
   },
   {
     "id": 42,
@@ -657,7 +657,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Masked[SP]Circle...[1205][000F][SP]Masked[SP]Circle...[1205][000F][SP]It's[SP]strange,\nbut[SP]I[SP]feel[SP]like[SP]I've[SP]heard[SP]of[SP]that[SP]before...\nIs[SP]it[SP]just[SP]my[SP]imagination?",
     "nom_fr": "Maya",
-    "texte_fr": "Cercle masqué.[1205][000F][1205][000F].. Cercle masqué...\nÉtrange, j'ai l'impression d'avoir déjà\nentendu ça... Est-ce mon imagination?"
+    "texte_fr": "Cercle masqué.[000F][1205][000F][1205].. Cercle masqué...\nÉtrange, j'ai l'impression d'avoir déjà\nentendu ça... Est-ce mon imagination?"
   },
   {
     "id": 44,
@@ -672,7 +672,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]is[SP]the[SP]last[SP]rumormonger,[SP]right?[1205][000F][SP]And[SP]no\nresults...[1205][000F][SP]Maybe[SP]no[SP]one[SP]knows[SP]after[SP]all...",
     "nom_fr": "Maya",
-    "texte_fr": "C'est le dernier colporteur, non? [1205][000F][1205][000F]Toujours\nrien... Peut-être que personne ne sait..."
+    "texte_fr": "C'est le dernier colporteur, non? [000F][1205][000F][1205]Toujours\nrien... Peut-être que personne ne sait..."
   },
   {
     "id": 45,
@@ -687,7 +687,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hey![1205][000A][SP]Why[SP]don't[SP]we[SP]go[SP]to[SP]that[SP]detective\nagency?[SP]Maybe[SP]they'll[SP]know[SP]something[SP]about\nthe[SP]Masked[SP]Circle!",
     "nom_fr": "Maya",
-    "texte_fr": "Hé![1205][000A] Si on allait à l'agence de\ndétectives? Ils savent peut-être\nquelque chose sur le Cercle masqué!"
+    "texte_fr": "Hé![000A][1205] Si on allait à l'agence de\ndétectives? Ils savent peut-être\nquelque chose sur le Cercle masqué!"
   },
   {
     "id": 46,
@@ -747,7 +747,7 @@
     "nom_orig": "Maya",
     "texte_orig": "At[SP]least[SP]we[SP]know[SP]the[SP]general[SP]direction[SP]of[SP]our\nnext[SP]target,[SP]thanks[SP]to[SP]Elly-san...[1205][000F][SP]I[SP]guess\nwe'll[SP]have[SP]to[SP]rely[SP]on[SP]our[SP]hunches[SP]from[SP]here.",
     "nom_fr": "Maya",
-    "texte_fr": "On connaît la direction générale grâce\nà Elly-san... [1205][000F]Je suppose qu'on devra\nse fier à nos intuitions désormais."
+    "texte_fr": "On connaît la direction générale grâce\nà Elly-san... [000F][1205]Je suppose qu'on devra\nse fier à nos intuitions désormais."
   },
   {
     "id": 50,
@@ -762,7 +762,7 @@
     "nom_orig": "Maya",
     "texte_orig": "If[SP]Elly-san[SP]is[SP]right,[SP]the[SP]next[SP]target[SP]should\nbe[SP]in[SP]Yumezaki.[1205][000F][SP]It's[SP]either[SP]Pachinko[SP]Silver...[1205][000A]\nor[SP]GOLD...",
     "nom_fr": "Maya",
-    "texte_fr": "Si Elly-san a raison,\nla cible est à Yumezaki.\n[1205][000F]Soit le Pachinko Silver...[1205][000A] soit le GOLD..."
+    "texte_fr": "Si Elly-san a raison,\nla cible est à Yumezaki.\n[000F][1205]Soit le Pachinko Silver...[000A][1205] soit le GOLD..."
   },
   {
     "id": 51,
@@ -777,7 +777,7 @@
     "nom_orig": "Maya",
     "texte_orig": "King[SP]Leo's[SP]planning[SP]to[SP]put[SP]an[SP]end[SP]to[SP]this[SP]at\nthe[SP]museum.[1205][000F][SP]This[SP]may[SP]be[SP]a[SP]trap,[SP]but[SP]we[SP]can't\nlet[SP]that[SP]flame[SP]burn[SP]out[SP]of[SP]control[SP]any[SP]longer.",
     "nom_fr": "Maya",
-    "texte_fr": "Le Roi Lion prévoit d'en finir au musée.\n[1205][000F]C'est peut-être un piège, mais on ne peut\nplus laisser cette flamme s'emballer."
+    "texte_fr": "Le Roi Lion prévoit d'en finir au musée.\n[000F][1205]C'est peut-être un piège, mais on ne peut\nplus laisser cette flamme s'emballer."
   },
   {
     "id": 52,
@@ -792,7 +792,7 @@
     "nom_orig": "Maya",
     "texte_orig": "He'll[SP]never[SP]just[SP]leave[SP]us[SP]be.[1205][000F][SP]If[SP]he[SP]wants[SP]to\nsettle[SP]this,[SP]I[SP]have[SP]no[SP]doubt[SP]that[SP]he'll[SP]be\nwaiting[SP]for[SP]us[SP]at[SP]the[SP]last[SP]target.",
     "nom_fr": "Maya",
-    "texte_fr": "Il ne nous laissera jamais tranquilles.\n[1205][000F]S'il veut régler ça, je suis sûre qu'il\nnous attendra à la dernière cible."
+    "texte_fr": "Il ne nous laissera jamais tranquilles.\n[000F][1205]S'il veut régler ça, je suis sûre qu'il\nnous attendra à la dernière cible."
   },
   {
     "id": 53,
@@ -807,7 +807,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Heh.[SP]Soon[SP]the[SP]people[SP]of[SP]this[SP]city[SP]will[SP]realize\nthe[SP]truths[SP]of[SP]the[SP]In[SP]Lak'ech[SP]and[SP]will[SP]wait[SP]for\nthe[SP]promised[SP]hour.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nThat,[SP]after[SP]all,[SP]is[SP]why[SP]the[SP]Masked[SP]Circle\ngranted[SP]people's[SP]ideals.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nThe[SP]Masked[SP]Circle[SP]is[SP]made[SP]of[SP]normal[SP]people,\nwhen[SP]you[SP]get[SP]down[SP]to[SP]it.[1205][000F][SP]They'll[SP]never[SP]stand\na[SP]chance[SP]against[SP]the[SP]Last[SP]Battalion...",
     "nom_fr": "Maya",
-    "texte_fr": "Pfff. Bientôt, les gens d'ici\nreconnaîtront les vérités\nde l'In Lak'ech et\nattendront l'heure promise.[E1][E2] [E3][E4][NULL][NULL]\"Maya\nC'est bien\npour ça que le Cercle masqué\na exaucé lesidéaux des gens.[E1][E2] [E3][E4][NULL][NULL]\"Maya\nLe Cercle masqué n'est\ncomposé que de gens normaux, tout bienconsidéré.\n[1205][000F]Il ne pourra jamais tenir face au\nBataillon..."
+    "texte_fr": "Pfff. Bientôt, les gens d'ici\nreconnaîtront les vérités\nde l'In Lak'ech et\nattendront l'heure promise.[E1][E2] [E3][E4][NULL][NULL]\"Maya\nC'est bien\npour ça que le Cercle masqué\na exaucé lesidéaux des gens.[E1][E2] [E3][E4][NULL][NULL]\"Maya\nLe Cercle masqué n'est\ncomposé que de gens normaux, tout bienconsidéré.\n[000F][1205]Il ne pourra jamais tenir face au\nBataillon..."
   },
   {
     "id": 54,
@@ -822,7 +822,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Shouldn't[SP]we[SP]be[SP]getting[SP]back[SP]to[SP]Sevens?[1205][001E]\n*sigh*[SP]I[SP]had[SP]a[SP]friend[SP]a[SP]few[SP]years[SP]back[SP]who[SP]was\njust[SP]like[SP]you...[SP]He[SP]loved[SP]making[SP]detours[SP]too.",
     "nom_fr": "Yukino",
-    "texte_fr": "On ne devrait pas retourner à Seven?[1205][001E]\n*soupir* J'avais un ami il y a quelques ans\ncomme toi... Il aimait les détours aussi."
+    "texte_fr": "On ne devrait pas retourner à Seven?[001E][1205]\n*soupir* J'avais un ami il y a quelques ans\ncomme toi... Il aimait les détours aussi."
   },
   {
     "id": 55,
@@ -837,7 +837,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Huh...[SP]The[SP]leaves[SP]are[SP]a[SP]nice[SP]color[SP]this[SP]time\nof[SP]year.[1205][001E][SP]The[SP]lawn[SP]is[SP]well-maintained[SP]too...[1205][001E]\nMight[SP]as[SP]well[SP]take[SP]a[SP]few[SP]pictures.",
     "nom_fr": "Yukino",
-    "texte_fr": "Hm... Les feuilles sont belles en cette\nsaison.[1205][001E] La pelouse est bien\nentretenue...[1205][001E] Autant prendre des photos."
+    "texte_fr": "Hm... Les feuilles sont belles en cette\nsaison.[001E][1205] La pelouse est bien\nentretenue...[001E][1205] Autant prendre des photos."
   },
   {
     "id": 56,
@@ -852,7 +852,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Huh...[1205][001E][SP]I[SP]wonder[SP]if[SP]Hamya[SP]really[SP]did[SP]die...",
     "nom_fr": "Yukino",
-    "texte_fr": "Hm...[1205][001E] Je me demande si Hamya est mort..."
+    "texte_fr": "Hm...[001E][1205] Je me demande si Hamya est mort..."
   },
   {
     "id": 57,
@@ -867,7 +867,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "He[SP]probably[SP]had[SP]the[SP]students'[SP]best[SP]interests\nin[SP]mind...[SP]It[SP]was[SP]just[SP]the[SP]way[SP]he[SP]went[SP]about[SP]it.[1205][001E]\nWell,[SP]he[SP]got[SP]what[SP]was[SP]coming[SP]to[SP]him.",
     "nom_fr": "Yukino",
-    "texte_fr": "Il avait probablement les intérêts des\nélèves à cœur... C'est juste sa méthode qui\nposait problème.[1205][001E] Eh bien, il l'a mérité."
+    "texte_fr": "Il avait probablement les intérêts des\nélèves à cœur... C'est juste sa méthode qui\nposait problème.[001E][1205] Eh bien, il l'a mérité."
   },
   {
     "id": 58,
@@ -897,7 +897,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]wonder[SP]if[SP]I'm[SP]a[SP]busybody.[1205][000F][SP]I[SP]just[SP]can't[SP]let\nreckless[SP]guys[SP]like[SP]him[SP]alone.[SP]I[SP]knew[SP]someone\nlike[SP]that[SP]a[SP]few[SP]years[SP]ago,[SP]too...",
     "nom_fr": "Yukino",
-    "texte_fr": "Je me demande si je suis trop curieuse.\n[1205][000F]Je ne peux pas ignorer les imprudents.\nJ'en connaissais un pareil autrefois..."
+    "texte_fr": "Je me demande si je suis trop curieuse.\n[000F][1205]Je ne peux pas ignorer les imprudents.\nJ'en connaissais un pareil autrefois..."
   },
   {
     "id": 60,
@@ -942,7 +942,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]think[SP]we[SP]can[SP]count[SP]on[SP]Tamaki[SP]and[SP]that\nchief[SP]detective.[1205][000F][SP]The[SP]other[SP]one's[SP]hopeless,\nthough,[SP]trust[SP]me.",
     "nom_fr": "Yukino",
-    "texte_fr": "On peut compter sur\nTamaki et le détective en\n[1205]chef. [000F]L'autre\nest irrécupérable, croyez-moi."
+    "texte_fr": "On peut compter sur\nTamaki et le détective en\n[1205]chef. [000F]L'autre est irrécupérable, croyez-moi."
   },
   {
     "id": 63,
@@ -987,7 +987,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "We'll[SP]never[SP]figure[SP]out[SP]the[SP]next[SP]target[SP]from\nthe[SP]Oracle[SP]alone.[1205][000F][SP]Let's[SP]hurry[SP]and[SP]head[SP]to\nDouble[SP]Slash.",
     "nom_fr": "Yukino",
-    "texte_fr": "On ne trouvera pas la cible avec l'Oracle\nseul. [1205][000F]Dépêchons-nous d'aller\nau Double Slash."
+    "texte_fr": "On ne trouvera pas la cible avec l'Oracle\nseul. [000F][1205]Dépêchons-nous d'aller\nau Double Slash."
   },
   {
     "id": 66,
@@ -1032,7 +1032,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "My[SP]money's[SP]on[SP]GOLD.[1205][000F][SP]It's[SP]just[SP]a[SP]feeling\nI[SP]have.[1205][000A][SP]You[SP]know,[SP]a[SP]hunch.",
     "nom_fr": "Yukino",
-    "texte_fr": "Je parie sur le GOLD. [1205][000F]Un\npressenti.[1205][000A] Une intuition."
+    "texte_fr": "Je parie sur le GOLD. [000F][1205]Un\npressenti.[000A][1205] Une intuition."
   },
   {
     "id": 69,
@@ -1107,7 +1107,7 @@
     "nom_orig": "Hanako's[SP]mother",
     "texte_orig": "My[SP]girl[SP]says[SP]she[SP]ventured[SP]through[SP]Sevens[SP]to\nsee[SP]the[SP]emblem[SP]curse[SP]at[SP]work.[1205][001E][SP]She's[SP]such[SP]a\nfearless[SP]child...",
     "nom_fr": "Mère de Hanako",
-    "texte_fr": "Ma fille a bravé Seven pour voir la\nmalédiction des emblèmes.[1205][001E] Quelle enfant\nintrépide..."
+    "texte_fr": "Ma fille a bravé Seven pour voir la\nmalédiction des emblèmes.[001E][1205] Quelle enfant\nintrépide..."
   },
   {
     "id": 74,
@@ -1137,7 +1137,7 @@
     "nom_orig": "Hanako",
     "texte_orig": "But[SP]then[SP]this[SP]boy[SP]came[SP]up[SP]to[SP]me[SP]and[SP]asked[SP]me\nwhat[SP]my[SP]name[SP]was.[SP]And[SP]I[SP]said,[SP][1432][NULL][NULL][0014]Hanako.[1432][NULL][NULL][0014][1205][000F][SP]And\nhe[SP]ran[SP]off[SP]screaming,[SP][1432][NULL][NULL][0014]It's[SP]Hanako![1432][NULL][NULL][0014]",
     "nom_fr": "Hanako",
-    "texte_fr": "Mais un garçon s'est approché et m'a\ndemandé mon nom. J'ai dit [1432][NULL][NULL][0014]Hanako.[1432][NULL][NULL][0014] Et\n[1205][000F]il s'est enfui en criant [1432][NULL][NULL][0014]C'est Hanako![1432][NULL][NULL][0014]"
+    "texte_fr": "Mais un garçon s'est approché et m'a\ndemandé mon nom. J'ai dit [1432][NULL][NULL][0014]Hanako.[1432][NULL][NULL][0014] Et\n[000F][1205]il s'est enfui en criant [1432][NULL][NULL][0014]C'est Hanako![1432][NULL][NULL][0014]"
   },
   {
     "id": 76,
@@ -1167,7 +1167,7 @@
     "nom_orig": "Defeated[SP]Masked[SP]Circle[SP]member",
     "texte_orig": "No[SP]one[SP]told[SP]me[SP]this[SP]mission[SP]would[SP]be[SP]so\nimpossible...[1205][000F][SP]That[SP]Joker...[1205][000A][SP]he[SP]tricked[SP]me...[1205][000A]\nH-He's[SP]a[SP]demon...!",
     "nom_fr": "Membre vaincu",
-    "texte_fr": "Personne ne m'a dit que cette mission\nserait aussi impossible.[1205][000F].. Ce Joker...[1205][000A]\nil m'a piégé...[1205][000A] C-C'est un démon...!"
+    "texte_fr": "Personne ne m'a dit que cette mission\nserait aussi impossible.[000F][1205].. Ce Joker...[000A][1205]\nil m'a piégé...[000A][1205] C-C'est un démon...!"
   },
   {
     "id": 78,
@@ -1182,7 +1182,7 @@
     "nom_orig": "Rescued[SP]man",
     "texte_orig": "I[SP]can't[SP]believe[SP]one[SP]of[SP]the[SP]Masked[SP]Circle[SP]saved\nme...[1205][000F][SP]I-It[SP]was[SP]Joker's[SP]orders,[SP]I[SP]guess?[1205][000A][SP]Huh...\nMaybe[SP]he's[SP]not[SP]a[SP]bad[SP]guy[SP]after[SP]all...",
     "nom_fr": "Homme secouru",
-    "texte_fr": "Je n'arrive pas à croire qu'un membre\n[1205][000F]du Cercle masqué m'ait sauvé... Joker?[1205][000A]\nHm... Pas si mauvais finalement..."
+    "texte_fr": "Je n'arrive pas à croire qu'un membre\n[000F][1205]du Cercle masqué m'ait sauvé... Joker?[000A][1205]\nHm... Pas si mauvais finalement..."
   },
   {
     "id": 79,
@@ -1197,7 +1197,7 @@
     "nom_orig": "Rescued[SP]woman",
     "texte_orig": "Looks[SP]like[SP]Joker[SP]ordered[SP]the[SP]Masked[SP]Circle\nto[SP]protect[SP]the[SP]people[SP]of[SP]the[SP]city.[1205][000F][SP]I[SP]bet[SP]that\nJoker[SP]has[SP]the[SP]heart[SP]of[SP]an[SP]angel!",
     "nom_fr": "Femme secourue",
-    "texte_fr": "Il paraît que Joker a ordonné au Cercle\nmasqué de protéger les habitants. [1205][000F]Je\nparie que Joker a le cœur d'un ange!"
+    "texte_fr": "Il paraît que Joker a ordonné au Cercle\nmasqué de protéger les habitants. [000F][1205]Je\nparie que Joker a le cœur d'un ange!"
   },
   {
     "id": 80,
@@ -1212,7 +1212,7 @@
     "nom_orig": "Rescued[SP]man",
     "texte_orig": "Could[SP]the[SP]Masked[SP]Circle[SP]actually[SP]be[SP]a\nbenevolent[SP]organization?[1205][000F][SP]Maybe[SP]Joker[SP]is\na[SP]good[SP]man[SP]after[SP]all.",
     "nom_fr": "Homme secouru",
-    "texte_fr": "Le Cercle masqué serait-il bienveillant?\n[1205][000F]Joker serait finalement un homme bien."
+    "texte_fr": "Le Cercle masqué serait-il bienveillant?\n[000F][1205]Joker serait finalement un homme bien."
   },
   {
     "id": 81,
@@ -1227,7 +1227,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "That's[SP]amazing![SP]I[SP]didn't[SP]know[SP]you[SP]were[SP]making\nyour[SP]debut,[SP]Lisa-san![SP]Wow![SP]...Alright,[SP]don't\nplay[SP]dumb.[SP]You're[SP]the[SP]third[SP]member,[SP]huh?",
     "nom_fr": "Lycéen",
-    "texte_fr": "C'est incroyable! Je savais\npas que tu faisais\ntes débuts, Lisa-san!\nWaouh!... Bon, fais pas\nl'innocente. Tu es la troisième membre?"
+    "texte_fr": "C'est incroyable! Je savais\npas que tu faisais\ntes débuts, Lisa-san! Waouh!... Bon, fais pas l'innocente. Tu es la troisième membre?"
   },
   {
     "id": 82,
@@ -1242,7 +1242,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "There's[SP]no[SP]need[SP]to[SP]try[SP]and[SP]hide[SP]it.[SP]Your[SP]group\nis[SP]already[SP]the[SP]talk[SP]of[SP]Sevens![1205][000F][SP]Do[SP]you[SP]have[SP]a\nsong[SP]lined[SP]up[SP]for[SP]your[SP]debut?",
     "nom_fr": "Lycéen",
-    "texte_fr": "Inutile de nier. Votre groupe fait\ndéjà parler à Seven! [1205][000F]Vous avez une\nchanson prête pour vos débuts?"
+    "texte_fr": "Inutile de nier. Votre groupe fait\ndéjà parler à Seven! [000F][1205]Vous avez une\nchanson prête pour vos débuts?"
   },
   {
     "id": 83,
@@ -1287,7 +1287,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "I'm[SP]currently[SP]listening[SP]in[SP]on[SP]the[SP]murmurs[SP]of\nsociety.[SP]Listening[SP]to[SP]rumors[SP]teaches[SP]you[SP]the\nlies[SP]and[SP]deceptions[SP]of[SP]the[SP]world[SP]very[SP]clearly.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "J'écoute actuellement les murmures de la\nsociété. Écouter les rumeurs enseigne\nclairement les mensonges\net tromperies du monde."
+    "texte_fr": "J'écoute actuellement les murmures de la\nsociété. Écouter les rumeurs enseigne\nclairement les mensonges et tromperies du monde."
   },
   {
     "id": 86,
@@ -1317,7 +1317,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Ah,[SP]it's[SP]you.[1205][000A][SP]Hello.",
     "nom_fr": "Toku-san",
-    "texte_fr": "Ah, c'est vous.[1205][000A] Bonjour."
+    "texte_fr": "Ah, c'est vous.[000A][1205] Bonjour."
   },
   {
     "id": 88,
@@ -1483,7 +1483,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Hm...[1205][001E][SP]The[SP]principal[SP]of[SP]Sevens[SP]suddenly[SP]grew\nsome[SP]hair?[SP]That[SP]may[SP]have[SP]been[SP]his[SP]request\nto[SP]Joker.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Hm...[1205][001E] Le directeur de\nSeven aurait poussé des\ncheveux? C'était peut-être\nsa requête à Joker."
+    "texte_fr": "Hm...[001E][1205] Le directeur de\nSeven aurait poussé des\ncheveux? C'était peut-être sa requête à Joker."
   },
   {
     "id": 95,
@@ -1528,7 +1528,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "He's[SP]a[SP]rather[SP]suspicious[SP]man[SP]who[SP]talks[SP]as[SP]if[SP]he\ncan[SP]see[SP]through[SP]people.[SP]He[SP]even[SP]calls[SP]himself\na[SP]Count...[SP]So[SP]this[SP]rumor[SP]comes[SP]as[SP]no[SP]surprise.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "C'est un homme assez\nsuspect qui parle comme\ns'il lisait dans les\npensées. Il se dit même\nComte... Cette rumeur ne m'étonne pas."
+    "texte_fr": "C'est un homme assez\nsuspect qui parle comme\ns'il lisait dans les pensées. Il se dit même Comte... Cette rumeur ne m'étonne pas."
   },
   {
     "id": 98,
@@ -1648,7 +1648,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "There's[SP]a[SP]cafe[SP]called[SP][E4][NULL][NULL][0006]Jolly[SP]Roger[E4][NULL][NULL][0002][SP]in[SP]Kounan,\nwhere[SP]it[SP]seems[SP]you[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002].[1205][000F][SP]Rumor\nis[SP]their[SP][E4][NULL][NULL][0006]quality[SP]and[SP]price[SP]is[SP]average[E4][NULL][NULL][0002].",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Il y a un café [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à Kounan\npour acheter de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002].\n[1205][000F][E4][NULL][NULL][0006]Qualité et prix dans la moyenne[E4][NULL][NULL][0002]."
+    "texte_fr": "Il y a un café [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à Kounan\npour acheter de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002].\n[000F][1205][E4][NULL][NULL][0006]Qualité et prix dans la moyenne[E4][NULL][NULL][0002]."
   },
   {
     "id": 106,
@@ -1663,7 +1663,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "The[SP][1432][NULL][NULL][0014]Jolly[SP]Roger[1432][NULL][NULL][0014][SP]refers[SP]to[SP]the[SP]skull[SP]and\ncrossbones...[SP]Between[SP]the[SP]ship-like[SP]decor[SP]and\nhis[SP]clothing,[SP]the[SP]owner[SP]may[SP]be[SP]an[SP]ex-pirate.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Le [1432][NULL][NULL][0014]Jolly Roger[1432][NULL][NULL][0014] désigne le crâne et os\ncroisés... Entre le décor marin et ses\nvêtements, le patron\nest peut-être un ex-pirate."
+    "texte_fr": "Le [1432][NULL][NULL][0014]Jolly Roger[1432][NULL][NULL][0014] désigne le crâne et os\ncroisés... Entre le décor marin et ses\nvêtements, le patron est peut-être un ex-pirate."
   },
   {
     "id": 107,
@@ -1678,7 +1678,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Oh...?[1205][001E][SP]Something[SP]terrible[SP]will[SP]happen[SP]when[SP]the\nclock[SP]at[SP]Sevens[SP]starts?[SP]Haha,[SP]I[SP]don't[SP]suppose\nthe[SP]world[SP]will[SP]end[SP]or[SP]anything.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Oh...?[1205][001E] Quelque chose de terrible quand\nl'horloge de Seven se remettra en marche?\nJ'espère que le monde ne va pas finir."
+    "texte_fr": "Oh...?[001E][1205] Quelque chose de terrible quand\nl'horloge de Seven se remettra en marche?\nJ'espère que le monde ne va pas finir."
   },
   {
     "id": 108,
@@ -1768,7 +1768,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "It[SP]seems[SP]the[SP]saleswoman[SP]there[SP]told[SP]her[SP]customer\nthat[SP]this[SP]year's[SP]fashions[SP]will[SP]be[SP]modeled\nafter[SP]armor...",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Il semble que la vendeuse\nait dit à sa cliente\nque les armures seront\nla mode de l'année..."
+    "texte_fr": "Il semble que la vendeuse\nait dit à sa cliente\nque les armures seront la mode de l'année..."
   },
   {
     "id": 114,
@@ -1783,7 +1783,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Ah,[SP]so[SP]this[SP]new[SP]Leader[SP]at[SP]Kasugayama[SP]used[SP]to\nbe[SP]the[SP]Death[SP]Boss'[SP]underling.[1205][000F][SP]The[SP]low[SP]overcomes\nthe[SP]high...[1205][000F][SP]All[SP]right,[SP]here's[SP]what[SP]I[SP]know.[E1][E2]\n[E3][E4][NULL][NULL]\"Rumormonger[SP]Toku-san\nThere's[SP]a[SP]branch[SP]of[SP][E4][NULL][NULL][0006]Rosa[SP]Candida[E4][NULL][NULL][0002][SP]in[SP]Aoba,[SP]and\nword[SP]is[SP]they[SP]sell[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]Their[SP][E4][NULL][NULL][0006]selection\nis[SP]paltry,[SP]but[SP]their[SP]resale[SP]prices[SP]are[SP]good[E4][NULL][NULL][0002].",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Ah, le nouveau Leader de Kasugayama était\nl'acolyte du Boss de la Mort. [1205][000F][1205][000F][1205][000F]Le bas\nsurpasse le haut... Voici ce que je sais.[E1][E2]\n[E3][E4][NULL][NULL]\"Toku-san l'informateur\nIl y a une [E4][NULL][NULL][0006]Rosa\nCandida[E4][NULL][NULL][0002] à Aoba, avec de [E4][NULL][NULL][0006]vraies\narmures[E4][NULL][NULL][0002].[E4][NULL][NULL][0006]Mauvais choix mais bons prix de revente[E4][NULL][NULL][0002]."
+    "texte_fr": "Ah, le nouveau Leader de Kasugayama était\nl'acolyte du Boss de la Mort. [000F][1205][000F][1205][000F][1205]Le bas\nsurpasse le haut... Voici ce que je sais.[E1][E2]\n[E3][E4][NULL][NULL]\"Toku-san l'informateur\nIl y a une [E4][NULL][NULL][0006]Rosa\nCandida[E4][NULL][NULL][0002] à Aoba, avec de [E4][NULL][NULL][0006]vraies\narmures[E4][NULL][NULL][0002].[E4][NULL][NULL][0006]Mauvais choix mais bons prix de revente[E4][NULL][NULL][0002]."
   },
   {
     "id": 115,
@@ -1843,7 +1843,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Tamaki[SP]at[SP]Kuzunoha[SP]Detective[SP]Agency[SP]is[SP]a[SP]real\nDevil[SP]Summoner?[SP]Is[SP]that[SP]an[SP]actual[SP]job?[SP]I've\nnever[SP]heard[SP]of[SP]it...[SP]Hmm.[SP]All[SP]right.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Tamaki de l'Agence Kuzunoha est une\nInvocatrice de Démons?\nC'est un vrai métier?\nJe n'en avais jamais entendu parler..."
+    "texte_fr": "Tamaki de l'Agence Kuzunoha est une\nInvocatrice de Démons?\nC'est un vrai métier? Je n'en avais jamais entendu parler..."
   },
   {
     "id": 119,
@@ -1873,7 +1873,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Ah...[SP]So[SP]demons[SP]really[SP]do[SP]exist?[1205][001E][SP]Now[SP]that's\nfar-fetched.[SP]I[SP]personally[SP]think[SP]it's[SP]more\nlikely[SP]that[SP]evil[SP]lurks[SP]in[SP]people's[SP]hearts.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Ah... Les démons existent vraiment?[1205][001E]\nVoilà qui est tiré par les cheveux. Je\npense que le mal réside dans les cœurs."
+    "texte_fr": "Ah... Les démons existent vraiment?[001E][1205]\nVoilà qui est tiré par les cheveux. Je\npense que le mal réside dans les cœurs."
   },
   {
     "id": 121,
@@ -1978,7 +1978,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Not[SP]only[SP]that,[SP]their[SP]tongues[SP]loosen.[SP]Here,[SP]one\nhears[SP]what[SP]people[SP]really[SP]think.[SP]Thus,[SP]I[SP]know\nthe[SP]miserable[SP]state[SP]of[SP]this[SP]world.",
     "nom_fr": "Toku-san",
-    "texte_fr": "De plus, les langues se délient. Ici, on\nentend ce que les gens pensent vraiment.\nAinsi je connais l'état\nmisérable du monde."
+    "texte_fr": "De plus, les langues se délient. Ici, on\nentend ce que les gens pensent vraiment.\nAinsi je connais l'état misérable du monde."
   },
   {
     "id": 128,
@@ -2008,7 +2008,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "The[SP]creature[SP]called[SP]society[SP]is[SP]really[SP]just[SP]a\nherd[SP]of[SP]people.[SP]Pay[SP]attention[SP]to[SP]people's[SP]true\nintentions,[SP]rumors,[SP]and[SP]you[SP]gain[SP]understanding.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "La créature appelée société n'est qu'un\ntroupeau d'hommes. Écoutez leurs vraies\nintentions, les rumeurs,\net vous comprendrez."
+    "texte_fr": "La créature appelée société n'est qu'un\ntroupeau d'hommes. Écoutez leurs vraies\nintentions, les rumeurs, et vous comprendrez."
   },
   {
     "id": 130,
@@ -2038,7 +2038,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "The[SP]Masked[SP]Circle[SP]is[SP]protecting[SP]the[SP]people...[1205][001E]\nJoker's[SP]actions[SP]seemed[SP]inconsistent[SP]at[SP]first,\nbut[SP]perhaps[SP]it's[SP]all[SP]driven[SP]by[SP]his[SP]conscience.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Le Cercle masqué protège les gens...[1205][001E] Les\nactions de Joker semblaient incohérentes au\npremier abord, mais sa conscience le guide."
+    "texte_fr": "Le Cercle masqué protège les gens...[001E][1205] Les\nactions de Joker semblaient incohérentes au\npremier abord, mais sa conscience le guide."
   },
   {
     "id": 132,
@@ -2068,7 +2068,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "I[SP]see.[SP]Come[SP]back[SP]here[SP]if[SP]you[SP]want[SP]to[SP]hear[SP]my\nrumors.[SP]I'll[SP]always[SP]be[SP]here,[SP]looking[SP]up[SP]at\nthe[SP]sky.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Je vois. Revenez si\nvous voulez entendre mes\nrumeurs. Je serai là,\nle regard vers le ciel."
+    "texte_fr": "Je vois. Revenez si\nvous voulez entendre mes\nrumeurs. Je serai là, le regard vers le ciel."
   },
   {
     "id": 134,
@@ -2113,7 +2113,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "There[SP]was[SP]this[SP]weird[SP]old[SP]guy[SP]who[SP]came[SP]running\nby?[SP]And[SP]he[SP]like,[SP]collapsed[SP]in[SP]front[SP]of[SP]me.\nThe[SP]ambulance[SP]took[SP]him[SP]away...[SP]Was[SP]he[SP]okay?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Il y avait ce vieux\nbizarre qui est passé en\ncourant? Et il s'est effondré devant moi.\nL'ambulance l'a emmené... Il allait bien?"
+    "texte_fr": "Il y avait ce vieux\nbizarre qui est passé en\ncourant? Et il s'est effondré devant moi. L'ambulance l'a emmené... Il allait bien?"
   },
   {
     "id": 137,
@@ -2128,7 +2128,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "C'mon,[SP]let's[SP]go[SP]see[SP]the[SP]Kasuga[SP]Festival.[1205][000F][SP]It'll\nbe[SP]sooo[SP]much[SP]fun![1205][000A][SP]I'm[SP]like,[SP]totally[SP]over[SP]this\npark[SP]already.[E1][E2]\n[E3][E4][NULL][NULL]\"Young[SP]woman\nGinji[SP]Sasaki[SP]is[SP]producing[SP]a[SP]new[SP]group,[SP]right?[1205][000F]\nHis[SP]songs[SP]are[SP]the[SP]best![SP]I'm[SP]sooooo[SP]looking\nforward[SP]to[SP]it!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Allez, on va voir le Festival Kasuga. [1205][000F][1205]Ce\n[000F]sera trop fun![1205][000A] J'en ai\ntrop marre de ce parc\nde toute façon.[E1][E2]\n[E3][E4][NULL][NULL]\"Jeune femme\nGinji Sasaki\nproduit un nouveau groupe, non? Ses chansonssont\ntrop bien! J'ai trop hâte de voir ça!"
+    "texte_fr": "Allez, on va voir le Festival Kasuga. [000F][1205][1205]Ce\n[000F]sera trop fun![000A][1205] J'en ai\ntrop marre de ce parc\nde toute façon.[E1][E2]\n[E3][E4][NULL][NULL]\"Jeune femme\nGinji Sasaki\nproduit un nouveau groupe, non? Ses chansonssont\ntrop bien! J'ai trop hâte de voir ça!"
   },
   {
     "id": 138,
@@ -2143,7 +2143,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "We[SP]just[SP]found[SP]out[SP]the[SP]third[SP]member[SP]of[SP]Muses,\nand[SP]they're[SP]already[SP]doing[SP]a[SP]show?[1205][000F][SP]Doesn't\nthat[SP]feel,[SP]like,[SP]kinda[SP]rushed?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "On vient de trouver la troisième\nmembre des Muses et elles font déjà un\n[1205][000F]show? Ça fait pas un peu précipité?"
+    "texte_fr": "On vient de trouver la troisième\nmembre des Muses et elles font déjà un\n[000F][1205]show? Ça fait pas un peu précipité?"
   },
   {
     "id": 139,
@@ -2158,7 +2158,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "W-Wait[SP]a[SP]sec.[1205][000A][SP]Why're[SP]you[SP]saying[SP]that?[1205][000A][SP]Did[SP]I\ndo[SP]something?[SP]What's[SP]gotten[SP]into[SP]you[SP]all[SP]of\na[SP]sudden!?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "A-Attends.[1205][000A] Pourquoi tu dis ça?[1205][000A]\nJ'ai fait quelque chose? Qu'est-ce\nqui te prend tout d'un coup!?"
+    "texte_fr": "A-Attends.[000A][1205] Pourquoi tu dis ça?[000A][1205]\nJ'ai fait quelque chose? Qu'est-ce\nqui te prend tout d'un coup!?"
   },
   {
     "id": 140,
@@ -2188,7 +2188,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Hey,[SP]can[SP]we[SP]like,[SP]get[SP]out[SP]of[SP]here,[SP]please?[1205][000A]\nThey've[SP]blown[SP]up[SP]six[SP]places[SP]already.[1205][000F][SP]It's[SP]too\ndangerous[SP]to[SP]stay[SP]here!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Hé, on peut partir d'ici?[1205][000A] Ils ont\n[1205]déjà fait exploser six endroits.\n[000F]C'est trop dangereux de rester!"
+    "texte_fr": "Hé, on peut partir d'ici?[000A][1205] Ils ont\n[1205]déjà fait exploser six endroits.\n[000F]C'est trop dangereux de rester!"
   },
   {
     "id": 142,
@@ -2203,7 +2203,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "I'm,[SP]like,[SP]super[SP]pissed![1205][000A][SP]Seriously![1205][000F][SP]What's\nwith[SP]him[SP]giving[SP]me[SP]the[SP]cold[SP]shoulder[SP]all[SP]of\na[SP]sudden?[SP]I'm,[SP]like,[SP]through[SP]with[SP]you!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Je suis trop en colère![1205][1205][000A] Sérieusement!\n[000F]Pourquoi il me fait la tête comme ça\ntout d'un coup? C'est fini entre nous!"
+    "texte_fr": "Je suis trop en colère![1205][000A][1205] Sérieusement!\n[000F]Pourquoi il me fait la tête comme ça\ntout d'un coup? C'est fini entre nous!"
   },
   {
     "id": 143,
@@ -2218,7 +2218,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Naoya...[1205][000A][SP]You[SP]gave[SP]everything[SP]you[SP]had[SP]to[SP]save\nme...[1205][000F][SP]You're[SP]the[SP]only[SP]guy[SP]for[SP]me[SP]after[SP]all.[1205][000F]\nLet's[SP]make[SP]up[SP]once[SP]you[SP]get[SP]better,[SP]okay?",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Naoya.[1205][1205]..[1205][000A] Tu as tout donné pour me sauver.[000F][000F]..\nT'es vraiment le seul pour moi.\nRéconcilions-nous quand\ntu iras mieux,d'accord?"
+    "texte_fr": "Naoya.[1205][1205]..[000A][1205] Tu as tout donné pour me sauver.[000F][000F]..\nT'es vraiment le seul pour moi.\nRéconcilions-nous quand tu iras mieux,d'accord?"
   },
   {
     "id": 144,
@@ -2293,7 +2293,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "No[SP]use[SP]getting[SP]your[SP]ideal[SP]granted[SP]if[SP]you[SP]end\nup[SP]dead.[SP]Wait,[SP]that[SP]was[SP]supposed[SP]to[SP]be[SP]a\nsecret...",
     "nom_fr": "Gars stylé",
-    "texte_fr": "À quoi bon avoir son\nidéal exaucé si on finit\nmort. Attends, c'était\ncensé rester secret..."
+    "texte_fr": "À quoi bon avoir son\nidéal exaucé si on finit\nmort. Attends, c'était censé rester secret..."
   },
   {
     "id": 149,
@@ -2308,7 +2308,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "They're[SP]going[SP]to[SP]have[SP]a[SP]masquerade[SP]this[SP]year,\nright?[1205][000F][SP]I[SP]heard[SP]the[SP]new[SP]student[SP]council[SP]president\nwas[SP]a[SP]real[SP]go-getter...[SP]Guess[SP]I[SP]heard[SP]right.",
     "nom_fr": "Gars stylé",
-    "texte_fr": "Il va y avoir un bal masqué cette\n[1205][000F]année? Le nouveau président est très\nactif... Je vois que c'est vrai."
+    "texte_fr": "Il va y avoir un bal masqué cette\n[000F][1205]année? Le nouveau président est très\nactif... Je vois que c'est vrai."
   },
   {
     "id": 150,
@@ -2323,7 +2323,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "M-[1205][000A]Masked[SP]Circle!?[1205][000F][SP]Wh...[SP]What're[SP]they?[1205][000A][SP]I-I've\ngot[SP]nothing[SP]to[SP]do[SP]with[SP]whatever[SP]it[SP]is!",
     "nom_fr": "Gars stylé",
-    "texte_fr": "C-[1205][000A]Cercle masqué![1205][000F]? Qu-... C'est quoi?[1205][000A]\nJ-Je n'ai rien à voir avec tout ça!"
+    "texte_fr": "C-[000A][1205]Cercle masqué![000F][1205]? Qu-... C'est quoi?[000A][1205]\nJ-Je n'ai rien à voir avec tout ça!"
   },
   {
     "id": 151,
@@ -2338,7 +2338,7 @@
     "nom_orig": "Cool[SP]guy",
     "texte_orig": "I[SP]hear[SP]that[SP]producer[SP]works[SP]fast,[SP]so[SP]maybe\nit's[SP]just[SP]that?[1205][000F][SP]Wait...[1205][000F][SP]Or[SP]does[SP]he[SP]work\nfaster[SP]with[SP]women?",
     "nom_fr": "Gars stylé",
-    "texte_fr": "J'entends que ce producteur est rapide.\n[1205][000F][1205][000F]Attends... Ou plus rapide avec les femmes?"
+    "texte_fr": "J'entends que ce producteur est rapide.\n[000F][1205][000F][1205]Attends... Ou plus rapide avec les femmes?"
   },
   {
     "id": 152,
@@ -2353,7 +2353,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Ugh,[SP]you're[SP]such[SP]an[SP]idiot![1205][000F][SP]Why[SP]would[SP]I[SP]have\nbeen[SP]serious[SP]about[SP]someone[SP]like[SP]you?[SP]What\na[SP]joke!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Ugh, t'es vraiment idiot! [1205][000F]Pourquoi j'aurais\nété sérieuse avec toi? Quelle blague!"
+    "texte_fr": "Ugh, t'es vraiment idiot! [000F][1205]Pourquoi j'aurais\nété sérieuse avec toi? Quelle blague!"
   },
   {
     "id": 153,
@@ -2368,7 +2368,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Joker[SP]made[SP]me[SP]rich.[1205][000F][SP]With[SP]this[SP]much[SP]cash,[SP]I[SP]can\nhave[SP]any[SP]girl[SP]I[SP]want![1205][000A][SP]Heh...[SP]Time[SP]to[SP]go[SP]look\nfor[SP]a[SP]hotter[SP]girlfriend.",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Joker m'a rendu riche. [1205][000F]Avec tout cet\nargent, je peux avoir la fille que\nje veux![1205][000A] Heh... Vais trouver mieux."
+    "texte_fr": "Joker m'a rendu riche. [000F][1205]Avec tout cet\nargent, je peux avoir la fille que\nje veux![000A][1205] Heh... Vais trouver mieux."
   },
   {
     "id": 154,
@@ -2398,7 +2398,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Shut[SP]up![1205][000A][SP]If[SP]you[SP]want[SP]to[SP]get[SP]out[SP]of[SP]here,[SP]you\ncan[SP]go[SP]wherever[SP]you[SP]want[SP]by[SP]yourself.",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Ferme-la![1205][000A] Si tu veux partir, tu\npeux aller où tu veux tout seul."
+    "texte_fr": "Ferme-la![000A][1205] Si tu veux partir, tu\npeux aller où tu veux tout seul."
   },
   {
     "id": 156,
@@ -2413,7 +2413,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "The[SP]In[SP]Lak'ech,[SP]huh...[1205][000F][SP]And[SP]the[SP]Oracle[SP]written\nin[SP]it...[SP]Isn't[SP]that[SP]what[SP]our[SP]Masked[SP]Circle\nhad[SP]been[SP]following?",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "L'In Lak'ech, hein.[1205][000F].. Et l'Oracle\nécrit dedans... N'est-ce pas ce\nque suivait notre Cercle masqué?"
+    "texte_fr": "L'In Lak'ech, hein.[000F][1205].. Et l'Oracle\nécrit dedans... N'est-ce pas ce\nque suivait notre Cercle masqué?"
   },
   {
     "id": 157,
@@ -2428,7 +2428,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "D-Don't[SP]get[SP]the[SP]wrong[SP]idea[SP]here...[1205][000A][SP]I[SP]was[SP]just\nfollowing[SP]Master[SP]Joker's[SP]orders...",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "N-Ne te méprends pas...[1205][000A] Je suivais\njuste les ordres du Maître Joker..."
+    "texte_fr": "N-Ne te méprends pas...[000A][1205] Je suivais\njuste les ordres du Maître Joker..."
   },
   {
     "id": 158,
@@ -2443,7 +2443,7 @@
     "nom_orig": "Young[SP]male[SP]shadowman",
     "texte_orig": "I[SP]got[SP]my[SP]ideal[SP]girlfriend...[1205][001E][SP]But[SP]she[SP]didn't\nnotice[SP]me[SP]and[SP]left...[1205][001E][SP]Well...[SP]I[SP]guess[SP]it\ndoesn't[SP]matter...",
     "nom_fr": "Jeune homme-ombre",
-    "texte_fr": "J'ai eu ma petite amie idéale...[1205][001E]\nMais elle ne m'a pas remarqué...[1205][001E] Eh\nbien... ça n'a pas d'importance..."
+    "texte_fr": "J'ai eu ma petite amie idéale...[001E][1205]\nMais elle ne m'a pas remarqué...[001E][1205] Eh\nbien... ça n'a pas d'importance..."
   },
   {
     "id": 159,
@@ -2458,7 +2458,7 @@
     "nom_orig": "Young[SP]male[SP]shadowman",
     "texte_orig": "Having[SP]your[SP]ideals[SP]granted[SP]is[SP]nothing[SP]special...[1205][001E]\nI[SP]thought[SP]it'd[SP]change[SP]my[SP]life...[1205][001E][SP]But[SP]everything\nis[SP]too[SP]much[SP]of[SP]a[SP]pain[SP]to[SP]bother[SP]with[SP]now...[1205][001E]",
     "nom_fr": "Jeune homme-ombre",
-    "texte_fr": "Avoir ses idéaux exaucés n'a rien de\nspécial...[1205][001E] Je pensais que ça changerait ma\nvie...[1205][001E] Mais tout\nme pèse trop pour quej'agisse...[1205][001E]"
+    "texte_fr": "Avoir ses idéaux exaucés n'a rien de\nspécial...[001E][1205] Je pensais que ça changerait ma\nvie...[001E][1205] Mais tout\nme pèse trop pour quej'agisse...[001E][1205]"
   },
   {
     "id": 160,
@@ -2473,7 +2473,7 @@
     "nom_orig": "Young[SP]male[SP]shadowman",
     "texte_orig": "I[SP]don't[SP]feel[SP]like[SP]doing[SP]anything...[1205][000F][SP]It's...\neasier[SP]this[SP]way...[1205][000A][SP]Hopes[SP]and[SP]ideals[SP]only[SP]let\nyou[SP]down...",
     "nom_fr": "Jeune homme-ombre",
-    "texte_fr": "Je n'ai envie de\nrien... [1205][000F]C'est plus simple...[1205][000A]\nLes espoirs et idéaux\nne font que décevoir..."
+    "texte_fr": "Je n'ai envie de\nrien... [000F][1205]C'est plus simple...[000A][1205]\nLes espoirs et idéaux ne font que décevoir..."
   },
   {
     "id": 161,
@@ -2488,7 +2488,7 @@
     "nom_orig": "Young[SP]male[SP]shadowman",
     "texte_orig": "Ngh...[1205][0005][SP]Nnggh...[1205][000A][SP]Auhh...",
     "nom_fr": "Jeune homme-ombre",
-    "texte_fr": "Ngh...[1205][0005] Nnggh...[1205][000A] Auhh..."
+    "texte_fr": "Ngh...[0005][1205] Nnggh...[000A][1205] Auhh..."
   },
   {
     "id": 162,
@@ -2503,7 +2503,7 @@
     "nom_orig": "Young[SP]male[SP]shadowman",
     "texte_orig": "U...[SP]Unnnghhh...[1205][000A][SP]Auhhh...",
     "nom_fr": "Jeune homme-ombre",
-    "texte_fr": "U... Unnnghhh...[1205][000A] Auhh..."
+    "texte_fr": "U... Unnnghhh...[000A][1205] Auhh..."
   },
   {
     "id": 163,
@@ -2548,7 +2548,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "You[SP]go[SP]to[SP]Sevens,[SP]right?[SP]Looks[SP]like[SP]Kasugayama\nHigh[SP]is[SP]more[SP]popular[SP]with[SP]the[SP]girls[SP]lately.\nI[SP]wonder[SP]if[SP]they'll[SP]shake[SP]the[SP]Cuss[SP]High[SP]name.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Tu vas à Seven?\nIl paraît que Kasugayama est\nplus populaire chez\nles filles ces temps-ci.\nVont-ils se débarrasser du nom Kakasu?"
+    "texte_fr": "Tu vas à Seven?\nIl paraît que Kasugayama est\nplus populaire chez les filles ces temps-ci. Vont-ils se débarrasser du nom Kakasu?"
   },
   {
     "id": 166,
@@ -2563,7 +2563,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "The[SP]Kasuga[SP]Festival,[SP]huh?[1205][000F][SP]This[SP]is[SP]the[SP]first\ntime[SP]I[SP]can[SP]remember[SP]Cuss[SP]High[SP]getting[SP]this\nmuch[SP]attention.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Le Festival Kasuga, hm? [1205][000F]C'est la\npremière fois que je me souviens que\nKakasu attire autant d'attention."
+    "texte_fr": "Le Festival Kasuga, hm? [000F][1205]C'est la\npremière fois que je me souviens que\nKakasu attire autant d'attention."
   },
   {
     "id": 167,
@@ -2578,7 +2578,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "There's[SP]this[SP]guy[SP]named[SP]Tony[SP]in[SP]the[SP]Yumezaki\nshopping[SP]district.[1205][000F][SP]Rumor[SP]is[SP]that[SP]he's[SP]a\nfence[SP]for[SP]the[SP]Mafia.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Il y a un gars nommé Tony dans le quartier\ncommerçant de Yumezaki. [1205][000F]La rumeur dit\nqu'il est receleur de la Mafia."
+    "texte_fr": "Il y a un gars nommé Tony dans le quartier\ncommerçant de Yumezaki. [000F][1205]La rumeur dit\nqu'il est receleur de la Mafia."
   },
   {
     "id": 168,
@@ -2608,7 +2608,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Aoba's[SP]outdoor[SP]concert[SP]hall[SP]is[SP]often[SP]used[SP]by\nfamous[SP]artists.[SP]It's[SP]pretty[SP]amazing[SP]that[SP]it'll\nbe[SP]the[SP]venue[SP]for[SP]their[SP]first[SP]show.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "La salle de concerts en plein air à Aoba\naccueille des artistes célèbres.\nImpressionnant que ce\nsoit leur première scène."
+    "texte_fr": "La salle de concerts en plein air à Aoba\naccueille des artistes célèbres.\nImpressionnant que ce soit leur première scène."
   },
   {
     "id": 170,
@@ -2623,7 +2623,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "There[SP]was[SP]a[SP]rumor[SP]about[SP]the[SP]Masked[SP]Circle[SP]being\nbehind[SP]this[SP]terrorism,[SP]but[SP]is[SP]it[SP]true?[1205][000F][SP]I[SP]wonder\nif[SP]they're[SP]really[SP]an[SP]evil[SP]organization...",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Il y avait une rumeur que le Cercle masqué\nétait derrière les\nattentats, mais c'est vrai?\n[1205][000F]Sont-ils vraiment\nune organisationmaléfique..."
+    "texte_fr": "Il y avait une rumeur que le Cercle masqué\nétait derrière les\nattentats, mais c'est vrai? [000F][1205]Sont-ils vraiment une organisationmaléfique..."
   },
   {
     "id": 171,
@@ -2638,7 +2638,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "The[SP]new[SP]rumor[SP]going[SP]around[SP]is[SP]that[SP]this[SP]Last\nBattalion[SP]are[SP]the[SP]real[SP]terrorists.[SP]Do[SP]they\neven[SP]exist?",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "La nouvelle rumeur dit\nque ce Bataillon sont\nles vrais\nterroristes. Existent-ils vraiment?"
+    "texte_fr": "La nouvelle rumeur dit\nque ce Bataillon sont\nles vrais terroristes. Existent-ils vraiment?"
   },
   {
     "id": 172,
@@ -2683,7 +2683,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Those[SP]Last[SP]Battalion[SP]guys[SP]won't[SP]hesitate[SP]to\nattack[SP]even[SP]women[SP]and[SP]children![1205][000F][SP]They're[SP]like\nsome[SP]kind[SP]of[SP]killing[SP]machines!",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Ces gars du Bataillon n'hésitent pas\nà attaquer même les femmes et les\n[1205][000F]enfants! De vraies machines à tuer!"
+    "texte_fr": "Ces gars du Bataillon n'hésitent pas\nà attaquer même les femmes et les\n[000F][1205]enfants! De vraies machines à tuer!"
   },
   {
     "id": 175,
@@ -2698,7 +2698,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Did[SP]you[SP]hear[SP]the[SP]rumor?[SP]That[SP]ghost[SP]Hanako[SP]is\nsupposedly[SP]haunting[SP]Sevens.[1205][000F][SP]It's[SP]kinda[SP]scary,\nbut[SP]I'd[SP]like[SP]to[SP]see[SP]it[SP]if[SP]it's[SP]real.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "T'as entendu la rumeur? Le fantôme Hanako\nhante paraît-il Seven. [1205][000F]C'est flippant,\nmais j'aimerais le voir si c'est vrai."
+    "texte_fr": "T'as entendu la rumeur? Le fantôme Hanako\nhante paraît-il Seven. [000F][1205]C'est flippant,\nmais j'aimerais le voir si c'est vrai."
   },
   {
     "id": 176,
@@ -2743,7 +2743,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "There's[SP]an[SP]idol's[SP]ghost[SP]haunting[SP]the[SP]outdoor\nconcert[SP]hall.[1205][000F][SP]I[SP]hear[SP]a[SP]lot[SP]of[SP]scary[SP]stories\nabout[SP]that[SP]place...[SP]like[SP]talking[SP]flowers.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Il y a le fantôme d'une idole qui hante la\n[1205][000F]salle de concerts en plein air. J'entends\nbeaucoup d'histoires\neffrayantes sur celieu..."
+    "texte_fr": "Il y a le fantôme d'une idole qui hante la\n[000F][1205]salle de concerts en plein air. J'entends\nbeaucoup d'histoires effrayantes sur celieu..."
   },
   {
     "id": 179,
@@ -2758,7 +2758,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "They[SP]say[SP]a[SP]cursed[SP]taxi[SP]was[SP]seen[SP]at[SP]the\nabandoned[SP]factory[SP]in[SP]Kounan.[1205][000F][SP]I[SP]wonder[SP]if\nit's[SP]true.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Un taxi maudit vu à l'usine abandonée\nde Kounan. [1205][000F]Je me demande si c'est vrai."
+    "texte_fr": "Un taxi maudit vu à l'usine abandonée\nde Kounan. [000F][1205]Je me demande si c'est vrai."
   },
   {
     "id": 180,
@@ -2818,7 +2818,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "They[SP]say[SP]the[SP]Jumping[SP]Geezer[SP]has[SP]been[SP]seen[SP]at\nMt.[SP]Katatsumuri.[1205][000F][SP]I[SP]don't[SP]really[SP]know[SP]what[SP]that\nis...[SP]Is[SP]it[SP]basically[SP]what[SP]the[SP]name[SP]implies?",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "On dit que le Vieux\nSauteur a été vu au mont\nKatatsumuri. [1205][000F]Je ne sais pas vraiment ce que\nc'est... C'est ce que le nom implique?"
+    "texte_fr": "On dit que le Vieux\nSauteur a été vu au mont\nKatatsumuri. [000F][1205]Je ne sais pas vraiment ce que c'est... C'est ce que le nom implique?"
   },
   {
     "id": 184,
@@ -2833,7 +2833,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Yikes...[1205][000A][SP]I[SP]just[SP]heard[SP]a[SP]scary[SP]story...[1205][000F][SP]Hm?\nWhat[SP]was[SP]it[SP]about?[1205][000F][SP]I-It[SP]was[SP]about[SP]Kudan...[1205][000A]\nAt[SP]the[SP]abandoned[SP]factory...[SP]Brrrr...",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Aïe.[1205][1205]..[1205][000A] J'ai entendu une histoire\n[000F][000F]effrayante... C-C'était sur le Kudan...[1205][000A]\nÀ l'usine abandonnée... Brrr..."
+    "texte_fr": "Aïe.[1205][1205]..[000A][1205] J'ai entendu une histoire\n[000F][000F]effrayante... C-C'était sur le Kudan...[000A][1205]\nÀ l'usine abandonnée... Brrr..."
   },
   {
     "id": 185,
@@ -2848,7 +2848,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]secret[SP]CD[SP]at[SP]Giga[SP]Macho\nthat's[SP]not[SP]like[SP]ordinary[SP]CDs.[1205][000F][SP]I[SP]don't[SP]know\nthe[SP]details,[SP]but[SP]it's[SP]supposedly[SP]interesting.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Il y a un CD secret chez Giga Macho pas\ncomme les autres. [1205][000F]Je ne connais pas les\ndétails, mais c'est intéressant."
+    "texte_fr": "Il y a un CD secret chez Giga Macho pas\ncomme les autres. [000F][1205]Je ne connais pas les\ndétails, mais c'est intéressant."
   },
   {
     "id": 186,
@@ -2893,7 +2893,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Looks[SP]like[SP]Time[SP]Castle[SP]sells[SP]real[SP]weapons[SP]of\naverage[SP]quality[SP]and[SP]price.[SP]It's[SP]not[SP]just[SP]an\nantique[SP]shop[SP]after[SP]all.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Time Castle vend de\nvraies armes de qualité et\nprix moyens. Ce\nn'est pas qu'une antiquaire."
+    "texte_fr": "Time Castle vend de\nvraies armes de qualité et\nprix moyens. Ce n'est pas qu'une antiquaire."
   },
   {
     "id": 189,
@@ -3073,7 +3073,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Looks[SP]like[SP]Jolly[SP]Roger[SP]in[SP]Kounan[SP]sells[SP]real\nweapons.[SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]check[SP]'em[SP]out...\nTheir[SP]prices[SP]and[SP]quality[SP]seem[SP]pretty[SP]normal.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Il paraît que le Jolly\nRoger à Kounan vend de\nvraies armes. Je devrais y jeter un œil...\nLeurs prix et\nqualité semblent dans lamoyenne."
+    "texte_fr": "Il paraît que le Jolly\nRoger à Kounan vend de\nvraies armes. Je devrais y jeter un œil... Leurs prix et qualité semblent dans lamoyenne."
   },
   {
     "id": 201,
@@ -3118,7 +3118,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Looks[SP]like[SP]Jolly[SP]Roger[SP]in[SP]Kounan[SP]sells[SP]real\nweapons.[SP]Should[SP]I[SP]check[SP]'em[SP]out...?[SP]Their\nselection's[SP]poor,[SP]but[SP]the[SP]resale[SP]value's[SP]high.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Il paraît que le Jolly\nRoger à Kounan vend de\nvraies armes. Je\ndevrais y aller...? Mauvais\nchoix, mais bonne valeur de revente."
+    "texte_fr": "Il paraît que le Jolly\nRoger à Kounan vend de\nvraies armes. Je devrais y aller...? Mauvais choix, mais bonne valeur de revente."
   },
   {
     "id": 204,
@@ -3193,7 +3193,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "You[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima[SP]Mundi[SP]in\nYumezaki,[SP]right?[SP]I[SP]should[SP]tell[SP]my[SP]friends.\nTheir[SP]stuff's[SP]quality[SP]and[SP]price[SP]is[SP]average.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "On peut acheter de\nvraies armures chez Anima\nMundi à Yumezaki? Je devrais le dire à mes\namis. Qualité et prix dans la moyenne."
+    "texte_fr": "On peut acheter de\nvraies armures chez Anima\nMundi à Yumezaki? Je devrais le dire à mes amis. Qualité et prix dans la moyenne."
   },
   {
     "id": 209,
@@ -3223,7 +3223,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "You[SP]can[SP]buy[SP]real[SP]armor[SP]at[SP]Anima[SP]Mundi[SP]in\nYumezaki,[SP]right?[SP]I[SP]should[SP]tell[SP]my[SP]friends.[SP]The\nselection's[SP]good,[SP]but[SP]not[SP]the[SP]buyback[SP]prices.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "On peut acheter de\nvraies armures chez Anima\nMundi à Yumezaki? Je devrais le dire à mes\namis. Bon choix, mais faible revente."
+    "texte_fr": "On peut acheter de\nvraies armures chez Anima\nMundi à Yumezaki? Je devrais le dire à mes amis. Bon choix, mais faible revente."
   },
   {
     "id": 211,
@@ -3418,7 +3418,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Looks[SP]like[SP]winners[SP]of[SP]the[SP]magazine[SP]sweepstakes\nget[SP]real[SP]weapons.[SP]I[SP]hear[SP]it's[SP]rare[SP]to[SP]win,[SP]but\nthe[SP]prizes[SP]are[SP]extremely[SP]rare[SP]stuff.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Il paraît que les gagnants des loteries de\nmagazines reçoivent de\nvraies armes. Rare de\ngagner, mais les\nprix sont extrêmement rares."
+    "texte_fr": "Il paraît que les gagnants des loteries de\nmagazines reçoivent de\nvraies armes. Rare de gagner, mais les prix sont extrêmement rares."
   },
   {
     "id": 224,
@@ -3433,7 +3433,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Looks[SP]like[SP]winners[SP]of[SP]the[SP]magazine[SP]sweepstakes\nget[SP]real[SP]weapons.[SP]It's[SP]easy[SP]to[SP]win,[SP]but[SP]you\nrarely[SP]get[SP]anything[SP]good.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Les gagnants des loteries de magazines\nreçoivent de vraies\narmes. Facile de gagner,\nmais rarement quelque chose de bien."
+    "texte_fr": "Les gagnants des loteries de magazines\nreçoivent de vraies\narmes. Facile de gagner, mais rarement quelque chose de bien."
   },
   {
     "id": 225,
@@ -3568,7 +3568,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "You[SP]know[SP]that[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle?\nSounds[SP]like[SP]a[SP]demon[SP]stole[SP]it.[SP]Which[SP]is[SP]funny,\n'cause[SP]there's[SP]no[SP]such[SP]thing[SP]as[SP]demons.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Tu connais l'arme\nlégendaire de Time Castle?\nIl paraît qu'un démon l'a\nvolée. Ce qui est\ndrôle, c'est qu'il n'existe pas de démons."
+    "texte_fr": "Tu connais l'arme\nlégendaire de Time Castle?\nIl paraît qu'un démon l'a volée. Ce qui est drôle, c'est qu'il n'existe pas de démons."
   },
   {
     "id": 234,

--- a/traduction/event_scripts/script_282.json
+++ b/traduction/event_scripts/script_282.json
@@ -12,7 +12,7 @@
     "nom_orig": "Girl's[SP]voice",
     "texte_orig": "Oh![1205][000F][SP]There[SP]she[SP]is![1205][000F][SP]Can[SP]I[SP]have[SP]your[SP]autograph!?",
     "nom_fr": "Voix de fille",
-    "texte_fr": "Oh! [1205][000F][1205][000F]La voici! Je peux avoir un autographe!?"
+    "texte_fr": "Oh! [000F][1205][000F][1205]La voici! Je peux avoir un autographe!?"
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ooooh,[SP]an[SP]autograph,[SP]is[SP]it?[1205][000F][SP]Sure[SP]thing![1205][000F]\nLine[SP]up[SP]now![SP]No[SP]pushing[SP]or[SP]shoving!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Oooh, un autographe, hein? [1205][000F][1205][000F]Bien sûr!\nTous en ligne! Ne vous bousculez pas!"
+    "texte_fr": "Oooh, un autographe, hein? [000F][1205][000F][1205]Bien sûr!\nTous en ligne! Ne vous bousculez pas!"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "C'mon,[SP]Lisa![1205][000F][SP]Just[SP]one[SP]little[SP]autograph!?",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Allez, Lisa! [1205][000F]Juste un petit autographe!?"
+    "texte_fr": "Allez, Lisa! [000F][1205]Juste un petit autographe!?"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh!?[1205][000F][SP]Me!?[1205][000F][SP]Why[SP]me!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Gné![1205][000F][1205][000F]? Moi!? Mais!?"
+    "texte_fr": "Gné![000F][1205][000F][1205]? Moi!? Mais!?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "C'mon,[SP]don't[SP]play[SP]dumb.[1205][000F][SP]It[SP]was[SP]so[SP]obvious\nby[SP]that[SP]poster!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Roh, fais pas genre. [1205][000F]C'était\ntellement évident sur l'affiche!"
+    "texte_fr": "Roh, fais pas genre. [000F][1205]C'était\ntellement évident sur l'affiche!"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Congrats[SP]on[SP]your[SP]public[SP]debut![1205][000F][SP]So[SP]when's[SP]the\nbig[SP]announcement?[1205][000F][SP]There's[SP]no[SP]sense[SP]keeping[SP]it\na[SP]secret[SP]between[SP]you[SP]three[SP]anymore...",
     "nom_fr": "Lycéen",
-    "texte_fr": "Bravo pour tes débuts sur scène! [1205][000F][1205][000F]À quand\nla grande annonce? Ça sert plus à rien\nde garder le secret entre vous trois..."
+    "texte_fr": "Bravo pour tes débuts sur scène! [000F][1205][000F][1205]À quand\nla grande annonce? Ça sert plus à rien\nde garder le secret entre vous trois..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Debut?[1205][000F][SP]Poster?[1205][000F][SP]Wait[SP]a[SP]second,[SP]what[SP]the[SP]hell\nare[SP]you[SP]talking[SP]about?",
     "nom_fr": "Ginko",
-    "texte_fr": "Débuts? [1205][000F][1205][000F]Affiche? Une seconde,\nde quoi vous parlez au juste?"
+    "texte_fr": "Débuts? [000F][1205][000F][1205]Affiche? Une seconde,\nde quoi vous parlez au juste?"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Aww,[SP]okay...[1205][000F][SP]So[SP]you[SP]still[SP]gotta[SP]keep[SP]it\na[SP]secret.",
     "nom_fr": "Lycéen",
-    "texte_fr": "Oh, d'accord.[1205][000F].. Tu vas\ngarder ça secret alors."
+    "texte_fr": "Oh, d'accord.[000F][1205].. Tu vas\ngarder ça secret alors."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "We[SP]shouldn't[SP]push[SP]it.[1205][000F][SP]Let's[SP]hold[SP]off[SP]on\ngetting[SP]an[SP]autograph[SP]until[SP]later.",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Ne la forçons pas. [1205][000F]On se retiendra de\ndemander un autographe en attendant."
+    "texte_fr": "Ne la forçons pas. [000F][1205]On se retiendra de\ndemander un autographe en attendant."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "We'll[SP]totally[SP]be[SP]rooting[SP]for[SP]you,[SP]though![1205][000F]\nI[SP]hope[SP]your[SP]group[SP]can[SP]help[SP]restore[SP]Sevens'\nreputation!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "On va t'encourager à fond!\n[1205][000F]J'espère que ton groupe aidera à\nrestaurer la réputation de Seven!"
+    "texte_fr": "On va t'encourager à fond!\n[000F][1205]J'espère que ton groupe aidera à\nrestaurer la réputation de Seven!"
   },
   {
     "id": 13,

--- a/traduction/event_scripts/script_285.json
+++ b/traduction/event_scripts/script_285.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What[SP]the...?[1205][000F][SP]What're[SP]these[SP]guys[SP]doing?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mais...[1205][000F]? Qu'est-ce qu'ils font?"
+    "texte_fr": "Mais...[000F][1205]? Qu'est-ce qu'ils font?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]can't[SP]believe[SP]there[SP]was[SP]another[SP]way[SP]in.[1205][000F]\nAt[SP]least[SP]the[SP]Last[SP]Battalion[SP]made[SP]SOMETHING\nuseful...",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'y crois pas, il y\navait une autre entrée? [1205][000F]Le\nBataillon aura fait au\nmoins UN truc utile..."
+    "texte_fr": "J'y crois pas, il y\navait une autre entrée? [000F][1205]Le\nBataillon aura fait au moins UN truc utile..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah!?[1205][000F][SP]Is[SP]this[SP]some[SP]kinda[SP]cult?[1205][000F][SP]Did[SP]people\nstart[SP]worshipping[SP]this[SP]stuff?[1205][000F][SP]Yeeeesh...\nThis[SP]is[SP]getting[SP]out[SP]of[SP]hand.",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiyah![1205][000F][1205][000F][1205][000F]? C'est un genre de culte? Des\ngens se sont mis à vénérer ce truc?\nWoooow... Ça devient hors de contrôle."
+    "texte_fr": "Aiyah![000F][1205][000F][1205][000F][1205]? C'est un genre de culte? Des\ngens se sont mis à vénérer ce truc?\nWoooow... Ça devient hors de contrôle."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hoisamuro...[SP]Thank[SP]goodness.[1205][000F][SP]We'd[SP]be[SP]pounded\nbloody[SP]if[SP]we[SP]had[SP]to[SP]go[SP]down[SP]that[SP]Silver[SP]River\nevery[SP]time.",
     "nom_fr": "Ginko",
-    "texte_fr": "Hoisamuro... Dieu merci. [1205][000F]On serait\nabattus si on devait descendre la\nRivière d'Argent à chaque fois."
+    "texte_fr": "Hoisamuro... Dieu merci. [000F][1205]On serait\nabattus si on devait descendre la\nRivière d'Argent à chaque fois."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "They[SP]must[SP]be[SP]desperate[SP]to[SP]believe[SP]that[SP]they[SP]can\nevolve[SP]and[SP]escape[SP]this[SP]world's[SP]destruction.[1205][000F]\nPeople...[1205][000F][SP]can[SP]be[SP]pitiful[SP]at[SP]times[SP]like[SP]this...",
     "nom_fr": "Maya",
-    "texte_fr": "Ils doivent être desespérés pour\npenser pouvoir évoluer et fuir la fin\ndu monde. [1205][1205][000F]Les gens.[000F]..\npeuvent êtrepitoyables dans ces moments-là..."
+    "texte_fr": "Ils doivent être desespérés pour\npenser pouvoir évoluer et fuir la fin\ndu monde. [1205][000F][1205]Les gens.[000F].. peuvent êtrepitoyables dans ces moments-là..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Wellll...[1205][000F][SP]Speaking[SP]for[SP]myself,[SP]I[SP]had[SP]a[SP]lot[SP]of\nfun[SP]going[SP]down[SP]those[SP]rapids!",
     "nom_fr": "Maya",
-    "texte_fr": "Bennn.[1205][000F].. De mon côté, je me suis\nbeaucoup amusée à descendre ces rapides!"
+    "texte_fr": "Bennn.[000F][1205].. De mon côté, je me suis\nbeaucoup amusée à descendre ces rapides!"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Jun",
     "texte_orig": "The[SP]fulfillment[SP]of[SP]twisted[SP]ideals[SP]brings[SP]only\nschadenfreude,[SP]not[SP]real[SP]joy...[1205][000F][SP]I[SP]wanted[SP]a[SP]way\nfor[SP]all[SP]to[SP]reach[SP]true[SP]happiness.",
     "nom_fr": "Jun",
-    "texte_fr": "Réaliser des idéaux corrompus n'amène que\nschadenfreude, pas la joie.[1205][000F].. Je voulais\nque chacun atteigne le vrai bonheur."
+    "texte_fr": "Réaliser des idéaux corrompus n'amène que\nschadenfreude, pas la joie.[000F][1205].. Je voulais\nque chacun atteigne le vrai bonheur."
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Maybe[SP]there[SP]isn't[SP]any[SP]way[SP]for[SP]all[SP]to[SP]achieve\ntrue[SP]happiness...[1205][000F][SP]No,[SP]I'm[SP]sure[SP]there[SP]must[SP]be\nsomething.",
     "nom_fr": "Jun",
-    "texte_fr": "Le bonheur n'est peut-être pas\naccessible à tout le monde.[1205][000F].. Non,\nje sais qu'il existe un moyen."
+    "texte_fr": "Le bonheur n'est peut-être pas\naccessible à tout le monde.[000F][1205].. Non,\nje sais qu'il existe un moyen."
   },
   {
     "id": 9,
@@ -177,7 +177,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "I'm[SP]currently[SP]listening[SP]in[SP]on[SP]the[SP]murmurs[SP]of\nsociety.[SP]Listening[SP]to[SP]rumors[SP]teaches[SP]you[SP]the\nlies[SP]and[SP]deceptions[SP]of[SP]the[SP]world[SP]very[SP]clearly.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Actuellement j'écoute les murmures de la\nsociété. Écouter les rumeurs t'éduques très\nbien sur les mensonges\net duperies du monde."
+    "texte_fr": "Actuellement j'écoute les murmures de la\nsociété. Écouter les rumeurs t'éduques très\nbien sur les mensonges et duperies du monde."
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Look[SP]at[SP]them.[SP]They're[SP]praying[SP]together[SP]in[SP]the\nhopes[SP]of[SP]evolving[SP]safely.[SP]Does[SP]the[SP]entire\nworld's[SP]destruction[SP]mean[SP]nothing[SP]to[SP]them...?",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Regarde-les. Ils prient ensemble dans\nl'espoir d'évoluer en\nsûreté. La destruction\ndu monde entier ne\nsignifie rien pour eux...?"
+    "texte_fr": "Regarde-les. Ils prient ensemble dans\nl'espoir d'évoluer en\nsûreté. La destruction du monde entier ne signifie rien pour eux...?"
   },
   {
     "id": 14,
@@ -373,7 +373,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Hm...[1205][001E][SP]The[SP]principal[SP]of[SP]Sevens[SP]suddenly[SP]grew\nsome[SP]hair?[SP]That[SP]may[SP]have[SP]been[SP]his[SP]request\nto[SP]Joker.",
     "nom_fr": "Toku-san",
-    "texte_fr": "Hm...[1205][001E] Les cheveux du proviseur de\nSeven ont soudainement poussé? Il\na du demander ça au Joker."
+    "texte_fr": "Hm...[001E][1205] Les cheveux du proviseur de\nSeven ont soudainement poussé? Il\na du demander ça au Joker."
   },
   {
     "id": 21,
@@ -418,7 +418,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "He's[SP]a[SP]rather[SP]suspicious[SP]man[SP]who[SP]talks[SP]as[SP]if[SP]he\ncan[SP]see[SP]through[SP]people.[SP]He[SP]even[SP]calls[SP]himself\na[SP]Count...[SP]So[SP]this[SP]rumor[SP]comes[SP]as[SP]no[SP]surprise.",
     "nom_fr": "Toku-san",
-    "texte_fr": "Il est assez suspect et s'exprime comme\ns'il pouvait voir à travers les gens.\nIl se fait même appeler\nComte... Doncla rumeur ne m'étonne pas."
+    "texte_fr": "Il est assez suspect et s'exprime comme\ns'il pouvait voir à travers les gens.\nIl se fait même appeler Comte... Doncla rumeur ne m'étonne pas."
   },
   {
     "id": 24,
@@ -463,7 +463,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "I[SP]don't[SP]hear[SP]many[SP]nice[SP]rumors[SP]about[SP]him,[SP]you\nknow.[SP]Some[SP]even[SP]say[SP]he's[SP]part[SP]of[SP]some[SP]organized\ncrime[SP]group.[SP]Who[SP]knows?[SP]Maybe[SP]it's[SP]true.",
     "nom_fr": "Toku-san",
-    "texte_fr": "Je n'entend pas de\ntrès bonne rumeurs sur lui,\ntu sais. Certains disent même qu'il baigne\ndans le crime\norganisé. Peut-être, qui sait?"
+    "texte_fr": "Je n'entend pas de\ntrès bonne rumeurs sur lui,\ntu sais. Certains disent même qu'il baigne dans le crime organisé. Peut-être, qui sait?"
   },
   {
     "id": 27,
@@ -478,7 +478,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "The[SP]Death[SP]Boss[SP]of[SP]Cuss[SP]High...[SP]is[SP]no[SP]longer\nthe[SP]Boss?[1205][000F][SP]Yes...[SP]the[SP]young[SP]ones[SP]might[SP]be\ninterested[SP]to[SP]know[SP]that.[SP]Okay,[SP]here's[SP]one.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Le Boss Mortel de Kakasu... n'est plus\nle Boss? [1205][000F]Oui... ça pourrait intéresser\nles jeunes. Bien, voici une rumeur."
+    "texte_fr": "Le Boss Mortel de Kakasu... n'est plus\nle Boss? [000F][1205]Oui... ça pourrait intéresser\nles jeunes. Bien, voici une rumeur."
   },
   {
     "id": 28,
@@ -508,7 +508,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "I[SP]also[SP]hear[SP]the[SP]Garcon[SP]there[SP]drove[SP]away[SP]some\npunks[SP]who[SP]came[SP]with[SP]knives,[SP]and[SP]said[SP]he'd[SP]have\nrifles[SP]ready[SP]next[SP]time.[SP]He's[SP]no[SP]ordinary[SP]man.",
     "nom_fr": "Toku-san",
-    "texte_fr": "Aussi, le Garçon là-bas aurait chassé\ndes voyous armés de couteaux, ajoutant\nqu'il aurait un fusil la\nprochainefois. Il n'est pas ordinaire."
+    "texte_fr": "Aussi, le Garçon là-bas aurait chassé\ndes voyous armés de couteaux, ajoutant\nqu'il aurait un fusil la prochainefois. Il n'est pas ordinaire."
   },
   {
     "id": 30,
@@ -523,7 +523,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "What?[SP]That[SP]producer[SP]is[SP]actually[SP]part[SP]of[SP]the\nMasked[SP]Circle?[SP]Now[SP]that's[SP]useful[SP]information.\nI[SP]think[SP]I[SP]have[SP]a[SP]rumor[SP]worthy[SP]of[SP]that.",
     "nom_fr": "Toku-san",
-    "texte_fr": "Quoi? Ce producteur\nfaisait partie du Cercle\nMasqué? Voilà une information\nbien utile. Je\npense avoir une rumeur à la hauteur de ça."
+    "texte_fr": "Quoi? Ce producteur\nfaisait partie du Cercle\nMasqué? Voilà une information bien utile. Je pense avoir une rumeur à la hauteur de ça."
   },
   {
     "id": 31,
@@ -538,7 +538,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "There's[SP]a[SP]cafe[SP]called[SP][E4][NULL][NULL][0006]Jolly[SP]Roger[E4][NULL][NULL][0002][SP]in[SP]Kounan,\nwhere[SP]it[SP]seems[SP]you[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002].[1205][000F][SP]Rumor\nis[SP]their[SP][E4][NULL][NULL][0006]quality[SP]and[SP]price[SP]is[SP]average[E4][NULL][NULL][0002].",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Dans un café nommé [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à Kounan,\non a de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. Selon la rumeur\n[1205][000F]les [E4][NULL][NULL][0006]prix et la qualité sont convenables[E4][NULL][NULL][0002]."
+    "texte_fr": "Dans un café nommé [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à Kounan,\non a de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. Selon la rumeur\n[000F][1205]les [E4][NULL][NULL][0006]prix et la qualité sont convenables[E4][NULL][NULL][0002]."
   },
   {
     "id": 32,
@@ -553,7 +553,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "The[SP][1432][NULL][NULL][0014]Jolly[SP]Roger[1432][NULL][NULL][0014][SP]refers[SP]to[SP]the[SP]skull[SP]and\ncrossbones...[SP]Between[SP]the[SP]ship-like[SP]decor[SP]and\nhis[SP]clothing,[SP]the[SP]owner[SP]may[SP]be[SP]an[SP]ex-pirate.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Le [1432][NULL][NULL][0014]Jolly Roger[1432][NULL][NULL][0014] désigne le crâne aux os\ncroisés... Entre le décor\nnaval et ses habits,\nle proprio est sûrement un ex-pirate."
+    "texte_fr": "Le [1432][NULL][NULL][0014]Jolly Roger[1432][NULL][NULL][0014] désigne le crâne aux os\ncroisés... Entre le décor\nnaval et ses habits, le proprio est sûrement un ex-pirate."
   },
   {
     "id": 33,
@@ -568,7 +568,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Oh...?[1205][001E][SP]Something[SP]terrible[SP]will[SP]happen[SP]when[SP]the\nclock[SP]at[SP]Sevens[SP]starts?[SP]Haha,[SP]I[SP]don't[SP]suppose\nthe[SP]world[SP]will[SP]end[SP]or[SP]anything.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Oh...?[1205][001E] Un malheur se produira si l'horloge\nde Seven se met en marche? Haha, ça ne va\npas détruire le monde, non plus."
+    "texte_fr": "Oh...?[001E][1205] Un malheur se produira si l'horloge\nde Seven se met en marche? Haha, ça ne va\npas détruire le monde, non plus."
   },
   {
     "id": 34,
@@ -598,7 +598,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Do[SP]you[SP]know[SP]the[SP]boutique[SP][E4][NULL][NULL][0006]Rosa[SP]Candida[E4][NULL][NULL][0002]?[SP]It[SP]seems\nyou[SP]can[SP]actually[SP]buy[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002][SP]there.[SP]Rumor\nhas[SP]it[SP]their[SP][E4][NULL][NULL][0006]quality[SP]and[SP]prices[SP]are[SP]average[E4][NULL][NULL][0002].",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Tu vois cette boutique, [E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002]? On y\nachète de [E4][NULL][NULL][0006]vraies\narmures[E4][NULL][NULL][0002]. D'après la rumeur,\nles [E4][NULL][NULL][0006]prix et la qualité sont convenables[E4][NULL][NULL][0002]."
+    "texte_fr": "Tu vois cette boutique, [E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002]? On y\nachète de [E4][NULL][NULL][0006]vraies\narmures[E4][NULL][NULL][0002]. D'après la rumeur, les [E4][NULL][NULL][0006]prix et la qualité sont convenables[E4][NULL][NULL][0002]."
   },
   {
     "id": 36,
@@ -613,7 +613,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "I've[SP]heard[SP]that[SP]armor[SP]is[SP]this[SP]year's[SP]trend.\nA[SP]rube[SP]was[SP]here[SP]talking[SP]about[SP]it[SP]until[SP]a\nmoment[SP]ago.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Apparemment cette armure est\nà la mode cette\nannée. Un péquenaud en\nparlait tout à l'heure."
+    "texte_fr": "Apparemment cette armure est\nà la mode cette\nannée. Un péquenaud en parlait tout à l'heure."
   },
   {
     "id": 37,
@@ -628,7 +628,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "A[SP]secret[SP]lounge[SP]inside[SP]Zodiac,[SP]eh?[SP]I'd[SP]heard\nabout[SP]it,[SP]but[SP]to[SP]know[SP]it[SP]actually[SP]exists...\nAll[SP]right.[SP]Let[SP]me[SP]tell[SP]you[SP]what[SP]I[SP]know.",
     "nom_fr": "Toku-san",
-    "texte_fr": "Il y a un salon secret au Zodiac? J'en ai\nentendu parler, mais le fait qu'il existe\nvraiment... Très bien. Voici\nce que je sais."
+    "texte_fr": "Il y a un salon secret au Zodiac? J'en ai\nentendu parler, mais le fait qu'il existe\nvraiment... Très bien. Voici ce que je sais."
   },
   {
     "id": 38,
@@ -673,7 +673,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Ah,[SP]so[SP]this[SP]new[SP]Leader[SP]at[SP]Kasugayama[SP]used[SP]to\nbe[SP]the[SP]Death[SP]Boss'[SP]underling.[1205][000F][SP]The[SP]low[SP]overcomes\nthe[SP]high...[1205][000F][SP]All[SP]right,[SP]here's[SP]what[SP]I[SP]know.[E1][E2]\n[E3][E4][NULL][NULL]\"Rumormonger[SP]Toku-san\nThere's[SP]a[SP]branch[SP]of[SP][E4][NULL][NULL][0006]Rosa[SP]Candida[E4][NULL][NULL][0002][SP]in[SP]Aoba,[SP]and\nword[SP]is[SP]they[SP]sell[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]Their[SP][E4][NULL][NULL][0006]selection\nis[SP]paltry,[SP]but[SP]their[SP]resale[SP]prices[SP]are[SP]good[E4][NULL][NULL][0002].",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Ah, ce nouveau chef\nde Kakasu était le larbin\nde l'ancien Boss Mortel. [1205][000F][1205][000F][1205]Le faible surpasse\n[000F]le fort... D'accord, voilà ce que je sais.[E1][E2]\n[E3][E4][NULL][NULL]\"Colporteur Toku\n[E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002] a une branche à\nAoba, et ils y vendraient de [E4][NULL][NULL][0006]vraies\narmures[E4][NULL][NULL][0002].Leur [E4][NULL][NULL][0006]sélection est misérable, mais les prix\nde revente sont bons[E4][NULL][NULL][0002]."
+    "texte_fr": "Ah, ce nouveau chef\nde Kakasu était le larbin\nde l'ancien Boss Mortel. [000F][1205][000F][1205][1205]Le faible surpasse\n[000F]le fort... D'accord, voilà ce que je sais.[E1][E2]\n[E3][E4][NULL][NULL]\"Colporteur Toku\n[E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002] a une branche à\nAoba, et ils y vendraient de [E4][NULL][NULL][0006]vraies\narmures[E4][NULL][NULL][0002].Leur [E4][NULL][NULL][0006]sélection est misérable, mais les prix\nde revente sont bons[E4][NULL][NULL][0002]."
   },
   {
     "id": 41,
@@ -688,7 +688,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "The[SP]lucky[SP]cat[SP]statue[SP]at[SP]the[SP]Kuzunoha[SP]Detective\nAgency[SP]talks?[SP]Hahaha,[SP]I[SP]know[SP]some[SP]girls[SP]who'd\nbe[SP]delighted[SP]to[SP]hear[SP]it.[SP]Alright,[SP]here's[SP]one...",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "La statue de chat du bonheur de l'Agence de\nDétective Kuzunoha parle?\nHahaha, je connais\ndes filles qui adoreraient\nça. Bon, à moi..."
+    "texte_fr": "La statue de chat du bonheur de l'Agence de\nDétective Kuzunoha parle?\nHahaha, je connais des filles qui adoreraient ça. Bon, à moi..."
   },
   {
     "id": 42,
@@ -703,7 +703,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "There's[SP]a[SP]European-styled[SP]shop,[SP][E4][NULL][NULL][0006]London[SP]Clothier[E4][NULL][NULL][0002],\nin[SP]Kounan.[1205][000A][SP]You[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002][SP]there.[SP][E4][NULL][NULL][0006]Their\nselection[SP]is[SP]good,[SP]but[SP]the[SP]resale[SP]value[SP]isn't[E4][NULL][NULL][0002].",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Ce magasin au\nstyle européen, [E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002],\nà Kounan.[1205][000A] Tu peux y acheter de [E4][NULL][NULL][0006]vraies \narmures[E4][NULL][NULL][0002]. [E4][NULL][NULL][0006]Bon choix,\nmais mauvais prix derevente[E4][NULL][NULL][0002]."
+    "texte_fr": "Ce magasin au\nstyle européen, [E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002],\nà Kounan.[000A][1205] Tu peux y acheter de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [E4][NULL][NULL][0006]Bon choix, mais mauvais prix derevente[E4][NULL][NULL][0002]."
   },
   {
     "id": 43,
@@ -733,7 +733,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Tamaki[SP]at[SP]Kuzunoha[SP]Detective[SP]Agency[SP]is[SP]a[SP]real\nDevil[SP]Summoner?[SP]Is[SP]that[SP]an[SP]actual[SP]job?[SP]I've\nnever[SP]heard[SP]of[SP]it...[SP]Hmm.[SP]All[SP]right.",
     "nom_fr": "Toku-san",
-    "texte_fr": "Tamaki de l'Agence\nde Détective Kuzunoha est\nune Devil Summoner? C'est un vrai métier? \nJamais entendu parler... Hmm. Très bien."
+    "texte_fr": "Tamaki de l'Agence\nde Détective Kuzunoha est\nune Devil Summoner? C'est un vrai métier? Jamais entendu parler... Hmm. Très bien."
   },
   {
     "id": 45,
@@ -763,7 +763,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Ah...[SP]So[SP]demons[SP]really[SP]do[SP]exist?[1205][001E][SP]Now[SP]that's\nfar-fetched.[SP]I[SP]personally[SP]think[SP]it's[SP]more\nlikely[SP]that[SP]evil[SP]lurks[SP]in[SP]people's[SP]hearts.",
     "nom_fr": "Toku-san",
-    "texte_fr": "Ah... Donc les démons\nexistent pour de vrai?[1205][001E]\nVoilà qui est farfelu. Je pense plutôt que\nle mal se terre dans le coeur des gens."
+    "texte_fr": "Ah... Donc les démons\nexistent pour de vrai?[001E][1205]\nVoilà qui est farfelu. Je pense plutôt que\nle mal se terre dans le coeur des gens."
   },
   {
     "id": 47,
@@ -808,7 +808,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "What?[SP]The[SP]Last[SP]Battalion[SP]is[SP]led[SP]by[SP]the[SP]Fuhrer?[1205][000F]\nIs[SP]that[SP]even[SP]possible?",
     "nom_fr": "Toku-san",
-    "texte_fr": "Hein? Le Bataillon est mené par le\nFührer? [1205][000F]Est-ce seulement possible?"
+    "texte_fr": "Hein? Le Bataillon est mené par le\nFührer? [000F][1205]Est-ce seulement possible?"
   },
   {
     "id": 50,
@@ -823,7 +823,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Well,[SP]in[SP]Sumaru,[SP]perhaps...[1205][000F][SP]All[SP]right,[SP]I'll\nbelieve[SP]you.[1205][000F][SP]In[SP]which[SP]case,[SP]let[SP]me[SP]relate[SP]a\nspecial[SP]rumor[SP]I[SP]heard.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Enfin, à Sumaru, qui sait.[1205][000F][1205][000F].. Bien, je\nte crois. Par conséquent, laisse-moi\nte parler d'une rumeur spéciale."
+    "texte_fr": "Enfin, à Sumaru, qui sait.[000F][1205][000F][1205].. Bien, je\nte crois. Par conséquent, laisse-moi\nte parler d'une rumeur spéciale."
   },
   {
     "id": 51,
@@ -838,7 +838,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "The[SP][E4][NULL][NULL][0006]legendary[SP]weapon[SP]at[SP]Time[SP]Castle[E4][NULL][NULL][0002][SP]hasn't[SP]been\ndelivered[SP]yet...[1205][000A][SP]The[SP][E4][NULL][NULL][0006]owner[SP]is[SP]too[SP]scared[SP]to[SP]pick\nit[SP]up[SP]from[SP]the[SP]abandoned[SP]factory[E4][NULL][NULL][0002].",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "[E4][NULL][NULL][0006]L'arme légendaire au Time Castle[E4][NULL][NULL][0002] n'est pas\nlivrée...[1205][000A] Le [E4][NULL][NULL][0006]possesseur est trop apeuré\npour la récupérer à l'usine abandonnée[E4][NULL][NULL][0002]."
+    "texte_fr": "[E4][NULL][NULL][0006]L'arme légendaire au Time Castle[E4][NULL][NULL][0002] n'est pas\nlivrée...[000A][1205] Le [E4][NULL][NULL][0006]possesseur est trop apeuré\npour la récupérer à l'usine abandonnée[E4][NULL][NULL][0002]."
   },
   {
     "id": 52,
@@ -853,7 +853,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "A[SP][1432][NULL][NULL][0014]rumor[1432][NULL][NULL][0014][SP]only[SP]means[SP]unproven[SP]information.[1205][000F]\nBut[SP]call[SP]it[SP][1432][NULL][NULL][0014]word[SP]of[SP]mouth[1432][NULL][NULL][0014][SP]and[SP]people[SP]believe\nyou;[SP]call[SP]it[SP]a[SP][1432][NULL][NULL][0014]hoax[1432][NULL][NULL][0014][SP]and[SP]they[SP]won't.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "Une [1432][NULL][NULL][0014]rumeur[1432][NULL][NULL][0014] est une info non prouvée.\n[1205][000F]Appelle-la [1432][NULL][NULL][0014]bouche à oreille[1432][NULL][NULL][0014]; on te\ncroira; [1432][NULL][NULL][0014]canular[1432][NULL][NULL][0014]; ce ne sera plus le cas."
+    "texte_fr": "Une [1432][NULL][NULL][0014]rumeur[1432][NULL][NULL][0014] est une info non prouvée.\n[000F][1205]Appelle-la [1432][NULL][NULL][0014]bouche à oreille[1432][NULL][NULL][0014]; on te\ncroira; [1432][NULL][NULL][0014]canular[1432][NULL][NULL][0014]; ce ne sera plus le cas."
   },
   {
     "id": 53,
@@ -868,7 +868,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "Perhaps[SP]that's[SP]why[SP]people[SP]are[SP]so[SP]credible[SP]when\nit[SP]comes[SP]to[SP]rumors...[1205][000F][SP]Still,[SP]the[SP]rumors[SP]floating\naround[SP]Sumaru[SP]are[SP]particularly[SP]bizarre.",
     "nom_fr": "Toku-san l'informateur",
-    "texte_fr": "C'est peut-être pour ça que les gens sont\naussi réceptifs aux rumeurs.[1205][000F].. Ceci dit,\ncelles de\nSumaru sont particulièrementbizarres."
+    "texte_fr": "C'est peut-être pour ça que les gens sont\naussi réceptifs aux rumeurs.[000F][1205].. Ceci dit,\ncelles de Sumaru sont particulièrementbizarres."
   },
   {
     "id": 54,
@@ -913,7 +913,7 @@
     "nom_orig": "Rumormonger[SP]Toku-san",
     "texte_orig": "That's[SP]all[SP]the[SP]rumors[SP]I[SP]know[SP]of.[SP]I'll[SP]tell[SP]you\nmore[SP]when[SP]a[SP]new[SP]one[SP]comes[SP]in.[SP]Make[SP]sure[SP]you\nhave[SP]some[SP]interesting[SP]information[SP]ready[SP]for[SP]me!",
     "nom_fr": "Toku-san",
-    "texte_fr": "Ce sont les rumeurs que je connais.\nJe t'en dirais plus quand j'en aurais\nd'autres. Assure-toi d'avoir\ndesinformations alléchantes pour moi!"
+    "texte_fr": "Ce sont les rumeurs que je connais.\nJe t'en dirais plus quand j'en aurais\nd'autres. Assure-toi d'avoir desinformations alléchantes pour moi!"
   },
   {
     "id": 57,
@@ -973,7 +973,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "There[SP]are[SP]tons[SP]of[SP]rumors[SP]going[SP]around[SP]about[SP]how\nthe[SP]Grand[SP]Cross[SP]will[SP]be[SP]the[SP]end[SP]of[SP]the[SP]world.[1205][000F]\nA[SP]meteor[SP]hitting[SP]is[SP]the[SP]most[SP]popular[SP]theory...",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Il y a plein de\nrumeurs sur comment la Croix\nCosmique va amener la\nfin du monde. La chute\n[1205][000F]de météorite est\nla théorie la pluspopulaire..."
+    "texte_fr": "Il y a plein de\nrumeurs sur comment la Croix\nCosmique va amener la fin du monde. La chute [000F][1205]de météorite est la théorie la pluspopulaire..."
   },
   {
     "id": 61,
@@ -988,7 +988,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "When[SP]the[SP]Grand[SP]Cross[SP]happens,[SP]apparently[SP]the\nother[SP]planets'[SP]gravitational[SP]pull[SP]will[SP]cause\ngravity[SP]to[SP]be[SP]nullified[SP]here[SP]on[SP]Earth.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Quand la Croix Cosmique se produira, il\nparaît que la force\nde gravitation des autres\nplanètes nullifiera la gravité sur Terre."
+    "texte_fr": "Quand la Croix Cosmique se produira, il\nparaît que la force\nde gravitation des autres planètes nullifiera la gravité sur Terre."
   },
   {
     "id": 62,
@@ -1003,7 +1003,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "And[SP]as[SP]a[SP]result,[SP]all[SP]the[SP]air[SP]on[SP]Earth[SP]will\nflow[SP]out[SP]into[SP]space.[1205][000F][SP]I[SP]think[SP]maybe[SP]that's[SP]how\nthe[SP]world[SP]is[SP]going[SP]to[SP]end.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Résultat, l'atmosphère terrestre\ns'échappera dans l'espace. [1205][000F]Peut-être que\nla fin du monde se produira comme ça."
+    "texte_fr": "Résultat, l'atmosphère terrestre\ns'échappera dans l'espace. [000F][1205]Peut-être que\nla fin du monde se produira comme ça."
   },
   {
     "id": 63,
@@ -1033,7 +1033,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "That'd[SP]be[SP]insane,[SP]huh?[1205][000F][SP]Everything[SP]on[SP]the[SP]face\nof[SP]the[SP]Earth[SP]would[SP]be[SP]jolted[SP]to[SP]the[SP]east[SP]at\nthe[SP]speed[SP]of[SP]light.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Ce serait fou, hein? [1205][000F]Toute la\nsurface de la Terre se ferait\nsouffler à la vitesse de la lumière."
+    "texte_fr": "Ce serait fou, hein? [000F][1205]Toute la\nsurface de la Terre se ferait\nsouffler à la vitesse de la lumière."
   },
   {
     "id": 65,
@@ -1063,7 +1063,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Did[SP]you[SP]hear[SP]the[SP]rumor?[SP]That[SP]ghost[SP]Hanako[SP]is\nsupposedly[SP]haunting[SP]Sevens.[1205][000F][SP]It's[SP]kinda[SP]scary,\nbut[SP]I'd[SP]like[SP]to[SP]see[SP]it[SP]if[SP]it's[SP]real.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Tu connais la rumeur? Le fantôme Hanako\nhanterait Seven apparemment. [1205][000F]C'est assez\nflippant, mais j'aimerais\nvoir si c'est vrai."
+    "texte_fr": "Tu connais la rumeur? Le fantôme Hanako\nhanterait Seven apparemment. [000F][1205]C'est assez\nflippant, mais j'aimerais voir si c'est vrai."
   },
   {
     "id": 67,
@@ -1093,7 +1093,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "There's[SP]an[SP]idol's[SP]ghost[SP]haunting[SP]the[SP]outdoor\nconcert[SP]hall.[1205][000F][SP]I[SP]hear[SP]a[SP]lot[SP]of[SP]scary[SP]stories\nabout[SP]that[SP]place...[SP]like[SP]talking[SP]flowers.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Un fantôme d'idol hante la salle de concert\n[1205]en plein air. [000F]J'entend\nplein de trucs atroces\nlié à ça... comme des fleurs loquaces."
+    "texte_fr": "Un fantôme d'idol hante la salle de concert\n[1205]en plein air. [000F]J'entend\nplein de trucs atroces lié à ça... comme des fleurs loquaces."
   },
   {
     "id": 69,
@@ -1108,7 +1108,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "They[SP]say[SP]a[SP]cursed[SP]taxi[SP]was[SP]seen[SP]at[SP]the\nabandoned[SP]factory[SP]in[SP]Kounan.[1205][000F][SP]I[SP]wonder[SP]if\nit's[SP]true.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Un taxi maudit aurait été vu à l'usine\nabandonnée de Kounan. [1205]Je\n[000F]me demande si c'est\nvrai."
+    "texte_fr": "Un taxi maudit aurait été vu à l'usine\nabandonnée de Kounan. [1205]Je\n[000F]me demande si c'est vrai."
   },
   {
     "id": 70,
@@ -1168,7 +1168,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "They[SP]say[SP]the[SP]Jumping[SP]Geezer[SP]has[SP]been[SP]seen[SP]at\nMt.[SP]Katatsumuri.[1205][000F][SP]I[SP]don't[SP]really[SP]know[SP]what[SP]that\nis...[SP]Is[SP]it[SP]basically[SP]what[SP]the[SP]name[SP]implies?",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Apparemment le Vieux Rebondissant\na été vu au\n[1205]Mont Katatsumuri. [000F]Je sais pas trop ce que\nc'est... Peut-être juste\nce que son nomimplie?"
+    "texte_fr": "Apparemment le Vieux Rebondissant\na été vu au\n[1205]Mont Katatsumuri. [000F]Je sais pas trop ce que c'est... Peut-être juste ce que son nomimplie?"
   },
   {
     "id": 74,
@@ -1183,7 +1183,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Yikes...[1205][000A][SP]I[SP]just[SP]heard[SP]a[SP]scary[SP]story...[1205][000F][SP]Hm?\nWhat[SP]was[SP]it[SP]about?[1205][000F][SP]I-It[SP]was[SP]about[SP]Kudan...[1205][000A]\nAt[SP]the[SP]abandoned[SP]factory...[SP]Brrrr...",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Ugh...[1205][000A] J'ai entendu\nune histoire flippante.[000F][000F]..[1205][000A]\nHm? De quoi ça\nparle?[1205] Ç-Ça parle de Kudan...[1205]\nÀ l'usine abandonnée... Brr..."
+    "texte_fr": "Ugh...[000A][1205] J'ai entendu\nune histoire flippante.[000F][000F]..[000A][1205]\nHm? De quoi ça parle?[1205] Ç-Ça parle de Kudan...[1205] À l'usine abandonnée... Brr..."
   },
   {
     "id": 75,
@@ -1198,7 +1198,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "I[SP]heard[SP]there's[SP]a[SP]secret[SP]CD[SP]at[SP]Giga[SP]Macho\nthat's[SP]not[SP]like[SP]ordinary[SP]CDs.[1205][000F][SP]I[SP]don't[SP]know\nthe[SP]details,[SP]but[SP]it's[SP]supposedly[SP]interesting.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "J'ai entendu dire que le Giga Macho a un CD\nsecret, différent des CD normaux. [1205][000F]J'ai pas\nles détails, mais ça semble intéressant."
+    "texte_fr": "J'ai entendu dire que le Giga Macho a un CD\nsecret, différent des CD normaux. [000F][1205]J'ai pas\nles détails, mais ça semble intéressant."
   },
   {
     "id": 76,
@@ -1423,7 +1423,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Looks[SP]like[SP]Jolly[SP]Roger[SP]in[SP]Kounan[SP]sells[SP]real\nweapons.[SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]check[SP]'em[SP]out...\nTheir[SP]prices[SP]and[SP]quality[SP]seem[SP]pretty[SP]normal.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "On dirait que Jolly Roger à Kounan vend de\nvraies armes. Je pourrais\ny faire un tour...\nLeurs prix et\nleur sélection semblent normaux."
+    "texte_fr": "On dirait que Jolly Roger à Kounan vend de\nvraies armes. Je pourrais\ny faire un tour... Leurs prix et leur sélection semblent normaux."
   },
   {
     "id": 91,
@@ -1438,7 +1438,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Looks[SP]like[SP]Jolly[SP]Roger[SP]in[SP]Kounan[SP]sells[SP]real\nweapons.[SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]check[SP]'em[SP]out...\nTheir[SP]stuff[SP]is[SP]low[SP]quality,[SP]but[SP]cheap.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "On dirait que Jolly Roger à Kounan vend de\nvraies armes. Je pourrais\ny faire un tour...\nY'a du bon matos, mais de basse qualité."
+    "texte_fr": "On dirait que Jolly Roger à Kounan vend de\nvraies armes. Je pourrais\ny faire un tour... Y'a du bon matos, mais de basse qualité."
   },
   {
     "id": 92,
@@ -1468,7 +1468,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Looks[SP]like[SP]Jolly[SP]Roger[SP]in[SP]Kounan[SP]sells[SP]real\nweapons.[SP]Should[SP]I[SP]check[SP]'em[SP]out...?[SP]Their\nselection's[SP]poor,[SP]but[SP]the[SP]resale[SP]value's[SP]high.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "On dirait que Jolly Roger à Kounan vend de\nvraies armes. Et si\nj'y allais? C'est bas de\ngamme, mais le prix de revente est élevé."
+    "texte_fr": "On dirait que Jolly Roger à Kounan vend de\nvraies armes. Et si\nj'y allais? C'est bas de gamme, mais le prix de revente est élevé."
   },
   {
     "id": 94,
@@ -1483,7 +1483,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Looks[SP]like[SP]Jolly[SP]Roger[SP]in[SP]Kounan[SP]sells[SP]real\nweapons.[SP]I[SP]wonder[SP]if[SP]I[SP]should[SP]check[SP]'em[SP]out...\nThey[SP]cost[SP]a[SP]lot,[SP]but[SP]the[SP]quality's[SP]worth[SP]it.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "On dirait que Jolly Roger à Kounan vend de\nvraies armes. Je pourrais\ny faire un tour...\nC'est très cher, mais\nla qualité vaut le coup."
+    "texte_fr": "On dirait que Jolly Roger à Kounan vend de\nvraies armes. Je pourrais\ny faire un tour... C'est très cher, mais la qualité vaut le coup."
   },
   {
     "id": 95,
@@ -1768,7 +1768,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "Looks[SP]like[SP]winners[SP]of[SP]the[SP]magazine[SP]sweepstakes\nget[SP]real[SP]weapons.[SP]I[SP]hear[SP]it's[SP]rare[SP]to[SP]win,[SP]but\nthe[SP]prizes[SP]are[SP]extremely[SP]rare[SP]stuff.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "On dirait que les\nloteries de magazines font\ngagner de vraies armes. Gagner serait rare,\nmais les prix seraient très rares aussi."
+    "texte_fr": "On dirait que les\nloteries de magazines font\ngagner de vraies armes. Gagner serait rare, mais les prix seraient très rares aussi."
   },
   {
     "id": 114,
@@ -1918,7 +1918,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "You[SP]know[SP]that[SP]legendary[SP]weapon[SP]at[SP]Time[SP]Castle?\nSounds[SP]like[SP]a[SP]demon[SP]stole[SP]it.[SP]Which[SP]is[SP]funny,\n'cause[SP]there's[SP]no[SP]such[SP]thing[SP]as[SP]demons.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "T'es au courant pour l'arme légendaire au\nTime Castle? Un démon\nl'aurait volée. Ce qui\nest marrant, car les démons n'existent pas."
+    "texte_fr": "T'es au courant pour l'arme légendaire au\nTime Castle? Un démon\nl'aurait volée. Ce qui est marrant, car les démons n'existent pas."
   },
   {
     "id": 124,
@@ -1963,7 +1963,7 @@
     "nom_orig": "Bored[SP]college[SP]student",
     "texte_orig": "The[SP]second[SP]floor[SP]of[SP]the[SP]secret[SP]lounge[SP]seems[SP]to\nbe[SP]a[SP]huge[SP]maze,[SP]for[SP]some[SP]reason.[SP]But[SP]I've[SP]heard\nsome[SP]people[SP]have[SP]found[SP]great[SP]stuff[SP]there.",
     "nom_fr": "Étudiant ennuyé",
-    "texte_fr": "Le deuxième étage du\nsalon secret semble être\nun énorme labyrinthe,\nva savoir pourquoi. Des\ngens y auraient trouvé de super trucs."
+    "texte_fr": "Le deuxième étage du\nsalon secret semble être\nun énorme labyrinthe, va savoir pourquoi. Des gens y auraient trouvé de super trucs."
   },
   {
     "id": 127,
@@ -1993,7 +1993,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]We[SP]are[SP]the[SP]chosen![1205][000F]\nWe[SP]are[SP]the[SP]master[SP]race!",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[1205][000F][1205][000F][1205][000F]Nyarshtan Nyargashana Vivalba! Nous\nsommes les élus! La race supérieure!"
+    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[000F][1205][000F][1205][000F][1205]Nyarshtan Nyargashana Vivalba! Nous\nsommes les élus! La race supérieure!"
   },
   {
     "id": 129,
@@ -2008,7 +2008,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]*pant*[SP]*pant*[SP]I'm[SP]out\nof[SP]breath...",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[1205][000F][1205][000F]Nyarshtan Nyargashana Vivalba!\nPff... Pff... Plus de souffle..."
+    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[000F][1205][000F][1205]Nyarshtan Nyargashana Vivalba!\nPff... Pff... Plus de souffle..."
   },
   {
     "id": 130,
@@ -2023,7 +2023,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]Won't[SP]you[SP]join[SP]us?\nLet's[SP]pray[SP]together.",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[1205][000F][1205][000F]Nyarshtan Nyargashana Vivalba!\nTu me rejoins? Prions ensemble."
+    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[000F][1205][000F][1205]Nyarshtan Nyargashana Vivalba!\nTu me rejoins? Prions ensemble."
   },
   {
     "id": 131,
@@ -2038,7 +2038,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]It's[SP]not[SP]too[SP]late,[SP]you\nknow.[SP]You[SP]should[SP]join[SP]us!",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba! [1205][000F][1205][000F]Nyarshtan\nNyargashana Vivalba! Rejoins-nous, il\nn'est jamais trop tard pour!"
+    "texte_fr": "Nyarshtan Nyargashana Vivalba! [000F][1205][000F][1205]Nyarshtan\nNyargashana Vivalba! Rejoins-nous, il\nn'est jamais trop tard pour!"
   },
   {
     "id": 132,
@@ -2053,7 +2053,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]All[SP]together[SP]now!",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba! [1205][000F][1205][000F]Nyarshtan\nNyargashana Vivalba! Tous ensemble!"
+    "texte_fr": "Nyarshtan Nyargashana Vivalba! [000F][1205][000F][1205]Nyarshtan\nNyargashana Vivalba! Tous ensemble!"
   },
   {
     "id": 133,
@@ -2068,7 +2068,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]The[SP]light[SP]streaming[SP]from\nSevens[SP]is[SP]a[SP]sign[SP]of[SP]our[SP]evolution!",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba! [1205][000F][1205][000F]Nyarshtan\nNyargashana Vivalba! La lumière émise par\nSeven est le signe de notre évolution!"
+    "texte_fr": "Nyarshtan Nyargashana Vivalba! [000F][1205][000F][1205]Nyarshtan\nNyargashana Vivalba! La lumière émise par\nSeven est le signe de notre évolution!"
   },
   {
     "id": 134,
@@ -2083,7 +2083,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP][1432][NULL][NULL][0014]Vivalba[1432][NULL][NULL][0014][SP]is[SP]short[SP]for\n[1432][NULL][NULL][0014]Viva[SP]Xibalba.[1432][NULL][NULL][0014]",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[1205][000F][1205][000F]Nyarshtan Nyargashana Vivalba!\n[1432][NULL][NULL][0014]Vivalba[1432][NULL][NULL][0014] c'est pour [1432][NULL][NULL][0014]Viva Xibalba.[1432][NULL][NULL][0014]"
+    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[000F][1205][000F][1205]Nyarshtan Nyargashana Vivalba!\n[1432][NULL][NULL][0014]Vivalba[1432][NULL][NULL][0014] c'est pour [1432][NULL][NULL][0014]Viva Xibalba.[1432][NULL][NULL][0014]"
   },
   {
     "id": 135,
@@ -2098,7 +2098,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "That[SP][1432][NULL][NULL][0014]Nyarshtan[SP]Nyargashanna[1432][NULL][NULL][0014][SP]chant...[1205][000F][SP]What\ndoes[SP]it[SP]mean?[1205][000F][SP]Even[SP]I[SP]don't[SP]know.",
     "nom_fr": "Cultiste",
-    "texte_fr": "Ce chant, [1432][NULL][NULL][0014]Nyarshtan Nyargashana[1432][NULL][NULL][0014].[1205][000F][1205][000F]..\nÇa veut dire quoi? Je sais même pas."
+    "texte_fr": "Ce chant, [1432][NULL][NULL][0014]Nyarshtan Nyargashana[1432][NULL][NULL][0014].[000F][1205][000F][1205]..\nÇa veut dire quoi? Je sais même pas."
   },
   {
     "id": 136,
@@ -2113,7 +2113,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]Ow...[1205][000A][SP]Bit[SP]my[SP]tongue...",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba! [1205][000F][1205][000F]Nyarshtan\nNyargashana Vivalba! Aïe...[1205][000A] Ma langue..."
+    "texte_fr": "Nyarshtan Nyargashana Vivalba! [000F][1205][000F][1205]Nyarshtan\nNyargashana Vivalba! Aïe...[000A][1205] Ma langue..."
   },
   {
     "id": 137,
@@ -2128,7 +2128,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]Ow![1205][000A][SP]I[SP]bit[SP]my[SP]tongue\nagain...",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba! [1205][000F][1205][000F]Nyarshtan\nNyargashana Vivalba! Aïe![1205][000A] Me suis encore\nmordu..."
+    "texte_fr": "Nyarshtan Nyargashana Vivalba! [000F][1205][000F][1205]Nyarshtan\nNyargashana Vivalba! Aïe![000A][1205] Me suis encore\nmordu..."
   },
   {
     "id": 138,
@@ -2143,7 +2143,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivaldi![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivaldi![1205][000F][SP]Huh...?[1205][000A][SP]My[SP]chant[SP]is\ndifferent[SP]from[SP]everyone[SP]else's?",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivaldi!\n[1205][000F][1205][000F]Nyarshtan Nyargashana Vivaldi! Hein...?[1205][000A]\nMon chant différe de celui des autres?"
+    "texte_fr": "Nyarshtan Nyargashana Vivaldi!\n[000F][1205][000F][1205]Nyarshtan Nyargashana Vivaldi! Hein...?[000A][1205]\nMon chant différe de celui des autres?"
   },
   {
     "id": 139,
@@ -2158,7 +2158,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Revolver![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Revolver![1205][000F][SP]Huh...?[1205][000A][SP]Mine[SP]is[SP]still\ndifferent?",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Revolver!\n[1205][000F][1205][000F]Nyarshtan Nyargashana Revolver!\nHein...?[1205][000A] C'est encore différent?"
+    "texte_fr": "Nyarshtan Nyargashana Revolver!\n[000F][1205][000F][1205]Nyarshtan Nyargashana Revolver!\nHein...?[000A][1205] C'est encore différent?"
   },
   {
     "id": 140,
@@ -2173,7 +2173,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]The[SP]cadence[SP]is[SP]important.\nListen[SP]and[SP]follow[SP]the[SP]rhythm.",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba! [1205][000F][1205][000F]Nyarshtan\nNyargashana Vivalba! Il faut tenir le\nrythme et la cadence. C'est important."
+    "texte_fr": "Nyarshtan Nyargashana Vivalba! [000F][1205][000F][1205]Nyarshtan\nNyargashana Vivalba! Il faut tenir le\nrythme et la cadence. C'est important."
   },
   {
     "id": 141,
@@ -2188,7 +2188,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]The[SP]heralded[SP]hour[SP]of\nevolution![1205][000A][SP]Behold!",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[1205][000F][1205][000F]Nyarshtan Nyargashana Vivalba!\nAdmirez![1205][000A] Voici l'heure de l'évolution!"
+    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[000F][1205][000F][1205]Nyarshtan Nyargashana Vivalba!\nAdmirez![000A][1205] Voici l'heure de l'évolution!"
   },
   {
     "id": 142,
@@ -2203,7 +2203,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]Thank[SP]goodness...\nWe[SP]don't[SP]have[SP]to[SP]die[SP]anymore!",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[1205][000F][1205][000F]Nyarshtan Nyargashana Vivalba! Dieu\nmerci... On a plus besoin de mourir!"
+    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[000F][1205][000F][1205]Nyarshtan Nyargashana Vivalba! Dieu\nmerci... On a plus besoin de mourir!"
   },
   {
     "id": 143,
@@ -2218,7 +2218,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]It's[SP]the[SP]beginning[SP]of\nthe[SP]end[SP]for[SP]our[SP]world.",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[1205][000F][1205][000F]Nyarshtan Nyargashana Vivalba!\nC'est le début de la fin du monde."
+    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[000F][1205][000F][1205]Nyarshtan Nyargashana Vivalba!\nC'est le début de la fin du monde."
   },
   {
     "id": 144,
@@ -2233,7 +2233,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]There[SP]is[SP]no[SP]need[SP]for\nthe[SP]weak,[SP]or[SP]for[SP]this[SP]earth!",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[1205][000F][1205][000F]Nyarshtan Nyargashana Vivalba! Plus\nbesoin de faibles, ou même de terre!"
+    "texte_fr": "Nyarshtan Nyargashana Vivalba!\n[000F][1205][000F][1205]Nyarshtan Nyargashana Vivalba! Plus\nbesoin de faibles, ou même de terre!"
   },
   {
     "id": 145,
@@ -2248,7 +2248,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]Farewell,[SP]world!\nFarewell,[SP]humans!",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba! [1205][000F][1205][000F]Nyarshtan\nNyargashana Vivalba! Adieu, monde! Adieu,\nhumains!"
+    "texte_fr": "Nyarshtan Nyargashana Vivalba! [000F][1205][000F][1205]Nyarshtan\nNyargashana Vivalba! Adieu, monde! Adieu,\nhumains!"
   },
   {
     "id": 146,
@@ -2263,7 +2263,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]We[SP]will[SP]be[SP]reborn!",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba! [1205][000F][1205][000F]Nyarshtan\nNyargashana Vivalba! Nous renaîtrons!"
+    "texte_fr": "Nyarshtan Nyargashana Vivalba! [000F][1205][000F][1205]Nyarshtan\nNyargashana Vivalba! Nous renaîtrons!"
   },
   {
     "id": 147,
@@ -2278,7 +2278,7 @@
     "nom_orig": "Cultist",
     "texte_orig": "Nyarshtan[SP]Nyargashanna[SP]Vivalba![1205][000F][SP]Nyarshtan\nNyargashanna[SP]Vivalba![1205][000F][SP]Evolution![SP]EVOLUTION!",
     "nom_fr": "Cultiste",
-    "texte_fr": "Nyarshtan Nyargashana Vivalba! [1205][000F][1205][000F]Nyarshtan\nNyargashana Vivalba! Évolution! ÉVOLUTION!"
+    "texte_fr": "Nyarshtan Nyargashana Vivalba! [000F][1205][000F][1205]Nyarshtan\nNyargashana Vivalba! Évolution! ÉVOLUTION!"
   },
   {
     "id": 148,
@@ -2353,7 +2353,7 @@
     "nom_orig": "Cult[SP]founder",
     "texte_orig": "Ah![SP]See,[SP]my[SP]brethren![1205][000F][SP]An[SP]arrow[SP]of[SP]light[SP]has[SP]been\nloosed[SP]from[SP]the[SP]school[SP]burdened[SP]with[SP]the[SP]fate[SP]of\nthe[SP]seven[SP]sisters![1205][000F][SP]Our[SP]evolution[SP]begins!",
     "nom_fr": "Chef du culte",
-    "texte_fr": "Ah! Voyez, mes frères!\n[1205][000F][1205][000F]Une flèche de lumière\nfut tirée de l'école portant le fardeau du\ndestin des sept\nsoeurs! Notre évolutiondémarre!"
+    "texte_fr": "Ah! Voyez, mes frères!\n[000F][1205][000F][1205]Une flèche de lumière\nfut tirée de l'école portant le fardeau du destin des sept soeurs! Notre évolutiondémarre!"
   },
   {
     "id": 153,
@@ -2368,7 +2368,7 @@
     "nom_orig": "Cult[SP]founder",
     "texte_orig": "Now[SP]is[SP]when[SP]we[SP]shall[SP]become[SP]Idealians![1205][000F]\nPrepare[SP]yourselves!",
     "nom_fr": "Chef du culte",
-    "texte_fr": "Préparez-vous! Nous allons\n[1205][000F]devenir des Idéaliens!"
+    "texte_fr": "Préparez-vous! Nous allons\n[000F][1205]devenir des Idéaliens!"
   },
   {
     "id": 154,

--- a/traduction/event_scripts/script_286.json
+++ b/traduction/event_scripts/script_286.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "H-Hey...[1205][001E][SP]I'm[SP]getting[SP]some[SP]bad[SP]mojo[SP]from[SP]Dads\nhere.[SP]H-He's[SP]not[SP]interested[SP]in[SP]me[SP]or[SP]anything,\ni-is[SP]he?",
     "nom_fr": "Eikichi",
-    "texte_fr": "H-Hé...[1205][001E] Ce père me donne de mauvaises\nvibrations. I-Il ne\ns'intéresse pas à moi...\nn-non?"
+    "texte_fr": "H-Hé...[001E][1205] Ce père me donne de mauvaises\nvibrations. I-Il ne\ns'intéresse pas à moi... n-non?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "A[SP]traditional[SP]haori[SP]coat[SP]and[SP]a[SP]Japanese-style\nhome...[SP]I[SP]wonder[SP]what[SP]he[SP]thinks[SP]is[SP]so[SP]great\nabout[SP]this[SP]country.[SP]I[SP]don't[SP]get[SP]it[SP]at[SP]all.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Un haori traditionnel et une maison\njaponaise... Je me demande\nce qu'il trouve si \nformidable dans ce\npays. Je n'y comprendsrien."
+    "texte_fr": "Un haori traditionnel et une maison\njaponaise... Je me demande\nce qu'il trouve si formidable dans ce pays. Je n'y comprendsrien."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Japanese[SP]dancing,[SP]huh...?[1205][000F][SP]Ooooh...[SP]Maybe[SP]he\ntaught[SP]it[SP]to[SP]Ginko,[SP]and[SP]she's[SP]secretly[SP]really\ngood[SP]at[SP]it.",
     "nom_fr": "Eikichi",
-    "texte_fr": "La danse japonaise, hein.[1205][000F]..?\nOhhh... Il l'a peut-être appris à\nGinko qui est très douée en secret."
+    "texte_fr": "La danse japonaise, hein.[000F][1205]..?\nOhhh... Il l'a peut-être appris à\nGinko qui est très douée en secret."
   },
   {
     "id": 3,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey[SP][1113],[SP]looks[SP]like[SP]Dads[SP]doesn't[SP]know\nabout[SP]his[SP]daughter's[SP]little[SP]debut.[1205][000F][SP]Should[SP]we\ntell[SP]him?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, [1113], le père ne semble pas au courant\ndu petit début de sa fille. [1205][000F]On lui dit?"
+    "texte_fr": "Hé, [1113], le père ne semble pas au courant\ndu petit début de sa fille. [000F][1205]On lui dit?"
   },
   {
     "id": 7,
@@ -207,7 +207,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Sheesh![SP]Sitting[SP]with[SP]your[SP]legs[SP]folded[SP]all\nthe[SP]time[SP]screws[SP]you[SP]up![SP]And[SP]he[SP]keeps[SP]wasting\nmoney[SP]on[SP]junk[SP]like[SP]bonsai[SP]and[SP]pottery,[SP]too!",
     "nom_fr": "Lisa",
-    "texte_fr": "Pfff! Rester assis les jambes croisées tout\nle temps, ça abîme! Et il continue à \ngaspiller son argent\nen bonsaïs et poteries!"
+    "texte_fr": "Pfff! Rester assis les jambes croisées tout\nle temps, ça abîme! Et il continue à \ngaspiller son argent en bonsaïs et poteries!"
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Sheesh![SP]Sitting[SP]with[SP]your[SP]legs[SP]folded[SP]all\nthe[SP]time[SP]screws[SP]you[SP]up![SP]And[SP]he[SP]keeps[SP]wasting\nmoney[SP]on[SP]junk[SP]like[SP]bonsai[SP]and[SP]pottery,[SP]too!",
     "nom_fr": "Ginko",
-    "texte_fr": "Pfff! Rester assis les jambes croisées tout\nle temps, ça abîme! Et il continue à \ngaspiller son argent\nen bonsaïs et poteries!"
+    "texte_fr": "Pfff! Rester assis les jambes croisées tout\nle temps, ça abîme! Et il continue à \ngaspiller son argent en bonsaïs et poteries!"
   },
   {
     "id": 15,
@@ -372,7 +372,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "If[SP]even[SP]my[SP]old[SP]man[SP]knows,[SP]that[SP]shows[SP]how[SP]far\nthe[SP]rumor's[SP]spread,[SP]right?[SP]Why[SP]is[SP]everyone[SP]so\nwilling[SP]to[SP]believe[SP]in[SP]the[SP]Last[SP]Battalion?",
     "nom_fr": "Ginko",
-    "texte_fr": "Si même mon vieux est au courant, ça montre\nà quel point la\nrumeur s'est répandue, non?\nPourquoi tout le monde croit au Bataillon?"
+    "texte_fr": "Si même mon vieux est au courant, ça montre\nà quel point la\nrumeur s'est répandue, non? Pourquoi tout le monde croit au Bataillon?"
   },
   {
     "id": 25,
@@ -432,7 +432,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Wow,[SP]she[SP]must[SP]really[SP]hate[SP]him.[1205][001E][SP]There's[SP]gotta\nbe[SP]some[SP]deep-seated[SP]reason[SP]for[SP]that.",
     "nom_fr": "Maya",
-    "texte_fr": "Wow, elle doit vraiment le détester.[1205][001E] Il\ny a sûrement une raison profonde à ça."
+    "texte_fr": "Wow, elle doit vraiment le détester.[001E][1205] Il\ny a sûrement une raison profonde à ça."
   },
   {
     "id": 29,
@@ -522,7 +522,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Lisa...[1205][000F][SP]She's[SP]right.[SP]We[SP]need[SP]to[SP]save[SP]those\ngirls.[SP]Them,[SP]Eikichi's[SP]friends,[SP]and[SP]everyone\nelse[SP]in[SP]the[SP]city.",
     "nom_fr": "Maya",
-    "texte_fr": "Lisa.[1205][000F].. Elle a raison. On doit sauver\nces filles, les amis d'Eikichi et\ntout le monde dans la ville."
+    "texte_fr": "Lisa.[000F][1205].. Elle a raison. On doit sauver\nces filles, les amis d'Eikichi et\ntout le monde dans la ville."
   },
   {
     "id": 35,
@@ -582,7 +582,7 @@
     "nom_orig": "Maya",
     "texte_orig": "People's[SP]hearts[SP]try[SP]to[SP]protect[SP]their[SP]ego.[SP]When\na[SP]crisis[SP]arises[SP]that[SP]threatens[SP]to[SP]destroy[SP]it,\nthey[SP]create[SP]false[SP]memories[SP]as[SP]a[SP]defense.",
     "nom_fr": "Maya",
-    "texte_fr": "Le cœur des gens cherche à protéger l'ego.\nQuand une crise menace de le détruire, ils\ncréent de faux souvenirs\nen guise de défense."
+    "texte_fr": "Le cœur des gens cherche à protéger l'ego.\nQuand une crise menace de le détruire, ils\ncréent de faux souvenirs en guise de défense."
   },
   {
     "id": 39,
@@ -612,7 +612,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Dad...[1205][000F][SP]I[SP]wish...[1205][000F][SP]I[SP]wish[SP]my[SP]dad[SP]had[SP]cared\nabout[SP]protecting[SP]his[SP]home,[SP]too...",
     "nom_fr": "Maya",
-    "texte_fr": "Papa.[1205][000F][1205][000F].. J'aurais voulu... Que mon\npère protège les siens aussi..."
+    "texte_fr": "Papa.[000F][1205][000F][1205].. J'aurais voulu... Que mon\npère protège les siens aussi..."
   },
   {
     "id": 41,
@@ -627,7 +627,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "This[SP]place[SP]is[SP]like[SP]a[SP]mansion![1205][001E][SP]You[SP]don't[SP]see\nauthentic[SP]Japanese[SP]architecture[SP]like[SP]this[SP]much\nanymore.[SP]This'd[SP]make[SP]a[SP]great[SP]photo...",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est comme un manoir![1205][001E]\nOn ne voit plus souvent\nune architecture\njaponaise authentique comme\nça. Ça ferait une belle photo..."
+    "texte_fr": "C'est comme un manoir![001E][1205]\nOn ne voit plus souvent\nune architecture japonaise authentique comme ça. Ça ferait une belle photo..."
   },
   {
     "id": 42,
@@ -642,7 +642,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Fathers,[SP]huh?[1205][001E][SP]I[SP]did[SP]pretty[SP]much[SP]everything\non[SP]my[SP]own,[SP]so[SP]I[SP]don't[SP]really[SP]feel[SP]the[SP]need[SP]for\none...",
     "nom_fr": "Yukino",
-    "texte_fr": "Les pères, hein?[1205][001E] J'ai fait\npresque tout seule, donc je n'en\nressens pas vraiment le besoin..."
+    "texte_fr": "Les pères, hein?[001E][1205] J'ai fait\npresque tout seule, donc je n'en\nressens pas vraiment le besoin..."
   },
   {
     "id": 43,
@@ -732,7 +732,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Her[SP]two[SP]friends[SP]must've[SP]helped[SP]get[SP]rid[SP]of[SP]the\nshell[SP]over[SP]Lisa's[SP]heart.[1205][000F][SP]Just[SP]like[SP]mine[SP]did\nback[SP]then...",
     "nom_fr": "Yukino",
-    "texte_fr": "Ses amies ont brisé\nla coquille autour du cœur\nde Lisa. [1205]Tout comme\n[000F]les miennes à l'époque..."
+    "texte_fr": "Ses amies ont brisé\nla coquille autour du cœur\nde Lisa. [1205]Tout comme [000F]les miennes à l'époque..."
   },
   {
     "id": 49,
@@ -747,7 +747,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Maya-san,[SP]are[SP]you[SP]sure[SP]letting[SP]that[SP]Ixquic[SP]girl\ngo[SP]was[SP]the[SP]right[SP]thing[SP]to[SP]do?[SP]I[SP]have[SP]a[SP]sinking\nfeeling[SP]she'll[SP]be[SP]back[SP]to[SP]harass[SP]us[SP]again...",
     "nom_fr": "Yukino",
-    "texte_fr": "Maya-san, tu es sûre qu'il était juste de\nlaisser cette Ixquic partir?\nJ'ai un mauvais \npressentiment qu'elle\nreviendra nousharceler..."
+    "texte_fr": "Maya-san, tu es sûre qu'il était juste de\nlaisser cette Ixquic partir?\nJ'ai un mauvais pressentiment qu'elle reviendra nousharceler..."
   },
   {
     "id": 50,
@@ -762,7 +762,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "The[SP]Last[SP]Battalion[SP]was[SP]the[SP]Fuhrer's[SP]special\nunit[SP]from[SP]way[SP]back,[SP]right?[SP]Why[SP]would[SP]people\nthink[SP]they[SP]were[SP]the[SP]ones[SP]who[SP]did[SP]this?",
     "nom_fr": "Yukino",
-    "texte_fr": "Le Bataillon était\nl'unité spéciale du Führer\nde jadis, non? Pourquoi les gens\npenseraient-ils qu'ils sont\nderrière tout ça?"
+    "texte_fr": "Le Bataillon était\nl'unité spéciale du Führer\nde jadis, non? Pourquoi les gens penseraient-ils qu'ils sont derrière tout ça?"
   },
   {
     "id": 51,
@@ -777,7 +777,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "What's[SP]wrong[SP]with[SP]Eikichi[SP]and[SP]Lisa?[SP]They've[SP]been\nacting[SP]funny[SP]ever[SP]since[SP]we[SP]left[SP]the[SP]detective\nagency.[1205][000F][SP]Did[SP]something[SP]happen[SP]to[SP]you[SP]guys?",
     "nom_fr": "Yukino",
-    "texte_fr": "Qu'est-ce qui ne va\npas avec Eikichi et Lisa?\nIls se comportent\nbizarrement depuis qu'on a\n[1205][000F]quitté l'agence. Quelque chose s'est passé?"
+    "texte_fr": "Qu'est-ce qui ne va\npas avec Eikichi et Lisa?\nIls se comportent bizarrement depuis qu'on a [000F][1205]quitté l'agence. Quelque chose s'est passé?"
   },
   {
     "id": 52,
@@ -792,7 +792,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]wonder[SP]how[SP]many[SP]of[SP]them[SP]there[SP]are.[1205][000F][SP]Seriously,\nthey[SP]keep[SP]showing[SP]up,[SP]one[SP]after[SP]another...",
     "nom_fr": "Yukino",
-    "texte_fr": "Je me demande\ncombien ils sont. [1205][000F]Sérieusement,\nils n'arrêtent pas d'apparaître..."
+    "texte_fr": "Je me demande\ncombien ils sont. [000F][1205]Sérieusement,\nils n'arrêtent pas d'apparaître..."
   },
   {
     "id": 53,
@@ -863,7 +863,7 @@
     "nom_orig": "Lisa's[SP]father",
     "texte_orig": "The[SP]sweepstakes,[SP]you[SP]say?[SP]There[SP]have[SP]been[SP]no\ndeliveries...[SP]Are[SP]you[SP]early,[SP]perhaps?[SP]Why[SP]not\ncome[SP]back[SP]after[SP]the[SP]passing[SP]of[SP]some[SP]time?",
     "nom_fr": "Père de Lisa",
-    "texte_fr": "Le tirage au sort, vous dites? Il n'y a pas\neu de livraison... Êtes-vous en avance?\nRevenez après quelque\ntemps, s'il vous plaît."
+    "texte_fr": "Le tirage au sort, vous dites? Il n'y a pas\neu de livraison... Êtes-vous en avance?\nRevenez après quelque temps, s'il vous plaît."
   },
   {
     "id": 57,
@@ -878,7 +878,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "The[SP]sweepstakes,[SP]you[SP]say?[SP]There[SP]have[SP]been[SP]no\ndeliveries...[SP]Are[SP]you[SP]early,[SP]perhaps?[SP]Why[SP]not\ncome[SP]back[SP]after[SP]the[SP]passing[SP]of[SP]some[SP]time?",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Le tirage au sort, vous dites? Il n'y a pas\neu de livraison... Êtes-vous en avance?\nRevenez après quelque\ntemps, s'il vous plaît."
+    "texte_fr": "Le tirage au sort, vous dites? Il n'y a pas\neu de livraison... Êtes-vous en avance?\nRevenez après quelque temps, s'il vous plaît."
   },
   {
     "id": 58,
@@ -923,7 +923,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "The[SP]sweepstakes,[SP]you[SP]say?[SP]Ah,[SP]yes,[SP]of[SP]course.\nThis[SP]was[SP]delivered[SP]here.[SP]Go[SP]on,[SP]take[SP]it.",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Le tirage au sort,\nvous dites? Ah, oui, bien\nsûr. On vous l'a\nlivré ici. Allez, prenez-le. \nLettre [NULL][NULL]Merci de votre participation au\ntirage. Hélas, vous n'êtes pas gagnant\ncettefois. Nous vous encourageons à continuer![NULL][NULL]"
+    "texte_fr": "Le tirage au sort,\nvous dites? Ah, oui, bien\nsûr. On vous l'a livré ici. Allez, prenez-le. Lettre [NULL][NULL]Merci de votre participation au tirage. Hélas, vous n'êtes pas gagnant cettefois. Nous vous encourageons à continuer![NULL][NULL]"
   },
   {
     "id": 61,
@@ -938,7 +938,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "The[SP]sweepstakes,[SP]you[SP]say?[SP]Ah,[SP]yes,[SP]of[SP]course.\nThis[SP]was[SP]delivered[SP]here.[SP]Go[SP]on,[SP]take[SP]it.",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Le tirage au sort,\nvous dites? Ah, oui, bien\nsûr. On vous l'a\nlivré ici. Allez, prenez-le. \nLettre [NULL][NULL]Merci de votre participation au\ntirage. Félicitations! Vous avez étésélectionné\ncomme gagnant! [NULL][NULL]Veuillez accepter [E4][NULL][NULL][NULL][E4][NULL][NULL]\nen guise de prix. Continuez à participer![NULL][NULL] \nVous n'avez pas de\nplace pour un(e) autre [E4][NULL][NULL][NULL][E4][NULL][NULL]..."
+    "texte_fr": "Le tirage au sort,\nvous dites? Ah, oui, bien\nsûr. On vous l'a livré ici. Allez, prenez-le. Lettre [NULL][NULL]Merci de votre participation au tirage. Félicitations! Vous avez étésélectionné comme gagnant! [NULL][NULL]Veuillez accepter [E4][NULL][NULL][NULL][E4][NULL][NULL] en guise de prix. Continuez à participer![NULL][NULL] Vous n'avez pas de place pour un(e) autre [E4][NULL][NULL][NULL][E4][NULL][NULL]..."
   },
   {
     "id": 62,
@@ -953,7 +953,7 @@
     "nom_orig": "Lisa's[SP]father",
     "texte_orig": "I[SP]see[SP]now![SP]This[SP]must[SP]be[SP]that[SP]wastrel[SP]blue-head's\nfault.[SP]I[SP]hear[SP]that[SP]a[SP]child's[SP]delinquency[SP]is\ngreatly[SP]affected[SP]by[SP]the[SP]company[SP]she[SP]keeps.",
     "nom_fr": "Père de Lisa",
-    "texte_fr": "Je vois! Ce doit être\nla faute de ce vaurien\naux cheveux bleus. La\ndélinquance d'un enfant\nest très influencée par ses fréquentations."
+    "texte_fr": "Je vois! Ce doit être\nla faute de ce vaurien\naux cheveux bleus. La délinquance d'un enfant est très influencée par ses fréquentations."
   },
   {
     "id": 63,
@@ -983,7 +983,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "I[SP]see[SP]now![SP]This[SP]must[SP]be[SP]that[SP]wastrel[SP]blue-head's\nfault.[SP]I[SP]hear[SP]that[SP]a[SP]child's[SP]delinquency[SP]is\ngreatly[SP]affected[SP]by[SP]the[SP]company[SP]she[SP]keeps.",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Je vois! Ce doit être\nla faute de ce vaurien\naux cheveux bleus. La\ndélinquance d'un enfant\nest très influencée par ses fréquentations."
+    "texte_fr": "Je vois! Ce doit être\nla faute de ce vaurien\naux cheveux bleus. La délinquance d'un enfant est très influencée par ses fréquentations."
   },
   {
     "id": 65,
@@ -1013,7 +1013,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "The[SP]strange[SP]illness[SP]befalling[SP]Seven[SP]Sisters\nHigh[SP]seems[SP]to[SP]have[SP]calmed.[SP]I[SP]was[SP]worried[SP]Lisa\nmight[SP]contract[SP]it,[SP]but[SP]it's[SP]over[SP]and[SP]done[SP]now.",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "L'étrange maladie du Lycée Seven Sisters\nsemble s'être calmée. Je craignais que Lisa\nne l'attrape, mais\nc'est terminé maintenant."
+    "texte_fr": "L'étrange maladie du Lycée Seven Sisters\nsemble s'être calmée. Je craignais que Lisa\nne l'attrape, mais c'est terminé maintenant."
   },
   {
     "id": 67,
@@ -1028,7 +1028,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "Kasugayama[SP]High[SP]is[SP]throwing[SP]a[SP]masquerade,[SP]eh?\nHow[SP]regrettable[SP]that[SP]such[SP]a[SP]foreign[SP]event[SP]will\nbe[SP]taking[SP]place[SP]at[SP]a[SP]Japanese[SP]school...",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Kasugayama organise un\nbal masqué, vraiment?\nQuelle regrettable idée\nqu'un tel événement\nétranger se tienne dans un lycée japonais."
+    "texte_fr": "Kasugayama organise un\nbal masqué, vraiment?\nQuelle regrettable idée qu'un tel événement étranger se tienne dans un lycée japonais."
   },
   {
     "id": 68,
@@ -1043,7 +1043,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "Don't[SP]you[SP]think[SP]Japanese[SP]dances[SP]are[SP]better?\nAs[SP]the[SP]young[SP]will[SP]shape[SP]this[SP]country's[SP]future,\nI[SP]wish[SP]they[SP]were[SP]better[SP]learned[SP]in[SP]its[SP]ways...",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "La danse japonaise\nn'est-elle pas préférable?\nLes jeunes façonneront l'avenir du pays,\nj'aurais aimé\nqu'ils maîtrisent sestraditions..."
+    "texte_fr": "La danse japonaise\nn'est-elle pas préférable?\nLes jeunes façonneront l'avenir du pays, j'aurais aimé qu'ils maîtrisent sestraditions..."
   },
   {
     "id": 69,
@@ -1058,7 +1058,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "Masked[SP]Circle?[1205][000F][SP]Hmm...[SP]I've[SP]never[SP]heard[SP]of[SP]such\na[SP]thing.[SP]Perhaps[SP]you've[SP]confused[SP]it[SP]for[SP]the\nmasked[SP]circus?",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Le Cercle masqué? [1205][000F]Hmm... Jamais\nentendu parler d'une telle chose.\nVous confondez avec un cirque masqué?"
+    "texte_fr": "Le Cercle masqué? [000F][1205]Hmm... Jamais\nentendu parler d'une telle chose.\nVous confondez avec un cirque masqué?"
   },
   {
     "id": 70,
@@ -1103,7 +1103,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "Where[SP]is[SP]Lisa?[SP]Was[SP]she[SP]not[SP]with[SP]you?[1205][000F][SP]Hm?\nAn[SP]idol[SP]group?[SP]Hahaha,[SP]alas,[SP]my[SP]musical\nawareness[SP]extends[SP]only[SP]to[SP]enka[SP]ballads.",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Où est Lisa? N'était-elle pas avec vous?\n[1205][000F]Hm? Un groupe d'idoles? Hélas, ma culture\nmusicale se limite aux ballades enka."
+    "texte_fr": "Où est Lisa? N'était-elle pas avec vous?\n[000F][1205]Hm? Un groupe d'idoles? Hélas, ma culture\nmusicale se limite aux ballades enka."
   },
   {
     "id": 73,
@@ -1118,7 +1118,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "Hm...[1205][000A][SP]Despite[SP]this[SP]wave[SP]of[SP]terrorism,[SP]Lisa\nwishes[SP]to[SP]go[SP]out...[SP]Her[SP]eyes[SP]have[SP]the[SP]gleam[SP]of\none[SP]whose[SP]resolve[SP]is[SP]strong[SP]as[SP]steel...",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Hm...[1205][000A] Malgré cette\nvague de terrorisme, Lisa\nsouhaite sortir... Son regard a l'éclat de\nquelqu'un à la résolution d'acier..."
+    "texte_fr": "Hm...[000A][1205] Malgré cette\nvague de terrorisme, Lisa\nsouhaite sortir... Son regard a l'éclat de quelqu'un à la résolution d'acier..."
   },
   {
     "id": 74,
@@ -1133,7 +1133,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "I[SP]believe[SP]Lisa[SP]has[SP]learned[SP]something[SP]vital.[SP]It\nis[SP]a[SP]father's[SP]duty[SP]to[SP]silently[SP]let[SP]her[SP]have[SP]her\nway...[SP]I[SP]pray[SP]for[SP]your[SP]safe[SP]return,[SP]my[SP]daughter.",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Je crois que Lisa a appris quelque\nchose vital. C'est le devoir d'un\npère de la laisser agir en\nsilence...Je prie pour ton retour, ma fille."
+    "texte_fr": "Je crois que Lisa a appris quelque\nchose vital. C'est le devoir d'un\npère de la laisser agir en silence...Je prie pour ton retour, ma fille."
   },
   {
     "id": 75,
@@ -1148,7 +1148,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "I[SP]hear[SP]of[SP]a[SP]small[SP]band[SP]who[SP]stopped[SP]the[SP]bombing\nof[SP]Smile[SP]Hirasaka.[SP]That[SP]willingness[SP]to[SP]risk\ntheir[SP]lives...[SP]They[SP]are[SP]true[SP]children[SP]of[SP]Japan!",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "J'entends parler d'un petit groupe qui a\nstoppé l'attentat de\nSmile Hirasaka. Vouloir\nrisquer leurs vies...\nDe vrais enfants duJapon!"
+    "texte_fr": "J'entends parler d'un petit groupe qui a\nstoppé l'attentat de\nSmile Hirasaka. Vouloir risquer leurs vies... De vrais enfants duJapon!"
   },
   {
     "id": 76,
@@ -1193,7 +1193,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "What[SP]is[SP]the[SP]matter[SP]with[SP]Lisa?[SP]I've[SP]never[SP]known\nher[SP]expression[SP]to[SP]be[SP]so[SP]pained...[SP]Well,[SP]save\nperhaps[SP]for[SP]once[SP]in[SP]the[SP]past...",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Qu'est-ce qui ne va pas avec Lisa? Je\nn'avais jamais vu\nce visage si douloureux...\nSauf peut-être une fois, autrefois..."
+    "texte_fr": "Qu'est-ce qui ne va pas avec Lisa? Je\nn'avais jamais vu\nce visage si douloureux... Sauf peut-être une fois, autrefois..."
   },
   {
     "id": 79,

--- a/traduction/event_scripts/script_287.json
+++ b/traduction/event_scripts/script_287.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Looks[SP]like[SP]whoever[SP]takes[SP]a[SP]chance[SP]on[SP]Ginko\nisn't[SP]getting[SP]away[SP]clean...[1205][000F][SP]He'd[SP]be[SP]risking\nhis[SP]life[SP]for[SP]love.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Quiconque tente sa chance\navec Ginko s'en sort\npas indemne.[1205][000F].. Il risque\nsa vie pour l'amour."
+    "texte_fr": "Quiconque tente sa chance\navec Ginko s'en sort\npas indemne.[000F][1205].. Il risque sa vie pour l'amour."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Might[SP]as[SP]well[SP]save[SP]that[SP]teacher[SP]and[SP]the[SP]guys\nat[SP]Sevens[SP]all[SP]at[SP]once.[1205][000F][SP]Heroes[SP]never[SP]leave\nanyone[SP]behind!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Autant sauver ce prof et les gars\nde Seven d'un coup. Les héros\n[1205][000F]n'abandonnent jamais personne!"
+    "texte_fr": "Autant sauver ce prof et les gars\nde Seven d'un coup. Les héros\n[000F][1205]n'abandonnent jamais personne!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Panicking[SP]won't[SP]do[SP]us[SP]any[SP]good.[1205][000F][SP]We[SP]know\nthey're[SP]both[SP]in[SP]there.[1205][000F][SP]Let's[SP]corner[SP]them\nand[SP]make[SP]them[SP]quit[SP]this[SP]crap!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Paniquer ne sert à\n[1205][1205]rien. [000F][000F]On sait qu'ils sont\nlà. Acculons-les et obligeons-les à arrêter\nça!"
+    "texte_fr": "Paniquer ne sert à\n[1205][1205]rien. [000F][000F]On sait qu'ils sont\nlà. Acculons-les et obligeons-les à arrêter ça!"
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]wonder[SP]if[SP]Ms.[SP]Saeko[SP]and[SP]the[SP]others[SP]are[SP]okay.[1205][000F]\nThe[SP]Last[SP]Battalion's[SP]pretty[SP]ruthless...[1205][000F][SP]I[SP]hope\nshe[SP]doesn't[SP]try[SP]anything[SP]stupid...",
     "nom_fr": "Ginko",
-    "texte_fr": "Je me demande si Mme Saeko et les autres\n[1205][000F][1205][000F]vont bien. Le Bataillon est sans pitié...\nJ'espère qu'elle fait pas de bêtises..."
+    "texte_fr": "Je me demande si Mme Saeko et les autres\n[000F][1205][000F][1205]vont bien. Le Bataillon est sans pitié...\nJ'espère qu'elle fait pas de bêtises..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hmm...[1205][000A][SP]That[SP]Fuhrer[SP]and[SP]Jun's[SP]dad[SP]are[SP]nowhere\nto[SP]be[SP]found.[1205][000F][SP]Where[SP]are[SP]they?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hmm.[1205]..[1205][000A] Le Führer et le père de Jun\nsont introuvables. [000F]Où sont-ils?"
+    "texte_fr": "Hmm.[1205]..[000A][1205] Le Führer et le père de Jun\nsont introuvables. [000F]Où sont-ils?"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Did[SP]Lisa's[SP]father[SP]defeat[SP]the[SP]Last[SP]Battalion[SP]\nwith[SP]his[SP]bare[SP]hands?[1205][000A][SP]That's[SP]amazing...[1205][000F][SP]I[SP]don't\nknow[SP]if[SP]even[SP]my[SP]Persona's[SP]that[SP]strong.",
     "nom_fr": "Maya",
-    "texte_fr": "Le père de Lisa a battu le Bataillon à\nmains nues?[1205][1205][000A] C'est incroyable.[000F].. Ma\nPersona n'est peut-être pas aussi forte."
+    "texte_fr": "Le père de Lisa a battu le Bataillon à\nmains nues?[1205][000A][1205] C'est incroyable.[000F].. Ma\nPersona n'est peut-être pas aussi forte."
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]true[SP]that[SP]Xibalba[SP]has[SP]a[SP]disturbing\natmosphere...[1205][000A][SP]like[SP]someone's[SP]always[SP]watching\nus[SP]there...",
     "nom_fr": "Maya",
-    "texte_fr": "C'est vrai, Xibalba a une ambiance\ntroublante...[1205][000A] Comme si quelqu'un\nnous regardait toujours..."
+    "texte_fr": "C'est vrai, Xibalba a une ambiance\ntroublante...[000A][1205] Comme si quelqu'un\nnous regardait toujours..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It[SP]could[SP]still[SP]be[SP]hiding[SP]some[SP]secrets[SP]we're\nnot[SP]prepared[SP]for.[1205][000A][SP]It[SP]might[SP]be[SP]best[SP]to[SP]be\nvery[SP]careful[SP]as[SP]we[SP]go[SP]through[SP]it...",
     "nom_fr": "Maya",
-    "texte_fr": "Il cache peut-être des secrets pour\nlesquels on n'est pas prêt.[1205][000A] Mieux vaut\nêtre très prudent en le traversant..."
+    "texte_fr": "Il cache peut-être des secrets pour\nlesquels on n'est pas prêt.[000A][1205] Mieux vaut\nêtre très prudent en le traversant..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Jun",
     "texte_orig": "So[SP]that's[SP]Lisa's[SP]father...[1205][000F][SP]I[SP]vaguely[SP]remember\nhim.[SP]He[SP]wore[SP]that[SP]haori[SP]coat[SP]back[SP]then,[SP]too.",
     "nom_fr": "Jun",
-    "texte_fr": "Alors c'est le père\n[1205][000F]de Lisa... Je me souviens\nvaguement de lui. Il portait déjà ce haori."
+    "texte_fr": "Alors c'est le père\n[000F][1205]de Lisa... Je me souviens\nvaguement de lui. Il portait déjà ce haori."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Jun",
     "texte_orig": "It[SP]looks[SP]like[SP]the[SP]entrance[SP]to[SP]Xibalba[SP]has\nalready[SP]been[SP]opened.[1205][000F][SP]Ms.[SP]Ideal[SP]is[SP]no[SP]doubt\ninside...[1205][000F][SP]I[SP]think[SP]we[SP]ought[SP]to[SP]hurry.",
     "nom_fr": "Jun",
-    "texte_fr": "L'entrée de Xibalba est déjà ouverte. [1205]Mme\n[1205][000F][000F]Idéale est sûrement là... On devrait se\ndépêcher."
+    "texte_fr": "L'entrée de Xibalba est déjà ouverte. [1205]Mme\n[000F][1205][000F]Idéale est sûrement là... On devrait se\ndépêcher."
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Jun",
     "texte_orig": "That[SP]anxiety...[1205][000A][SP]What[SP]could[SP]it[SP]be...?",
     "nom_fr": "Jun",
-    "texte_fr": "Cette angoisse...[1205][000A] Qu'est-ce...?"
+    "texte_fr": "Cette angoisse...[000A][1205] Qu'est-ce...?"
   },
   {
     "id": 14,
@@ -263,7 +263,7 @@
     "nom_orig": "Lisa's[SP]father",
     "texte_orig": "The[SP]sweepstakes,[SP]you[SP]say?[SP]There[SP]have[SP]been[SP]no\ndeliveries...[SP]Are[SP]you[SP]early,[SP]perhaps?[SP]Why[SP]not\ncome[SP]back[SP]after[SP]the[SP]passing[SP]of[SP]some[SP]time?",
     "nom_fr": "Père de Lisa",
-    "texte_fr": "Le tirage au sort, vous dites? Il n'y a pas\neu de livraison... Êtes-vous en avance?\nRevenez après quelque\ntemps, s'il vous plaît."
+    "texte_fr": "Le tirage au sort, vous dites? Il n'y a pas\neu de livraison... Êtes-vous en avance?\nRevenez après quelque temps, s'il vous plaît."
   },
   {
     "id": 17,
@@ -278,7 +278,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "The[SP]sweepstakes,[SP]you[SP]say?[SP]There[SP]have[SP]been[SP]no\ndeliveries...[SP]Are[SP]you[SP]early,[SP]perhaps?[SP]Why[SP]not\ncome[SP]back[SP]after[SP]the[SP]passing[SP]of[SP]some[SP]time?",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Le tirage au sort, vous dites? Il n'y a pas\neu de livraison... Êtes-vous en avance?\nRevenez après quelque\ntemps, s'il vous plaît."
+    "texte_fr": "Le tirage au sort, vous dites? Il n'y a pas\neu de livraison... Êtes-vous en avance?\nRevenez après quelque temps, s'il vous plaît."
   },
   {
     "id": 18,
@@ -323,7 +323,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "The[SP]sweepstakes,[SP]you[SP]say?[SP]Ah,[SP]yes,[SP]of[SP]course.\nThis[SP]was[SP]delivered[SP]here.[SP]Go[SP]on,[SP]take[SP]it.",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Le tirage au sort,\nvous dites? Ah, oui, bien\nsûr. On vous l'a\nlivré ici. Allez, prenez-le. \nLettre [NULL][NULL]Merci de votre participation au\ntirage. Hélas, vous n'êtes pas gagnant\ncettefois. Nous vous encourageons à continuer![NULL][NULL]"
+    "texte_fr": "Le tirage au sort,\nvous dites? Ah, oui, bien\nsûr. On vous l'a livré ici. Allez, prenez-le. Lettre [NULL][NULL]Merci de votre participation au tirage. Hélas, vous n'êtes pas gagnant cettefois. Nous vous encourageons à continuer![NULL][NULL]"
   },
   {
     "id": 21,
@@ -338,7 +338,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "The[SP]sweepstakes,[SP]you[SP]say?[SP]Ah,[SP]yes,[SP]of[SP]course.\nThis[SP]was[SP]delivered[SP]here.[SP]Go[SP]on,[SP]take[SP]it.",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Le tirage au sort,\nvous dites? Ah, oui, bien\nsûr. On vous l'a\nlivré ici. Allez, prenez-le. \nLettre [NULL][NULL]Merci de votre participation au\ntirage. Félicitations! Vous avez étésélectionné\ncomme gagnant! [NULL][NULL]Veuillez accepter [E4][NULL][NULL][NULL][E4][NULL][NULL]\nen guise de prix. Continuez à participer![NULL][NULL] \nVous n'avez pas de\nplace pour un(e) autre [E4][NULL][NULL][NULL][E4][NULL][NULL]..."
+    "texte_fr": "Le tirage au sort,\nvous dites? Ah, oui, bien\nsûr. On vous l'a livré ici. Allez, prenez-le. Lettre [NULL][NULL]Merci de votre participation au tirage. Félicitations! Vous avez étésélectionné comme gagnant! [NULL][NULL]Veuillez accepter [E4][NULL][NULL][NULL][E4][NULL][NULL] en guise de prix. Continuez à participer![NULL][NULL] Vous n'avez pas de place pour un(e) autre [E4][NULL][NULL][NULL][E4][NULL][NULL]..."
   },
   {
     "id": 22,
@@ -353,7 +353,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "Ah,[SP]so[SP]this[SP]is[SP]the[SP]Last[SP]Battalion.[1205][000F][SP]They[SP]tried\nto[SP]force[SP]their[SP]way[SP]into[SP]my[SP]home[SP]without[SP]my\npermission,[SP]so[SP]I[SP]gave[SP]them[SP]a[SP]thrashing!",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Ah, c'est donc le Bataillon. [1205][000F]Ils ont\nessayé de s'introduire chez moi de force,\nsans permission, alors je les ai corrigés!"
+    "texte_fr": "Ah, c'est donc le Bataillon. [000F][1205]Ils ont\nessayé de s'introduire chez moi de force,\nsans permission, alors je les ai corrigés!"
   },
   {
     "id": 23,
@@ -383,7 +383,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "I[SP]am[SP]powerless[SP]to[SP]stop[SP]my[SP]daughter[SP]at[SP]this[SP]point.[1205][000F]\nThat[SP]is[SP]why[SP]I'd[SP]like[SP]to[SP]entrust[SP]her[SP]safety[SP]to\nyou.[SP]Please[SP]look[SP]after[SP]Lisa[SP]in[SP]my[SP]stead.",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Je ne peux plus retenir\nma fille à ce stade.\n[1205][000F]C'est pourquoi je voudrais vous confier sa\nsécurité. Veuillez veiller sur\nLisa à maplace."
+    "texte_fr": "Je ne peux plus retenir\nma fille à ce stade.\n[000F][1205]C'est pourquoi je voudrais vous confier sa sécurité. Veuillez veiller sur Lisa à maplace."
   },
   {
     "id": 25,
@@ -398,7 +398,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "I[SP]heard[SP]the[SP]soldiers[SP]invaded[SP]Seven[SP]Sisters[SP]High\nas[SP]well.[SP]Are[SP]the[SP]students[SP]and[SP]teachers[SP]there\nsafe?[1205][000F][SP]What[SP]gall,[SP]attacking[SP]even[SP]the[SP]schools...!",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "J'ai entendu que des soldats ont envahi le\nLycée Seven Sisters. Les élèves et profs\n[1205]sont-ils sains? [000F]S'attaquer\naux lycées, quelleaudace!"
+    "texte_fr": "J'ai entendu que des soldats ont envahi le\nLycée Seven Sisters. Les élèves et profs\n[1205]sont-ils sains? [000F]S'attaquer aux lycées, quelleaudace!"
   },
   {
     "id": 26,
@@ -413,7 +413,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "Were[SP]I[SP]able,[SP]I'd[SP]go[SP]to[SP]Sevens[SP]myself[SP]and[SP]deal\nwith[SP]the[SP]insolent[SP]lot.[1205][000F][SP]But[SP]as[SP]the[SP]head[SP]of[SP]this\nhousehold,[SP]I[SP]must[SP]remain[SP]where[SP]I[SP]am[SP]needed.",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Si je le pouvais, j'irais à Seven corriger\nces insolents. [1205][000F]Mais en tant que chef de\nfamille, je dois rester à mon poste."
+    "texte_fr": "Si je le pouvais, j'irais à Seven corriger\nces insolents. [000F][1205]Mais en tant que chef de\nfamille, je dois rester à mon poste."
   },
   {
     "id": 27,
@@ -443,6 +443,6 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "I[SP]heard[SP]someone[SP]stepped[SP]in[SP]to[SP]save[SP]the[SP]students\nof[SP]Seven[SP]Sisters[SP]High.[1205][000F][SP]So[SP]there[SP]are[SP]still[SP]those\nin[SP]Sumaru[SP]willing[SP]to[SP]stand[SP]up[SP]and[SP]fight...",
     "nom_fr": "",
-    "texte_fr": "J'ai entendu que quelqu'un était intervenu\npour sauver les élèves de Seven Sisters High.[1205][000F]\nIl reste donc des gens à Sumaru prêts à se battre..."
+    "texte_fr": "J'ai entendu que quelqu'un était intervenu\npour sauver les élèves de Seven Sisters High.[000F][1205]\nIl reste donc des gens à Sumaru prêts à se battre..."
   }
 ]

--- a/traduction/event_scripts/script_288.json
+++ b/traduction/event_scripts/script_288.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "*sigh*[1205][001E][SP]*gaze*[1205][001E][SP]*sigh*[1205][001E][SP]Do[SP]you[SP]ever[SP]think[SP]about\nthe[SP]past[SP]and[SP]wish[SP]you'd[SP]done[SP]things[SP]different?",
     "nom_fr": "Eikichi",
-    "texte_fr": "*soupir*[1205][001E] *regard*[1205][001E] *soupir*[1205][001E] Tu penses au\npassé en voulant tout changer parfois?"
+    "texte_fr": "*soupir*[001E][1205] *regard*[001E][1205] *soupir*[001E][1205] Tu penses au\npassé en voulant tout changer parfois?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]know[SP]you[SP]can't[SP]change[SP]the[SP]past...[1205][001E][SP]But[SP]every\ntime[SP]I[SP]remember,[SP]it[SP]hurts[SP]again.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le passé est fixe, je sais...[1205][001E] Mais\nchaque souvenir ravive la douleur."
+    "texte_fr": "Le passé est fixe, je sais...[001E][1205] Mais\nchaque souvenir ravive la douleur."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ngh...[1205][000A][SP]Hey,[SP][1113]...[SP]What[SP]can[SP]I[SP]say[SP]to\nmake[SP]it[SP]up[SP]to[SP]her?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ngh...[1205][000A] Hé, [1113]...\nComment je peux me racheter?"
+    "texte_fr": "Ngh...[000A][1205] Hé, [1113]...\nComment je peux me racheter?"
   },
   {
     "id": 4,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Deviates...?[1205][000F][SP]My[SP]memories...[1205][000A][SP]changed?[1205][000F][SP]It[SP]can't\nbe...[1205][000A][SP]But[SP]that[SP]must[SP]have[SP]been...[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nTh-Then[SP]the[SP]lady[SP]who[SP]was[SP]here[SP]took[SP]off[SP]to[SP]fight\nthe[SP]Last[SP]Battalion!?[SP]C-C'mon,[SP]that's[SP]crazy!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Déviée.[1205][000F][1205].[000F].? Mes souvenirs...[1205][000A] modifiés?\nImpossible...[1205][000A] Mais ça devait être...[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\n A-Alors la dame d'ici est partie\nbattre le Bataillon!? C-C'est de la folie!"
+    "texte_fr": "Déviée.[000F][1205][1205].[000F].? Mes souvenirs...[000A][1205] modifiés?\nImpossible...[000A][1205] Mais ça devait être...[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\n A-Alors la dame d'ici est partie\nbattre le Bataillon!? C-C'est de la folie!"
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Maybe[SP]he's[SP]right...[1205][001E][SP]We[SP]worry[SP]about[SP]the[SP]present\nand[SP]get[SP]anxious[SP]over[SP]the[SP]future[SP]because[SP]we're\nalways[SP]thinking[SP]about[SP]what's[SP]ahead...",
     "nom_fr": "Lisa",
-    "texte_fr": "Il a sûrement raison...[1205][001E] On\ns'inquiète du présent et de l'avenir\ncar on pense toujours à la suite..."
+    "texte_fr": "Il a sûrement raison...[001E][1205] On\ns'inquiète du présent et de l'avenir\ncar on pense toujours à la suite..."
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Maybe[SP]he's[SP]right...[1205][001E][SP]We[SP]worry[SP]about[SP]the[SP]present\nand[SP]get[SP]anxious[SP]over[SP]the[SP]future[SP]because[SP]we're\nalways[SP]thinking[SP]about[SP]what's[SP]ahead...",
     "nom_fr": "Ginko",
-    "texte_fr": "Il a sûrement raison...[1205][001E] On\ns'inquiète du présent et de l'avenir\ncar on pense toujours à la suite..."
+    "texte_fr": "Il a sûrement raison...[001E][1205] On\ns'inquiète du présent et de l'avenir\ncar on pense toujours à la suite..."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#13![1205][001E][SP][1432][NULL][NULL][0014]Ng[SP]Hai[1432][NULL][NULL][0014][SP]means...[1205][000F]\nWell,[SP]it's[SP]kind[SP]of[SP]like,[SP][1432][NULL][NULL][0014]No[SP]no[SP]no[SP]no![1432][NULL][NULL][0014]",
     "nom_fr": "Ginko",
-    "texte_fr": "Leçon de cantonais n°13![1205][1205][001E] [1432][NULL][NULL][0014]Ng Hai[1432][NULL][NULL][0014] veut\n[000F]dire... En gros, c'est [1432][NULL][NULL][0014]Non non non![1432][NULL][NULL][0014]"
+    "texte_fr": "Leçon de cantonais n°13![1205][001E][1205] [1432][NULL][NULL][0014]Ng Hai[1432][NULL][NULL][0014] veut\n[000F]dire... En gros, c'est [1432][NULL][NULL][0014]Non non non![1432][NULL][NULL][0014]"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "That[SP]woman[SP]said[SP]she[SP]got[SP]rich...[SP]You[SP]think[SP]she\nasked[SP]Joker[SP]for[SP]it?[1205][000F][SP]Nah...",
     "nom_fr": "Ginko",
-    "texte_fr": "Cette femme s'est enrichie...\nVia le Joker tu crois? [1205][000F]Nan..."
+    "texte_fr": "Cette femme s'est enrichie...\nVia le Joker tu crois? [000F][1205]Nan..."
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]don't[SP]like[SP]time.[SP]It's[SP]always[SP]passing,[SP]but[SP]you\ncan[SP]never[SP]sense[SP]it.[1205][000F][SP]How[SP]many[SP]times[SP]have[SP]you\nbeen[SP]caught[SP]off[SP]guard[SP]by[SP]how[SP]late[SP]it[SP]was?",
     "nom_fr": "Ginko",
-    "texte_fr": "Je n'aime pas le temps. Il file sans\nqu'on le sente. [1205][000F]T'as jamais été\nsurpris par l'heure qu'il était, toi?"
+    "texte_fr": "Je n'aime pas le temps. Il file sans\nqu'on le sente. [000F][1205]T'as jamais été\nsurpris par l'heure qu'il était, toi?"
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]wonder[SP]if[SP]everyone'll[SP]forget[SP]what[SP]happened\nat[SP]Smile[SP]Hirasaka[SP]and[SP]GOLD[SP]after[SP]a[SP]while...[1205][000F]\nHoushonah...[SP]I[SP]don't[SP]like[SP]the[SP]idea[SP]of[SP]that...",
     "nom_fr": "Ginko",
-    "texte_fr": "Les gens oublieront ce qu'il s'est passé à\nSmile Hirasaka et GOLD avec le temps.[1205][000F]..?\nHoushonah... ça ne me plaît pas..."
+    "texte_fr": "Les gens oublieront ce qu'il s'est passé à\nSmile Hirasaka et GOLD avec le temps.[000F][1205]..?\nHoushonah... ça ne me plaît pas..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "If[SP]I'm[SP]right[SP]about[SP]Joker...[1205][000F][SP]Then[SP]the[SP]Masked\nCircle[SP]is[SP]just[SP]carrying[SP]out[SP]their[SP]will...[1205][000F][SP]No...",
     "nom_fr": "Ginko",
-    "texte_fr": "Si j'ai raison sur le Joker.[1205][000F][1205][000F].. Alors le\nCercle masqué exécute sa volonté... Non..."
+    "texte_fr": "Si j'ai raison sur le Joker.[000F][1205][000F][1205].. Alors le\nCercle masqué exécute sa volonté... Non..."
   },
   {
     "id": 19,
@@ -312,7 +312,7 @@
     "nom_orig": "Maya",
     "texte_orig": "People[SP]really[SP]can't[SP]escape[SP]the[SP]chains[SP]of[SP]their\npast...[1205][001E][SP]But[SP]however[SP]painful[SP]it[SP]seems,[SP]it's\nbecause[SP]of[SP]that[SP]past[SP]that[SP]we[SP]have[SP]a[SP]future.",
     "nom_fr": "Maya",
-    "texte_fr": "Les gens ne peuvent fuir leur passé...[1205][001E]\nMais même s'il est douloureux, c'est\ngrâce à lui que nous avons un avenir."
+    "texte_fr": "Les gens ne peuvent fuir leur passé...[001E][1205]\nMais même s'il est douloureux, c'est\ngrâce à lui que nous avons un avenir."
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Maya",
     "texte_orig": "No[SP]one[SP]can[SP]stop[SP]themselves[SP]from[SP]making[SP]mistakes\nor[SP]having[SP]regrets.[SP]What's[SP]important[SP]is[SP]that[SP]you\nlearn[SP]from[SP]them.[1205][001E][SP]Right...?",
     "nom_fr": "Maya",
-    "texte_fr": "Personne ne peut s'empêcher de faire des\nerreurs ou d'avoir des regrets. L'important\nest d'en tirer des leçons.[1205][001E] Non ?"
+    "texte_fr": "Personne ne peut s'empêcher de faire des\nerreurs ou d'avoir des regrets. L'important\nest d'en tirer des leçons.[001E][1205] Non ?"
   },
   {
     "id": 22,
@@ -357,7 +357,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Man's[SP]lifespan[SP]is[SP]limited.[1205][000A][SP]That's[SP]why[SP]we[SP]live\nto[SP]the[SP]fullest[SP]and[SP]shine[SP]our[SP]brightest[SP]until\nthe[SP]very[SP]end.[SP]No[SP]one[SP]can[SP]take[SP]away[SP]that[SP]light!",
     "nom_fr": "Maya",
-    "texte_fr": "La vie humaine est courte.[1205][000A] C'est pour ça\nqu'on vit à fond et qu'on brille jusqu'à la\nfin. Nul ne peut nous voler cette lumière!"
+    "texte_fr": "La vie humaine est courte.[000A][1205] C'est pour ça\nqu'on vit à fond et qu'on brille jusqu'à la\nfin. Nul ne peut nous voler cette lumière!"
   },
   {
     "id": 24,
@@ -387,7 +387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]can't[SP]sense[SP]time[SP]itself,[SP]but[SP]we[SP]remember\nthe[SP]things[SP]we've[SP]experienced[SP]over[SP]time...\nThose[SP]things[SP]make[SP]up[SP]our[SP]past.",
     "nom_fr": "Maya",
-    "texte_fr": "On ne perçoit pas le\ntemps, mais on garde nos\nsouvenirs... C'est ça\nqui forge notre passé."
+    "texte_fr": "On ne perçoit pas le\ntemps, mais on garde nos\nsouvenirs... C'est ça qui forge notre passé."
   },
   {
     "id": 26,
@@ -432,7 +432,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]Last[SP]Battalion[SP]is[SP]after[SP]the[SP]Rings[SP]of[SP]Time.\nThey[SP]must[SP]be[SP]related[SP]to[SP]Xibalba[SP]somehow...[1205][000F]\nWe[SP]should[SP]hurry.",
     "nom_fr": "Maya",
-    "texte_fr": "Le Bataillon traque les Anneaux du\nTemps. Ils doivent être liés à\nXibalba... [1205][000F]On devrait se dépêcher."
+    "texte_fr": "Le Bataillon traque les Anneaux du\nTemps. Ils doivent être liés à\nXibalba... [000F][1205]On devrait se dépêcher."
   },
   {
     "id": 29,
@@ -477,7 +477,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Everyone[SP]has[SP]keepsakes,[SP]right?[1205][000F][SP]And[SP]looking[SP]at\nthem[SP]brings[SP]back[SP]certain[SP]memories.[1205][000A][SP]Good[SP]ones...[1205][000F]\nand[SP]bad[SP]ones...",
     "nom_fr": "Yukino",
-    "texte_fr": "On a tous des souvenirs, non? [1205][000F][1205][000F]Et\nles regarder ravive la mémoire.[1205][000A]\nLes bons... comme les mauvais..."
+    "texte_fr": "On a tous des souvenirs, non? [000F][1205][000F][1205]Et\nles regarder ravive la mémoire.[000A][1205]\nLes bons... comme les mauvais..."
   },
   {
     "id": 32,
@@ -492,7 +492,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Even[SP]a[SP]shadowman's[SP]parents[SP]forget[SP]about[SP]him?[1205][000F]\nThat's[SP]just...",
     "nom_fr": "Yukino",
-    "texte_fr": "Même les parents d'une Ombre\nl'oublient? [1205][000F]C'est juste..."
+    "texte_fr": "Même les parents d'une Ombre\nl'oublient? [000F][1205]C'est juste..."
   },
   {
     "id": 33,
@@ -567,7 +567,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Why'd[SP]the[SP]Last[SP]Battalion[SP]go[SP]to[SP]Mt.[SP]Katatsumuri?[1205][000F]\nIs[SP]Xibalba[SP]on[SP]top[SP]of[SP]a[SP]mountain!?[SP]And[SP]why[SP]now,\nof[SP]all[SP]times...?",
     "nom_fr": "Yukino",
-    "texte_fr": "Pourquoi le Bataillon est-il allé au\n[1205][000F]mont Katatsumuri? Xibalba est sur un\nmont!? Et pourquoi maintenant?"
+    "texte_fr": "Pourquoi le Bataillon est-il allé au\n[000F][1205]mont Katatsumuri? Xibalba est sur un\nmont!? Et pourquoi maintenant?"
   },
   {
     "id": 38,
@@ -667,7 +667,7 @@
     "nom_orig": "Count",
     "texte_orig": "Time[SP]cannot[SP]be[SP]stopped.[SP]The[SP]past[SP]you've[SP]lost\ncannot[SP]be[SP]reclaimed.[1205][001E][SP]This[SP]is[SP]why[SP]man[SP]desires\nantiques...[SP]To[SP]recall[SP]a[SP]long-forgotten[SP]past.",
     "nom_fr": "Comte",
-    "texte_fr": "Le temps ne s'arrête pas. Le passé perdu ne\nse rattrape pas.[1205][001E]\nL'homme aime les antiquités\npour ça... Se rappeler d'un passé oublié."
+    "texte_fr": "Le temps ne s'arrête pas. Le passé perdu ne\nse rattrape pas.[001E][1205]\nL'homme aime les antiquités\npour ça... Se rappeler d'un passé oublié."
   },
   {
     "id": 42,
@@ -712,7 +712,7 @@
     "nom_orig": "Count",
     "texte_orig": "That[SP]is[SP]why[SP]machine-loving[SP]humans[SP]disassociate\nwith[SP]people,[SP]favoring[SP]connections[SP]with[SP]their\nmachines...[1205][001E][SP]Ring[SP]a[SP]bell,[SP]does[SP]it?",
     "nom_fr": "Comte",
-    "texte_fr": "C'est pourquoi ceux qui aiment les\nmachines fuyent les gens, favorisant leurs\ncréations...[1205][001E] Ça vous rappelle quelqu'un?"
+    "texte_fr": "C'est pourquoi ceux qui aiment les\nmachines fuyent les gens, favorisant leurs\ncréations...[001E][1205] Ça vous rappelle quelqu'un?"
   },
   {
     "id": 45,
@@ -727,7 +727,7 @@
     "nom_orig": "Count",
     "texte_orig": "Man[SP]has[SP]no[SP]conception[SP]of[SP]the[SP]flow[SP]of[SP]time.[1205][000F][SP]What\nyou[SP]call[SP]time[SP]is[SP]only[SP]events[SP]passing[SP]before[SP]your\neyes.[SP]The[SP]past[SP]is[SP]only[SP]what[SP]you[SP]can[SP]recall.",
     "nom_fr": "Comte",
-    "texte_fr": "L'homme ne conçoit pas\nle temps. [1205][000F]Ce que vous\nappelez le temps n'est qu'un défilé\nd'événements. Le passé\nn'est qu'un souvenir."
+    "texte_fr": "L'homme ne conçoit pas\nle temps. [000F][1205]Ce que vous\nappelez le temps n'est qu'un défilé d'événements. Le passé n'est qu'un souvenir."
   },
   {
     "id": 46,
@@ -757,7 +757,7 @@
     "nom_orig": "Count",
     "texte_orig": "Man[SP]believes[SP]in[SP]what[SP]he[SP]can[SP]see.[1205][000F][SP]But[SP]the[SP]heart\nyearns[SP]for,[SP]obsesses[SP]over,[SP]what[SP]cannot[SP]be[SP]seen.[1205][000A]\nThat[SP]is[SP]why[SP]man[SP]craves[SP]a[SP]fixed[SP]star[SP]to[SP]steer[SP]by.",
     "nom_fr": "Comte",
-    "texte_fr": "L'homme croit ce qu'il voit. [1205][000F]Mais le\ncœur obnubile sur l'invisible.[1205][000A] C'est\npourquoi il cherche un repère."
+    "texte_fr": "L'homme croit ce qu'il voit. [000F][1205]Mais le\ncœur obnubile sur l'invisible.[000A][1205] C'est\npourquoi il cherche un repère."
   },
   {
     "id": 48,
@@ -772,7 +772,7 @@
     "nom_orig": "Count",
     "texte_orig": "Indeed,[SP]time[SP]rules[SP]over[SP]man's[SP]heart.[1205][000F][SP]But[SP]time\nitself[SP]cannot[SP]be[SP]seen[SP]or[SP]felt.[SP]Clocks,[SP]then,\nare[SP]idols[SP]in[SP]reverence[SP]to[SP]man's[SP]true[SP]god:[SP]time.",
     "nom_fr": "Comte",
-    "texte_fr": "Le temps gouverne le cœur de l'homme.\n[1205][000F]Mais le temps ne se voit ni ne se sent.\nLes horloges sont des idoles à son dieu."
+    "texte_fr": "Le temps gouverne le cœur de l'homme.\n[000F][1205]Mais le temps ne se voit ni ne se sent.\nLes horloges sont des idoles à son dieu."
   },
   {
     "id": 49,
@@ -787,7 +787,7 @@
     "nom_orig": "Count",
     "texte_orig": "What[SP]is[SP]time[SP]for[SP]you?[1205][000F][SP]Numbers[SP]demarcating[SP]a\nlimited[SP]span?[SP]Or[SP]a[SP]means[SP]of[SP]measuring[SP]the\nmoment[SP]we[SP]call[SP]the[SP]present?",
     "nom_fr": "Comte",
-    "texte_fr": "Qu'est-ce que le temps pour vous?\n[1205][000F]Des nombres délimitant une durée?\nOu un moyen de mesurer le présent?"
+    "texte_fr": "Qu'est-ce que le temps pour vous?\n[000F][1205]Des nombres délimitant une durée?\nOu un moyen de mesurer le présent?"
   },
   {
     "id": 50,
@@ -832,7 +832,7 @@
     "nom_orig": "Count",
     "texte_orig": "Antiques[SP]that[SP]remind[SP]men[SP]of[SP]their[SP]past[SP]are\nshards[SP]of[SP]time[SP]created[SP]by[SP]that[SP]process.[1205][000F][SP]You\nsurely[SP]already[SP]know[SP]of[SP]which[SP]I[SP]speak.",
     "nom_fr": "Comte",
-    "texte_fr": "Les reliques rappelant le passé aux hommes\nsont des fragments nés de ce processus.\n[1205][000F]Vous savez sûrement de quoi je parle."
+    "texte_fr": "Les reliques rappelant le passé aux hommes\nsont des fragments nés de ce processus.\n[000F][1205]Vous savez sûrement de quoi je parle."
   },
   {
     "id": 53,
@@ -847,7 +847,7 @@
     "nom_orig": "Count",
     "texte_orig": "Time[SP]is[SP]an[SP]absolute[SP]property[SP]that[SP]cannot[SP]be[SP]seen\nor[SP]felt.[SP]But[SP]it[SP]invisibly[SP]shapes[SP]the[SP]lives[SP]and\nthe[SP]hearts[SP]of[SP]man[SP]by[SP]its[SP]passage.",
     "nom_fr": "Comte",
-    "texte_fr": "Le temps est absolu, invisible et\ninsensible. Mais son passage façonne\ninvisiblement les vies et\ncœurs des hommes."
+    "texte_fr": "Le temps est absolu, invisible et\ninsensible. Mais son passage façonne\ninvisiblement les vies et cœurs des hommes."
   },
   {
     "id": 54,
@@ -892,7 +892,7 @@
     "nom_orig": "Count",
     "texte_orig": "The[SP]transience[SP]of[SP]his[SP]heart...[1205][000F][SP]The[SP]torrent\nswirling[SP]within[SP]man[SP]cannot[SP]be[SP]stopped[SP]or[SP]seen.[1205][000F]\nYet[SP]it[SP]controls[SP]everything.[1205][000F][SP]As[SP]with[SP]that[SP]lady.",
     "nom_fr": "Comte",
-    "texte_fr": "L'éphémère de son cœur.[1205][000F][1205][000F][1205][000F].. Le torrent en\nlui ne peut être vu ni stoppé. Pourtant\nil contrôle tout. Comme pour cette dame."
+    "texte_fr": "L'éphémère de son cœur.[000F][1205][000F][1205][000F][1205].. Le torrent en\nlui ne peut être vu ni stoppé. Pourtant\nil contrôle tout. Comme pour cette dame."
   },
   {
     "id": 57,
@@ -937,7 +937,7 @@
     "nom_orig": "Count",
     "texte_orig": "The[SP]rings[SP]of[SP]time[SP]affect[SP]everything...[1205][000F][SP]Even[SP]the\npast[SP]can[SP]become[SP]the[SP]future[SP]someday.[1205][000F][SP]No[SP]human\nalive[SP]can[SP]escape[SP]that[SP]fate.",
     "nom_fr": "Comte",
-    "texte_fr": "Les anneaux du temps touchent tout.[1205][000F][1205][000F]..\nLe passé peut redevenir l'avenir un\njour. Personne ne peut fuir ce destin."
+    "texte_fr": "Les anneaux du temps touchent tout.[000F][1205][000F][1205]..\nLe passé peut redevenir l'avenir un\njour. Personne ne peut fuir ce destin."
   },
   {
     "id": 60,
@@ -982,7 +982,7 @@
     "nom_orig": "Count",
     "texte_orig": "Even[SP]the[SP]most[SP]precise[SP]clock[SP]will[SP]eventually\ndeviate...[SP]I[SP]must[SP]fix[SP]them[SP]each[SP]time[SP]it[SP]happens.\nBut[SP]then,[SP]the[SP]same[SP]can[SP]be[SP]said[SP]about[SP]man.",
     "nom_fr": "Comte",
-    "texte_fr": "Même la montre la plus précise finira par\ndévier... Je dois les\nréparer à chaque fois.\nMais on peut dire la même chose des hommes."
+    "texte_fr": "Même la montre la plus précise finira par\ndévier... Je dois les\nréparer à chaque fois. Mais on peut dire la même chose des hommes."
   },
   {
     "id": 63,
@@ -997,7 +997,7 @@
     "nom_orig": "Count",
     "texte_orig": "Though[SP]man[SP]believes[SP]them[SP]to[SP]be[SP]accurate,[SP]his\nmemories[SP]slowly[SP]deviate[SP]over[SP]time.[SP]Only[SP]these\nantiques[SP]with[SP]no[SP]hearts[SP]point[SP]at[SP]the[SP]truth.",
     "nom_fr": "Comte",
-    "texte_fr": "Bien que l'homme les croie précis, ses\nsouvenirs dévient avec le temps. Seules ces\nantiquités sans cœur\npointent vers la vérité."
+    "texte_fr": "Bien que l'homme les croie précis, ses\nsouvenirs dévient avec le temps. Seules ces\nantiquités sans cœur pointent vers la vérité."
   },
   {
     "id": 64,
@@ -1012,7 +1012,7 @@
     "nom_orig": "Count",
     "texte_orig": "Even[SP]the[SP]most[SP]precise[SP]clock[SP]will[SP]eventually\ndeviate...[1205][000F][SP]It[SP]is[SP]the[SP]same[SP]with[SP]man.[1205][000F][SP]His[SP]memories\nbecome[SP]less[SP]accurate[SP]with[SP]time.",
     "nom_fr": "Comte",
-    "texte_fr": "Même l'horloge la plus précise finit\n[1205][000F][1205][000F]par dévier... Pareil pour l'homme. Ses\nsouvenirs s'altèrent avec le temps."
+    "texte_fr": "Même l'horloge la plus précise finit\n[000F][1205][000F][1205]par dévier... Pareil pour l'homme. Ses\nsouvenirs s'altèrent avec le temps."
   },
   {
     "id": 65,
@@ -1102,7 +1102,7 @@
     "nom_orig": "Count",
     "texte_orig": "Who[SP]decided[SP]that[SP]tomorrow[SP]will[SP]be[SP]a[SP]bright[SP]new\nday?[1205][001E][SP]Such[SP]proclamations[SP]are[SP]the[SP]source[SP]of[SP]man's\nanxiety.[1205][001E][SP]Peace[SP]lies[SP]with[SP]the[SP]cold,[SP]still[SP]past.",
     "nom_fr": "Comte",
-    "texte_fr": "Qui a dit que\ndemain serait un jour nouveau?[1205][001E]\nDe telles annonces créent l'angoisse.[1205][001E] La\npaix réside dans le\npassé froid et immobile."
+    "texte_fr": "Qui a dit que\ndemain serait un jour nouveau?[001E][1205]\nDe telles annonces créent l'angoisse.[001E][1205] La\npaix réside dans le\npassé froid et immobile."
   },
   {
     "id": 71,
@@ -1132,7 +1132,7 @@
     "nom_orig": "Nouveau-riche[SP]woman",
     "texte_orig": "The[SP]first[SP]thing[SP]I'll[SP]do[SP]is[SP]furnish[SP]my[SP]house[SP]with\nan[SP]antique[SP]wall[SP]clock.[1205][001E][SP]Oof,[SP]this[SP]is[SP]expensive...[1205][001E]\nOh,[SP]wait,[SP]I'm[SP]rich[SP]now!",
     "nom_fr": "Nouvelle riche",
-    "texte_fr": "Je vais d'abord acheter une horloge murale\nantique pour chez moi.[1205][001E] Ouf, c'est cher...[1205][001E]\nOh, attendez, je suis riche maintenant!"
+    "texte_fr": "Je vais d'abord acheter une horloge murale\nantique pour chez moi.[001E][1205] Ouf, c'est cher...[001E][1205]\nOh, attendez, je suis riche maintenant!"
   },
   {
     "id": 73,
@@ -1162,7 +1162,7 @@
     "nom_orig": "Nouveau-riche[SP]woman",
     "texte_orig": "[1432][NULL][NULL][0014]He[1432][NULL][NULL][0014]...?[1205][000F][SP]O-Oh[SP]yes,[SP]Takeshi...[1205][000F][SP]H-Haha...[SP]How\ncould[SP]I[SP]forget[SP]my[SP]own[SP]son's[SP]name...?[1205][000F][SP]I[SP]think\nI'm[SP]a[SP]little[SP]drunk[SP]off[SP]this[SP]sudden[SP]fortune.",
     "nom_fr": "Nouvelle riche",
-    "texte_fr": "[1432][NULL][NULL][0014]Il[1432][NULL][NULL][0014].[1205][000F][1205][000F][1205][000F]..? O-Oh oui,\nTakeshi... H-Haha... Comment\noublier le nom de mon fils...? Je crois que\nje suis un peu ivre de cette fortune."
+    "texte_fr": "[1432][NULL][NULL][0014]Il[1432][NULL][NULL][0014].[000F][1205][000F][1205][000F][1205]..? O-Oh oui,\nTakeshi... H-Haha... Comment\noublier le nom de mon fils...? Je crois que je suis un peu ivre de cette fortune."
   },
   {
     "id": 75,
@@ -1177,7 +1177,7 @@
     "nom_orig": "Nouveau-riche[SP]woman",
     "texte_orig": "I[SP]wonder[SP]if[SP]being[SP]rich[SP]makes[SP]you[SP]forgetful.[1205][000F]\nI[SP]frequently[SP]forget[SP]my[SP]own[SP]son's[SP]name[SP]lately...[1205][000F]\nHis[SP]name's[SP]Takeshi,[SP]but...[1205][000A][SP]Haha,[SP]shameful,[SP]no?",
     "nom_fr": "Nouvelle riche",
-    "texte_fr": "La richesse rend\npeut-être amnésique. [1205][000F][1205][000F]J'oublie\nsouvent le nom de mon fils... Il s'appelle\nTakeshi, mais...[1205][000A] Haha, c'est honteux."
+    "texte_fr": "La richesse rend\npeut-être amnésique. [000F][1205][000F][1205]J'oublie\nsouvent le nom de mon fils... Il s'appelle Takeshi, mais...[000A][1205] Haha, c'est honteux."
   },
   {
     "id": 76,
@@ -1207,7 +1207,7 @@
     "nom_orig": "Nouveau-riche[SP]woman",
     "texte_orig": "M-Masked[SP]Circle?[1205][000A][SP]Wh-What's[SP]that?[1205][000F][SP]I've[SP]never\nheard[SP]of[SP]any[SP]such[SP]organization.[1205][000F][SP]N-Now,[SP]what\nshould[SP]I[SP]buy[SP]next...?",
     "nom_fr": "Nouvelle riche",
-    "texte_fr": "C-Cercle masqué?[1205][1205][1205][000A] Q-Qu'est-ce que c'est?\n[000F][000F]Je ne connais pas ce groupe. Q-Que\ndevrais-je acheter maintenant...?"
+    "texte_fr": "C-Cercle masqué?[1205][1205][000A][1205] Q-Qu'est-ce que c'est?\n[000F][000F]Je ne connais pas ce groupe. Q-Que\ndevrais-je acheter maintenant...?"
   },
   {
     "id": 78,
@@ -1252,7 +1252,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Hahahaha,[SP]what[SP]fun![SP]This[SP]city[SP]should[SP]burn[SP]to\nthe[SP]ground![SP]That's[SP]what'll[SP]make[SP]me[SP]feel[SP]better!\nHahahaha![E1][E2]\n[E3][E4][NULL][NULL]\"Masked[SP]Circle[SP]member\nAaaaagh...[SP]Time's[SP]spinning...[1205][000F][SP]Something's\nmissing[SP]from[SP]inside[SP]me...[1205][000F][SP]Stop[SP]it...[SP]Stop\nthis[SP]clock!",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "Hahahaha, amusant! Cette ville devrait\nbrûler! Ça me fera me sentir mieux!\nHahahaha![E1][E2]\n[E3][E4][NULL][NULL]\"Membre du Cercle\nAaaaagh...\n[1205]Le temps tourne.[1205][000F][000F].. Il manque un truc en\nmoi... Arrête... Arrête cette horloge!"
+    "texte_fr": "Hahahaha, amusant! Cette ville devrait\nbrûler! Ça me fera me sentir mieux!\nHahahaha![E1][E2]\n[E3][E4][NULL][NULL]\"Membre du Cercle\nAaaaagh...\n[1205]Le temps tourne.[000F][1205][000F].. Il manque un truc en\nmoi... Arrête... Arrête cette horloge!"
   },
   {
     "id": 81,
@@ -1267,7 +1267,7 @@
     "nom_orig": "Quiet[SP]gentleman",
     "texte_orig": "I[SP]regret[SP]my[SP]past[SP]as[SP]well...[1205][001E][SP]The[SP]pain[SP]in[SP]my[SP]heart\nremains[SP]as[SP]time[SP]mercilessly[SP]marches[SP]on...[1205][001E][SP]By[SP]the\ntime[SP]I[SP]caught[SP]on,[SP]I'd[SP]reached[SP]this[SP]age.",
     "nom_fr": "Gentilhomme calme",
-    "texte_fr": "Je regrette mon passé aussi...[1205][001E] La douleur\nreste alors que le temps passe...[1205][001E] Quand je\nm'en suis rendu compte, j'avais cet âge."
+    "texte_fr": "Je regrette mon passé aussi...[001E][1205] La douleur\nreste alors que le temps passe...[001E][1205] Quand je\nm'en suis rendu compte, j'avais cet âge."
   },
   {
     "id": 82,
@@ -1282,7 +1282,7 @@
     "nom_orig": "Quiet[SP]gentleman",
     "texte_orig": "I[SP]wish[SP]I[SP]could[SP]forget[SP]these[SP]painful[SP]memories,\nbut[SP]for[SP]some[SP]reason,[SP]they[SP]stay[SP]with[SP]me.[1205][000F][SP]I[SP]came\nhere[SP]because[SP]I[SP]can't[SP]endure[SP]such[SP]anguish.",
     "nom_fr": "Gentilhomme calme",
-    "texte_fr": "J'aimerais oublier\nces souvenirs douloureux,\nmais ils me restent. [1205][000F]Je suis venu car cette\nangoisse m'est insupportable."
+    "texte_fr": "J'aimerais oublier\nces souvenirs douloureux,\nmais ils me restent. [000F][1205]Je suis venu car cette angoisse m'est insupportable."
   },
   {
     "id": 83,
@@ -1312,7 +1312,7 @@
     "nom_orig": "Quiet[SP]gentleman",
     "texte_orig": "One[SP]life[SP]is[SP]only[SP]the[SP]blink[SP]of[SP]an[SP]eye[SP]compared\nto[SP]the[SP]infinite[SP]span[SP]of[SP]time.[SP]However[SP]happy[SP]a\nman's[SP]life[SP]is,[SP]it[SP]only[SP]lasts[SP]so[SP]long.",
     "nom_fr": "Gentilhomme calme",
-    "texte_fr": "Une vie n'est qu'un clin d'œil face à\nl'infini du temps.\nAussi heureuse soit-elle,\nla vie d'un homme ne dure qu'un temps."
+    "texte_fr": "Une vie n'est qu'un clin d'œil face à\nl'infini du temps.\nAussi heureuse soit-elle, la vie d'un homme ne dure qu'un temps."
   },
   {
     "id": 85,
@@ -1342,7 +1342,7 @@
     "nom_orig": "Quiet[SP]gentleman",
     "texte_orig": "A[SP]moment[SP]of[SP]prosperity...[1205][000A][SP]A[SP]flash[SP]of[SP]joy...[1205][000F]\nAntiques[SP]reveal[SP]such[SP]evanescence.[SP]That[SP]lady\nmust[SP]have[SP]realized[SP]this[SP]as[SP]well.",
     "nom_fr": "Gentilhomme calme",
-    "texte_fr": "Un moment de prospérité.[1205]..[1205][000A] Un éclair\n[000F]de joie... Les antiquités le montrent.\nCette dame a dû le réaliser aussi."
+    "texte_fr": "Un moment de prospérité.[1205]..[000A][1205] Un éclair\n[000F]de joie... Les antiquités le montrent.\nCette dame a dû le réaliser aussi."
   },
   {
     "id": 87,
@@ -1357,7 +1357,7 @@
     "nom_orig": "Quiet[SP]gentleman",
     "texte_orig": "This[SP]clock[SP]here[SP]is[SP]one[SP]that[SP]I[SP]myself[SP]sold[SP]to\nthe[SP]shop.[1205][000F][SP]It[SP]was[SP]my[SP]mother's[SP]heirloom...",
     "nom_fr": "Gentilhomme calme",
-    "texte_fr": "J'ai moi-même vendu cette horloge à la\nboutique. [1205][000F]C'était un héritage de ma mère..."
+    "texte_fr": "J'ai moi-même vendu cette horloge à la\nboutique. [000F][1205]C'était un héritage de ma mère..."
   },
   {
     "id": 88,
@@ -1372,7 +1372,7 @@
     "nom_orig": "Quiet[SP]gentleman",
     "texte_orig": "I[SP]hated[SP]the[SP]sight[SP]of[SP]it,[SP]because[SP]it[SP]seemed[SP]like\nthe[SP]time[SP]when[SP]my[SP]mother[SP]was[SP]alive[SP]kept[SP]slipping\nfarther[SP]and[SP]farther[SP]into[SP]the[SP]past...",
     "nom_fr": "Gentilhomme calme",
-    "texte_fr": "Je détestais la voir, car il semblait que\nl'époque où ma mère\nétait en vie s'éloignait\nde plus en plus dans le passé..."
+    "texte_fr": "Je détestais la voir, car il semblait que\nl'époque où ma mère\nétait en vie s'éloignait de plus en plus dans le passé..."
   },
   {
     "id": 89,
@@ -1417,7 +1417,7 @@
     "nom_orig": "Count",
     "texte_orig": "Welcome[SP]to[SP]Time[SP]Castle...[1205][000A][SP]The[SP]onrush[SP]of[SP]time[SP]is\nswift[SP]and[SP]unceasing.[1205][000A][SP]Now,[SP]state[SP]your[SP]business.\n[1208][0006][1210][U+03BA]Buy[SP]weapons\nBuy[SP]accessories\nSell[SP]items\nTalk[SP]to[SP]the[SP]Count\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Comte",
-    "texte_fr": "Bienvenue au Time Castle...[1205][000A] Le temps\ns'écoule rapidement et sans cesse.[1205][000A]\nMaintenant, que voulez-vous?\n[1208][0006][1210]Acheter armes\nAcheter accessoires\nVendre objets\nParler au Comte\nRien\nQuitter[U+03BA]",
+    "texte_fr": "Bienvenue au Time Castle...[000A][1205] Le temps\ns'écoule rapidement et sans cesse.[000A][1205]\nMaintenant, que voulez-vous?\n[1208][0006][1210]Acheter armes\nAcheter accessoires\nVendre objets\nParler au Comte\nRien\nQuitter[U+03BA]",
     "question_orig": "Welcome[SP]to[SP]Time[SP]Castle...[1205][000A][SP]The[SP]onrush[SP]of[SP]time[SP]is\nswift[SP]and[SP]unceasing.[1205][000A][SP]Now,[SP]state[SP]your[SP]business.",
     "choix_orig": [
       "[1210]Buy[SP]weapons",
@@ -1602,7 +1602,7 @@
     "nom_orig": "Count",
     "texte_orig": "The[SP]resale[SP]price[SP]is[SP]about[SP]50%[SP]of[SP]the[SP]original\nprice.[SP]Equipped[SP]items[SP]and[SP]certain[SP]special[SP]items\ncannot[SP]be[SP]sold.[SP]That[SP]should[SP]cover[SP]it,[SP]I[SP]think.",
     "nom_fr": "Comte",
-    "texte_fr": "Le prix de revente\nest d'environ 50% du prix\ninitial. Les objets équipés et spéciaux ne\npeuvent être vendus. C'est tout."
+    "texte_fr": "Le prix de revente\nest d'environ 50% du prix\ninitial. Les objets équipés et spéciaux ne peuvent être vendus. C'est tout."
   },
   {
     "id": 101,
@@ -1692,7 +1692,7 @@
     "nom_orig": "Count",
     "texte_orig": "The[SP]resale[SP]price[SP]is[SP]about[SP]50%[SP]of[SP]the[SP]original\nprice.[SP]Equipped[SP]items[SP]and[SP]certain[SP]special[SP]items\ncannot[SP]be[SP]sold.[SP]That[SP]should[SP]cover[SP]it,[SP]I[SP]think.",
     "nom_fr": "Comte",
-    "texte_fr": "Le prix de revente\nest d'environ 50% du prix\ninitial. Les objets équipés et spéciaux ne\npeuvent être vendus. C'est tout."
+    "texte_fr": "Le prix de revente\nest d'environ 50% du prix\ninitial. Les objets équipés et spéciaux ne peuvent être vendus. C'est tout."
   },
   {
     "id": 107,

--- a/traduction/event_scripts/script_289.json
+++ b/traduction/event_scripts/script_289.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Sheesh,[SP]first[SP]a[SP]spaceship,[SP]now[SP]a[SP]sacrifice...?[1205][001E]\nWhat[SP]year[SP]are[SP]we[SP]living[SP]in[SP]again?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Punaise, un vaisseau, puis un\nsacrifice...?[1205][001E] On est en quelle époque?"
+    "texte_fr": "Punaise, un vaisseau, puis un\nsacrifice...?[001E][1205] On est en quelle époque?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]bet[SP]that[SP]King[SP]Leo[SP]guy[SP]was[SP]doing[SP]some[SP]kind[SP]of\nritual[SP]so[SP]the[SP]shrines[SP]would[SP]appear...[1205][001E][SP]That's[SP]why\nhe[SP]burned[SP]down[SP]the[SP]concert[SP]hall[SP]and[SP]museum.",
     "nom_fr": "Ginko",
-    "texte_fr": "Le Roi Lion faisait sûrement un rituel\npour faire venir les lieux...[1205][001E] C'est\npourquoi il a brûlé la salle et le musée."
+    "texte_fr": "Le Roi Lion faisait sûrement un rituel\npour faire venir les lieux...[001E][1205] C'est\npourquoi il a brûlé la salle et le musée."
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]constellations[SP]of[SP]the[SP]Grand[SP]Cross...[1205][001E][SP]Taurus,\nScorpio,[SP]Aquarius...[SP]and[SP]Leo.[SP]Huh,[SP]those[SP]are\nyou[SP]guys'[SP]signs.",
     "nom_fr": "Maya",
-    "texte_fr": "Les constellations de la Croix...[1205][001E]\nTaureau, Scorpion, Verseau... et\nLion. Tiens, ce sont vos signes."
+    "texte_fr": "Les constellations de la Croix...[001E][1205]\nTaureau, Scorpion, Verseau... et\nLion. Tiens, ce sont vos signes."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]In[SP]Lak'ech[SP]seems[SP]to[SP]be[SP]based[SP]on[SP]Mayan\nmythology,[SP]after[SP]all...[SP][1205][001E][SP]Maybe[SP]the[SP]sacrifice\nthing[SP]came[SP]from[SP]there[SP]too.",
     "nom_fr": "Maya",
-    "texte_fr": "L'In Lak'ech est fondé sur la\nmythologie Maya...[1205][001E] Les sacrifices\nviennent peut-être de là aussi."
+    "texte_fr": "L'In Lak'ech est fondé sur la\nmythologie Maya...[001E][1205] Les sacrifices\nviennent peut-être de là aussi."
   },
   {
     "id": 6,
@@ -132,7 +132,7 @@
     "nom_orig": "Jun",
     "texte_orig": "That's[SP]why[SP]I[SP]made[SP]your[SP]doubles[SP]my[SP]new\nexecutives,[SP]under[SP]my[SP]father's[SP]command...[1205][001E]\nI'm[SP]sorry...",
     "nom_fr": "Jun",
-    "texte_fr": "J'ai fait de vos doubles mes exécutants\nsur ordre de père...[1205][001E] Pardon..."
+    "texte_fr": "J'ai fait de vos doubles mes exécutants\nsur ordre de père...[001E][1205] Pardon..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Jun",
     "texte_orig": "This[SP]is[SP]a[SP]problem...[1205][001E][SP]We[SP]have[SP]the[SP]four[SP]skulls,\nbut[SP]if[SP]he[SP]demands[SP]we[SP]hand[SP]them[SP]over[SP]in[SP]return\nfor[SP]Ms.[SP]Okamura...",
     "nom_fr": "Jun",
-    "texte_fr": "C'est un souci...[1205][001E] On a les quatre\ncrânes, mais s'il exige qu'on les\ndonne pour Mme Okamura..."
+    "texte_fr": "C'est un souci...[001E][1205] On a les quatre\ncrânes, mais s'il exige qu'on les\ndonne pour Mme Okamura..."
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Where[SP]we[SP]came[SP]from,[SP]where[SP]we'll[SP]go...[1205][001E][SP]Why[SP]we\nwere[SP]born...[1205][001E][SP]He[SP]said[SP]Idealians[SP]were[SP]the[SP]ones\nwho[SP]would[SP]finally[SP]find[SP]those[SP]answers...",
     "nom_fr": "Jun",
-    "texte_fr": "D'où l'on vient, où l'on va...[1205][001E] Pourquoi\nnaître...[1205][001E] Il disait que les Idéaliens\nfiniraient par trouver ces réponses..."
+    "texte_fr": "D'où l'on vient, où l'on va...[001E][1205] Pourquoi\nnaître...[001E][1205] Il disait que les Idéaliens\nfiniraient par trouver ces réponses..."
   },
   {
     "id": 12,
@@ -277,7 +277,7 @@
     "nom_orig": "Count",
     "texte_orig": "So...[SP]Xibalba[SP]has[SP]finally[SP]shown[SP]itself.[1205][001E]\nBut[SP]even[SP]this[SP]is[SP]only[SP]a[SP]grain[SP]of[SP]sand[SP]in[SP]the\neternal[SP]desert[SP]of[SP]time.",
     "nom_fr": "Comte",
-    "texte_fr": "Xibalba s'est enfin révélé.[1205][001E] Mais\nce n'est qu'un grain de sable\ndans l'éternel désert du temps."
+    "texte_fr": "Xibalba s'est enfin révélé.[001E][1205] Mais\nce n'est qu'un grain de sable\ndans l'éternel désert du temps."
   },
   {
     "id": 16,
@@ -337,7 +337,7 @@
     "nom_orig": "Count",
     "texte_orig": "Whether[SP]one[SP]accepts[SP]one's[SP]true[SP]self[SP]or[SP]denies\nit...[1205][001E][SP]I'll[SP]sit[SP]back[SP]and[SP]savor[SP]that[SP]a[SP]little[SP]longer...",
     "nom_fr": "Comte",
-    "texte_fr": "Qu'on accepte son vrai moi ou non...[1205][001E]\nJe vais savourer cela encore un peu..."
+    "texte_fr": "Qu'on accepte son vrai moi ou non...[001E][1205]\nJe vais savourer cela encore un peu..."
   },
   {
     "id": 20,
@@ -352,7 +352,7 @@
     "nom_orig": "Count",
     "texte_orig": "The[SP]gates[SP]of[SP]the[SP]netherworld[SP]are[SP]finally[SP]open...[1205][001E]\nThe[SP]end[SP]of[SP]time[SP]may[SP]be[SP]drawing[SP]near.",
     "nom_fr": "Comte",
-    "texte_fr": "Les portes des enfers sont ouvertes...[1205][001E]\nLa fin des temps approche."
+    "texte_fr": "Les portes des enfers sont ouvertes...[001E][1205]\nLa fin des temps approche."
   },
   {
     "id": 21,
@@ -382,7 +382,7 @@
     "nom_orig": "Count",
     "texte_orig": "And[SP]I...?[1205][001E][SP]I[SP]would[SP]hope[SP]that[SP]you[SP]continue[SP]to\nrun[SP]until[SP]the[SP]end.[SP]I[SP]want[SP]the[SP]limits[SP]of[SP]man's\npotential[SP]to[SP]be[SP]tested.",
     "nom_fr": "Comte",
-    "texte_fr": "Et moi?![1205][001E] J'espère que vous courrez\njusqu'au bout. Je veux que les limites\ndu potentiel humain soient éprouvées."
+    "texte_fr": "Et moi?![001E][1205] J'espère que vous courrez\njusqu'au bout. Je veux que les limites\ndu potentiel humain soient éprouvées."
   },
   {
     "id": 23,
@@ -397,7 +397,7 @@
     "nom_orig": "Count",
     "texte_orig": "The[SP]Last[SP]Battalion[SP]is[SP]on[SP]the[SP]march...[1205][001E][SP]The[SP]end\nof[SP]time[SP]may[SP]be[SP]drawing[SP]near...[1205][001E][SP]And[SP]you?[SP]How\nwill[SP]you[SP]respond?",
     "nom_fr": "Comte",
-    "texte_fr": "Le Bataillon est en marche...[1205][001E] La fin des\ntemps approche...[1205][001E] Et vous? Que ferez-vous?"
+    "texte_fr": "Le Bataillon est en marche...[001E][1205] La fin des\ntemps approche...[001E][1205] Et vous? Que ferez-vous?"
   },
   {
     "id": 24,
@@ -412,7 +412,7 @@
     "nom_orig": "Count",
     "texte_orig": "Man[SP]cannot[SP]defy[SP]the[SP]working[SP]of[SP]time.[SP]Knowing\nthis,[SP]will[SP]you[SP]fight[SP]against[SP]the[SP]end?[1205][001E][SP]Yes...\nRise[SP]up[SP]against[SP]it.",
     "nom_fr": "Comte",
-    "texte_fr": "L'homme ne peut défier le temps. Le\nsachant, allez-vous combattre la fin?[1205][001E]\nOui... Dressez-vous contre elle."
+    "texte_fr": "L'homme ne peut défier le temps. Le\nsachant, allez-vous combattre la fin?[001E][1205]\nOui... Dressez-vous contre elle."
   },
   {
     "id": 25,
@@ -427,7 +427,7 @@
     "nom_orig": "Count",
     "texte_orig": "A[SP]pawn[SP]has[SP]meaning[SP]only[SP]if[SP]it[SP]moves...[1205][001E][SP]It[SP]won't\nbe[SP]much,[SP]but[SP]I'll[SP]lend[SP]you[SP]my[SP]strength.[SP]Take\nyour[SP]time[SP]and[SP]browse[SP]my[SP]new[SP]wares.",
     "nom_fr": "Comte",
-    "texte_fr": "Un pion a du sens s'il bouge...[1205][001E] Ce\nn'est rien, mais je vous prête ma\nforce. Explorez mes nouveaux articles."
+    "texte_fr": "Un pion a du sens s'il bouge...[001E][1205] Ce\nn'est rien, mais je vous prête ma\nforce. Explorez mes nouveaux articles."
   },
   {
     "id": 26,
@@ -442,7 +442,7 @@
     "nom_orig": "Count",
     "texte_orig": "Who[SP]decided[SP]that[SP]tomorrow[SP]will[SP]be[SP]a[SP]bright[SP]new\nday?[1205][001E][SP]Such[SP]proclamations[SP]are[SP]the[SP]source[SP]of[SP]man's\nanxiety.[1205][001E][SP]Peace[SP]lies[SP]with[SP]the[SP]cold,[SP]still[SP]past.",
     "nom_fr": "Comte",
-    "texte_fr": "Qui décida que demain serait radieux?[1205][001E]\nC'est la source de l'angoisse humaine.[1205][001E]\nLa paix réside dans le passé."
+    "texte_fr": "Qui décida que demain serait radieux?[001E][1205]\nC'est la source de l'angoisse humaine.[001E][1205]\nLa paix réside dans le passé."
   },
   {
     "id": 27,
@@ -457,7 +457,7 @@
     "nom_orig": "Quiet[SP]gentleman",
     "texte_orig": "Everything[SP]seems[SP]fleeting[SP]in[SP]the[SP]endless[SP]flow\nof[SP]time.[1205][000F][SP]But[SP]to[SP]see[SP]this[SP]city[SP]soar[SP]through\nthe[SP]skies...",
     "nom_fr": "Homme tranquille",
-    "texte_fr": "Tout semble éphémère dans le flot du temps.\n[1205][000F]Mais voir cette ville\nvoler dans les cieux..."
+    "texte_fr": "Tout semble éphémère dans le flot du temps.\n[000F][1205]Mais voir cette ville\nvoler dans les cieux..."
   },
   {
     "id": 28,
@@ -487,7 +487,7 @@
     "nom_orig": "Quiet[SP]gentleman",
     "texte_orig": "Rather[SP]than[SP]regret[SP]a[SP]past[SP]that[SP]cannot[SP]be\nchanged,[SP]one[SP]should[SP]look[SP]toward[SP]the[SP]future\nabout[SP]to[SP]come.[1205][000F][SP]So[SP]they[SP]say,[SP]but[SP]should[SP]we?",
     "nom_fr": "Homme tranquille",
-    "texte_fr": "Plutôt que de regretter un passé immuable,\non devrait se tourner vers l'avenir. \n[1205][000F]C'est ce qu'on dit, mais le faut-il?"
+    "texte_fr": "Plutôt que de regretter un passé immuable,\non devrait se tourner vers l'avenir. \n[000F][1205]C'est ce qu'on dit, mais le faut-il?"
   },
   {
     "id": 30,
@@ -502,7 +502,7 @@
     "nom_orig": "Quiet[SP]gentleman",
     "texte_orig": "The[SP]past[SP]is[SP]the[SP]foundation[SP]of[SP]ourselves.[1205][000F][SP]It[SP]is\nthe[SP]only[SP]proof[SP]I[SP]have[SP]that[SP]I[SP]exist.[1205][000F][SP]I[SP]cannot\ngo[SP]on[SP]by[SP]ignoring[SP]it.",
     "nom_fr": "Homme tranquille",
-    "texte_fr": "Le passé est le fondement de\n[1205][000F][1205][000F]nous-mêmes. C'est ma seule preuve\nd'existence. Je ne peux l'ignorer."
+    "texte_fr": "Le passé est le fondement de\n[000F][1205][000F][1205]nous-mêmes. C'est ma seule preuve\nd'existence. Je ne peux l'ignorer."
   },
   {
     "id": 31,
@@ -517,7 +517,7 @@
     "nom_orig": "Quiet[SP]gentleman",
     "texte_orig": "I[SP]am[SP]a[SP]man[SP]who[SP]can[SP]only[SP]live[SP]for[SP]the[SP]past.[1205][000F]\nWho[SP]continues[SP]to[SP]gaze[SP]upon[SP]the[SP]fixed[SP]past\ncalled[SP]the[SP]present.[1205][000F][SP]That[SP]is[SP]best,[SP]I[SP]think.",
     "nom_fr": "Homme tranquille",
-    "texte_fr": "Je ne vis que pour le passé.\n[1205][000F][1205][000F]Contempler ce passé figé qu'on nomme\nprésent. C'est ce qu'il y a de mieux."
+    "texte_fr": "Je ne vis que pour le passé.\n[000F][1205][000F][1205]Contempler ce passé figé qu'on nomme\nprésent. C'est ce qu'il y a de mieux."
   },
   {
     "id": 32,
@@ -532,7 +532,7 @@
     "nom_orig": "Count",
     "texte_orig": "I[SP]see...[1205][000F][SP]So[SP]you[SP]spread[SP]a[SP]rumor[SP]that[SP]I[SP]stock\na[SP]legendary[SP]flower[SP]here...",
     "nom_fr": "Comte",
-    "texte_fr": "Je vois.[1205][000F].. Vous avez répandu la\nrumeur que je vends cette fleur..."
+    "texte_fr": "Je vois.[000F][1205].. Vous avez répandu la\nrumeur que je vends cette fleur..."
   },
   {
     "id": 33,
@@ -547,7 +547,7 @@
     "nom_orig": "Count",
     "texte_orig": "Pawns[SP]that[SP]occupy[SP]the[SP]eternal[SP]rings[SP]of[SP]time\nattempt[SP]to[SP]defy[SP]it,[SP]even[SP]now...[1205][001E][SP]Interesting.",
     "nom_fr": "Comte",
-    "texte_fr": "Les pions des anneaux du temps\ntentent de le défier...[1205][001E] Intéressant."
+    "texte_fr": "Les pions des anneaux du temps\ntentent de le défier...[001E][1205] Intéressant."
   },
   {
     "id": 34,
@@ -562,7 +562,7 @@
     "nom_orig": "Count",
     "texte_orig": "Then[SP]I[SP]will[SP]continue[SP]to[SP]play[SP]my[SP]role[SP]a[SP]while\nmore.[1205][001E][SP]Just[SP]as[SP]you[SP]wish[SP]me[SP]to...[1205][001E][SP]as[SP]fellow\nmarionettes[SP]of[SP]time...",
     "nom_fr": "Comte",
-    "texte_fr": "Alors je continuerai mon rôle un\npeu. [1205][001E] Comme vous le souhaitez...[1205][001E] en\ntant que marionnettes du temps..."
+    "texte_fr": "Alors je continuerai mon rôle un\npeu. [001E][1205] Comme vous le souhaitez...[001E][1205] en\ntant que marionnettes du temps..."
   },
   {
     "id": 35,
@@ -577,7 +577,7 @@
     "nom_orig": "Count",
     "texte_orig": "My[SP]castle[SP]does[SP]handle[SP]the[SP]legendary[SP]flower.[1205][001E]\nBut[SP]it[SP]is[SP]a[SP]rare[SP]thing.[SP]I[SP]cannot[SP]part[SP]with[SP]it\neasily.[1205][001E][SP]If[SP]you[SP]doubled[SP]its[SP]price,[SP]then...\n[1208][0006][1210][U+03BA]Buy[SP]weapons\nBuy[SP]accessories\nBuy[SP]items\nTalk[SP]to[SP]the[SP]Count\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Comte",
-    "texte_fr": "Mon château a bien cette fleur.[1205][001E]\nMais elle est rare. Dur de s'en\nséparer.[1205][001E] Si vous doubliez le prix...\n[1208][0006][1210]Acheter armes\nAcheter accessoires\nAcheter objets\nPapoter\nNon\nQuitter[U+03BA]",
+    "texte_fr": "Mon château a bien cette fleur.[001E][1205]\nMais elle est rare. Dur de s'en\nséparer.[001E][1205] Si vous doubliez le prix...\n[1208][0006][1210]Acheter armes\nAcheter accessoires\nAcheter objets\nPapoter\nNon\nQuitter[U+03BA]",
     "question_orig": "My[SP]castle[SP]does[SP]handle[SP]the[SP]legendary[SP]flower.[1205][001E]\nBut[SP]it[SP]is[SP]a[SP]rare[SP]thing.[SP]I[SP]cannot[SP]part[SP]with[SP]it\neasily.[1205][001E][SP]If[SP]you[SP]doubled[SP]its[SP]price,[SP]then...",
     "choix_orig": [
       "[1210]Buy[SP]weapons",
@@ -606,7 +606,7 @@
     "nom_orig": "Count",
     "texte_orig": "Welcome[SP]to[SP]Time[SP]Castle...[1205][000A][SP]The[SP]onrush[SP]of[SP]time[SP]is\nswift[SP]and[SP]unceasing.[1205][000A][SP]Now,[SP]state[SP]your[SP]business.\n[1208][0006][1210][U+03BA]Buy[SP]weapons\nBuy[SP]accessories\nSell[SP]items\nTalk[SP]to[SP]the[SP]Count\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Comte",
-    "texte_fr": "Bienvenue au Château du Temps...[1205][000A]\nLe flot du temps est\nrapide.[1205][000A] Dites-moi votre requête.\n[1208][0006][1210]Acheter armes\nAcheter accessoires\nVendre objets\nPapoter\nNon\nQuitter[U+03BA]",
+    "texte_fr": "Bienvenue au Château du Temps...[000A][1205]\nLe flot du temps est\nrapide.[000A][1205] Dites-moi votre requête.\n[1208][0006][1210]Acheter armes\nAcheter accessoires\nVendre objets\nPapoter\nNon\nQuitter[U+03BA]",
     "question_orig": "Welcome[SP]to[SP]Time[SP]Castle...[1205][000A][SP]The[SP]onrush[SP]of[SP]time[SP]is\nswift[SP]and[SP]unceasing.[1205][000A][SP]Now,[SP]state[SP]your[SP]business.",
     "choix_orig": [
       "[1210]Buy[SP]weapons",
@@ -706,7 +706,7 @@
     "nom_orig": "Count",
     "texte_orig": "The[SP]answer[SP]is[SP]the[SP]same[SP]no[SP]matter[SP]how[SP]many[SP]times\nyou[SP]ask.[1205][000F][SP]There[SP]is[SP]no[SP]such[SP]thing[SP]as[SP]a[SP]legendary\nflower[SP]at[SP]this[SP]castle.",
     "nom_fr": "Comte",
-    "texte_fr": "Ma réponse ne change pas. Il n'existe\n[1205][000F]pas de fleur légendaire dans ce château."
+    "texte_fr": "Ma réponse ne change pas. Il n'existe\n[000F][1205]pas de fleur légendaire dans ce château."
   },
   {
     "id": 41,
@@ -736,7 +736,7 @@
     "nom_orig": "Middle-aged[SP]woman",
     "texte_orig": "I'll[SP]pay[SP]whatever[SP]you[SP]ask.[1205][000F][SP]The[SP]legendary[SP]flower\nis[SP]here,[SP]isn't[SP]it?[1205][000F][SP]Please[SP]sell[SP]it[SP]to[SP]me.",
     "nom_fr": "Femme mûre",
-    "texte_fr": "Je paierai le prix fort. [1205][000F][1205][000F]Elle est\nbien là, n'est-ce pas? Vendez-la-moi."
+    "texte_fr": "Je paierai le prix fort. [000F][1205][000F][1205]Elle est\nbien là, n'est-ce pas? Vendez-la-moi."
   },
   {
     "id": 43,
@@ -751,7 +751,7 @@
     "nom_orig": "Count",
     "texte_orig": "Legendary,[SP]hm...[1205][000F][SP]To[SP]what[SP]extent[SP]does[SP]man\nactually[SP]understand[SP]the[SP]weight[SP]of[SP]time\nconveyed[SP]by[SP]that[SP]word...?",
     "nom_fr": "Comte",
-    "texte_fr": "Légendaire, hm.[1205][000F].. L'homme comprend-il le\npoids du temps véhiculé par ce mot...?"
+    "texte_fr": "Légendaire, hm.[000F][1205].. L'homme comprend-il le\npoids du temps véhiculé par ce mot...?"
   },
   {
     "id": 44,
@@ -811,7 +811,7 @@
     "nom_orig": "College[SP]student",
     "texte_orig": "I[SP]dunno,[SP]maybe[SP]it[SP]just[SP]hasn't[SP]been[SP]delivered\nhere[SP]yet...[1205][000F][SP]Maybe[SP]the[SP]seller's[SP]somewhere[SP]else.",
     "nom_fr": "Étudiant",
-    "texte_fr": "Peut-être pas encore livré ici...\n[1205][000F]Le vendeur est peut-être ailleurs."
+    "texte_fr": "Peut-être pas encore livré ici...\n[000F][1205]Le vendeur est peut-être ailleurs."
   },
   {
     "id": 48,
@@ -826,7 +826,7 @@
     "nom_orig": "Student",
     "texte_orig": "It[SP]could[SP]be[SP]that[SP]someone[SP]already[SP]bought[SP]it.[1205][000F]\nIf[SP]that's[SP]the[SP]case,[SP]he[SP]should[SP]just[SP]say[SP]so!",
     "nom_fr": "Lycéen",
-    "texte_fr": "Quelqu'un l'a déjà achetée. [1205][000F]Si\nc'est le cas, qu'il le dise!"
+    "texte_fr": "Quelqu'un l'a déjà achetée. [000F][1205]Si\nc'est le cas, qu'il le dise!"
   },
   {
     "id": 49,
@@ -971,7 +971,7 @@
     "nom_orig": "Count",
     "texte_orig": "The[SP]resale[SP]price[SP]is[SP]about[SP]50%[SP]of[SP]the[SP]original\nprice.[SP]Equipped[SP]items[SP]and[SP]certain[SP]special[SP]items\ncannot[SP]be[SP]sold.[SP]That[SP]should[SP]cover[SP]it,[SP]I[SP]think.",
     "nom_fr": "Comte",
-    "texte_fr": "Revente à 50% du\nprix. Les objets équipés et\nspéciaux ne sont pas\nvendables. C'est tout."
+    "texte_fr": "Revente à 50% du\nprix. Les objets équipés et\nspéciaux ne sont pas vendables. C'est tout."
   },
   {
     "id": 58,
@@ -1061,7 +1061,7 @@
     "nom_orig": "Count",
     "texte_orig": "The[SP]resale[SP]price[SP]is[SP]about[SP]50%[SP]of[SP]the[SP]original\nprice.[SP]Equipped[SP]items[SP]and[SP]certain[SP]special[SP]items\ncannot[SP]be[SP]sold.[SP]That[SP]should[SP]cover[SP]it,[SP]I[SP]think.",
     "nom_fr": "Comte",
-    "texte_fr": "Revente à 50% du\nprix. Les objets équipés et\nspéciaux ne sont pas\nvendables. C'est tout."
+    "texte_fr": "Revente à 50% du\nprix. Les objets équipés et\nspéciaux ne sont pas vendables. C'est tout."
   },
   {
     "id": 64,

--- a/traduction/event_scripts/script_290.json
+++ b/traduction/event_scripts/script_290.json
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#14![SP][1432][NULL][NULL][0014]Sorry-ia[1432][NULL][NULL][0014][SP]means...[1205][001E]\nWell,[SP]you[SP]probably[SP]figured[SP]that[SP]one[SP]out.",
     "nom_fr": "Ginko",
-    "texte_fr": "Leçon de cantonais n°14! [1432][NULL][NULL][0014]Sorry-ia[1432][NULL][NULL][0014] veut\ndire...[1205][001E] Bah, vous avez sans doute deviné."
+    "texte_fr": "Leçon de cantonais n°14! [1432][NULL][NULL][0014]Sorry-ia[1432][NULL][NULL][0014] veut\ndire...[001E][1205] Bah, vous avez sans doute deviné."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#16![1205][001E][SP][1432][NULL][NULL][0014]Hai[1432][NULL][NULL][0014][SP]is[SP]used[SP]like\n[1432][NULL][NULL][0014]Okay![1432][NULL][NULL][0014][SP]when[SP]you[SP]want[SP]to[SP]agree[SP]with[SP]something.\nIt's[SP]pretty[SP]straightforward.",
     "nom_fr": "Ginko",
-    "texte_fr": "Leçon de cantonais n°16![1205][001E] [1432][NULL][NULL][0014]Hai[1432][NULL][NULL][0014] s'utilise\ncomme [1432][NULL][NULL][0014]Okay![1432][NULL][NULL][0014] quand on est d'accord avec\nquelque chose. C'est plutôt simple."
+    "texte_fr": "Leçon de cantonais n°16![001E][1205] [1432][NULL][NULL][0014]Hai[1432][NULL][NULL][0014] s'utilise\ncomme [1432][NULL][NULL][0014]Okay![1432][NULL][NULL][0014] quand on est d'accord avec\nquelque chose. C'est plutôt simple."
   },
   {
     "id": 11,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]don't[SP]know[SP]anything[SP]about[SP]fashion.[SP]Even[SP]these\nclothes[SP]are[SP]stuff[SP]my[SP]friend[SP]picked[SP]out.[1205][001E][SP]Everyone\nsays[SP]they're[SP]too[SP]flashy,[SP]though...[SP]You[SP]think?",
     "nom_fr": "Maya",
-    "texte_fr": "J'y connais rien en mode. Ces vêtements,\nc'est une amie qui les a choisis.[1205][001E] Tout le\nmonde les trouve trop voyants... Ton avis?"
+    "texte_fr": "J'y connais rien en mode. Ces vêtements,\nc'est une amie qui les a choisis.[001E][1205] Tout le\nmonde les trouve trop voyants... Ton avis?"
   },
   {
     "id": 15,
@@ -252,7 +252,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm...[SP]I[SP]don't[SP]really[SP]understand[SP]this[SP]store's\ntaste...[1205][000F][SP]How[SP]could[SP]something[SP]like[SP]this[SP]cost\n180,000[SP]yen?",
     "nom_fr": "Maya",
-    "texte_fr": "Hmm... Je ne comprends pas les goûts de ce\n[1205][000F]magasin... Comment ça peut coûter 180 000\nyens?"
+    "texte_fr": "Hmm... Je ne comprends pas les goûts de ce\n[000F][1205]magasin... Comment ça peut coûter 180 000\nyens?"
   },
   {
     "id": 17,
@@ -282,7 +282,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Do[SP]you[SP]doubt[SP]the[SP]In[SP]Lak'ech[SP]as[SP]well?[SP]People[SP]now\nhave[SP]no[SP]hearts[SP]to[SP]realize[SP]their[SP]sins,[SP]but[SP]in\nthe[SP]end,[SP]there's[SP]no[SP]choice[SP]but[SP]to[SP]believe.",
     "nom_fr": "Maya",
-    "texte_fr": "Tu doutes aussi de l'In Lak'ech? Les gens\nn'ont pas de cœur\npour réaliser leurs péchés,\nmais à la fin, il faut bien y croire."
+    "texte_fr": "Tu doutes aussi de l'In Lak'ech? Les gens\nn'ont pas de cœur\npour réaliser leurs péchés, mais à la fin, il faut bien y croire."
   },
   {
     "id": 19,
@@ -327,7 +327,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I'd[SP]think[SP]flashy[SP]clothes[SP]like[SP]this[SP]would[SP]get\nin[SP]the[SP]way[SP]of[SP]my[SP]job...[1205][001E][SP]Do[SP]men[SP]really[SP]like\nthis[SP]kind[SP]of[SP]thing?",
     "nom_fr": "Yukino",
-    "texte_fr": "Des vêtements aussi voyants me\ngêneraient pour travailler...[1205][001E] Les hommes\naiment vraiment ce genre de trucs?"
+    "texte_fr": "Des vêtements aussi voyants me\ngêneraient pour travailler...[001E][1205] Les hommes\naiment vraiment ce genre de trucs?"
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Huh?[SP]Why[SP]don't[SP]I[SP]take[SP]a[SP]picture[SP]of[SP]that[SP]person\ntoo?[1205][000F][SP]Sorry,[SP][1113],[SP]I[SP]specialize[SP]in[SP]scenery.",
     "nom_fr": "Yukino",
-    "texte_fr": "Hein? Pourquoi je ne\nla prends pas en photo?\n[1205][000F]Désolée [1113], je préfère les paysages."
+    "texte_fr": "Hein? Pourquoi je ne\nla prends pas en photo?\n[000F][1205]Désolée [1113], je préfère les paysages."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "There[SP]was[SP]a[SP]Rosa[SP]Candida[SP]in[SP]Mikage-cho,\nwhere[SP]I[SP]used[SP]to[SP]live.[1205][000F][SP]Seems[SP]like[SP]it's[SP]just[SP]as\nexpensive,[SP]wherever[SP]you[SP]go.",
     "nom_fr": "Yukino",
-    "texte_fr": "Il y avait un Rosa Candida à Mikage-cho,\noù je vivais. [1205][000F]On dirait que c'est aussi\ncher, peu importe où l'on va."
+    "texte_fr": "Il y avait un Rosa Candida à Mikage-cho,\noù je vivais. [000F][1205]On dirait que c'est aussi\ncher, peu importe où l'on va."
   },
   {
     "id": 24,
@@ -402,7 +402,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Who'd[SP]have[SP]thought[SP]King[SP]Leo[SP]was[SP]part[SP]of[SP]the\ngroup[SP]who[SP]wrote[SP]the[SP]In[SP]Lak'ech...[SP]Did[SP]he[SP]bring\nthe[SP]book[SP]into[SP]the[SP]Masked[SP]Circle[SP]too?[SP]Why...?",
     "nom_fr": "Yukino",
-    "texte_fr": "Qui aurait cru que le\nRoi Lion était de ceux\nqui ont écrit l'In Lak'ech... A-t-il amené\nce livre au Cercle masqué? Pourquoi...?"
+    "texte_fr": "Qui aurait cru que le\nRoi Lion était de ceux\nqui ont écrit l'In Lak'ech... A-t-il amené ce livre au Cercle masqué? Pourquoi...?"
   },
   {
     "id": 27,
@@ -576,7 +576,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "I[SP]hear[SP]Sevens'[SP]curse[SP]is[SP]lifted.[SP]Maybe[SP]there's\nno[SP]hope[SP]its[SP]image[SP]will[SP]recover,[SP]but[SP]cheer[SP]up\nand[SP]improve[SP]YOUR[SP]image[SP]with[SP]our[SP]fashions!",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Il paraît que la malédiction de Seven est\nlevée. Leur réputation\nest peut-être ruinée,\nmais améliorez la VÔTRE avec nos vêtements!"
+    "texte_fr": "Il paraît que la malédiction de Seven est\nlevée. Leur réputation\nest peut-être ruinée, mais améliorez la VÔTRE avec nos vêtements!"
   },
   {
     "id": 36,
@@ -711,7 +711,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "I've[SP]got[SP]it...[1205][000F][SP]Our[SP]high[SP]concept[SP]for[SP]next[SP]year...[1205][000F]\nDisaster[SP]protection[SP]gear!",
     "nom_fr": "Vendeuse",
-    "texte_fr": "J'ai trouvé.[1205][000F][1205].[000F]. Notre concept de l'an\nprochain... La tenue anti-catastrophe!"
+    "texte_fr": "J'ai trouvé.[000F][1205][1205].[000F]. Notre concept de l'an\nprochain... La tenue anti-catastrophe!"
   },
   {
     "id": 45,
@@ -741,7 +741,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "In[SP]other[SP]words,[SP]you[SP]have[SP]to[SP]protect[SP]yourself.\nArmor[SP]is[SP]a[SP]must![1205][000F][SP]Good[SP]looks,[SP]good[SP]feel,[SP]and\ngood[SP]protection![1205][000F][SP]We[SP]stand[SP]by[SP]our[SP]product!",
     "nom_fr": "Vendeuse",
-    "texte_fr": "En bref, il faut se protéger. L'armure est\nessentielle! [1205][000F][1205][000F]Belle, confortable, et\nprotectrice! Nous soutenons notre produit!"
+    "texte_fr": "En bref, il faut se protéger. L'armure est\nessentielle! [000F][1205][000F][1205]Belle, confortable, et\nprotectrice! Nous soutenons notre produit!"
   },
   {
     "id": 47,
@@ -816,7 +816,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "We'll[SP]be[SP]evolving[SP]soon,[SP]but[SP]I[SP]must[SP]say,[SP]it's\nquite[SP]chaotic[SP]out[SP]there.[1205][000F][SP]If[SP]they[SP]end[SP]up[SP]dead,\nthey'll[SP]neither[SP]evolve[SP]nor[SP]regress.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Nous allons bientôt évoluer, mais c'est\nassez chaotique dehors. [1205][000F]S'ils finissent\nmorts, ils n'évolueront ni ne régresseront."
+    "texte_fr": "Nous allons bientôt évoluer, mais c'est\nassez chaotique dehors. [000F][1205]S'ils finissent\nmorts, ils n'évolueront ni ne régresseront."
   },
   {
     "id": 52,
@@ -831,7 +831,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "You're[SP]here?[SP]Now?[1205][000F][SP]Are[SP]you[SP]planning[SP]to[SP]fight\nthose[SP]men[SP]who[SP]came[SP]from[SP]the[SP]sky?[SP]I[SP]do[SP]believe\nyou're[SP]out[SP]of[SP]your[SP]mind.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Vous êtes ici? [1205][000F]Maintenant? Vous comptez\ncombattre ces hommes venus du ciel? Je\ncrois que vous avez perdu la raison."
+    "texte_fr": "Vous êtes ici? [000F][1205]Maintenant? Vous comptez\ncombattre ces hommes venus du ciel? Je\ncrois que vous avez perdu la raison."
   },
   {
     "id": 53,
@@ -846,7 +846,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "It's[SP]one[SP]thing[SP]to[SP]scatter[SP]your[SP]petals[SP]bravely,\nbut[SP]wouldn't[SP]you[SP]rather[SP]blossom[SP]as[SP]a[SP]flower[SP]of\nvictory?[SP]Then[SP]you[SP]must[SP]clad[SP]yourself[SP]in[SP]blooms.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "C'est bien d'éparpiller bravement vos\npétales, mais ne préférez-vous pas\nêtre une fleur de victoire?\nAlorsvous devez vous vêtir de fleurs."
+    "texte_fr": "C'est bien d'éparpiller bravement vos\npétales, mais ne préférez-vous pas\nêtre une fleur de victoire? Alorsvous devez vous vêtir de fleurs."
   },
   {
     "id": 54,
@@ -876,7 +876,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "See[SP]you[SP]again.[1205][000A][SP]Come[SP]back[SP]when[SP]this[SP]emblem[SP]curse\nhas[SP]been[SP]lifted.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "À bientôt.[1205][000A] Revenez quand la\nmalédiction de l'emblème sera finie."
+    "texte_fr": "À bientôt.[000A][1205] Revenez quand la\nmalédiction de l'emblème sera finie."
   },
   {
     "id": 56,
@@ -891,7 +891,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "You[SP]really[SP]need[SP]better[SP]taste[SP]in[SP]fashion.[1205][000F]\nI'll[SP]give[SP]you[SP]a[SP]personal[SP]lesson[SP]next[SP]time.[1205][000F]\nSee[SP]you[SP]again.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Vous devez vraiment améliorer vos\n[1205][000F][1205][000F]goûts. Je vous donnerai une leçon\nla prochaine fois. À bientôt."
+    "texte_fr": "Vous devez vraiment améliorer vos\n[000F][1205][000F][1205]goûts. Je vous donnerai une leçon\nla prochaine fois. À bientôt."
   },
   {
     "id": 57,
@@ -906,7 +906,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Hey![1205][000A][SP]That's[SP]the[SP]dressing[SP]room.[1205][000A][SP]Don't[SP]go[SP]in\nthere[SP]if[SP]you[SP]don't[SP]need[SP]to[SP]use[SP]it.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Hé![1205][000A] C'est la cabine d'essayage.[1205][000A] N'y\nallez pas si vous ne l'utilisez pas."
+    "texte_fr": "Hé![000A][1205] C'est la cabine d'essayage.[000A][1205] N'y\nallez pas si vous ne l'utilisez pas."
   },
   {
     "id": 58,
@@ -936,7 +936,7 @@
     "nom_orig": "Hayseed",
     "texte_orig": "'At's[SP]what[SP]that[SP]lady[SP]said.[SP]City[SP]folk[SP]sure[SP]are\ndifferent[SP]if'n[SP]armor[SP]kin[SP]be[SP]a[SP]trend...[SP]Ah[SP]should\ncall[SP]up[SP]the[SP]folks[SP]back[SP]home[SP]and[SP]tell[SP]'em.",
     "nom_fr": "Péquenaud",
-    "texte_fr": "C'qu'a dit la dame.\nLes gens d'la ville sont\nbien différents si l'armure\nest à la mode...\nJ'devrais appeler les miens pour leur dire."
+    "texte_fr": "C'qu'a dit la dame.\nLes gens d'la ville sont\nbien différents si l'armure est à la mode... J'devrais appeler les miens pour leur dire."
   },
   {
     "id": 60,
@@ -951,7 +951,7 @@
     "nom_orig": "Hayseed",
     "texte_orig": "A-Ah[SP]didn't[SP]akshully[SP]come[SP]to[SP]buy[SP]clothes[SP]fer\nmahself...[1205][000A][SP]I-It's[SP]gonna[SP]be[SP]a[SP]present,[SP]like...[1205][000F]\nBut[SP]what[SP]kinda[SP]clothes[SP]would[SP]she[SP]want?",
     "nom_fr": "Péquenaud",
-    "texte_fr": "J'suis pas v'nu acheter des vêtements\npour moi.[1205]..[1205][000A] C-C'est pour un cadeau..[000F].\nQuel genre de vêtements elle voudrait?"
+    "texte_fr": "J'suis pas v'nu acheter des vêtements\npour moi.[1205]..[000A][1205] C-C'est pour un cadeau..[000F].\nQuel genre de vêtements elle voudrait?"
   },
   {
     "id": 61,
@@ -966,7 +966,7 @@
     "nom_orig": "Hayseed",
     "texte_orig": "There's[SP]this[SP]ladyfriend[SP]ah[SP]almost[SP]admired...\nShe[SP]don't[SP]cotton[SP]to[SP]me,[SP]though.[1205][000F][SP]Her[SP]birthday's\ncomin'[SP]up,[SP]and[SP]ah[SP]thought...",
     "nom_fr": "Péquenaud",
-    "texte_fr": "Y'a cette amie que j'admirais presque...\nMais elle s'intéresse pas à moi. [1205][000F]Son\nanniv' approche, et j'me suis dit..."
+    "texte_fr": "Y'a cette amie que j'admirais presque...\nMais elle s'intéresse pas à moi. [000F][1205]Son\nanniv' approche, et j'me suis dit..."
   },
   {
     "id": 62,
@@ -981,7 +981,7 @@
     "nom_orig": "Hayseed",
     "texte_orig": "'At's[SP]the[SP]only[SP]way[SP]ah[SP]kin[SP]get[SP]through[SP]to[SP]her.[1205][000F]\nAh[SP]know[SP]ah'm[SP]no[SP]kid[SP]anymore...[1205][000F][SP]But[SP]some[SP]things\nain't[SP]changed[SP]at[SP]all...",
     "nom_fr": "Péquenaud",
-    "texte_fr": "C'est l'seul moyen d'l'atteindre.\n[1205][000F][1205][000F]J'sais qu'j'suis plus un gosse... Mais\ny'a des choses qu'ont pas changé..."
+    "texte_fr": "C'est l'seul moyen d'l'atteindre.\n[000F][1205][000F][1205]J'sais qu'j'suis plus un gosse... Mais\ny'a des choses qu'ont pas changé..."
   },
   {
     "id": 63,
@@ -996,7 +996,7 @@
     "nom_orig": "Hayseed",
     "texte_orig": "'At[SP]one[SP]there[SP]says[SP]she's[SP]in[SP]the[SP]Masked[SP]Circle,\nbut[SP]is[SP]she[SP]havin'[SP]me[SP]on?[1205][000F][SP]Ah[SP]mean,[SP]she's[SP]a[SP]lady![1205][000F]\nThe[SP]city's[SP]a[SP]terrifyin'[SP]place,[SP]ah[SP]tell[SP]ya.",
     "nom_fr": "Péquenaud",
-    "texte_fr": "Celle-là dit être\ndans l'Cercle masqué, mais\nelle m'fait marcher? [1205][000F][1205][000F]J'veux dire, c'est une\ndame! La ville\nc'est effrayant, j'vous jure."
+    "texte_fr": "Celle-là dit être\ndans l'Cercle masqué, mais\nelle m'fait marcher? [000F][1205][000F][1205]J'veux dire, c'est une dame! La ville c'est effrayant, j'vous jure."
   },
   {
     "id": 64,
@@ -1011,7 +1011,7 @@
     "nom_orig": "Hayseed",
     "texte_orig": "Th'[SP]next[SP]part[SP]of[SP]the[SP]Oracle's[SP]somethin'[SP]about\na[SP]lion's[SP]roar?[1205][000F][SP]Probably[SP]about[SP]them[SP]Leonids.[1205][000F]\nNah,[SP]ah[SP]ain't[SP]foolin'.[SP]Ah[SP]heard[SP]a[SP]rumor.",
     "nom_fr": "Péquenaud",
-    "texte_fr": "La suite d'l'Oracle parle d'un cri d'lion?\n[1205][000F][1205][000F]Sûrement à propos des Léonides. Nan,\nj'plaisante pas. J'ai entendu la rumeur."
+    "texte_fr": "La suite d'l'Oracle parle d'un cri d'lion?\n[000F][1205][000F][1205]Sûrement à propos des Léonides. Nan,\nj'plaisante pas. J'ai entendu la rumeur."
   },
   {
     "id": 65,
@@ -1056,7 +1056,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "But[SP]wouldn't[SP]you[SP]hate[SP]for[SP]people[SP]to[SP]think[SP]less\nof[SP]you[SP]for[SP]that?[SP]That's[SP]why[SP]I[SP]want[SP]some[SP]decent\nclothes.[SP]My[SP]pay's[SP]low,[SP]but[SP]I[SP]can[SP]charge[SP]it...",
     "nom_fr": "Femme active",
-    "texte_fr": "Mais ne détestez-vous pas\nqu'on vous juge pour\nça? C'est pourquoi je veux des vêtements\ndécents. Je gagne peu,\nmais je paie àcrédit..."
+    "texte_fr": "Mais ne détestez-vous pas\nqu'on vous juge pour\nça? C'est pourquoi je veux des vêtements décents. Je gagne peu, mais je paie àcrédit..."
   },
   {
     "id": 68,
@@ -1071,7 +1071,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Everything[SP]here's[SP]so[SP]expensive.[1205][000A][SP]But[SP]I[SP]can't\ncompete[SP]with[SP]her[SP]if[SP]I[SP]don't[SP]have[SP]something...[1205][000F]\nI[SP]guess[SP]I'll[SP]take[SP]out[SP]a[SP]loan,[SP]then.",
     "nom_fr": "Femme active",
-    "texte_fr": "Tout est cher ici.[1205][1205][000A] Mais je ne peux pas\nrivaliser avec elle sans rien avoir.[000F]..\nJe crois que je vais faire un emprunt."
+    "texte_fr": "Tout est cher ici.[1205][000A][1205] Mais je ne peux pas\nrivaliser avec elle sans rien avoir.[000F]..\nJe crois que je vais faire un emprunt."
   },
   {
     "id": 69,
@@ -1086,7 +1086,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Hah,[SP]I[SP]made[SP]up[SP]my[SP]mind[SP]to[SP]buy[SP]this[SP]coat![1205][000F]\n42,000[SP]yen![1205][000F][SP]Heehee,[SP]I[SP]almost[SP]feel[SP]bad[SP]putting\nit[SP]on.[SP]I[SP]should[SP]keep[SP]it[SP]safe[SP]in[SP]my[SP]closet.",
     "nom_fr": "Femme active",
-    "texte_fr": "Hah, j'ai décidé d'acheter ce manteau! [1205][000F][1205][000F]42\n000 yens! Héhé, je me sens presque mal de\nle mettre. Je devrais le garder au placard."
+    "texte_fr": "Hah, j'ai décidé d'acheter ce manteau! [000F][1205][000F][1205]42\n000 yens! Héhé, je me sens presque mal de\nle mettre. Je devrais le garder au placard."
   },
   {
     "id": 70,
@@ -1101,7 +1101,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Hey,[SP]are[SP]the[SP]Masked[SP]Circle[SP]those[SP]terrorists?[1205][000F]\nThat's[SP]what[SP]I[SP]heard[SP]from[SP]someone.[SP]I[SP]knew[SP]it...\nI[SP]knew[SP]the[SP]Masked[SP]Circle[SP]was[SP]dangerous.",
     "nom_fr": "Femme active",
-    "texte_fr": "Hé, le Cercle masqué sont ces terroristes?\n[1205][000F]C'est ce qu'on m'a dit. Je m'en doutais...\nJe savais ce Cercle masqué dangereux."
+    "texte_fr": "Hé, le Cercle masqué sont ces terroristes?\n[000F][1205]C'est ce qu'on m'a dit. Je m'en doutais...\nJe savais ce Cercle masqué dangereux."
   },
   {
     "id": 71,
@@ -1131,7 +1131,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "What[SP]do[SP]you[SP]think[SP]Idealians[SP]are[SP]like?[SP]I've[SP]been\ncurious[SP]ever[SP]since[SP]reading[SP]that[SP]book.[SP]They're\nhumans[SP]who[SP]know[SP]the[SP]meaning[SP]of[SP]life,[SP]right?",
     "nom_fr": "Femme active",
-    "texte_fr": "À quoi ressemblent les Idéaliens? Je suis\ncurieuse depuis que j'ai\nlu ce livre. Ce sont\ndes humains connaissant le\nsens de la vie,non?"
+    "texte_fr": "À quoi ressemblent les Idéaliens? Je suis\ncurieuse depuis que j'ai\nlu ce livre. Ce sont des humains connaissant le sens de la vie,non?"
   },
   {
     "id": 73,
@@ -1176,7 +1176,7 @@
     "nom_orig": "Knockout[SP]woman",
     "texte_orig": "Feast[SP]your[SP]eyes.[SP]I've[SP]finally[SP]got[SP]the[SP]glamorous\nbody[SP]I[SP]always[SP]wanted.[SP]A[SP]little[SP]flash[SP]of[SP]leg,\nand[SP]the[SP]men[SP]won't[SP]be[SP]able[SP]to[SP]look[SP]away.",
     "nom_fr": "Femme fatale",
-    "texte_fr": "Admirez. J'ai enfin le\ncorps glamour que j'ai\ntoujours voulu. Un bout de jambe, et les\nhommes ne pourront\nplus détourner le regard."
+    "texte_fr": "Admirez. J'ai enfin le\ncorps glamour que j'ai\ntoujours voulu. Un bout de jambe, et les hommes ne pourront plus détourner le regard."
   },
   {
     "id": 76,
@@ -1191,7 +1191,7 @@
     "nom_orig": "Knockout[SP]woman",
     "texte_orig": "An[SP]amazing[SP]body[SP]like[SP]mine[SP]needs[SP]elegant[SP]clothes\nto[SP]match.[1205][000A][SP]Otherwise,[SP]these[SP]curves[SP]will[SP]just[SP]go\nto[SP]waste.[1205][000A][SP]Ahahahaha!",
     "nom_fr": "Femme fatale",
-    "texte_fr": "Un tel corps de rêve a besoin de\nvêtements élégants.[1205][000A] Sinon, ces courbes\nseront bien gâchées.[1205][000A] Ahahahaha!"
+    "texte_fr": "Un tel corps de rêve a besoin de\nvêtements élégants.[000A][1205] Sinon, ces courbes\nseront bien gâchées.[000A][1205] Ahahahaha!"
   },
   {
     "id": 77,
@@ -1236,7 +1236,7 @@
     "nom_orig": "Knockout[SP]woman",
     "texte_orig": "Not[SP]to[SP]get[SP]back[SP]with[SP]him,[SP]no.[SP]Now[SP]I'm[SP]going[SP]to\nsay[SP]the[SP]same[SP]thing[SP]to[SP]men[SP]who[SP]come[SP]crawling\nto[SP]me![1205][000F][SP]Haha...[SP]I'm[SP]a[SP]piece[SP]of[SP]work,[SP]aren't[SP]I?",
     "nom_fr": "Femme fatale",
-    "texte_fr": "Pas pour y retourner,\nnon. Maintenant je dirai\nla même chose aux\nhommes qui rampent vers moi!\n[1205][000F]Haha... Je suis un sacré numéro, non?"
+    "texte_fr": "Pas pour y retourner,\nnon. Maintenant je dirai\nla même chose aux hommes qui rampent vers moi! [000F][1205]Haha... Je suis un sacré numéro, non?"
   },
   {
     "id": 80,
@@ -1281,7 +1281,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Sumaru's[SP]secret[SP]treasure...[1205][000F][SP]Xibalba...[1205][000F]\nIt[SP]will[SP]transform[SP]us[SP]into[SP]Idealians[SP]and\nteach[SP]us[SP]the[SP]meaning[SP]of[SP]life!",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "Le trésor secret de Sumaru.[1205][000F][1205][000F].. Xibalba...\nIl nous transformera en Idéaliens et\nnous apprendra le sens de la vie!"
+    "texte_fr": "Le trésor secret de Sumaru.[000F][1205][000F][1205].. Xibalba...\nIl nous transformera en Idéaliens et\nnous apprendra le sens de la vie!"
   },
   {
     "id": 83,
@@ -1311,7 +1311,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Th-The[SP]Exalted[SP]One...[1205][000A][SP]told[SP]us[SP]to[SP]protect...[1205][000F]\nprotect[SP]the[SP]people[SP]of[SP]this[SP]city...[1205][000F][SP]He[SP]ordered\nus[SP]to[SP]fight[SP]against[SP]those[SP]soldiers!",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "L-L'Élu...[1205][1205][1205][000A] nous a dit de protéger.[000F][000F]..\nprotéger les gens de cette ville... Il\nnous a ordonné de combattre ces soldats!"
+    "texte_fr": "L-L'Élu...[1205][1205][000A][1205] nous a dit de protéger.[000F][000F]..\nprotéger les gens de cette ville... Il\nnous a ordonné de combattre ces soldats!"
   },
   {
     "id": 85,
@@ -1326,7 +1326,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "How[SP]can[SP]I[SP]do[SP]that!?[SP]I-I[SP]only[SP]wanted[SP]my[SP]dream\nfigure...[1205][000F][SP]Apart[SP]from[SP]that,[SP]I'm[SP]just[SP]an[SP]ordinary\ngirl[SP]inside!",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "Comment faire ça!? Je voulais juste\nma silhouette de rêve.[1205][000F].. À part ça,\nje suis une fille ordinaire!"
+    "texte_fr": "Comment faire ça!? Je voulais juste\nma silhouette de rêve.[000F][1205].. À part ça,\nje suis une fille ordinaire!"
   },
   {
     "id": 86,
@@ -1341,7 +1341,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Ah,[SP]welcome.[1205][000A][SP]We[SP]sell[SP]only[SP]the[SP]finest[SP]clothes\nhere.[1205][000F][SP]What[SP]do[SP]you[SP]think?[1205][000A][SP]Feel[SP]free[SP]to[SP]buy\nwithout[SP]hesitation!\n[1208][0005]Buy[SP]armor\nSell[SP]items\nTalk[SP]to[SP]the[SP]saleswoman\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Ah, bienvenue.[1205][1205][000A] Nous ne vendons que les \n[000F]plus\nbeaux vêtements ici. Qu'en dites-vous?[1205][000A]\nAchetez sans hésiter!\n[1208][0005]Acheter armures\nVendre objets\nParler\nRien\nQuitter",
+    "texte_fr": "Ah, bienvenue.[1205][000A][1205] Nous ne vendons que les \n[000F]plus\nbeaux vêtements ici. Qu'en dites-vous?[000A][1205]\nAchetez sans hésiter!\n[1208][0005]Acheter armures\nVendre objets\nParler\nRien\nQuitter",
     "question_orig": "Ah,[SP]welcome.[1205][000A][SP]We[SP]sell[SP]only[SP]the[SP]finest[SP]clothes\nhere.[1205][000F][SP]What[SP]do[SP]you[SP]think?[1205][000A][SP]Feel[SP]free[SP]to[SP]buy\nwithout[SP]hesitation!",
     "choix_orig": [
       "Buy[SP]armor",

--- a/traduction/event_scripts/script_291.json
+++ b/traduction/event_scripts/script_291.json
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Eikichi[SP]might[SP]be[SP]right...[1205][000F][SP]With[SP]everything[SP]going[SP]on,\nwho[SP]knows[SP]what[SP]weird[SP]ideas[SP]the[SP]townspeople\nare[SP]gonna[SP]get[SP]about[SP]it.",
     "nom_fr": "Ginko",
-    "texte_fr": "Eikichi a peut-être raison.[1205][000F].. Avec\ntout ce qui se passe, qui sait quelles\nidées folles les gens vont avoir."
+    "texte_fr": "Eikichi a peut-être raison.[000F][1205].. Avec\ntout ce qui se passe, qui sait quelles\nidées folles les gens vont avoir."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Not[SP]everyone[SP]wants[SP]to[SP]evolve...[1205][000F][SP]They[SP]just[SP]want\nto[SP]escape[SP]the[SP]annihilation[SP]of[SP]Earth.[SP]They[SP]want\nto[SP]believe[SP]they'll[SP]be[SP]saved.",
     "nom_fr": "Maya",
-    "texte_fr": "Tout le monde ne veut pas évoluer.[1205][000F]..\nIls fuient la destruction de la Terre.\nIls croient qu'ils seront sauvés."
+    "texte_fr": "Tout le monde ne veut pas évoluer.[000F][1205]..\nIls fuient la destruction de la Terre.\nIls croient qu'ils seront sauvés."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "A[SP]reason[SP]to[SP]exist...[1205][001E][SP]Everyone[SP]needs[SP]to[SP]find\nthat[SP]for[SP]themselves.[SP]You[SP]can't[SP]just[SP]hope\nsomeone[SP]else[SP]spoon-feeds[SP]you[SP]the[SP]answers...",
     "nom_fr": "Maya",
-    "texte_fr": "Une raison d'exister...[1205][001E] Chacun doit la\ntrouver lui-même. On ne peut pas espérer\nque quelqu'un d'autre vous la serve."
+    "texte_fr": "Une raison d'exister...[001E][1205] Chacun doit la\ntrouver lui-même. On ne peut pas espérer\nque quelqu'un d'autre vous la serve."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Joker,[SP]hm...?[1205][001E][SP]Dreams[SP]are[SP]meaningless[SP]if[SP]you\ndon't[SP]achieve[SP]them[SP]yourself.[1205][001E][SP]All[SP]I[SP]did[SP]was[SP]to\ncloud[SP]people's[SP]eyes[SP]to[SP]that...",
     "nom_fr": "Jun",
-    "texte_fr": "Joker, hm...?[1205][001E] Les rêves n'ont aucun\nsens si on ne les réalise pas soi-même.[1205][001E]\nJ'ai juste aveuglé les gens à ça."
+    "texte_fr": "Joker, hm...?[001E][1205] Les rêves n'ont aucun\nsens si on ne les réalise pas soi-même.[001E][1205]\nJ'ai juste aveuglé les gens à ça."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Jun",
     "texte_orig": "My[SP]father's[SP]concept[SP]of[SP]an[SP]Idealian[SP]was[SP]someone\nwho[SP]understood[SP]their[SP]reason[SP]to[SP]live...[1205][001E][SP]Everyone\nhas[SP]it[SP]all[SP]wrong...",
     "nom_fr": "Jun",
-    "texte_fr": "Pour mon père, un Idéalien était\nquelqu'un qui comprenait sa raison de\nvivre...[1205][001E] Tout le monde se trompe..."
+    "texte_fr": "Pour mon père, un Idéalien était\nquelqu'un qui comprenait sa raison de\nvivre...[001E][1205] Tout le monde se trompe..."
   },
   {
     "id": 8,
@@ -231,7 +231,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "I[SP]feel[SP]sorry[SP]for[SP]the[SP]people[SP]below,[SP]but[SP]that's\nfate.[1205][000F][SP]Anyway,[SP]I'm[SP]looking[SP]forward[SP]to[SP]evolving.\nWe'll[SP]be[SP]even[SP]more[SP]beautiful![1205][000F][SP]Hahaha.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Je plains les gens d'en bas, mais c'est le\n[1205][000F][1205][000F]destin. En tout cas, j'ai hâte d'évoluer.\nNous serons encore plus belles! Hahaha."
+    "texte_fr": "Je plains les gens d'en bas, mais c'est le\n[000F][1205][000F][1205]destin. En tout cas, j'ai hâte d'évoluer.\nNous serons encore plus belles! Hahaha."
   },
   {
     "id": 13,
@@ -246,7 +246,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "The[SP]war's[SP]being[SP]fought[SP]inside[SP]that[SP]temple.\nIt's[SP]still[SP]dangerous[SP]to[SP]go[SP]outside...[1205][000F][SP]Oh,[SP]what\na[SP]pity[SP]it[SP]would[SP]be[SP]if[SP]I[SP]died[SP]before[SP]evolving!",
     "nom_fr": "Vendeuse",
-    "texte_fr": "La guerre se déroule dans ce temple. C'est\nencore dangereux de sortir.[1205][000F].. Oh, quelle\npitié si je mourais avant d'évoluer!"
+    "texte_fr": "La guerre se déroule dans ce temple. C'est\nencore dangereux de sortir.[000F][1205].. Oh, quelle\npitié si je mourais avant d'évoluer!"
   },
   {
     "id": 14,
@@ -261,7 +261,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Anyway.[1205][0008][SP]How[SP]about[SP]our[SP]fashion[SP]concept[SP]for[SP]this\nyear?[1205][000F][SP]We[SP]were[SP]smart[SP]to[SP]pick[SP]armor,[SP]weren't[SP]we?[1205][000F]\nOur[SP]forecasts[SP]are[SP]never[SP]wrong,[SP]hahaha.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Bref.[1205][1205][1205][0008] Et notre concept\nmode pour cette année?\n[000F][000F]On a eu raison de\nmiser sur les armures? Nos\nprévisions ne se trompent jamais!"
+    "texte_fr": "Bref.[1205][1205][0008][1205] Et notre concept\nmode pour cette année?\n[000F][000F]On a eu raison de miser sur les armures? Nos prévisions ne se trompent jamais!"
   },
   {
     "id": 15,
@@ -321,7 +321,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Aren't[SP]you[SP]a[SP]Sevens[SP]student[SP]too?[1205][000F][SP]You[SP]wouldn't\nleave[SP]your[SP]friends[SP]behind,[SP]would[SP]you?",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Tu es aussi un élève de Seven? [1205][000F]Tu\nn'abandonnerais pas tes amis, n'est-ce pas?"
+    "texte_fr": "Tu es aussi un élève de Seven? [000F][1205]Tu\nn'abandonnerais pas tes amis, n'est-ce pas?"
   },
   {
     "id": 19,
@@ -336,7 +336,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Now[SP]how[SP]about[SP]some[SP]new[SP]armor[SP]we[SP]just[SP]got[SP]in?[1205][000F]\nIt's[SP]as[SP]beautiful[SP]as[SP]anything[SP]else[SP]in[SP]here,\nnaturally.[1205][0008][SP]I'll[SP]throw[SP]in[SP]a[SP]kiss[SP]if[SP]you[SP]buy!",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Et si vous regardiez nos nouvelles armures\n[1205][000F]? Elles sont belles comme tout le reste\nici,[1205][0008] J'offre un baiser si vous achetez!"
+    "texte_fr": "Et si vous regardiez nos nouvelles armures\n[000F][1205]? Elles sont belles comme tout le reste\nici,[0008][1205] J'offre un baiser si vous achetez!"
   },
   {
     "id": 20,
@@ -351,7 +351,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "You[SP]really[SP]need[SP]better[SP]taste[SP]in[SP]fashion.[1205][000F]\nI'll[SP]give[SP]you[SP]a[SP]personal[SP]lesson[SP]next[SP]time.[1205][000F]\nSee[SP]you[SP]again.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Vous avez besoin d'affiner votre goût. [1205][000F][1205][000F]Je\nvous ferai une\nleçon personnelle. A bientôt."
+    "texte_fr": "Vous avez besoin d'affiner votre goût. [000F][1205][000F][1205]Je\nvous ferai une\nleçon personnelle. A bientôt."
   },
   {
     "id": 21,
@@ -366,7 +366,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Hey![1205][000A][SP]That's[SP]the[SP]dressing[SP]room.[1205][000A][SP]Don't[SP]go[SP]in\nthere[SP]if[SP]you[SP]don't[SP]need[SP]to[SP]use[SP]it.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Hé![1205][000A] C'est la cabine d'essayage.[1205][000A] N'entrez\npas sans avoir besoin de l'utiliser."
+    "texte_fr": "Hé![000A][1205] C'est la cabine d'essayage.[000A][1205] N'entrez\npas sans avoir besoin de l'utiliser."
   },
   {
     "id": 22,
@@ -381,7 +381,7 @@
     "nom_orig": "Hayseed",
     "texte_orig": "Well[SP]ah'll[SP]be[SP]damned.[1205][000A][SP]The[SP]city's[SP]flyin'[SP]in\nthe[SP]sky![1205][000A][SP]Seems[SP]like[SP]everythin'[SP]that[SP]happens\nin[SP]the[SP]city[SP]is[SP]crazy!",
     "nom_fr": "Péquenaud",
-    "texte_fr": "Ben ça alors![1205][000A] La ville vole dans\nle ciel![1205][000A] Y'a vraiment des trucs\nde dingues qui arrivent en ville!"
+    "texte_fr": "Ben ça alors![000A][1205] La ville vole dans\nle ciel![000A][1205] Y'a vraiment des trucs\nde dingues qui arrivent en ville!"
   },
   {
     "id": 23,
@@ -396,7 +396,7 @@
     "nom_orig": "Hayseed",
     "texte_orig": "What!?[SP]No[SP]one[SP]told[SP]me![1205][000A][SP]So[SP]if[SP]this[SP]Grand[SP]Cross\nthing[SP]happens,[SP]everythin'[SP]down[SP]there's[SP]done[SP]fer?",
     "nom_fr": "Péquenaud",
-    "texte_fr": "Quoi!? Personne m'a prévenu![1205][000A] Si la Croix\nCosmique se produit, tout en bas est fichu?"
+    "texte_fr": "Quoi!? Personne m'a prévenu![000A][1205] Si la Croix\nCosmique se produit, tout en bas est fichu?"
   },
   {
     "id": 24,
@@ -411,7 +411,7 @@
     "nom_orig": "Hayseed",
     "texte_orig": "What[SP]am[SP]ah[SP]gonna[SP]do?[1205][0008][SP]Ma's[SP]still[SP]down[SP]there...[1205][000A]\nShe's[SP]gonna[SP]die![SP]Ah[SP]gotta...[1205][000F][SP]Ah[SP]gotta[SP]get\ndown[SP]there!",
     "nom_fr": "Péquenaud",
-    "texte_fr": "Qu'est-ce que je vais faire?[1205][1205][0008] M'man est\nlà-bas...[1205][000A] Elle va\n[000F]mourir! Je dois descendre!"
+    "texte_fr": "Qu'est-ce que je vais faire?[1205][0008][1205] M'man est\nlà-bas...[000A][1205] Elle va\n[000F]mourir! Je dois descendre!"
   },
   {
     "id": 25,
@@ -486,7 +486,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Ohhhhohohoho![1205][000A][SP]I'm[SP]not[SP]satisfied[SP]with[SP]just[SP]this\nincredible[SP]body[SP]anymore![SP]I'll[SP]be[SP]reborn[SP]soon[SP]as\na[SP]transhuman.",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Ohhhhohohoho![1205][000A] Ce corps incroyable\nne me suffit plus! Je vais bientôt\nrenaître en tant que transhumain."
+    "texte_fr": "Ohhhhohohoho![000A][1205] Ce corps incroyable\nne me suffit plus! Je vais bientôt\nrenaître en tant que transhumain."
   },
   {
     "id": 30,
@@ -501,7 +501,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Whew...[1205][0008][SP]I[SP]got[SP]anxious[SP]when[SP]the[SP]Last[SP]Battalion\nshowed[SP]up...[1205][0008][SP]But[SP]Joker[SP]came[SP]through[SP]again![1205][000F]\nOhhhhohohoho!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Ouf.[1205]..[1205][0008] J'ai eu peur quand le\nBataillon est apparu...[1205][0008] Mais Joker\na encore assuré! [000F]Ohhhhohohoho!"
+    "texte_fr": "Ouf.[1205]..[0008][1205] J'ai eu peur quand le\nBataillon est apparu...[0008][1205] Mais Joker\na encore assuré! [000F]Ohhhhohohoho!"
   },
   {
     "id": 31,
@@ -516,7 +516,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Ohhhohoho![1205][000A][SP]That[SP]pillar[SP]of[SP]light[SP]rising[SP]from\nSevens[SP]must[SP]be[SP]part[SP]of[SP]the[SP]Oracle,[SP]too.[1205][000A]\nAnother[SP]passage[SP]fulfilled!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Ohhhohoho![1205][000A] Ce pilier de lumière\nde Seven fait partie de l'Oracle.[1205][000A]\nEncore une prophétie accomplie!"
+    "texte_fr": "Ohhhohoho![000A][1205] Ce pilier de lumière\nde Seven fait partie de l'Oracle.[000A][1205]\nEncore une prophétie accomplie!"
   },
   {
     "id": 32,
@@ -531,7 +531,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Ohhhhhohohoho![1205][0008][SP]It's[SP]almost[SP]time![1205][000A][SP]We'll[SP]become\nIdealians--practically[SP]gods![1205][000A][SP]Ohhhhohohoho!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Ohhhhhohohoho![1205][1205][0008] C'est l'heure![000A][1205][000A] On va\ndevenir des Idéaliens! Ohhhhohohoho!"
+    "texte_fr": "Ohhhhhohohoho![1205][0008][1205] C'est l'heure![000A][000A][1205] On va\ndevenir des Idéaliens! Ohhhhohohoho!"
   },
   {
     "id": 33,
@@ -546,7 +546,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Ah,[SP]welcome.[1205][000A][SP]We[SP]sell[SP]only[SP]the[SP]finest[SP]clothes\nhere.[1205][000F][SP]What[SP]do[SP]you[SP]think?[1205][000A][SP]Feel[SP]free[SP]to[SP]buy\nwithout[SP]hesitation!\n[1208][0005]Buy[SP]armor\nSell[SP]items\nTalk[SP]to[SP]the[SP]saleswoman\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Ah, bienvenue.[1205][1205][000A] Que des vêtements\nsuperbes ici. [000F]Qu'en\npensez-vous?[1205][000A] N'hésitez pas\nà acheter!\n[1208][0005]Acheter armure\nVendre objets\nParler à la vendeuse\nLaisser tomber\nQuitter",
+    "texte_fr": "Ah, bienvenue.[1205][000A][1205] Que des vêtements\nsuperbes ici. [000F]Qu'en\npensez-vous?[000A][1205] N'hésitez pas\nà acheter!\n[1208][0005]Acheter armure\nVendre objets\nParler à la vendeuse\nLaisser tomber\nQuitter",
     "question_orig": "Ah,[SP]welcome.[1205][000A][SP]We[SP]sell[SP]only[SP]the[SP]finest[SP]clothes\nhere.[1205][000F][SP]What[SP]do[SP]you[SP]think?[1205][000A][SP]Feel[SP]free[SP]to[SP]buy\nwithout[SP]hesitation!",
     "choix_orig": [
       "Buy[SP]armor",
@@ -730,7 +730,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "The[SP]resale[SP]price[SP]is[SP]roughly[SP]half[SP]the[SP]original\nprice.[SP]You[SP]can't[SP]sell[SP]anything[SP]you're[SP]wearing,\nor[SP]certain[SP]special[SP]items.[SP]That[SP]about[SP]does[SP]it.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "La revente est environ\nla moitié du prix. Pas\nde vente de ce que\nvous portez ni de certains\nobjets spéciaux. Voilà, c'est tout."
+    "texte_fr": "La revente est environ\nla moitié du prix. Pas\nde vente de ce que vous portez ni de certains objets spéciaux. Voilà, c'est tout."
   },
   {
     "id": 43,

--- a/traduction/event_scripts/script_292.json
+++ b/traduction/event_scripts/script_292.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Diet[SP]food[SP]is[SP]popular,[SP]but[SP]if[SP]you[SP]wanna[SP]lose\nweight,[SP]just[SP]don't[SP]eat.[SP]Then[SP]you[SP]can[SP]be[SP]like\nme[SP]and--[1205][001E]Uhh,[SP]never[SP]mind.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Les régimes, c'est bien, mais pour\nmaigrir, arrête de manger. Tu serais\ncomme moi et--[1205][001E]Euh, laisse tomber."
+    "texte_fr": "Les régimes, c'est bien, mais pour\nmaigrir, arrête de manger. Tu serais\ncomme moi et--[001E][1205]Euh, laisse tomber."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What's[SP]Ginko[SP]talking[SP]about?[1205][000A][SP]C'mon,[SP]trust[SP]us[SP]a\nlittle.[1205][000F][SP]I'll[SP]save[SP]both[SP]of[SP]'em,[SP]and[SP]I'll[SP]do[SP]it\nwith[SP]style[SP]and[SP]grace!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Que raconte Ginko?[1205][1205][000A] Allez, faites-nous\n[000F]confiance! Je les sauverai toutes les\ndeux avec classe et élégance!"
+    "texte_fr": "Que raconte Ginko?[1205][000A][1205] Allez, faites-nous\n[000F]confiance! Je les sauverai toutes les\ndeux avec classe et élégance!"
   },
   {
     "id": 2,
@@ -72,7 +72,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Y-Yeah...[1205][001E][SP]I[SP]mean,[SP]I[SP]have[SP]lots[SP]of[SP]friends.[1205][001E]\nWe[SP]go[SP]out[SP]together[SP]all[SP]the[SP]time...",
     "nom_fr": "Lisa",
-    "texte_fr": "O-Oui...[1205][001E] Enfin, j'ai plein d'amis.[1205][001E]\nOn sort ensemble tout le temps..."
+    "texte_fr": "O-Oui...[001E][1205] Enfin, j'ai plein d'amis.[001E][1205]\nOn sort ensemble tout le temps..."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Y-Yeah...[1205][001E][SP]I[SP]mean,[SP]I[SP]have[SP]lots[SP]of[SP]friends.[1205][001E]\nWe[SP]go[SP]out[SP]together[SP]all[SP]the[SP]time...",
     "nom_fr": "Ginko",
-    "texte_fr": "O-Oui...[1205][001E] Enfin, j'ai plein d'amis.[1205][001E]\nOn sort ensemble tout le temps..."
+    "texte_fr": "O-Oui...[001E][1205] Enfin, j'ai plein d'amis.[001E][1205]\nOn sort ensemble tout le temps..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#15![1205][001E][SP][1432][NULL][NULL][0014]Seoi[SP]Lo[1432][NULL][NULL][0014][SP]is[SP]used\nwhen[SP]you're[SP]disappointed.[SP]It's[SP]kinda[SP]like,\n[1432][NULL][NULL][0014]What[SP]bad[SP]luck...[1432][NULL][NULL][0014][SP]or[SP][1432][NULL][NULL][0014]What[SP]a[SP]bummer...[1432][NULL][NULL][0014]",
     "nom_fr": "Ginko",
-    "texte_fr": "Leçon de cantonais n°15![1205][001E] [1432][NULL][NULL][0014]Seoi Lo[1432][NULL][NULL][0014]\ns'utilise quand on est déçu. C'est comme,\n[1432][NULL][NULL][0014]Quelle malchance...[1432][NULL][NULL][0014] ou [1432][NULL][NULL][0014]Quelle poisse...[1432][NULL][NULL][0014]"
+    "texte_fr": "Leçon de cantonais n°15![001E][1205] [1432][NULL][NULL][0014]Seoi Lo[1432][NULL][NULL][0014]\ns'utilise quand on est déçu. C'est comme,\n[1432][NULL][NULL][0014]Quelle malchance...[1432][NULL][NULL][0014] ou [1432][NULL][NULL][0014]Quelle poisse...[1432][NULL][NULL][0014]"
   },
   {
     "id": 8,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What[SP]should[SP]we[SP]do...?[1205][000F][SP]If[SP]the[SP]people[SP]keep[SP]being\nafraid[SP]of[SP]the[SP]Masked[SP]Circle,[SP]won't[SP]Jun[SP]become\njust[SP]what[SP]the[SP]rumors[SP]say[SP]he[SP]is?",
     "nom_fr": "Ginko",
-    "texte_fr": "Que faire...? Si\n[1205][000F]les gens craignent toujours\nle Cercle masqué, Jun ne deviendra-t-il pas\ntel que le disent les rumeurs?"
+    "texte_fr": "Que faire...? Si\n[000F][1205]les gens craignent toujours\nle Cercle masqué, Jun ne deviendra-t-il pas tel que le disent les rumeurs?"
   },
   {
     "id": 11,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Ummm...[1205][000F][SP][1432][NULL][NULL][0014]Drink[SP]this[SP]for[SP]100[SP]times[SP]the[SP]energy...[1432][NULL][NULL][0014]\n[1432][NULL][NULL][0014]Refreshing![1432][NULL][NULL][0014][1205][000F][SP]Satomitan[SP]Z?[1205][000F][SP]Oooh,[SP]it[SP]comes[SP]in\na[SP]Super[SP]version?",
     "nom_fr": "Maya",
-    "texte_fr": "Voyons.[1205][000F][1205][000F][1205][000F].. [1432][NULL][NULL][0014]Pour 100 fois plus\nd'énergie...[1432][NULL][NULL][0014] [1432][NULL][NULL][0014]Rafraîchissant![1432][NULL][NULL][0014] Satomitan\nZ? Ooh, il a une version Super?"
+    "texte_fr": "Voyons.[000F][1205][000F][1205][000F][1205].. [1432][NULL][NULL][0014]Pour 100 fois plus\nd'énergie...[1432][NULL][NULL][0014] [1432][NULL][NULL][0014]Rafraîchissant![1432][NULL][NULL][0014] Satomitan\nZ? Ooh, il a une version Super?"
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Phew...[SP]Can[SP]people[SP]not[SP]get[SP]through[SP]the[SP]day\nwithout[SP]medicine[SP]anymore?[1205][000F][SP]Isn't[SP]that...\nkind[SP]of[SP]sad...?",
     "nom_fr": "Maya",
-    "texte_fr": "Pfff... On ne peut plus vivre un jour sans\nmédicaments? [1205][000F]C'est pas un peu... triste...?"
+    "texte_fr": "Pfff... On ne peut plus vivre un jour sans\nmédicaments? [000F][1205]C'est pas un peu... triste...?"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Don't[SP]worry.[SP]The[SP]rumor[SP]has[SP]been[SP]spread.\nWhat's[SP]more...[SP]it's[SP]become[SP]reality.[1205][000F][SP]This[SP]is\nanother[SP]result[SP]that[SP]humanity[SP]desired.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nJun-kun...[1205][000A][SP]He's[SP]trying[SP]to[SP]carry[SP]the[SP]karma[SP]of\neveryone[SP]in[SP]the[SP]city[SP]by[SP]himself.[1205][000F][SP]He's[SP]too\nkind,[SP]really...",
     "nom_fr": "Maya",
-    "texte_fr": "Rassurez-vous. La rumeur a été répandue.\nEt... elle est devenue réalité. [1205][000F][1205][000F]C'est un\nautre résultat voulu par l'humanité.[E1][E2] [E3][E4][NULL][NULL]\"Maya\nJun-kun...[1205][000A] Il veut porter le karma de\ntoutela ville seul. Il est vraiment trop gentil..."
+    "texte_fr": "Rassurez-vous. La rumeur a été répandue.\nEt... elle est devenue réalité. [000F][1205][000F][1205]C'est un\nautre résultat voulu par l'humanité.[E1][E2] [E3][E4][NULL][NULL]\"Maya\nJun-kun...[000A][1205] Il veut porter le karma de\ntoutela ville seul. Il est vraiment trop gentil..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]have[SP]to[SP]save[SP]him![1205][000F][SP]He[SP]doesn't[SP]need[SP]to[SP]suffer\nthrough[SP]this[SP]alone.[1205][000F][SP]I[SP]want[SP]to[SP]get[SP]Jun-kun[SP]back\nto[SP]his[SP]normal[SP]self...",
     "nom_fr": "Maya",
-    "texte_fr": "Il faut le sauver! [1205][000F][1205][000F]Il n'a pas besoin de\nsouffrir seul comme ça. Je veux retrouver\nJun-kun tel qu'il était avant..."
+    "texte_fr": "Il faut le sauver! [000F][1205][000F][1205]Il n'a pas besoin de\nsouffrir seul comme ça. Je veux retrouver\nJun-kun tel qu'il était avant..."
   },
   {
     "id": 17,
@@ -282,7 +282,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Blurrgh...[1205][001E][SP]God,[SP]just[SP]remembering[SP]it[SP]makes[SP]me\nqueasy...[1205][001E][SP]And[SP]she's[SP]still[SP]thin![SP]She's[SP]famous\nat[SP]the[SP]office[SP]for[SP]her[SP][1432][NULL][NULL][0014]black[SP]hole[SP]stomach.[1432][NULL][NULL][0014]",
     "nom_fr": "Yukino",
-    "texte_fr": "Beurk...[1205][001E] Y penser me donne la nausée...[1205][001E]\nEt elle reste mince! Elle est célèbre à\nla rédac pour son [1432][NULL][NULL][0014]estomac trou noir.[1432][NULL][NULL][0014]"
+    "texte_fr": "Beurk...[001E][1205] Y penser me donne la nausée...[001E][1205]\nEt elle reste mince! Elle est célèbre à\nla rédac pour son [1432][NULL][NULL][0014]estomac trou noir.[1432][NULL][NULL][0014]"
   },
   {
     "id": 19,
@@ -342,7 +342,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Rumors[SP]can[SP]even[SP]change[SP]someone's[SP]personality...\nTrying[SP]to[SP]save[SP]Jun[SP]right[SP]now[SP]is[SP]like[SP]going\nagainst[SP]everyone[SP]spreading[SP]those[SP]rumors.",
     "nom_fr": "Yukino",
-    "texte_fr": "Les rumeurs peuvent altérer la\npersonnalité... Sauver\nJun maintenant revient\nà affronter tous ceux qui les répandent."
+    "texte_fr": "Les rumeurs peuvent altérer la\npersonnalité... Sauver\nJun maintenant revient à affronter tous ceux qui les répandent."
   },
   {
     "id": 23,
@@ -457,7 +457,7 @@
     "nom_orig": "Sister[SP]#3",
     "texte_orig": "*sniffle*[1205][001E][SP]My[SP]son[SP]decided[SP]to[SP]become[SP]a[SP]detective.\nHe's[SP]such[SP]a[SP]disgrace,[SP]I[SP]could[SP]cry.",
     "nom_fr": "Sœur n°3",
-    "texte_fr": "*renifl*[1205][001E] Mon fils veut devenir détective.\nC'est une telle honte, j'en pleurerais."
+    "texte_fr": "*renifl*[001E][1205] Mon fils veut devenir détective.\nC'est une telle honte, j'en pleurerais."
   },
   {
     "id": 28,
@@ -487,7 +487,7 @@
     "nom_orig": "Sister[SP]#3",
     "texte_orig": "We've[SP]been[SP]getting[SP]a[SP]lot[SP]of[SP]young[SP]customers\nlately.[SP]It[SP]must[SP]be[SP]madness[SP]over[SP]at[SP]our[SP]Yumezaki\nbranch.[SP]That's[SP]where[SP]they[SP]all[SP]hang[SP]out.",
     "nom_fr": "Sœur n°3",
-    "texte_fr": "On a beaucoup\nde jeunes clients dernièrement.\nÇa doit être la folie\nà notre succursale de\nYumezaki. C'est là qu'ils traînent tous."
+    "texte_fr": "On a beaucoup\nde jeunes clients dernièrement.\nÇa doit être la folie à notre succursale de Yumezaki. C'est là qu'ils traînent tous."
   },
   {
     "id": 30,
@@ -547,7 +547,7 @@
     "nom_orig": "Sister[SP]#3",
     "texte_orig": "Yikes![SP]Even[SP]the[SP]Masked[SP]Circle's[SP]out[SP]and[SP]about.[1205][000F]\nIt's[SP]a[SP]war[SP]zone[SP]out[SP]there![1205][000A][SP]I[SP]wonder[SP]if[SP]my\nTadashi's[SP]okay.",
     "nom_fr": "Sœur n°3",
-    "texte_fr": "Aïe! Le Cercle masqué est de sortie.\n[1205][000F]C'est une zone de guerre dehors![1205][000A]\nJ'espère que mon Tadashi va bien."
+    "texte_fr": "Aïe! Le Cercle masqué est de sortie.\n[000F][1205]C'est une zone de guerre dehors![000A][1205]\nJ'espère que mon Tadashi va bien."
   },
   {
     "id": 34,
@@ -562,7 +562,7 @@
     "nom_orig": "Sister[SP]#3",
     "texte_orig": "I[SP]hope[SP]he[SP]keeps[SP]a[SP]low[SP]profile,[SP]but[SP]I[SP]know[SP]my\nboy...[SP]He'll[SP]probably[SP]try[SP]something[SP]stupid.[1205][000F]\nI[SP]can't[SP]worry[SP]enough[SP]about[SP]him...[1205][000F][SP]*sniff*",
     "nom_fr": "Sœur n°3",
-    "texte_fr": "J'espère qu'il est discret, mais je connais\nmon fils... Il va faire une bêtise. [1205][000F][1205][000F]Je\nm'inquiète tellement pour lui... *snif*"
+    "texte_fr": "J'espère qu'il est discret, mais je connais\nmon fils... Il va faire une bêtise. [000F][1205][000F][1205]Je\nm'inquiète tellement pour lui... *snif*"
   },
   {
     "id": 35,
@@ -592,7 +592,7 @@
     "nom_orig": "Man",
     "texte_orig": "My[SP]daughter[SP]won't[SP]leave[SP]her[SP]room,[SP]now[SP]she's\nasking[SP]me[SP]to[SP]get[SP]medicine[SP]for[SP]swelling...[1205][001E]\nIt's[SP]not[SP]her[SP]belly[SP]getting[SP]bigger,[SP]is[SP]it!?",
     "nom_fr": "Homme",
-    "texte_fr": "Ma fille ne sort plus, et maintenant elle\nveut un remède contre les gonflements...[1205][001E]\nJ'espère que ce n'est pas son ventre!?"
+    "texte_fr": "Ma fille ne sort plus, et maintenant elle\nveut un remède contre les gonflements...[001E][1205]\nJ'espère que ce n'est pas son ventre!?"
   },
   {
     "id": 37,
@@ -622,7 +622,7 @@
     "nom_orig": "Man",
     "texte_orig": "This[SP]isn't[SP]funny.[SP]How[SP]long[SP]are[SP]the[SP]terrorists\ngoing[SP]to[SP]keep[SP]this[SP]up?[SP]My[SP]daughter's[SP]cheered[SP]up\nnow,[SP]but[SP]I[SP]can't[SP]go[SP]home.[SP]Where[SP]are[SP]the[SP]police?",
     "nom_fr": "Homme",
-    "texte_fr": "C'est pas drôle. Les terroristes vont\ncontinuer longtemps? Ma\nfille va mieux, mais\nje peux pas rentrer. Où est la police ?"
+    "texte_fr": "C'est pas drôle. Les terroristes vont\ncontinuer longtemps? Ma\nfille va mieux, mais je peux pas rentrer. Où est la police ?"
   },
   {
     "id": 39,
@@ -957,7 +957,7 @@
     "nom_orig": "Sister[SP]#3",
     "texte_orig": "Our[SP]resale[SP]prices[SP]are[SP]around[SP]half[SP]the[SP]original\nprice.[SP]You[SP]can't[SP]sell[SP]anything[SP]you[SP]have[SP]equipped,\nand[SP]some[SP]special[SP]items[SP]are[SP]off-limits[SP]too.",
     "nom_fr": "Sœur n°3",
-    "texte_fr": "La revente est à moitié\nprix. On ne vend pas\nles objets équipés ni certains objets\nspéciaux."
+    "texte_fr": "La revente est à moitié\nprix. On ne vend pas\nles objets équipés ni certains objets spéciaux."
   },
   {
     "id": 58,

--- a/traduction/event_scripts/script_293.json
+++ b/traduction/event_scripts/script_293.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]normal[SP]to[SP]be[SP]confused.[1205][000A][SP]The[SP]guys[SP]who[SP]believe\nthe[SP]In[SP]Lak'ech[SP]and[SP]talk[SP]about[SP]evolution[SP]and\nIdealians[SP]are[SP]the[SP]weird[SP]ones.",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est normal d'être perdu.[1205][000A] Ceux qui croient\nen In Lak'ech et parlent d'évolution et\nd'Idéaliens, ce sont les bizarres."
+    "texte_fr": "C'est normal d'être perdu.[000A][1205] Ceux qui croient\nen In Lak'ech et parlent d'évolution et\nd'Idéaliens, ce sont les bizarres."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Looks[SP]like[SP]a[SP]lot[SP]of[SP]people[SP]are[SP]confused.[1205][000F]\nThough[SP]I[SP]don't[SP]blame[SP]them,[SP]what[SP]with[SP]Sumaru\ntaking[SP]off[SP]and[SP]all...",
     "nom_fr": "Ginko",
-    "texte_fr": "Beaucoup de gens ont l'air perdus. [1205][000F]Je les\ncomprends, avec Sumaru qui s'est envolé et\ntout..."
+    "texte_fr": "Beaucoup de gens ont l'air perdus. [000F][1205]Je les\ncomprends, avec Sumaru qui s'est envolé et\ntout..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Sounds[SP]like[SP]that[SP]Prince[SP]Taurus[SP]guy[SP]kidnapped\nMs.[SP]Ideal.[1205][000A]",
     "nom_fr": "Ginko",
-    "texte_fr": "Il paraît que le Prince\nTaureau a enlevé Mme Ideal.[1205][000A]"
+    "texte_fr": "Il paraît que le Prince\nTaureau a enlevé Mme Ideal.[000A][1205]"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]so[SP]wanted[SP]to[SP]beat[SP]the[SP]crap[SP]out[SP]of[SP]Prince\nTaurus[SP]with[SP]my[SP]own[SP]hands...[1205][000F][SP]I'm[SP]not,[SP]uhhhh,\nyou[SP]know,[SP]sorry[SP]for[SP]him,[SP]or[SP]anything...",
     "nom_fr": "Ginko",
-    "texte_fr": "J'aurais tellement voulu régler son compte\nau Prince Taureau de mes propres mains.[1205][000F]..\nJe ne le plains pas, euh, vous voyez..."
+    "texte_fr": "J'aurais tellement voulu régler son compte\nau Prince Taureau de mes propres mains.[000F][1205]..\nJe ne le plains pas, euh, vous voyez..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]true[SP]that[SP]crises[SP]can[SP]help[SP]people[SP]grow.[1205][000A]\nI[SP]think[SP]they[SP]exist[SP]to[SP]be[SP]overcome.[1205][000F][SP]So[SP]let's\nfocus[SP]on[SP]overcoming[SP]this[SP]crisis[SP]right[SP]now!",
     "nom_fr": "Maya",
-    "texte_fr": "C'est vrai que les crises nous font\n[1205]grandir.[1205][000A] Elles existent pour être\n[000F]surmontées. Concentrons-nous sur celle-ci!"
+    "texte_fr": "C'est vrai que les crises nous font\n[1205]grandir.[000A][1205] Elles existent pour être\n[000F]surmontées. Concentrons-nous sur celle-ci!"
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Prince[SP]Taurus[SP]probably[SP]took[SP]advantage[SP]of[SP]that\nand[SP]broke[SP]in.[1205][000A][SP]Nothing[SP]we[SP]could[SP]have[SP]done.",
     "nom_fr": "Maya",
-    "texte_fr": "Le Prince Taureau en a sûrement profité\npour s'infiltrer.[1205][000A] On n'y pouvait rien."
+    "texte_fr": "Le Prince Taureau en a sûrement profité\npour s'infiltrer.[000A][1205] On n'y pouvait rien."
   },
   {
     "id": 9,
@@ -277,7 +277,7 @@
     "nom_orig": "Sister[SP]#3",
     "texte_orig": "What[SP]are[SP]we[SP]going[SP]to[SP]do!?[1205][000A][SP]The[SP]city's[SP]flying![1205][000A]\nI[SP]don't[SP]know[SP]what[SP]this[SP]Xibalba[SP]thing[SP]is,\nbut[SP]this[SP]isn't[SP]funny!",
     "nom_fr": "Sœur n°3",
-    "texte_fr": "Qu'allons-nous faire!?[1205][000A] La ville\nvole![1205][000A] Je ne sais pas ce qu'est\nXibalba, mais c'est pas drôle!"
+    "texte_fr": "Qu'allons-nous faire!?[000A][1205] La ville\nvole![000A][1205] Je ne sais pas ce qu'est\nXibalba, mais c'est pas drôle!"
   },
   {
     "id": 16,
@@ -292,7 +292,7 @@
     "nom_orig": "Sister[SP]#3",
     "texte_orig": "We'll[SP]never[SP]accomplish[SP]the[SP]grand[SP]scheme[SP]now![1205][000A]\nHow[SP]long[SP]are[SP]we[SP]going[SP]to[SP]be[SP]airborne?\nF...[SP]Forever?[1205][000F][SP]*sniff*",
     "nom_fr": "Sœur n°3",
-    "texte_fr": "On n'accomplira jamais le grand\nplan![1205][1205][000A] Combien de temps on restera\nen l'air? Pour toujours? [000F]*snif*"
+    "texte_fr": "On n'accomplira jamais le grand\nplan![1205][000A][1205] Combien de temps on restera\nen l'air? Pour toujours? [000F]*snif*"
   },
   {
     "id": 17,
@@ -307,7 +307,7 @@
     "nom_orig": "Sister[SP]#3",
     "texte_orig": "Hey,[SP]what's[SP]that[SP]light?[1205][000A][SP]The[SP]one[SP]rising[SP]up[SP]out\nof[SP]Sevens.",
     "nom_fr": "Sœur n°3",
-    "texte_fr": "Hé, c'est quoi cette lumière?[1205][000A]\nCelle qui monte du Seven."
+    "texte_fr": "Hé, c'est quoi cette lumière?[000A][1205]\nCelle qui monte du Seven."
   },
   {
     "id": 18,
@@ -382,7 +382,7 @@
     "nom_orig": "Man",
     "texte_orig": "Isn't[SP]our[SP]situation[SP]more[SP]precarious?[SP]Oh[SP]no...[1205][000A]\nAre[SP]we[SP]the[SP]ones[SP]who'll[SP]be[SP]annihilated...?[1205][000F]\nArgh![SP]What[SP]am[SP]I[SP]supposed[SP]to[SP]do!?",
     "nom_fr": "Homme",
-    "texte_fr": "Notre situation est-elle précaire?\n[1205]Oh non...[1205][000A] Sommes-nous ceux qui\n[000F]seront anéantis? Aah! Que faire!?"
+    "texte_fr": "Notre situation est-elle précaire?\n[1205]Oh non...[000A][1205] Sommes-nous ceux qui\n[000F]seront anéantis? Aah! Que faire!?"
   },
   {
     "id": 23,
@@ -397,7 +397,7 @@
     "nom_orig": "Man",
     "texte_orig": "I-Is[SP]that[SP]light[SP]some[SP]kind[SP]of[SP]Oracle[SP]too?[1205][000A]\nNow[SP]what!?[1205][000A][SP]Don't[SP]tell[SP]me[SP]the[SP]annihilation's\nabout[SP]to[SP]start...?",
     "nom_fr": "Homme",
-    "texte_fr": "C-C'est quoi cette lumière, un Oracle?[1205][000A]\nMaintenant quoi?![1205][000A] Pas la destruction qui\ncommence...?"
+    "texte_fr": "C-C'est quoi cette lumière, un Oracle?[000A][1205]\nMaintenant quoi?![000A][1205] Pas la destruction qui\ncommence...?"
   },
   {
     "id": 24,
@@ -442,7 +442,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "So[SP]what's[SP]your[SP]prediction?[1205][000F][SP]My[SP]friends[SP]and[SP]I\nhave[SP]our[SP]own[SP]theories.[SP]I'll[SP]let[SP]you[SP]know[SP]if\nwe[SP]come[SP]to[SP]a[SP]consensus.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "C'est quoi votre pronostic? [1205][000F]Mes amis\net moi avons nos théories. Je vous\ndirai si on arrive à un consensus."
+    "texte_fr": "C'est quoi votre pronostic? [000F][1205]Mes amis\net moi avons nos théories. Je vous\ndirai si on arrive à un consensus."
   },
   {
     "id": 27,
@@ -532,7 +532,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "But[SP]man,[SP]stopping[SP]the[SP]Earth's[SP]rotation...?[1205][000A]\nThe[SP]Grand[SP]Cross[SP]must[SP]be[SP]insanely[SP]powerful.[1205][000A]\nI[SP]feel[SP]sorry[SP]for[SP]the[SP]guys[SP]left[SP]behind...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Arrêter la rotation de la Terre...[1205][000A] La\nCroix Cosmique doit être incroyablement\npuissante.[1205][000A] Je plains ceux qui sont restés."
+    "texte_fr": "Arrêter la rotation de la Terre...[000A][1205] La\nCroix Cosmique doit être incroyablement\npuissante.[000A][1205] Je plains ceux qui sont restés."
   },
   {
     "id": 33,
@@ -732,7 +732,7 @@
     "nom_orig": "Sister[SP]#3",
     "texte_orig": "Our[SP]resale[SP]prices[SP]are[SP]around[SP]half[SP]the[SP]original\nprice.[SP]You[SP]can't[SP]sell[SP]anything[SP]you[SP]have[SP]equipped,\nand[SP]some[SP]special[SP]items[SP]are[SP]off-limits[SP]too.",
     "nom_fr": "Sœur n°3",
-    "texte_fr": "Nos prix de rachat\nsont environ la moitié du\nprix d'origine. Vous ne\npouvez pas vendre ce\nque vous portez,\nni certains objets spéciaux."
+    "texte_fr": "Nos prix de rachat\nsont environ la moitié du\nprix d'origine. Vous ne pouvez pas vendre ce que vous portez, ni certains objets spéciaux."
   },
   {
     "id": 43,

--- a/traduction/event_scripts/script_294.json
+++ b/traduction/event_scripts/script_294.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Heheh...[SP]Coming[SP]to[SP]a[SP]place[SP]like[SP]this[SP]is[SP]for\nchumps.[1205][001E][SP]I[SP]naturally[SP]release[SP]pheromones[SP]called\n[1432][NULL][NULL][0014]Pheroma[SP]XX,[1432][NULL][NULL][0014][SP]so[SP]I[SP]don't[SP]need[SP]any[SP]cologne.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Héhé... Venir ici c'est pour les nuls.[1205][001E]\nJ'émets des phéromones nommées [1432][NULL][NULL][0014]Pheroma\nXX[1432][NULL][NULL][0014], j'ai pas besoin d'eau de cologne."
+    "texte_fr": "Héhé... Venir ici c'est pour les nuls.[001E][1205]\nJ'émets des phéromones nommées [1432][NULL][NULL][0014]Pheroma\nXX[1432][NULL][NULL][0014], j'ai pas besoin d'eau de cologne."
   },
   {
     "id": 1,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]mean,[SP]the[SP]stuff[SP]that[SP]teacher[SP]was[SP]saying[SP]made\nno[SP]sense[SP]at[SP]all...[1205][000F][SP]Can[SP]we[SP]really[SP]trust[SP]her?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Les délires de cette prof n'avaient aucun\nsens... On peut\n[1205][000F]vraiment lui faire confiance?"
+    "texte_fr": "Les délires de cette prof n'avaient aucun\nsens... On peut\n[000F][1205]vraiment lui faire confiance?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Pheroma[SP]XX?[SP]More[SP]like[SP]Terrible[SP]BO.[1205][001E][SP][1113],\non[SP]the[SP]other[SP]hand,[SP]smells[SP]great![1205][001E][SP]Awww,[SP]you're\nmy[SP]favorite,[SP]Chinyan!",
     "nom_fr": "Lisa",
-    "texte_fr": "Pheroma XX? Plutôt odeur de bouc.[1205][001E]\n[1113], lui, sent super bon![1205][001E] Oh,\nt'es mon préféré, Chinyan!"
+    "texte_fr": "Pheroma XX? Plutôt odeur de bouc.[001E][1205]\n[1113], lui, sent super bon![001E][1205] Oh,\nt'es mon préféré, Chinyan!"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Pheroma[SP]XX?[SP]More[SP]like[SP]Terrible[SP]BO.[1205][001E][SP][1113],\non[SP]the[SP]other[SP]hand,[SP]smells[SP]great![1205][001E][SP]Awww,[SP]you're\nmy[SP]favorite,[SP]Chinyan!",
     "nom_fr": "Ginko",
-    "texte_fr": "Pheroma XX? Plutôt odeur de bouc.[1205][001E]\n[1113], lui, sent super bon![1205][001E] Oh,\nt'es mon préféré, Chinyan!"
+    "texte_fr": "Pheroma XX? Plutôt odeur de bouc.[001E][1205]\n[1113], lui, sent super bon![001E][1205] Oh,\nt'es mon préféré, Chinyan!"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey[SP]Chinyan,[SP]aromatherapy[SP]helps[SP]with[SP]constipation\ntoo.[1205][000F][SP]Did[SP]you[SP]know[SP]that?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé Chinyan, l'aromathérapie aide\n[1205][000F]contre la constipation. Tu savais?"
+    "texte_fr": "Hé Chinyan, l'aromathérapie aide\n[000F][1205]contre la constipation. Tu savais?"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "*gasp*[SP]Aiyah![SP]N-Not[SP]that[SP]I'm[SP]constipated[SP]or\nanything![1205][000F][SP]Haha...ha...",
     "nom_fr": "Ginko",
-    "texte_fr": "*surpris* Aiyah! N-Non que je\nsois constipée! [1205][000F]Haha... ha..."
+    "texte_fr": "*surpris* Aiyah! N-Non que je\nsois constipée! [000F][1205]Haha... ha..."
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hmmm...[1205][000A][SP]Hey,[SP][1113].[1205][000F][SP]I[SP]wonder[SP]if[SP]those[SP]kids\nmade[SP]sure[SP]to[SP]spread[SP]that[SP]rumor.[1205][000F][SP]We're[SP]not[SP]going\nto[SP]change[SP]because[SP]of[SP]the[SP]other[SP]rumor,[SP]are[SP]we?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hmmm.[1205][1205]..[000F][1205][000F][000A] Hé, [1113]. Ils ont bien\nrépandu la rumeur? On va pas changer\nà cause de l'autre rumeur, hein?"
+    "texte_fr": "Hmmm.[1205][1205]..[000F][000F][1205][000A] Hé, [1113]. Ils ont bien\nrépandu la rumeur? On va pas changer\nà cause de l'autre rumeur, hein?"
   },
   {
     "id": 11,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Mmmmmm...[1205][001E][SP]Such[SP]a[SP]nice[SP]smell.[SP]The[SP]only[SP]thing[SP]my\nroom[SP]smells[SP]like[SP]is[SP]the[SP]mildew[SP]from[SP]my[SP]AC.[SP]When\ndid[SP]I[SP]last[SP]clean[SP]the[SP]filter?[SP]Two[SP]years[SP]ago...?",
     "nom_fr": "Maya",
-    "texte_fr": "Mmmmmm...[1205][001E] Quelle bonne\nodeur. Ma chambre sent\nle moisi de ma clim. Quand ai-je nettoyé le\nfiltre la dernière fois?\nIl y a deux ans...?"
+    "texte_fr": "Mmmmmm...[001E][1205] Quelle bonne\nodeur. Ma chambre sent\nle moisi de ma clim. Quand ai-je nettoyé le filtre la dernière fois? Il y a deux ans...?"
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Has[SP]the[SP]smell[SP]of[SP]grass[SP]ever[SP]made[SP]you[SP]remember\nyour[SP]hometown?[SP]Or[SP]can[SP]you[SP]smell[SP]the[SP]seasons\nchanging[SP]on[SP]the[SP]wind?[SP]Scents[SP]have[SP]that[SP]power.",
     "nom_fr": "Maya",
-    "texte_fr": "L'odeur de l'herbe t'a-t-elle déjà rappelé\nton foyer? Ou peux-tu\nsentir le vent changer\nles saisons? Les parfums ont ce pouvoir."
+    "texte_fr": "L'odeur de l'herbe t'a-t-elle déjà rappelé\nton foyer? Ou peux-tu\nsentir le vent changer les saisons? Les parfums ont ce pouvoir."
   },
   {
     "id": 15,
@@ -469,7 +469,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Oh...[1205][000F][SP]Everyone[SP]is[SP]in[SP]fine[SP]health.[1205][000F][SP]It[SP]seems\nthere's[SP]no[SP]need[SP]for[SP]my[SP]services.",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Oh.[1205][000F][1205][000F].. Tout le monde est en forme.\nMes services ne sont pas utiles."
+    "texte_fr": "Oh.[000F][1205][000F][1205].. Tout le monde est en forme.\nMes services ne sont pas utiles."
   },
   {
     "id": 30,
@@ -629,7 +629,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Peppermint[SP]wakes[SP]you[SP]up[SP]and[SP]clears[SP]your[SP]mind.[1205][000F]\nEucalyptus'[SP]scent[SP]helps[SP]increase[SP]concentration.[1205][000F]\nMay[SP]your[SP]day[SP]be[SP]a[SP]wonderful[SP]one.",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "La menthe réveille et clarifie l'esprit.\n[1205][000F][1205][000F]L'eucalyptus aide à la concentration.\nPassez une excellente journée."
+    "texte_fr": "La menthe réveille et clarifie l'esprit.\n[000F][1205][000F][1205]L'eucalyptus aide à la concentration.\nPassez une excellente journée."
   },
   {
     "id": 40,
@@ -659,7 +659,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Geranium[SP]helps[SP]balance[SP]the[SP]mind,[SP]while[SP]the\nscent[SP]of[SP]neroli[SP]cheers[SP]you[SP]up.[1205][000F][SP]May[SP]your[SP]day\nbe[SP]a[SP]wonderful[SP]one.",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Le géranium équilibre l'esprit,\net le néroli remonte le moral.\n[1205][000F]Passez une excellente journée."
+    "texte_fr": "Le géranium équilibre l'esprit,\net le néroli remonte le moral.\n[000F][1205]Passez une excellente journée."
   },
   {
     "id": 42,
@@ -719,7 +719,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Geranium[SP]will[SP]help[SP]your[SP]mind[SP]regain[SP]balance\nand[SP]the[SP]rose's[SP]aroma[SP]brings[SP]back[SP]cheerfulness.\nMay[SP]your[SP]day[SP]be[SP]a[SP]wonderful[SP]one.",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Le géranium aide à\néquilibrer l'esprit et la\nrose la gaieté.\nPassez une excellente journée."
+    "texte_fr": "Le géranium aide à\néquilibrer l'esprit et la\nrose la gaieté. Passez une excellente journée."
   },
   {
     "id": 46,
@@ -839,7 +839,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Nothing[SP]is[SP]more[SP]uncertain[SP]than[SP]one's[SP]self...\nIf[SP]I[SP]become[SP]an[SP]Idealian,[SP]will[SP]I[SP]come[SP]to\nunderstand[SP]that...?",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Rien n'est plus\nincertain que soi-même... Si\nje deviens\nIdéalienne, le comprendrai-je...?"
+    "texte_fr": "Rien n'est plus\nincertain que soi-même... Si\nje deviens Idéalienne, le comprendrai-je...?"
   },
   {
     "id": 54,
@@ -1011,7 +1011,7 @@
     "nom_orig": "Older[SP]woman",
     "texte_orig": "[1432][NULL][NULL][0014]The[SP]lion's[SP]roar[SP]echoes[SP]far[SP]and[SP]wide...[1432][NULL][NULL][0014][1205][000F][SP]Is[SP]that\nhow[SP]it[SP]went?[1205][000F][SP]Some[SP]say[SP]that[SP]passage[SP]is[SP]about\nthe[SP]Leonids...[1205][000F][SP]Will[SP]it[SP]come[SP]true[SP]too...?",
     "nom_fr": "Dame âgée",
-    "texte_fr": "[1432][NULL][NULL][0014]Le rugissement du lion résonne...[1205][000F][1205][000F][1205][000F][1432][NULL][NULL][0014] C'est ça?\nCertains disent que ce passage concerne les\nLéonides... Ça va aussi se réaliser...?"
+    "texte_fr": "[1432][NULL][NULL][0014]Le rugissement du lion résonne...[000F][1205][000F][1205][000F][1205][1432][NULL][NULL][0014] C'est ça?\nCertains disent que ce passage concerne les\nLéonides... Ça va aussi se réaliser...?"
   },
   {
     "id": 64,
@@ -1026,7 +1026,7 @@
     "nom_orig": "Concerned[SP]mother",
     "texte_orig": "Of[SP]course[SP]the[SP]PTA[SP]didn't[SP]take[SP]the[SP]disease\nraging[SP]through[SP]the[SP]school[SP]lightly.[SP]We[SP]told\nthe[SP]principal[SP]to[SP]investigate[SP]the[SP]cause...",
     "nom_fr": "Mère inquiète",
-    "texte_fr": "L'APE n'a pas pris la\nmaladie à l'école à la\nlégère. On a demandé au proviseur\nd'enquêter..."
+    "texte_fr": "L'APE n'a pas pris la\nmaladie à l'école à la\nlégère. On a demandé au proviseur d'enquêter..."
   },
   {
     "id": 65,
@@ -1056,7 +1056,7 @@
     "nom_orig": "Concerned[SP]mother",
     "texte_orig": "I[SP]heard[SP]your[SP]no-good[SP]principal[SP]disappeared.\nI[SP]thought[SP]my[SP]son[SP]would[SP]snap[SP]out[SP]of[SP]it,[SP]but[SP]now\nhe[SP]has[SP]a[SP]photo[SP]of[SP]the[SP]man[SP]in[SP]his[SP]room!",
     "nom_fr": "Mère inquiète",
-    "texte_fr": "J'ai appris que votre proviseur a disparu.\nJe pensais que mon\nfils allait se ressaisir,\nmais il a sa photo dans sa chambre!"
+    "texte_fr": "J'ai appris que votre proviseur a disparu.\nJe pensais que mon\nfils allait se ressaisir, mais il a sa photo dans sa chambre!"
   },
   {
     "id": 67,
@@ -1146,7 +1146,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "*sigh*[SP]I'd[SP]let[SP]her[SP]know[SP]my[SP]passion[SP]for[SP]her...\nBut[SP]I[SP]wonder[SP]if[SP]she[SP]has[SP]a[SP]boyfriend.[1205][001E][SP]How[SP]could\na[SP]woman[SP]with[SP]her[SP]beauty[SP]not?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "*soupir* J'aimerais lui avouer ma\npassion... Mais a-t-elle un petit-ami?[1205][001E]\nUne telle beauté... c'est obligé."
+    "texte_fr": "*soupir* J'aimerais lui avouer ma\npassion... Mais a-t-elle un petit-ami?[001E][1205]\nUne telle beauté... c'est obligé."
   },
   {
     "id": 73,
@@ -1176,7 +1176,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Yesterday,[SP]she[SP]taught[SP]me[SP]about[SP]tea[SP]tree[SP]and\nbergamot.[1205][000F][SP]She[SP]said[SP]they're[SP]effective[SP]against\ndandruff.[SP]Eh...heheh...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Hier, elle m'a parlé de tea tree et\nde bergamote. [1205][000F]C'est efficace contre\nles pellicules. Eh... héhé..."
+    "texte_fr": "Hier, elle m'a parlé de tea tree et\nde bergamote. [000F][1205]C'est efficace contre\nles pellicules. Eh... héhé..."
   },
   {
     "id": 75,
@@ -1191,7 +1191,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "T-Terrorism...?[1205][000F][SP]N-No![SP]This[SP]is[SP]exactly[SP]the[SP]time\nfor[SP]me[SP]to[SP]step[SP]up![SP]I'll[SP]use[SP]my[SP]body[SP]as[SP]a[SP]shield\nto[SP]protect[SP]Miss[SP]Kaori,[SP]and...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "T-Terrorisme.[1205][000F]..? N-Non! C'est le moment\nde me dépasser! Je serai un bouclier\npour protéger Mlle Kaori, et..."
+    "texte_fr": "T-Terrorisme.[000F][1205]..? N-Non! C'est le moment\nde me dépasser! Je serai un bouclier\npour protéger Mlle Kaori, et..."
   },
   {
     "id": 76,
@@ -1206,7 +1206,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Umm,[SP]no,[SP]I[SP]shouldn't[SP]try[SP]to[SP]be[SP]a[SP]hero...\nThere's[SP]nothing[SP]special[SP]about[SP]me.[1205][000F][SP]B-But[SP]I[SP]still\ncan't[SP]just[SP]do[SP]nothing...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Euh, non, pas de héroïsme... Je\nn'ai rien de spécial. M-Mais je ne\n[1205][000F]peux pas rester les bras croisés..."
+    "texte_fr": "Euh, non, pas de héroïsme... Je\nn'ai rien de spécial. M-Mais je ne\n[000F][1205]peux pas rester les bras croisés..."
   },
   {
     "id": 77,
@@ -1281,7 +1281,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Then[SP]today,[SP]the[SP]fragrance[SP]of[SP]ylang-ylang...[1205][000F][SP]It's\na[SP]tree[SP]valued[SP]for[SP]its[SP]perfume.[1205][000A][SP]The[SP]sweet,[SP]heavy\nfragrances[SP]is[SP]good[SP]for[SP]the[SP]mind[SP]and[SP]body.",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Pour aujourd'hui,\nle parfum d'ylang-ylang.[1205][000F]..\nUn arbre prisé pour son parfum.[1205][000A] Cette odeur\nsucrée est idéale pour\nle corps et l'esprit."
+    "texte_fr": "Pour aujourd'hui,\nle parfum d'ylang-ylang.[000F][1205]..\nUn arbre prisé pour son parfum.[000A][1205] Cette odeur sucrée est idéale pour le corps et l'esprit."
   },
   {
     "id": 82,
@@ -1296,7 +1296,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Then[SP]today,[SP]the[SP]fragrance[SP]of[SP]asphodel.[SP]The[SP]way\nit[SP]embraces[SP]death[SP]and[SP]sorrow[SP]will[SP]lure[SP]you[SP]to\neternal[SP]liberation[SP]and[SP]your[SP]next[SP]journey.",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Pour aujourd'hui, le parfum d'asphodèle.\nEmbrassant mort et\ntristesse, il vous mènera\nvers la libération\net votre prochain voyage."
+    "texte_fr": "Pour aujourd'hui, le parfum d'asphodèle.\nEmbrassant mort et\ntristesse, il vous mènera vers la libération et votre prochain voyage."
   },
   {
     "id": 83,
@@ -1326,7 +1326,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Then[SP]today,[SP]the[SP]fragrance[SP]of[SP]lilies.[SP]They're\nsymbols[SP]of[SP]regeneration[SP]and[SP]immortality...\nTheir[SP]scent[SP]will[SP]lead[SP]you[SP]to[SP]a[SP]rebirth.",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Pour aujourd'hui, le\nparfum de lys. Symboles\nde régénération et d'immortalité... Leur\nodeur vous mènera vers une renaissance."
+    "texte_fr": "Pour aujourd'hui, le\nparfum de lys. Symboles\nde régénération et d'immortalité... Leur odeur vous mènera vers une renaissance."
   },
   {
     "id": 85,
@@ -1356,7 +1356,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Then[SP]today,[SP]the[SP]fragrances[SP]of[SP]irises.[SP]These\nare[SP]said[SP]to[SP]be[SP]the[SP]flower[SP]of[SP]the[SP]Virgin[SP]Mary.\nTheir[SP]scent[SP]grants[SP]the[SP]power[SP]of[SP]light.",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Pour aujourd'hui, le parfum d'iris.\nConsidérée comme la fleur\nde la Vierge Marie.\nSon odeur accorde le pouvoir de la lumière."
+    "texte_fr": "Pour aujourd'hui, le parfum d'iris.\nConsidérée comme la fleur\nde la Vierge Marie. Son odeur accorde le pouvoir de la lumière."
   },
   {
     "id": 87,
@@ -1401,7 +1401,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Then[SP]today,[SP]the[SP]fragrance[SP]of[SP]amaranth.[SP]It[SP]has\nsworn[SP]undying[SP]love...[SP]Their[SP]fragrance[SP]will[SP]bring\npower[SP]to[SP]those[SP]who[SP]accomplish[SP]this.",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Pour aujourd'hui, le parfum d'amarante.\nSymbole d'amour éternel... Leur odeur\napportera la puissance\nà ceux qui yparviennent."
+    "texte_fr": "Pour aujourd'hui, le parfum d'amarante.\nSymbole d'amour éternel... Leur odeur\napportera la puissance à ceux qui yparviennent."
   },
   {
     "id": 90,

--- a/traduction/event_scripts/script_295.json
+++ b/traduction/event_scripts/script_295.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]Last[SP]Battalion[SP]and[SP]the[SP]Masked[SP]Circle[SP]are\nboth[SP]in[SP]that[SP]temple...[1205][000F][SP]This[SP]isn't[SP]gonna[SP]be\neasy,[SP]is[SP]it?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le Bataillon et le Cercle masqué\nsont tous les deux dans ce temple.[1205][000F]..\nÇa va pas être simple, hein?"
+    "texte_fr": "Le Bataillon et le Cercle masqué\nsont tous les deux dans ce temple.[000F][1205]..\nÇa va pas être simple, hein?"
   },
   {
     "id": 1,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]next[SP]part[SP]of[SP]the[SP]Oracle[SP]can't[SP]be[SP]fulfilled\nuntil[SP]one[SP]side[SP]has[SP]all[SP]the[SP]skulls,[SP]right?[1205][000F][SP]So[SP]I\nthink[SP]we[SP]still[SP]have[SP]a[SP]chance.",
     "nom_fr": "Maya",
-    "texte_fr": "La suite de l'Oracle ne peut s'accomplir\nque si l'un d'eux a tous les crânes,\n[1205][000F]non? On a encore notre chance."
+    "texte_fr": "La suite de l'Oracle ne peut s'accomplir\nque si l'un d'eux a tous les crânes,\n[000F][1205]non? On a encore notre chance."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Ms.[SP]Okamura[SP]kept[SP]watch[SP]over[SP]the[SP]Narurato[SP]Stone\nfor[SP]so[SP]long...[1205][001E][SP]I[SP]wonder[SP]what[SP]went[SP]through[SP]her\nmind,[SP]watching[SP]over[SP]it[SP]for[SP]10[SP]years...",
     "nom_fr": "Maya",
-    "texte_fr": "Mme Okamura a veillé si longtemps sur la\nPierre Narurato...[1205][001E] À quoi pensait-elle\ndurant ces 10 années de garde..."
+    "texte_fr": "Mme Okamura a veillé si longtemps sur la\nPierre Narurato...[001E][1205] À quoi pensait-elle\ndurant ces 10 années de garde..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Jun",
     "texte_orig": "The[SP]Masked[SP]Circle[SP]is[SP]fighting[SP]under[SP]my[SP]orders.[1205][000F]\nAt[SP]this[SP]rate,[SP]they'll[SP]all[SP]be[SP]killed.[SP]We[SP]must\nhurry[SP]and[SP]stop[SP]this[SP]war.",
     "nom_fr": "Jun",
-    "texte_fr": "Le Cercle masqué combat sur mes ordres.\n[1205][000F]À ce rythme, ils vont tous mourir. Il\nfaut vite mettre fin à cette guerre."
+    "texte_fr": "Le Cercle masqué combat sur mes ordres.\n[000F][1205]À ce rythme, ils vont tous mourir. Il\nfaut vite mettre fin à cette guerre."
   },
   {
     "id": 9,
@@ -207,7 +207,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Legendary[SP]weapon?[SP]Yes,[SP]I[SP]did[SP]buy[SP]a[SP]flower[SP]from\nthe[SP]Count[SP]at[SP]Time[SP]Castle,[SP]but...[1205][000F][SP]You[SP]mean[SP]to\nsay[SP]the[SP]flower[SP]was[SP]this[SP]weapon?",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Une arme légendaire? J'ai bien acheté\nune fleur au Comte du Château du Temps,\n[1205][000F]mais... Cette fleur était cette arme?"
+    "texte_fr": "Une arme légendaire? J'ai bien acheté\nune fleur au Comte du Château du Temps,\n[000F][1205]mais... Cette fleur était cette arme?"
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "But[SP]you[SP]say[SP]you[SP]desperately[SP]needed[SP]that[SP]flower?[1205][0014]\nI[SP]understand...",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Vous aviez absolument besoin de\ncette fleur?[1205][0014] Je comprends..."
+    "texte_fr": "Vous aviez absolument besoin de\ncette fleur?[0014][1205] Je comprends..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Then[SP]from[SP]now[SP]on,[SP]when[SP]you[SP]visit,[SP]I[SP]will[SP]share\nthe[SP]legendary[SP]flower's[SP]fragrance[SP]at[SP]no[SP]cost...[1205][000F]\nI[SP]hope[SP]that[SP]excuses[SP]my[SP]mistake...",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Dorénavant, à chaque\nvisite, je partagerai le\nparfum de la fleur légendaire sans frais.[1205].[000F].\nJ'espère que ça répare mon erreur..."
+    "texte_fr": "Dorénavant, à chaque\nvisite, je partagerai le\nparfum de la fleur légendaire sans frais.[1205].[000F]. J'espère que ça répare mon erreur..."
   },
   {
     "id": 17,
@@ -379,7 +379,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Oh...[1205][000F][SP]Everyone[SP]is[SP]in[SP]fine[SP]health.[1205][000F][SP]It[SP]seems\nthere's[SP]no[SP]need[SP]for[SP]my[SP]services.",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Oh.[1205][000F][1205][000F].. Tout le monde est en forme.\nMes services ne semblent pas utiles."
+    "texte_fr": "Oh.[000F][1205][000F][1205].. Tout le monde est en forme.\nMes services ne semblent pas utiles."
   },
   {
     "id": 24,
@@ -434,7 +434,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "The[SP]saucer[SP]raising[SP]this[SP]city[SP]is[SP]going[SP]to[SP]make\nus[SP]into[SP]Idealians?[1205][000F][SP]I[SP]can't[SP]say[SP]I[SP]particularly\nwant[SP]to[SP]become[SP]such[SP]a[SP]thing...",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "La soucoupe qui soulève cette ville va\nnous transformer en Idéaliens? [1205][000F]Je ne\npeux pas dire que j'y aspire vraiment..."
+    "texte_fr": "La soucoupe qui soulève cette ville va\nnous transformer en Idéaliens? [000F][1205]Je ne\npeux pas dire que j'y aspire vraiment..."
   },
   {
     "id": 27,
@@ -449,7 +449,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "I[SP]believe[SP]man[SP]is[SP]perfectly[SP]capable[SP]of[SP]finding\nhappiness.[1205][000A][SP]I[SP]only[SP]want[SP]a[SP]quiet[SP]life[SP]amidst[SP]the\nfragrances,[SP]in[SP]this[SP]store[SP]he[SP]dreamed[SP]of...",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Je crois que l'homme\nest tout à fait capable\nde trouver le bonheur.[1205][000A]\nJe veux juste une vie\npaisible, dans sa boutique..."
+    "texte_fr": "Je crois que l'homme\nest tout à fait capable\nde trouver le bonheur.[000A][1205] Je veux juste une vie paisible, dans sa boutique..."
   },
   {
     "id": 28,
@@ -479,7 +479,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Weren't[SP]there[SP]students[SP]and[SP]teachers[SP]still\ninside?[1205][000F][SP]I[SP]wonder[SP]if[SP]they're[SP]all[SP]right...",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Il y avait encore des élèves et des profs\n[1205][000F]dedans? J'espère qu'ils vont bien..."
+    "texte_fr": "Il y avait encore des élèves et des profs\n[000F][1205]dedans? J'espère qu'ils vont bien..."
   },
   {
     "id": 30,
@@ -576,7 +576,7 @@
     "nom_orig": "Older[SP]woman",
     "texte_orig": "Oh[SP]my,[SP]what[SP]should[SP]I[SP]do!?[1205][000A][SP]It's[SP]all[SP]happening\nin[SP]accordance[SP]with[SP]the[SP]In[SP]Lak'ech!",
     "nom_fr": "Femme âgée",
-    "texte_fr": "Oh là là, que faire?![1205][000A] Tout se\npasse conformément à l'In Lak'ech!"
+    "texte_fr": "Oh là là, que faire?![000A][1205] Tout se\npasse conformément à l'In Lak'ech!"
   },
   {
     "id": 35,
@@ -606,7 +606,7 @@
     "nom_orig": "Older[SP]woman",
     "texte_orig": "I[SP]can't[SP]just[SP]stand[SP]here![1205][000A][SP]Let's[SP]see,[SP]what's[SP]the\nnext[SP]part[SP]of[SP]the[SP]Oracle...[1205][000A][SP][1432][NULL][NULL][0014]Five[SP]skulls[SP]glow\nin[SP]the[SP]depths[SP]of[SP]the[SP]earth[1432][NULL][NULL][0014]?",
     "nom_fr": "Femme âgée",
-    "texte_fr": "Je ne peux pas rester là![1205][000A] Voyons, la\nsuite de l'Oracle...[1205][000A] [1432][NULL][NULL][0014]Cinq crânes brillent\ndans les profondeurs de la terre[1432][NULL][NULL][0014]?"
+    "texte_fr": "Je ne peux pas rester là![000A][1205] Voyons, la\nsuite de l'Oracle...[000A][1205] [1432][NULL][NULL][0014]Cinq crânes brillent\ndans les profondeurs de la terre[1432][NULL][NULL][0014]?"
   },
   {
     "id": 37,
@@ -621,7 +621,7 @@
     "nom_orig": "Older[SP]woman",
     "texte_orig": "Hmm...[SP]I[SP]bet[SP]that[SP]will[SP]happen[SP]soon,[SP]too...[1205][000A]\nBut[SP]what[SP]could[SP]it[SP]mean?",
     "nom_fr": "Femme âgée",
-    "texte_fr": "Hmm... Ça va sûrement arriver\nbientôt...[1205][000A] Mais ça signifie quoi?"
+    "texte_fr": "Hmm... Ça va sûrement arriver\nbientôt...[000A][1205] Mais ça signifie quoi?"
   },
   {
     "id": 38,
@@ -711,7 +711,7 @@
     "nom_orig": "Concerned[SP]mother",
     "texte_orig": "This[SP]is[SP]no[SP]laughing[SP]matter![1205][000A][SP]Those[SP]soldiers[SP]have\neven[SP]broken[SP]into[SP]Sevens[SP]now!",
     "nom_fr": "Mère inquiète",
-    "texte_fr": "C'est grave![1205][000A] Ces soldats ont\nmême envahi Seven maintenant!"
+    "texte_fr": "C'est grave![000A][1205] Ces soldats ont\nmême envahi Seven maintenant!"
   },
   {
     "id": 44,
@@ -726,7 +726,7 @@
     "nom_orig": "Concerned[SP]mother",
     "texte_orig": "It's[SP]unconscionable[SP]that[SP]they'd[SP]break[SP]into[SP]a\nplace[SP]of[SP]learning[SP]with[SP]loaded[SP]weapons![1205][000A][SP]Are[SP]they\ngoing[SP]to[SP]steal[SP]even[SP]our[SP]children's[SP]education!?",
     "nom_fr": "Mère inquiète",
-    "texte_fr": "C'est inadmissible de forcer l'entrée d'un\nlieu d'enseignement avec\ndes armes![1205][000A] Ils vont\nvoler jusqu'à l'éducation de nos enfants!?"
+    "texte_fr": "C'est inadmissible de forcer l'entrée d'un\nlieu d'enseignement avec\ndes armes![000A][1205] Ils vont voler jusqu'à l'éducation de nos enfants!?"
   },
   {
     "id": 45,
@@ -741,7 +741,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "The[SP]Masked[SP]Circle[SP]and[SP]the[SP]Last[SP]Battalion[SP]are\nstill[SP]fighting[SP]inside[SP]that[SP]weird[SP]building.[1205][000F]\nThe[SP]city's[SP]still[SP]not[SP]safe.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Le Cercle masqué et le Bataillon se\nbattent encore dans cet étrange bâtiment.\n[1205][000F]La ville n'est toujours pas sûre."
+    "texte_fr": "Le Cercle masqué et le Bataillon se\nbattent encore dans cet étrange bâtiment.\n[000F][1205]La ville n'est toujours pas sûre."
   },
   {
     "id": 46,
@@ -756,7 +756,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "B-But[SP]I[SP]won't[SP]run.[1205][000A][SP]I'll[SP]protect[SP]Miss[SP]Kaori[SP]from\nthe[SP]wind,[SP]the[SP]cold,[SP]and[SP]the[SP]soldiers[SP]like[SP]a\nlittle[SP]glass[SP]globe.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "M-Mais je ne fuirai pas.[1205][000A] Je protègerai\nMlle Kaori du vent, du froid et des\nsoldats, comme un globe de verre."
+    "texte_fr": "M-Mais je ne fuirai pas.[000A][1205] Je protègerai\nMlle Kaori du vent, du froid et des\nsoldats, comme un globe de verre."
   },
   {
     "id": 47,
@@ -771,7 +771,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "This[SP]place[SP]isn't[SP]safe[SP]either,[SP]with[SP]those[SP]guys\naround...[1205][000A][SP]But[SP]for[SP]her[SP]to[SP]worry[SP]about[SP]Sevens\neven[SP]now...[1205][000A][SP]Ah,[SP]Miss[SP]Kaori[SP]is[SP]so[SP]considerate!",
     "nom_fr": "Jeune homme",
-    "texte_fr": "C'est pas sûr ici\nnon plus, avec ces types...[1205][000A]\nMais qu'elle s'inquiète pour Seven même\nmaintenant...[1205][000A] Mlle Kaori\nest si attentionnée!"
+    "texte_fr": "C'est pas sûr ici\nnon plus, avec ces types...[000A][1205]\nMais qu'elle s'inquiète pour Seven même maintenant...[000A][1205] Mlle Kaori est si attentionnée!"
   },
   {
     "id": 48,
@@ -816,7 +816,7 @@
     "nom_orig": "Miss[SP]Kaori",
     "texte_orig": "Then[SP]today,[SP]the[SP]fragrance[SP]of[SP]ylang-ylang...[1205][000F][SP]It's\na[SP]tree[SP]valued[SP]for[SP]its[SP]perfume.[1205][000A][SP]The[SP]sweet,[SP]heavy\nfragrances[SP]is[SP]good[SP]for[SP]the[SP]mind[SP]and[SP]body.",
     "nom_fr": "Mlle Kaori",
-    "texte_fr": "Aujourd'hui, le parfum d'ylang-ylang.[1205].[000F]. Un\narbre précieux pour son parfum.[1205][000A] Ses douces\nfragrances apaisent l'esprit et le corps."
+    "texte_fr": "Aujourd'hui, le parfum d'ylang-ylang.[1205].[000F]. Un\narbre précieux pour son parfum.[000A][1205] Ses douces\nfragrances apaisent l'esprit et le corps."
   },
   {
     "id": 51,

--- a/traduction/event_scripts/script_296.json
+++ b/traduction/event_scripts/script_296.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]know,[SP]I've[SP]always[SP]been[SP]curious[SP]about[SP]this\ndoor[SP]ever[SP]since[SP]I[SP]was[SP]a[SP]kid...[1205][001E][SP]I'd[SP]see[SP]it[SP]for\njust[SP]a[SP]second,[SP]and[SP]it[SP]would[SP]disappear.",
     "nom_fr": "[NULL][E4][NULL][NULL]\"Eikichi",
-    "texte_fr": "Cette porte m'intrigue depuis que\nje suis gamin...[1205][001E] Je la voyais une\nseconde, puis elle disparaissait."
+    "texte_fr": "Cette porte m'intrigue depuis que\nje suis gamin...[001E][1205] Je la voyais une\nseconde, puis elle disparaissait."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Mmm,[SP]that's[SP]some[SP]sweet[SP]piano...[1205][000F][SP]I[SP]should[SP]invite\nthis[SP]Nameless[SP]dude[SP]to[SP]join[SP]Gas[SP]Chamber.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mmm, joli piano... [1205][000F]Je devrais inviter\nce Nameless dans Gas Chamber."
+    "texte_fr": "Mmm, joli piano... [000F][1205]Je devrais inviter\nce Nameless dans Gas Chamber."
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]new[SP]student[SP]council[SP]president's[SP]this[SP]guy\nnamed[SP]Yasuo...[1205][000A][SP]He[SP]always[SP]had[SP]these[SP]big[SP]schemes.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le nouveau président des\nélèves est un certain\nYasuo...[1205][000A] Il a toujours\neu de grands projets."
+    "texte_fr": "Le nouveau président des\nélèves est un certain\nYasuo...[000A][1205] Il a toujours eu de grands projets."
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]was[SP]just[SP]gonna[SP]do[SP]what[SP]I[SP]did[SP]with[SP]Sugimoto...[1205][000F]\nA[SP]couple[SP]of[SP]punches[SP]would've[SP]settled[SP]it.[1205][000F][SP]But...[1205][000F]\nI[SP]can't[SP]believe[SP]he's[SP]dead...",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'allais faire comme avec Sugimoto...\n[1205][000F][1205][000F][1205][000F]Quelques poings auraient suffi. Mais... Je\nn'arrive pas à croire qu'il soit mort..."
+    "texte_fr": "J'allais faire comme avec Sugimoto...\n[000F][1205][000F][1205][000F][1205]Quelques poings auraient suffi. Mais... Je\nn'arrive pas à croire qu'il soit mort..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "There's[SP]no[SP]turning[SP]back[SP]now...[1205][000F][SP]We[SP]can't[SP]do[SP]much\nif[SP]we[SP]keep[SP]looking[SP]back.[SP]Always[SP]move[SP]forward,\neven[SP]when[SP]facing[SP]death![SP]That's[SP]how[SP]a[SP]man[SP]acts!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pas de retour en arrière.[1205][000F].. Inutile de\nregarder le passé. Toujours avancer, même\nface à la mort! C'est ça, être un homme!"
+    "texte_fr": "Pas de retour en arrière.[000F][1205].. Inutile de\nregarder le passé. Toujours avancer, même\nface à la mort! C'est ça, être un homme!"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What[SP]the[SP]hell[SP]is[SP]Ginko[SP]talking[SP]about!?[SP]Those\nMasked[SP]Circle[SP]guys[SP]killed[SP]Yasuo![SP]How[SP]can[SP]she[SP]be\nso[SP]sure[SP]they[SP]won't[SP]do[SP]the[SP]same[SP]to[SP]those[SP]two!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "De quoi parle Ginko!?\nLe Cercle masqué a tué\nYasuo! Comment peut-elle\nêtre si sûre qu'ils\nne feront pas pareil à ces deux-là!?"
+    "texte_fr": "De quoi parle Ginko!?\nLe Cercle masqué a tué\nYasuo! Comment peut-elle être si sûre qu'ils ne feront pas pareil à ces deux-là!?"
   },
   {
     "id": 10,
@@ -252,7 +252,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Mankind's[SP]responsibility...[1205][000F][SP]is[SP]to[SP]be\nannihilated...?[1205][000F][SP]If[SP]that[SP]wasn't[SP]a[SP]dream,\nthen[SP]how[SP]am[SP]I[SP]gonna[SP]take[SP]responsibility...?",
     "nom_fr": "Eikichi",
-    "texte_fr": "La responsabilité de l'homme.[1205][000F][1205][000F].. est\nd'être anéanti...? Si ce n'était\npas un rêve, comment l'assumer...?"
+    "texte_fr": "La responsabilité de l'homme.[000F][1205][000F][1205].. est\nd'être anéanti...? Si ce n'était\npas un rêve, comment l'assumer...?"
   },
   {
     "id": 17,
@@ -368,7 +368,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ooh![1205][000A][SP]Really?[1205][000F][SP]Perfect![1205][000F][SP]Then[SP][1114][SP]will[SP]be\nour[SP]guitarist!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ooh![1205][1205][1205][000A] Vrai? [000F][000F]Super! [1114] sera notre guitariste!"
+    "texte_fr": "Ooh![1205][1205][000A][1205] Vrai? [000F][000F]Super! [1114] sera notre guitariste!"
   },
   {
     "id": 24,
@@ -383,7 +383,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "A-All[SP]right...[1205][000F][SP]You[SP]were[SP]my[SP]last[SP]hope...\nBut[SP]oh[SP]well.",
     "nom_fr": "Eikichi",
-    "texte_fr": "O-OK... [1205][000F]Tu étais mon\ndernier espoir... Mais bon."
+    "texte_fr": "O-OK... [000F][1205]Tu étais mon\ndernier espoir... Mais bon."
   },
   {
     "id": 25,
@@ -398,7 +398,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Jun's[SP]keyboards[SP]and[SP][1114]'s[SP]guitar![1205][000F][SP]Add[SP]my\nsinging[SP]to[SP]the[SP]mix[SP]and[SP]it's[SP]an[SP]unbeatable\nteam![1205][000F][SP]Even[SP]the[SP]demons[SP]will[SP]be[SP]all[SP]over[SP]us.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Jun aux claviers et [1114] à la guitare!\n[1205][000F][1205][000F]Ajoute ma voix et on est imbattables!\nMême les démons nous adoreront."
+    "texte_fr": "Jun aux claviers et [1114] à la guitare!\n[000F][1205][000F][1205]Ajoute ma voix et on est imbattables!\nMême les démons nous adoreront."
   },
   {
     "id": 26,
@@ -458,7 +458,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Crying[SP]because[SP]you[SP]lost[SP]something[SP]you[SP]shouldn't\nhave[SP]let[SP]go...[1205][000F][SP]Going[SP]through[SP]that[SP]once[SP]is[SP]more\nthan[SP]enough...",
     "nom_fr": "Ginko",
-    "texte_fr": "Pleurer car tu as perdu ce que tu\nn'aurais pas dû lâcher.[1205][000F].. Le vivre\nune fois suffit amplement..."
+    "texte_fr": "Pleurer car tu as perdu ce que tu\nn'aurais pas dû lâcher.[000F][1205].. Le vivre\nune fois suffit amplement..."
   },
   {
     "id": 30,
@@ -473,7 +473,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Maya-san[SP]says[SP]otherwise,[SP]but[SP]there's[SP]no[SP]way\nUndie[SP]Boss[SP]is[SP]that[SP]sensitive.[1205][000F][SP]She's[SP]just\noverthinking[SP]things.",
     "nom_fr": "Ginko",
-    "texte_fr": "Maya dit l'inverse, mais\nBoss des calbutes n'est\npas si sensible. [1205][000F]Elle\nse prend trop la tête."
+    "texte_fr": "Maya dit l'inverse, mais\nBoss des calbutes n'est\npas si sensible. [000F][1205]Elle se prend trop la tête."
   },
   {
     "id": 31,
@@ -503,7 +503,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hmph,[SP]serves[SP]him[SP]right[SP]for[SP]spreading[SP]rumors\nabout[SP]the[SP]curse.[SP]I[SP]don't[SP]feel[SP]the[SP]least[SP]bit\nsorry[SP]for[SP]him.[1205][000F][SP]Do[SP]you,[SP][1113]?",
     "nom_fr": "Ginko",
-    "texte_fr": "Bien fait pour lui d'avoir répandu\nces rumeurs. Je n'ai aucune pitié\npour lui. [1205][000F]Et toi, [1113]?"
+    "texte_fr": "Bien fait pour lui d'avoir répandu\nces rumeurs. Je n'ai aucune pitié\npour lui. [000F][1205]Et toi, [1113]?"
   },
   {
     "id": 33,
@@ -608,7 +608,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "No[SP]worries...[SP]No[SP]fears...[1205][000F][SP]Is[SP]there[SP]anyone\nlike[SP]that[SP]in[SP]the[SP]entire[SP]world?",
     "nom_fr": "Ginko",
-    "texte_fr": "Sans tracas ni peurs.[1205][000F].. Y a-t-il\nquelqu'un comme ça dans le monde?"
+    "texte_fr": "Sans tracas ni peurs.[000F][1205].. Y a-t-il\nquelqu'un comme ça dans le monde?"
   },
   {
     "id": 40,
@@ -653,7 +653,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "This[SP]place[SP]never[SP]changes,[SP]right?[1205][000F][SP]Feels[SP]just\nlike[SP]us...[1205][000F][SP]I'm[SP]still[SP]the[SP]same[SP]deep[SP]down[SP]as[SP]I\nused[SP]to[SP]be.[1205][000F][SP]And[SP]I'll[SP]probably[SP]stay[SP]that[SP]way...",
     "nom_fr": "Ginko",
-    "texte_fr": "Cet endroit ne change pas. [1205][000F][1205][000F][1205][000F]C'est comme\nnous... Au fond, je suis toujours la\nmême. Et je le resterai probablement..."
+    "texte_fr": "Cet endroit ne change pas. [000F][1205][000F][1205][000F][1205]C'est comme\nnous... Au fond, je suis toujours la\nmême. Et je le resterai probablement..."
   },
   {
     "id": 43,
@@ -668,7 +668,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What[SP]a[SP]wonderful[SP]song...[1205][001E][SP]It[SP]feels[SP]like[SP]it\ntouches[SP]my[SP]soul.[1205][001E][SP]Doesn't[SP]it[SP]make[SP]you[SP]incredibly\nat[SP]ease?",
     "nom_fr": "Maya",
-    "texte_fr": "Quelle belle chanson...[1205][001E]\nElle touche mon âme.[1205][001E]\nNe te sens-tu pas incroyablement apaisé?"
+    "texte_fr": "Quelle belle chanson...[001E][1205]\nElle touche mon âme.[001E][1205]\nNe te sens-tu pas incroyablement apaisé?"
   },
   {
     "id": 44,
@@ -683,7 +683,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We're[SP]human[SP]because[SP]we[SP]dream,[SP]huh...?[1205][000F][SP]If[SP]what\nwe[SP]see[SP]when[SP]we're[SP]asleep[SP]are[SP]dreams,[SP]then[SP]to\nimagine[SP]your[SP]ideal[SP]self[SP]is[SP]to[SP]dream[SP]too...",
     "nom_fr": "Maya",
-    "texte_fr": "Nous sommes humains car nous rêvons.[1205][000F].. Si\nce qu'on voit en dormant sont des rêves,\nimaginer son soi idéal l'est aussi..."
+    "texte_fr": "Nous sommes humains car nous rêvons.[000F][1205].. Si\nce qu'on voit en dormant sont des rêves,\nimaginer son soi idéal l'est aussi..."
   },
   {
     "id": 45,
@@ -773,7 +773,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Those[SP]two[SP]knew[SP]how[SP]Lisa[SP]really[SP]felt.[SP]I'm[SP]sure\nthey'll[SP]be[SP]great[SP]friends[SP]again[SP]once[SP]this[SP]is\nall[SP]over!",
     "nom_fr": "Maya",
-    "texte_fr": "Elles savaient ce\nque Lisa ressentait. Elles\nredeviendront amies une\nfois tout ça terminé!"
+    "texte_fr": "Elles savaient ce\nque Lisa ressentait. Elles\nredeviendront amies une fois tout ça terminé!"
   },
   {
     "id": 51,
@@ -788,7 +788,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Lisa's[SP]been[SP]upset[SP]ever[SP]since[SP]we[SP]left[SP]Smile\nHirasaka.[1205][000F][SP]It's[SP]like[SP]something's[SP]eating[SP]away\nat[SP]her...",
     "nom_fr": "Maya",
-    "texte_fr": "Lisa est bouleversée depuis Smile Hirasaka.\n[1205][000F]Comme si quelque chose la rongeait..."
+    "texte_fr": "Lisa est bouleversée depuis Smile Hirasaka.\n[000F][1205]Comme si quelque chose la rongeait..."
   },
   {
     "id": 52,
@@ -938,7 +938,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "This[SP]brings[SP]back[SP]memories...[1205][001E][SP]This[SP]place[SP]was[SP]a\nhuge[SP]help[SP]for[SP]me[SP]and[SP]my[SP]friends[SP]when[SP]we[SP]were\nyounger.[1205][001E][SP]It[SP]was[SP]fun,[SP]despite[SP]everything.",
     "nom_fr": "Yukino",
-    "texte_fr": "Que de souvenirs...[1205][001E] Cet endroit nous\na beaucoup aidés, mes amis et moi,\nquand on était jeunes.[1205][001E] C'était sympa."
+    "texte_fr": "Que de souvenirs...[001E][1205] Cet endroit nous\na beaucoup aidés, mes amis et moi,\nquand on était jeunes.[001E][1205] C'était sympa."
   },
   {
     "id": 62,
@@ -953,7 +953,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Listen[SP]to[SP]me,[SP][1113].[SP]Don't[SP]waste[SP]your[SP]youth\non[SP]things[SP]you'll[SP]regret.[1205][001E][SP]You're[SP]only[SP]young\nonce,[SP]after[SP]all...",
     "nom_fr": "Yukino",
-    "texte_fr": "Écoute, [1113]. Ne gâche pas ta jeunesse\nà faire des choses regrettables.[1205][001E] On n'est\njeune qu'une fois..."
+    "texte_fr": "Écoute, [1113]. Ne gâche pas ta jeunesse\nà faire des choses regrettables.[001E][1205] On n'est\njeune qu'une fois..."
   },
   {
     "id": 63,
@@ -968,7 +968,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "This[SP]really[SP]takes[SP]me[SP]back...[1205][000F][SP]I'm[SP]older[SP]now,\nobviously,[SP]but[SP]these[SP]guys[SP]haven't[SP]changed[SP]a\nbit[SP]since[SP]then...",
     "nom_fr": "Yukino",
-    "texte_fr": "Que de souvenirs... [1205][000F]J'ai vieilli,\nbien sûr, mais ces gars n'ont pas\nchangé d'un poil depuis..."
+    "texte_fr": "Que de souvenirs... [000F][1205]J'ai vieilli,\nbien sûr, mais ces gars n'ont pas\nchangé d'un poil depuis..."
   },
   {
     "id": 64,
@@ -1013,7 +1013,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]thought[SP]the[SP]student[SP]council[SP]president[SP]would\nbe...[SP]you[SP]know,[SP]popular.[SP]But[SP]that's[SP]not[SP]the\nsense[SP]I[SP]get[SP]from[SP]how[SP]Eikichi[SP]talks[SP]about[SP]him.",
     "nom_fr": "Yukino",
-    "texte_fr": "Je pensais que le président des élèves\nserait... populaire. Ce\nn'est pas l'impression\nque donne Eikichi quand il en parle."
+    "texte_fr": "Je pensais que le président des élèves\nserait... populaire. Ce\nn'est pas l'impression que donne Eikichi quand il en parle."
   },
   {
     "id": 67,
@@ -1103,7 +1103,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Rrrgh,[SP]this[SP]is[SP]so[SP]frustrating...[1205][000F][SP]We[SP]knew[SP]it\nwas[SP]a[SP]target,[SP]and[SP]we[SP]couldn't[SP]stop[SP]the[SP]bombs\nfrom[SP]going[SP]off...[1205][000F][SP]That[SP]King[SP]Leo's[SP]a[SP]dead[SP]man!",
     "nom_fr": "Yukino",
-    "texte_fr": "Rrrgh, si frustrant..[1205][1205].\n[000F][000F]On savait que c'était\nune cible, et on n'a pas pu empêcher les\nbombes... Le Roi Lion est mort!"
+    "texte_fr": "Rrrgh, si frustrant..[1205][1205].\n[000F][000F]On savait que c'était\nune cible, et on n'a pas pu empêcher les bombes... Le Roi Lion est mort!"
   },
   {
     "id": 73,
@@ -1293,7 +1293,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Personas[SP]are[SP]only[SP]a[SP]fraction[SP]of[SP]the[SP]countless\nexisting[SP]personalities.[SP]Whether[SP]they[SP]are[SP]untapped\npotential[SP]or[SP]bitter[SP]enemies[SP]is[SP]up[SP]to[SP]you.",
     "nom_fr": "Igor",
-    "texte_fr": "Les Personae ne sont qu'une fraction des\npersonnalités existantes. Potentiel\ninutilisé ou ennemis jurés,\nà vous de voir."
+    "texte_fr": "Les Personae ne sont qu'une fraction des\npersonnalités existantes. Potentiel\ninutilisé ou ennemis jurés, à vous de voir."
   },
   {
     "id": 84,
@@ -1323,7 +1323,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Ah...[SP]Your[SP]soul[SP]bears[SP]wounds[SP]too.[1205][000F][SP]It[SP]seems\nman's[SP]soul[SP]is[SP]more[SP]easily[SP]wounded[SP]than\nhis[SP]body.",
     "nom_fr": "Igor",
-    "texte_fr": "Ah... Votre âme porte aussi des blessures.\n[1205][000F]L'âme se blesse plus\nfacilement que le corps."
+    "texte_fr": "Ah... Votre âme porte aussi des blessures.\n[000F][1205]L'âme se blesse plus\nfacilement que le corps."
   },
   {
     "id": 86,
@@ -1338,7 +1338,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Personas[SP]are[SP]born[SP]from[SP]the[SP]sea[SP]of[SP]collective\nunconsciousness.[SP]They[SP]are[SP]another[SP]part[SP]of[SP]you,\nbut[SP]may[SP]also[SP]be[SP]people's[SP]souls[SP]given[SP]form.",
     "nom_fr": "Igor",
-    "texte_fr": "Les Personae naissent de la mer de\nl'inconscient collectif. Elles\nsont une autre\npart de vous, ou l'âme d'autrui incarnée."
+    "texte_fr": "Les Personae naissent de la mer de\nl'inconscient collectif. Elles\nsont une autre part de vous, ou l'âme d'autrui incarnée."
   },
   {
     "id": 87,
@@ -1549,7 +1549,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Those[SP]who[SP]can[SP]summon[SP]Personas[SP]into[SP]material\nforms[SP]and[SP]harness[SP]their[SP]power[SP]are[SP]called\nPersona-users.",
     "nom_fr": "Igor",
-    "texte_fr": "Ceux qui invoquent\ndes Personae et utilisent\nleur pouvoir sont\nappelés manieurs de Persona."
+    "texte_fr": "Ceux qui invoquent\ndes Personae et utilisent\nleur pouvoir sont appelés manieurs de Persona."
   },
   {
     "id": 98,
@@ -2359,7 +2359,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Only[SP]one[SP]Incense[SP]Card[SP]can[SP]be[SP]used[SP]in[SP]any\ngiven[SP]summoning.[SP]It[SP]will[SP]increase[SP]the\nstatistics[SP]of[SP]that[SP]Persona.",
     "nom_fr": "Igor",
-    "texte_fr": "Une seule Carte\nd'Encens par invocation. Elle\naugmentera les statistiques\nde cette Persona."
+    "texte_fr": "Une seule Carte\nd'Encens par invocation. Elle\naugmentera les statistiques de cette Persona."
   },
   {
     "id": 152,
@@ -2494,7 +2494,7 @@
     "nom_orig": "Igor",
     "texte_orig": "My[SP]duty[SP]is[SP]to[SP]summon[SP]new[SP]Personas.[SP]I[SP]use[SP]the\nTarot[SP]Cards[SP]you[SP]carry[SP]as[SP]a[SP]medium[SP]to[SP]summon\nthe[SP]Personas[SP]slumbering[SP]deep[SP]within[SP]your[SP]soul.",
     "nom_fr": "Igor",
-    "texte_fr": "Mon devoir est d'invoquer de nouvelles\nPersonae. J'utilise vos\nCartes de Tarot pour\ninvoquer celles qui sommeillent en vous."
+    "texte_fr": "Mon devoir est d'invoquer de nouvelles\nPersonae. J'utilise vos\nCartes de Tarot pour invoquer celles qui sommeillent en vous."
   },
   {
     "id": 161,
@@ -2539,7 +2539,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Some[SP]require[SP]special[SP]conditions[SP]to[SP]be[SP]summoned.\nThey[SP]slumber[SP]at[SP]the[SP]depths[SP]of[SP]the[SP]unconscious\nmind...[SP]You[SP]will[SP]need[SP]a[SP]way[SP]to[SP]awaken[SP]them.",
     "nom_fr": "Igor",
-    "texte_fr": "Certaines requièrent\ndes conditions spéciales\npour être invoquées. Elles\ndorment au fond de\nl'inconscient... Vous devrez les éveiller."
+    "texte_fr": "Certaines requièrent\ndes conditions spéciales\npour être invoquées. Elles dorment au fond de l'inconscient... Vous devrez les éveiller."
   },
   {
     "id": 164,
@@ -2599,7 +2599,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Though[SP]they[SP]are[SP]extremely[SP]powerful,[SP]if[SP]you\nreturn[SP]these[SP]Personas[SP]to[SP]the[SP]sea[SP]of\nunconsciousness[SP]here[SP]in[SP]the[SP]Velvet[SP]Room...",
     "nom_fr": "Igor",
-    "texte_fr": "Bien qu'extrêmement puissantes, si vous\nretournez ces Personae à la mer de\nl'inconscient dans la\nChambre de Velours..."
+    "texte_fr": "Bien qu'extrêmement puissantes, si vous\nretournez ces Personae à la mer de\nl'inconscient dans la Chambre de Velours..."
   },
   {
     "id": 168,
@@ -2719,7 +2719,7 @@
     "nom_orig": "Igor",
     "texte_orig": "But[SP]a[SP]higher-ranked[SP]Persona[SP]may[SP]mutate[SP]to\nlearn[SP]new[SP]skills...[SP]Depending[SP]on[SP]the[SP]Persona,\nit[SP]may[SP]become[SP]an[SP]entirely[SP]different[SP]Persona.",
     "nom_fr": "Igor",
-    "texte_fr": "Mais une Persona de haut rang peut muter et\napprendre de\nnouvelles compétences... Parfois,\nelle devient une Persona différente."
+    "texte_fr": "Mais une Persona de haut rang peut muter et\napprendre de\nnouvelles compétences... Parfois, elle devient une Persona différente."
   },
   {
     "id": 176,
@@ -3019,7 +3019,7 @@
     "nom_orig": "Igor",
     "texte_orig": "That[SP]should[SP]cover[SP]the[SP]basics,[SP]I[SP]think.[SP]There\nwill[SP]be[SP]times[SP]when[SP]demons[SP]will[SP]ask[SP]questions\nof[SP]you[SP]or[SP]open[SP]the[SP]battle[SP]by[SP]contacting[SP]you.",
     "nom_fr": "Igor",
-    "texte_fr": "Je pense que cela couvre les bases. Il y a\ndes moments où des démons vous posent des \nquestions ou vous\ncontactent pour combattre."
+    "texte_fr": "Je pense que cela couvre les bases. Il y a\ndes moments où des démons vous posent des \nquestions ou vous contactent pour combattre."
   },
   {
     "id": 196,
@@ -3109,7 +3109,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Their[SP]personalities[SP]can[SP]be[SP]divided[SP]into[SP]eight\nclassifications:[SP]wise,[SP]foolish,[SP]joyful,[SP]timid,\nforceful,[SP]gloomy,[SP]snappish,[SP]and[SP]haughty...",
     "nom_fr": "Igor",
-    "texte_fr": "Leurs personnalités se divisent en 8\ncatégories: sage, idiot, joyeux, timide,\nautoritaire, sombre, hargneux,\net hautain..."
+    "texte_fr": "Leurs personnalités se divisent en 8\ncatégories: sage, idiot, joyeux, timide,\nautoritaire, sombre, hargneux, et hautain..."
   },
   {
     "id": 202,
@@ -3199,7 +3199,7 @@
     "nom_orig": "Belladonna",
     "texte_orig": "All[SP]who[SP]live[U+070F]\nAre[SP]eternal[SP]wanderers[U+070F][1205][001E]\nYearning[SP]is[SP]the[SP]cross[SP]man[SP]must[SP]bear[U+070F]",
     "nom_fr": "Belladonna",
-    "texte_fr": "Tous les vivants Sont d'éternels\nerrants[1205][001E] Le désir, croix de l'homme[U+070F][U+070F][U+070F]"
+    "texte_fr": "Tous les vivants Sont d'éternels\nerrants[001E][1205] Le désir, croix de l'homme[U+070F][U+070F][U+070F]"
   },
   {
     "id": 208,
@@ -3274,7 +3274,7 @@
     "nom_orig": "Belladonna",
     "texte_orig": "Light[SP]makes[SP]shadow[U+070F]\nDarkness[SP]reveals[SP]the[SP]light's[SP]shine[U+070F]\nThe[SP]same[SP]can[SP]be[SP]said[SP]of[SP]your[SP]other[SP]self[U+070F]",
     "nom_fr": "Belladonna",
-    "texte_fr": "La lumière crée\nl'ombre L'obscurité révèle la\nlumière Il en va de\nmême pour votre autre soi[U+070F][U+070F][U+070F]"
+    "texte_fr": "La lumière crée\nl'ombre L'obscurité révèle la\nlumière Il en va de même pour votre autre soi[U+070F][U+070F][U+070F]"
   },
   {
     "id": 213,
@@ -3529,7 +3529,7 @@
     "nom_orig": "Belladonna",
     "texte_orig": "It[SP]is[SP]proof[U+070F]\nThat[SP]memories[SP]of[SP]a[SP]forgotten[SP]past[U+070F]\nAre[SP]rising[SP]as[SP]a[SP]herald[SP]to[SP]meet[SP]the[SP]true[SP]self[U+070F]",
     "nom_fr": "Belladonna",
-    "texte_fr": "C'est la preuve Que\nles souvenirs d'un passé\noublié S'élèvent pour\nrencontrer le vrai soi[U+070F][U+070F][U+070F]"
+    "texte_fr": "C'est la preuve Que\nles souvenirs d'un passé\noublié S'élèvent pour rencontrer le vrai soi[U+070F][U+070F][U+070F]"
   },
   {
     "id": 230,
@@ -3559,7 +3559,7 @@
     "nom_orig": "Nameless",
     "texte_orig": "For[SP]what[SP]reason[SP]were[SP]you[SP]born?[SP]I[SP]have[SP]yet[SP]to[SP]ask\nthat[SP]of[SP]myself.[1205][001E][SP]Thus,[SP]I[SP]ask[SP]you.",
     "nom_fr": "Nameless",
-    "texte_fr": "Pourquoi êtes-vous né? Je me dois de me\nle demander.[1205][001E] Alors, je vous le demande."
+    "texte_fr": "Pourquoi êtes-vous né? Je me dois de me\nle demander.[001E][1205] Alors, je vous le demande."
   },
   {
     "id": 232,
@@ -3605,7 +3605,7 @@
     "nom_orig": "Nameless",
     "texte_orig": "You[SP]are[SP]the[SP]300th[SP]and[SP]12th[SP]person[SP]to[SP]give[SP]that\nanswer.[1205][001E][SP]But[SP]I[SP]envy[SP]you.[SP]You[SP]know[SP]how[SP]to[SP]question\noneself...",
     "nom_fr": "Nameless",
-    "texte_fr": "Vous êtes le 312e à donner cette\nréponse.[1205][001E] Mais je vous envie. Vous\nsavez vous remettre en question..."
+    "texte_fr": "Vous êtes le 312e à donner cette\nréponse.[001E][1205] Mais je vous envie. Vous\nsavez vous remettre en question..."
   },
   {
     "id": 234,
@@ -3620,7 +3620,7 @@
     "nom_orig": "Nameless",
     "texte_orig": "You[SP]are[SP]the[SP]200th[SP]and[SP]76th[SP]person[SP]to[SP]respond\nin[SP]that[SP]way.[1205][001E][SP]I[SP]see.[SP]You[SP]have[SP]no[SP]answer.",
     "nom_fr": "Nameless",
-    "texte_fr": "Vous êtes le 276e à répondre ainsi.[1205][001E]\nJe vois. Vous n'avez pas de réponse."
+    "texte_fr": "Vous êtes le 276e à répondre ainsi.[001E][1205]\nJe vois. Vous n'avez pas de réponse."
   },
   {
     "id": 235,
@@ -3650,7 +3650,7 @@
     "nom_orig": "Nameless",
     "texte_orig": "You[SP]are[SP]the[SP]40th[SP]and[SP]3rd[SP]person[SP]to[SP]give[SP]that\nanswer.[1205][001E][SP]You[SP]are[SP]still[SP]on[SP]a[SP]journey...[SP]May[SP]it\nbe[SP]filled[SP]with[SP]good[SP]fortune.",
     "nom_fr": "Nameless",
-    "texte_fr": "Vous êtes le 43e à donner cette\nréponse.[1205][001E] Vous êtes toujours en\nvoyage... Qu'il soit rempli de chance."
+    "texte_fr": "Vous êtes le 43e à donner cette\nréponse.[001E][1205] Vous êtes toujours en\nvoyage... Qu'il soit rempli de chance."
   },
   {
     "id": 237,
@@ -3665,7 +3665,7 @@
     "nom_orig": "Nameless",
     "texte_orig": "Take[SP]this.[1205][001E][SP]The[SP]10th[SP]and[SP]7th[SP]man[SP]who[SP]gave[SP]your\nanswer[SP]left[SP]it.[SP]A[SP][E4][NULL][NULL][0004][U+1433][NULL][NULL][0002]Revival[SP]Bead[E4][NULL][NULL][0002]...[SP]I[SP]have[SP]no\nuse[SP]for[SP]it.",
     "nom_fr": "Nameless",
-    "texte_fr": "Prenez ceci.[1205][001E] Le 17e homme à donner\ncette réponse l'a laissé. [E4][NULL][NULL][0004][NULL][NULL][0002]Perle de\nVie[E4][NULL][NULL][0002]... Je n'en ai aucun usage.[U+1433]"
+    "texte_fr": "Prenez ceci.[001E][1205] Le 17e homme à donner\ncette réponse l'a laissé. [E4][NULL][NULL][0004][NULL][NULL][0002]Perle de\nVie[E4][NULL][NULL][0002]... Je n'en ai aucun usage.[U+1433]"
   },
   {
     "id": 238,
@@ -3680,7 +3680,7 @@
     "nom_orig": "Nameless",
     "texte_orig": "You[SP]are[SP]the[SP]40th[SP]and[SP]3rd[SP]person[SP]to[SP]give[SP]that\nanswer.[1205][001E][SP]You[SP]are[SP]still[SP]on[SP]a[SP]journey...[SP]May[SP]it\nbe[SP]filled[SP]with[SP]good[SP]fortune.",
     "nom_fr": "Nameless",
-    "texte_fr": "Vous êtes le 43e à donner cette\nréponse.[1205][001E] Vous êtes toujours en\nvoyage... Qu'il soit rempli de chance."
+    "texte_fr": "Vous êtes le 43e à donner cette\nréponse.[001E][1205] Vous êtes toujours en\nvoyage... Qu'il soit rempli de chance."
   },
   {
     "id": 239,
@@ -3695,7 +3695,7 @@
     "nom_orig": "Nameless",
     "texte_orig": "You...[1205][001E][SP]are[SP]the[SP]first[SP]to[SP]answer[SP]in[SP]such[SP]a[SP]way.[1205][001E]\nYou[SP]and[SP]I[SP]are[SP]alike.[SP]We[SP]know[SP]not[SP]how[SP]to[SP]question\nourselves.[SP]It[SP]seems[SP]you,[SP]too,[SP]are[SP]incomplete.",
     "nom_fr": "Nameless",
-    "texte_fr": "Vous...[1205][001E] êtes le premier à répondre ainsi.[1205][001E]\nNous nous ressemblons. Nous ne savons pas\nnous questionner. Vous\nêtes aussi incomplet."
+    "texte_fr": "Vous...[001E][1205] êtes le premier à répondre ainsi.[001E][1205]\nNous nous ressemblons. Nous ne savons pas\nnous questionner. Vous êtes aussi incomplet."
   },
   {
     "id": 240,
@@ -3740,7 +3740,7 @@
     "nom_orig": "Nameless",
     "texte_orig": "The[SP][1432][NULL][NULL][0014]you[1432][NULL][NULL][0014][SP]I[SP]know[SP]and[SP]the[SP][1432][NULL][NULL][0014]you[1432][NULL][NULL][0014][SP]that[SP]you[SP]know\nyourself...[1205][000F][SP]Are[SP]they[SP]the[SP]same?",
     "nom_fr": "Nameless",
-    "texte_fr": "Le [1432][NULL][NULL][0014]vous[1432][NULL][NULL][0014] que je connais et le [1432][NULL][NULL][0014]vous[1432][NULL][NULL][0014]\n[1205][000F]que vous connaissez... Les mêmes?"
+    "texte_fr": "Le [1432][NULL][NULL][0014]vous[1432][NULL][NULL][0014] que je connais et le [1432][NULL][NULL][0014]vous[1432][NULL][NULL][0014]\n[000F][1205]que vous connaissez... Les mêmes?"
   },
   {
     "id": 243,
@@ -3935,7 +3935,7 @@
     "nom_orig": "Nameless",
     "texte_orig": "We[SP]immortals[SP]do[SP]not[SP]grasp[SP]the[SP]weight[SP]of[SP]the\npresent.[SP]That[SP]is[SP]why[SP]I[SP]began[SP]counting.[SP]This,\nthat...[SP]everything[SP]that[SP]could[SP]be[SP]counted...",
     "nom_fr": "Nameless",
-    "texte_fr": "Nous, immortels, ignorons le poids du\nprésent. Alors j'ai\ncommencé à compter. Ceci,\ncela... tout ce qui pouvait être compté..."
+    "texte_fr": "Nous, immortels, ignorons le poids du\nprésent. Alors j'ai\ncommencé à compter. Ceci, cela... tout ce qui pouvait être compté..."
   },
   {
     "id": 256,
@@ -4153,7 +4153,7 @@
     "nom_orig": "Demon[SP]Painter",
     "texte_orig": "All[SP]Personas[SP]come[SP]from[SP]the[SP]same[SP]collective\nunconsciousness,[SP]but[SP]some[SP]can[SP]control[SP]them[SP]and\nsome[SP]can't.[SP]The[SP]soul[SP]is[SP]beyond[SP]one's[SP]control...",
     "nom_fr": "Demon Painter",
-    "texte_fr": "Toutes les Personae\nviennent de l'inconscient\ncollectif, mais certains les contrôlent et\nd'autres non. L'âme est hors de contrôle..."
+    "texte_fr": "Toutes les Personae\nviennent de l'inconscient\ncollectif, mais certains les contrôlent et d'autres non. L'âme est hors de contrôle..."
   },
   {
     "id": 269,
@@ -4273,7 +4273,7 @@
     "nom_orig": "Demon[SP]Painter",
     "texte_orig": "Ah...[SP]So[SP]that[SP]is[SP]one[SP]type[SP]of[SP]art[SP]given[SP]a[SP]soul\nas[SP]well...[1205][000F][SP]But[SP]it[SP]can't[SP]be[SP]called[SP]real.[1205][000F][SP]Looks\nlike[SP]it[SP]needs[SP]a[SP]little[SP]more[SP]practice.",
     "nom_fr": "Demon Painter",
-    "texte_fr": "Ah... Donc c'est aussi un type d'art doté\n[1205]d'une âme.[1205][000F][000F].. Mais ce n'est pas réel. On\ndirait qu'il faut plus de pratique."
+    "texte_fr": "Ah... Donc c'est aussi un type d'art doté\n[1205]d'une âme.[000F][1205][000F].. Mais ce n'est pas réel. On\ndirait qu'il faut plus de pratique."
   },
   {
     "id": 277,
@@ -4288,7 +4288,7 @@
     "nom_orig": "Demon[SP]Painter",
     "texte_orig": "The[SP]answer[SP]is[SP]always[SP]near,[SP]yet[SP]so[SP]far...[1205][000F][SP]But\nonce[SP]it's[SP]found,[SP]there's[SP]no[SP]need[SP]to[SP]hesitate\nanymore.[SP]It[SP]seems[SP]you've[SP]found[SP]it.",
     "nom_fr": "Demon Painter",
-    "texte_fr": "La réponse est toujours proche, mais\n[1205][000F]loin... Mais une fois trouvée, plus\nbesoin d'hésiter. Vous l'avez trouvée."
+    "texte_fr": "La réponse est toujours proche, mais\n[000F][1205]loin... Mais une fois trouvée, plus\nbesoin d'hésiter. Vous l'avez trouvée."
   },
   {
     "id": 278,
@@ -4509,7 +4509,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Hm?[1205][000F][SP]It[SP]seems[SP]one[SP]of[SP]your[SP]Personas[SP]is[SP]trying[SP]to\nbe[SP]reborn[SP]into[SP]a[SP]new[SP]form.",
     "nom_fr": "Igor",
-    "texte_fr": "Hm? [1205][000F]L'une de vos Personae tente de\nrenaître sous une nouvelle forme."
+    "texte_fr": "Hm? [000F][1205]L'une de vos Personae tente de\nrenaître sous une nouvelle forme."
   },
   {
     "id": 292,
@@ -4539,7 +4539,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]Fusion[SP]Spells?[1205][000F][SP]When[SP]you[SP]use\nthem,[SP]sometimes[SP]your[SP]Personas[SP]will[SP]undergo\nmutations.",
     "nom_fr": "Igor",
-    "texte_fr": "Connaissez-vous les Sorts de Fusion? [1205][000F]En les\nutilisant, vos Personae\npeuvent parfois muter."
+    "texte_fr": "Connaissez-vous les Sorts de Fusion? [000F][1205]En les\nutilisant, vos Personae\npeuvent parfois muter."
   },
   {
     "id": 294,
@@ -4554,7 +4554,7 @@
     "nom_orig": "Igor",
     "texte_orig": "These[SP]may[SP]take[SP]the[SP]form[SP]of[SP]increase[SP]in[SP]basic\nstats[SP]or[SP]the[SP]learning[SP]of[SP]new[SP]skills,[SP]but[SP]some\ncan[SP]also[SP]be[SP]reborn[SP]as[SP]new[SP]Personas.",
     "nom_fr": "Igor",
-    "texte_fr": "Cela peut se traduire\npar des stats accrues,\ndes nouvelles compétences, ou certaines\npeuvent renaître en nouvelles Personae."
+    "texte_fr": "Cela peut se traduire\npar des stats accrues,\ndes nouvelles compétences, ou certaines peuvent renaître en nouvelles Personae."
   },
   {
     "id": 295,
@@ -4689,7 +4689,7 @@
     "nom_orig": "Demon[SP]Painter",
     "texte_orig": "The[SP]Tarot[SP]is[SP]a[SP]model[SP]of[SP]the[SP]heart.[SP]One's[SP]heart\naffects[SP]one's[SP]destiny.[1205][001E][SP]Now,[SP]would[SP]you[SP]like[SP]me\nto[SP]paint[SP]you[SP]something?\n[1208][0004]Request[SP]card\nTalk\nCancel\nLeave",
     "nom_fr": "Demon Painter",
-    "texte_fr": "Le Tarot est un modèle du cœur. Le cœur \naffecte\nle destin.[1205][001E]\nVoudriez-vous que je vous\npeigne quelque chose ?\n[1208][0004]Demander carte\nParler\nAnnuler\nQuitter",
+    "texte_fr": "Le Tarot est un modèle du cœur. Le cœur \naffecte\nle destin.[001E][1205]\nVoudriez-vous que je vous\npeigne quelque chose ?\n[1208][0004]Demander carte\nParler\nAnnuler\nQuitter",
     "question_orig": "The[SP]Tarot[SP]is[SP]a[SP]model[SP]of[SP]the[SP]heart.[SP]One's[SP]heart\naffects[SP]one's[SP]destiny.[1205][001E][SP]Now,[SP]would[SP]you[SP]like[SP]me\nto[SP]paint[SP]you[SP]something?",
     "choix_orig": [
       "Request[SP]card",
@@ -4716,7 +4716,7 @@
     "nom_orig": "Jun",
     "texte_orig": "A[SP]room[SP]between[SP]the[SP]cracks[SP]of[SP]consciousness[SP]and\nunconsciousness...[SP]I[SP]locked[SP]away[SP]my[SP]unbearable\nguilt[SP]and[SP]ran[SP]from[SP]it[SP]all...[SP]Or[SP]so[SP]I[SP]thought.",
     "nom_fr": "Jun",
-    "texte_fr": "Une pièce entre\nconscience et inconscience...\nJ'ai enfoui ma culpabilité insoutenable et\nj'ai fui... Ou du moins je le croyais."
+    "texte_fr": "Une pièce entre\nconscience et inconscience...\nJ'ai enfoui ma culpabilité insoutenable et j'ai fui... Ou du moins je le croyais."
   },
   {
     "id": 303,

--- a/traduction/event_scripts/script_298.json
+++ b/traduction/event_scripts/script_298.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "By[SP]the[SP]way,[SP][1113],[SP]there's[SP]something[SP]I[SP]need\nto[SP]ask[SP]you[SP]before[SP]we[SP]beat[SP]the[SP]snot[SP]outta[SP]Yasuo.[1205][000F]\nIt's[SP]important.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Au fait, [1113], j'ai quelque chose\nà te demander avant qu'on règle son\ncompte à Yasuo. [1205][000F]C'est important."
+    "texte_fr": "Au fait, [1113], j'ai quelque chose\nà te demander avant qu'on règle son\ncompte à Yasuo. [000F][1205]C'est important."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You,[SP]the[SP]big[SP]man[SP]on[SP]campus[SP]at[SP]Sevens,[SP]and[SP]me,\na[SP]raging[SP]studmuffin[SP]of[SP]beauty.[1205][000F][SP]Who's[SP]cooler?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Toi, la grande star de Seven, et moi, le\nbeau gosse absolu. [1205][000F]Qui est le plus cool?"
+    "texte_fr": "Toi, la grande star de Seven, et moi, le\nbeau gosse absolu. [000F][1205]Qui est le plus cool?"
   },
   {
     "id": 2,
@@ -68,7 +68,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Heheheh...[SP]So[SP]you[SP]want[SP]to[SP]be[SP]rivals,[SP]do[SP]you?[1205][000F]\nInteresting.[SP]Then[SP]may[SP]the[SP]best[SP]man[SP]win!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hihihi. Tu veux être rivaux?\n[1205][000F]Intéressant. Que le meilleur gagne!"
+    "texte_fr": "Hihihi. Tu veux être rivaux?\n[000F][1205]Intéressant. Que le meilleur gagne!"
   },
   {
     "id": 4,
@@ -83,7 +83,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Wh-What?[1205][000F][SP]I[SP]wasn't[SP]expecting[SP]a[SP]quick[SP]answer[SP]like\nthat...[1205][000F][SP]W-Well,[SP]I'm[SP]not[SP]surprised[SP]you[SP]think[SP]so.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Q-Quoi? [1205][000F][1205][000F]Je m'attendais pas à une\nréponse si rapide... Enfin, ça\nm'étonne pas que tu le penses."
+    "texte_fr": "Q-Quoi? [000F][1205][000F][1205]Je m'attendais pas à une\nréponse si rapide... Enfin, ça\nm'étonne pas que tu le penses."
   },
   {
     "id": 5,
@@ -98,7 +98,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "*sigh*[SP]I[SP]can't[SP]believe[SP]a[SP]young[SP]upstart[SP]would\ntry[SP]and[SP]compete[SP]with[SP]me...[1205][000F][SP]Though[SP]it[SP]wouldn't\nbe[SP]much[SP]fun[SP]if[SP]you[SP]didn't.",
     "nom_fr": "Eikichi",
-    "texte_fr": "*soupir* Je reviens pas qu'un\nblanc-bec ose me défier... [1205][000F]Mais ça\nserait moins drôle si t'essayais pas."
+    "texte_fr": "*soupir* Je reviens pas qu'un\nblanc-bec ose me défier... [000F][1205]Mais ça\nserait moins drôle si t'essayais pas."
   },
   {
     "id": 6,
@@ -113,7 +113,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Now[SP]that[SP][1113]'s[SP]faced[SP]facts,[SP]there's[SP]no[SP]one\nleft[SP]who[SP]can[SP]compete[SP]with[SP]me...[1205][000F][SP]Though[SP]I[SP]always\nfigured[SP]this[SP]would[SP]happen,[SP]of[SP]course.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Maintenant que [1113] a reconnu les\nfaits, personne peut plus rivaliser avec\n[1205][000F]moi... Comme je l'avais prévu, bien sûr."
+    "texte_fr": "Maintenant que [1113] a reconnu les\nfaits, personne peut plus rivaliser avec\n[000F][1205]moi... Comme je l'avais prévu, bien sûr."
   },
   {
     "id": 7,
@@ -143,7 +143,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]mean,[SP]that[SP]was[SP]more[SP]trouble[SP]than[SP]it[SP]had[SP]to[SP]be\nbecause[SP]Eikichi[SP]broke[SP]the[SP]walkie-talkie[SP]and[SP]the\nmirror.[SP]It[SP]wasn't[SP]my[SP]fault,[SP]right,[SP][1113]?",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est Eikichi qui a\ncassé le talkie-walkie et\nle miroir, donc c'était plus compliqué que\nnécessaire. C'est pas ma faute, hein [1113]?"
+    "texte_fr": "C'est Eikichi qui a\ncassé le talkie-walkie et\nle miroir, donc c'était plus compliqué que nécessaire. C'est pas ma faute, hein [1113]?"
   },
   {
     "id": 9,
@@ -188,7 +188,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Looks[SP]like[SP]the[SP]president[SP]ordered[SP]him[SP]to[SP]lure[SP]us\nto[SP]the[SP]shelter.[1205][000F][SP]Well...[1205][000A][SP]I[SP]guess[SP]it[SP]wasn't[SP]really\nhis[SP]fault...[1205][000F][SP]We[SP]should[SP]forgive[SP]him.",
     "nom_fr": "Maya",
-    "texte_fr": "Il semble que le président lui ait ordonné\n[1205]de nous attirer à l'abri. [1205][000F][000F]Enfin...[1205][000A] c'était\npas sa faute... On devrait lui pardonner."
+    "texte_fr": "Il semble que le président lui ait ordonné\n[1205]de nous attirer à l'abri. [000F][1205][000F]Enfin...[000A][1205] c'était\npas sa faute... On devrait lui pardonner."
   },
   {
     "id": 12,
@@ -218,7 +218,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Sheesh,[SP]at[SP]least[SP]we[SP]made[SP]it[SP]out[SP]alive.[SP]But[SP]are\nEikichi[SP]and[SP]Lisa[SP]at[SP]least[SP]sorry[SP]about[SP]what[SP]they\ndid?[1205][000F][SP]From[SP]the[SP]looks[SP]of[SP]it...[SP]not[SP]really.",
     "nom_fr": "Yukino",
-    "texte_fr": "Pfff, au moins on s'en est sortis vivants.\nMais Eikichi et\nLisa regrettent-ils au moins\n[1205][000F]ce qu'ils ont fait? On dirait bien que non."
+    "texte_fr": "Pfff, au moins on s'en est sortis vivants.\nMais Eikichi et\nLisa regrettent-ils au moins [000F][1205]ce qu'ils ont fait? On dirait bien que non."
   },
   {
     "id": 14,
@@ -278,7 +278,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Um...[SP]Are[SP]you[SP]still[SP]looking[SP]for[SP]the[SP]president?\nI-I[SP]think[SP]you[SP]shouldn't...[SP]I-I[SP]mean,[SP]um...\nthe[SP]basement?[1205][000F][SP]I...[SP]saw[SP]him[SP]go[SP]down[SP]there...",
     "nom_fr": "Élève",
-    "texte_fr": "Euh... Vous cherchez encore le\nprésident? J-Je pense que vous devriez\npas... J-Je veux dire, euh.[1205]..\n[000F]lesous-sol? Je... l'ai vu descendre..."
+    "texte_fr": "Euh... Vous cherchez encore le\nprésident? J-Je pense que vous devriez\npas... J-Je veux dire, euh.[1205].. [000F]lesous-sol? Je... l'ai vu descendre..."
   },
   {
     "id": 18,
@@ -308,7 +308,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "The[SP]president[SP]ordered[SP]me[SP]to[SP]lure[SP]you[SP]all[SP]into\nthe[SP]shelter...[SP]I[SP]felt[SP]bad[SP]about[SP]it[SP]this[SP]whole\ntime...[SP]I'm[SP]so[SP]glad[SP]to[SP]see[SP]you[SP]safe!",
     "nom_fr": "Élève",
-    "texte_fr": "Le président m'avait\nordonné de vous attirer\ntous dans l'abri... Je me sentais si\ncoupable... Je suis si\nsoulagé de vous voirsains!"
+    "texte_fr": "Le président m'avait\nordonné de vous attirer\ntous dans l'abri... Je me sentais si coupable... Je suis si soulagé de vous voirsains!"
   },
   {
     "id": 20,
@@ -323,7 +323,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "All[SP]schools[SP]have[SP]at[SP]least[SP]seven[SP]ghost[SP]stories,\nbut[SP]this[SP]place[SP]only[SP]has[SP]one.[SP][1432][NULL][NULL][0014]Once[SP]you're[SP]in[SP]the\nbomb[SP]shelter,[SP]you[SP]can't[SP]find[SP]the[SP]exit.[1432][NULL][NULL][0014]",
     "nom_fr": "Élève",
-    "texte_fr": "Tous les lycées ont au moins sept légendes\nurbaines, mais ce lycée n'en a qu'une. [1432][NULL][NULL][0014]Une\nfois dans l'abri,\nimpossible de trouver lasortie.[1432][NULL][NULL][0014]"
+    "texte_fr": "Tous les lycées ont au moins sept légendes\nurbaines, mais ce lycée n'en a qu'une. [1432][NULL][NULL][0014]Une\nfois dans l'abri, impossible de trouver lasortie.[1432][NULL][NULL][0014]"
   },
   {
     "id": 21,

--- a/traduction/event_scripts/script_299.json
+++ b/traduction/event_scripts/script_299.json
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "This'll[SP]all[SP]be[SP]cleared[SP]up[SP]if[SP]we[SP]can[SP]catch[SP]that\nstudent[SP]council[SP]president[SP]and[SP]make[SP]him[SP]talk.\nIt's[SP]not[SP]like[SP]you[SP]had[SP]a[SP]decent[SP]answer,[SP]Eikichi!",
     "nom_fr": "Ginko",
-    "texte_fr": "Tout s'éclaircira si\non attrape ce président\ndu conseil et qu'on le fait parler. Toi non\nplus t'avais rien, Eikichi!"
+    "texte_fr": "Tout s'éclaircira si\non attrape ce président\ndu conseil et qu'on le fait parler. Toi non plus t'avais rien, Eikichi!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP][1113].[SP]Were[SP]you[SP]nervous[SP]when[SP]the\npresident[SP]was[SP]hitting[SP]on[SP]me?[1205][000F][SP]Heehee,[SP]don't\nworry.[1205][000F][SP]I'll[SP]always[SP]be[SP]yours[SP]and[SP]yours[SP]alone!",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, [1113]. Tu étais jaloux quand le\nprésident me draguait? [1205][000F][1205][000F]Hihihi, t'inquiète\npas. Je serai toujours rien qu'à toi!"
+    "texte_fr": "Hé, [1113]. Tu étais jaloux quand le\nprésident me draguait? [000F][1205][000F][1205]Hihihi, t'inquiète\npas. Je serai toujours rien qu'à toi!"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]guy[SP]demanded[SP]we[SP]give[SP]him[SP]a[SP]writeup[SP]in[SP]our\nmagazine,[SP]but[SP]was[SP]he[SP]that[SP]desperate[SP]for[SP]fame?\nOr[SP]are[SP]all[SP]high[SP]schoolers[SP]like[SP]that[SP]these[SP]days?",
     "nom_fr": "Maya",
-    "texte_fr": "Ce gars a exigé un article dans notre\nmagazine, il voulait\nvraiment la célébrité à\nce point? Les lycéens sont tous comme ça?"
+    "texte_fr": "Ce gars a exigé un article dans notre\nmagazine, il voulait\nvraiment la célébrité à ce point? Les lycéens sont tous comme ça?"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "If[SP]the[SP]masquerade's[SP]some[SP]kind[SP]of[SP]initiation,\nwould[SP]they[SP]bother[SP]giving[SP]tickets[SP]to[SP]new[SP]members?\nNo[SP]use[SP]roping[SP]in[SP]people[SP]who[SP]don't[SP]care.",
     "nom_fr": "Yukino",
-    "texte_fr": "Si le bal est une sorte d'initiation,\npourquoi donner des\ninvitations aux nouveaux?\nÀ quoi ça sert d'impliquer des gens?"
+    "texte_fr": "Si le bal est une sorte d'initiation,\npourquoi donner des\ninvitations aux nouveaux? À quoi ça sert d'impliquer des gens?"
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "The[SP]student[SP]council's[SP]prepping[SP]the[SP]masks[SP]for[SP]the\nmasquerade...[1205][000F][SP]They're[SP]pretty[SP]driven...[1205][000F][SP]I[SP]don't\nreally[SP]care,[SP]though...",
     "nom_fr": "Élève",
-    "texte_fr": "Le conseil prépare les masques pour\nle bal..[1205]. [1205][000F][000F]Ils sont vraiment\nmotivés... Moi ça m'est égal, hein..."
+    "texte_fr": "Le conseil prépare les masques pour\nle bal..[1205]. [000F][1205][000F]Ils sont vraiment\nmotivés... Moi ça m'est égal, hein..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "That[SP]reminds[SP]me...[SP]The[SP]masks[SP]the[SP]student[SP]council\nwas[SP]handing[SP]out...[1205][000F][SP]They[SP]were[SP]like[SP]the[SP]ones[SP]used\nat[SP]the[SP]meetings...[1205][000F][SP]Not[SP]that[SP]it[SP]matters...",
     "nom_fr": "Élève",
-    "texte_fr": "Tiens, ça me rappelle... Les masques que\n[1205]distribuait le conseil.[1205][000F][000F].. Ils ressemblent\nà ceux des réunions... Bon, peu importe..."
+    "texte_fr": "Tiens, ça me rappelle... Les masques que\n[1205]distribuait le conseil.[000F][1205][000F].. Ils ressemblent\nà ceux des réunions... Bon, peu importe..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Honestly,[SP]I[SP]wasn't[SP]very[SP]confident[SP]in[SP]my[SP]looks\nbefore.[SP]But[SP]thanks[SP]to[SP]a[SP]certain[SP]someone,[SP]I've\nbeen[SP]reborn![SP]The[SP]girls[SP]are[SP]all[SP]over[SP]me[SP]now!",
     "nom_fr": "Élève",
-    "texte_fr": "Franchement, avant je n'avais pas confiance\nen mon physique. Mais grâce à quelqu'un, je\nsuis transformé! Les\nfilles me courent après!"
+    "texte_fr": "Franchement, avant je n'avais pas confiance\nen mon physique. Mais grâce à quelqu'un, je\nsuis transformé! Les filles me courent après!"
   },
   {
     "id": 11,
@@ -251,7 +251,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Ah...[SP]I[SP]guess[SP]good[SP]looks[SP]are[SP]the[SP]first[SP]step\ntoward[SP]anything[SP]else.[1205][000F][SP]I[SP]don't[SP]think[SP]that's\nreally[SP]my[SP]ideal,[SP]though...[1205][000F][SP]*sigh*",
     "nom_fr": "Élève",
-    "texte_fr": "Ah... Le physique, c'est la première\nétape pour tout le reste. [1205][000F][1205][000F]Mais c'est\npas vraiment mon idéal... *soupir*"
+    "texte_fr": "Ah... Le physique, c'est la première\nétape pour tout le reste. [000F][1205][000F][1205]Mais c'est\npas vraiment mon idéal... *soupir*"
   },
   {
     "id": 16,
@@ -266,7 +266,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Yeesh,[SP]you[SP]sound[SP]like[SP]my[SP]teacher.[1205][000F][SP]Getting[SP]good\nmarks[SP]on[SP]my[SP]exams[SP]is[SP]an[SP]ideal?[SP]Isn't[SP]that[SP]sort\nof[SP]a[SP]petty[SP]use[SP]of[SP]my[SP]one[SP]chance?",
     "nom_fr": "Élève",
-    "texte_fr": "Beurk, tu parles comme mon prof. [1205][000F]Avoir de\nbonnes notes, c'est un idéal? C'est pas\nun peu minable pour une seule chance?"
+    "texte_fr": "Beurk, tu parles comme mon prof. [000F][1205]Avoir de\nbonnes notes, c'est un idéal? C'est pas\nun peu minable pour une seule chance?"
   },
   {
     "id": 17,

--- a/traduction/event_scripts/script_300.json
+++ b/traduction/event_scripts/script_300.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Argh![SP]There's[SP]mud[SP]on[SP]my[SP]favorite[SP]tunic...[1205][000F]\nDamn[SP]that[SP]Yasuo![SP]I'm[SP]sticking[SP]him[SP]with[SP]the\ncleaning[SP]bill!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Argh! Ma tunique préférée est pleine de\n[1205][000F]boue... Maudit Yasuo!\nIl paiera le pressing!"
+    "texte_fr": "Argh! Ma tunique préférée est pleine de\n[000F][1205]boue... Maudit Yasuo!\nIl paiera le pressing!"
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I-It[SP]wasn't[SP]my[SP]fault![SP]Eikichi[SP]went[SP]in,[SP]so[SP]I\nhad[SP]no[SP]choice...[1205][000F][SP]Right,[SP][1113]?",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est sa faute! J'ai dû suivre\nEikichi... [1205][000F]Pas vrai, [1113]?"
+    "texte_fr": "C'est sa faute! J'ai dû suivre\nEikichi... [000F][1205]Pas vrai, [1113]?"
   },
   {
     "id": 4,
@@ -117,7 +117,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "It's[SP]both[SP]your[SP]faults![1205][000F][SP]Seriously,[SP]without\nknowing[SP]what[SP]kind[SP]of[SP]traps[SP]there[SP]are,[SP]don't\neven[SP]think[SP]of[SP]wandering[SP]off[SP]like[SP]that[SP]again!",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est votre faute à tous les deux! [1205][000F]Sérieux,\narrêtez de vous aventurer comme ça sans\nmême connaître les pièges qui s'y trouvent!"
+    "texte_fr": "C'est votre faute à tous les deux! [000F][1205]Sérieux,\narrêtez de vous aventurer comme ça sans\nmême connaître les pièges qui s'y trouvent!"
   },
   {
     "id": 8,
@@ -222,7 +222,7 @@
     "nom_orig": "President's[SP]voice",
     "texte_orig": "I-I[SP]was[SP]wrong...[1205][000F][SP]I'll[SP]never[SP]do[SP]it[SP]again...[1205][000F]\nJ-Just[SP]forgive[SP]me...",
     "nom_fr": "Président",
-    "texte_fr": "J-J'avais tort.[1205][000F][1205][000F].. Je ne le referai\nplus jamais... P-Pardonnez-moi..."
+    "texte_fr": "J-J'avais tort.[000F][1205][000F][1205].. Je ne le referai\nplus jamais... P-Pardonnez-moi..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Forgive[SP]you?[1205][000F][SP]Forget[SP]that![SP]There's[SP]a[SP]whole\nlaundry[SP]list[SP]of[SP]stuff[SP]we[SP]gotta[SP]ask[SP]you!\nThere's[SP]no[SP]way[SP]we're[SP]just[SP]letting[SP]you[SP]go!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Te pardonner? [1205][000F]Oublie ça! On a toute une\nliste de trucs à te demander! Hors de\nquestion qu'on te laisse partir comme ça!"
+    "texte_fr": "Te pardonner? [000F][1205]Oublie ça! On a toute une\nliste de trucs à te demander! Hors de\nquestion qu'on te laisse partir comme ça!"
   },
   {
     "id": 16,
@@ -282,7 +282,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Arrgh...[1205][000F][SP]Why[SP]do[SP]they[SP]rush[SP]in[SP]without[SP]thinking!?",
     "nom_fr": "Yukino",
-    "texte_fr": "Arrgh.[1205][000F].. Pourquoi\nfoncent-ils sans réfléchir!?"
+    "texte_fr": "Arrgh.[000F][1205].. Pourquoi\nfoncent-ils sans réfléchir!?"
   },
   {
     "id": 19,
@@ -297,6 +297,6 @@
     "nom_orig": "Yukino",
     "texte_orig": "Better[SP]go[SP]after[SP]them.[1205][000F][SP]C'mon,[SP]let's[SP]go.",
     "nom_fr": "",
-    "texte_fr": "On ferait mieux d'aller les rejoindre.[1205][000F]\nAllez, on y va."
+    "texte_fr": "On ferait mieux d'aller les rejoindre.[000F][1205]\nAllez, on y va."
   }
 ]

--- a/traduction/event_scripts/script_301.json
+++ b/traduction/event_scripts/script_301.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I've[SP]never[SP]seen[SP]these[SP]guys[SP]so[SP]active[SP]before...[1205][001E]\nThis[SP]is[SP]a[SP]lot[SP]better,[SP]I[SP]say.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je ne les avais jamais vus aussi\nactifs...[1205][001E] C'est bien mieux comme ça."
+    "texte_fr": "Je ne les avais jamais vus aussi\nactifs...[001E][1205] C'est bien mieux comme ça."
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Dude...[1205][001E][SP]The[SP]masks[SP]these[SP]guys[SP]are[SP]wearing...[1205][001E]\nAren't[SP]they[SP]the[SP]same[SP]ones[SP]we[SP]saw[SP]at[SP]Zodiac?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mec...[1205][001E] Les masques qu'ils portent...[1205][001E]\nCe sont les mêmes qu'au Zodiac, non?"
+    "texte_fr": "Mec...[001E][1205] Les masques qu'ils portent...[001E][1205]\nCe sont les mêmes qu'au Zodiac, non?"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That[SP]bastard[SP]must[SP]still[SP]be[SP]inside[SP]the[SP]school![1205][000F]\nWe[SP]gotta[SP]hurry[SP]and[SP]find[SP]him,[SP][1113]!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Cet enfoiré doit encore être dans le lycée\n[1205][000F]! Vite, il faut le trouver, [1113]!"
+    "texte_fr": "Cet enfoiré doit encore être dans le lycée\n[000F][1205]! Vite, il faut le trouver, [1113]!"
   },
   {
     "id": 6,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "A[SP]masquerade...[1205][001E][SP]It's[SP]just[SP]like[SP]what[SP]was[SP]going\non[SP]at[SP]that[SP]club.[SP]I[SP]bet[SP]Joker[SP]set[SP]this[SP]up,[SP]too...",
     "nom_fr": "Maya",
-    "texte_fr": "Une mascarade...[1205][001E] Tout comme dans ce club.\nJe parie que le Joker a organisé ça..."
+    "texte_fr": "Une mascarade...[001E][1205] Tout comme dans ce club.\nJe parie que le Joker a organisé ça..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "In[SP]any[SP]case,[SP]it's[SP]masks[SP]again.[SP]Hmm...[1205][001E][SP]I[SP]wonder\nwhat[SP]this[SP]all[SP]means.",
     "nom_fr": "Maya",
-    "texte_fr": "Encore des masques. Hmm...[1205][001E]\nQu'est-ce que ça signifie?"
+    "texte_fr": "Encore des masques. Hmm...[001E][1205]\nQu'est-ce que ça signifie?"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]that[SP]crowded[SP]here?[1205][001E][SP]What's[SP]Joker[SP]want[SP]with\nso[SP]many[SP]people?",
     "nom_fr": "Maya",
-    "texte_fr": "Tant de monde?[1205][001E] Que veut le\nJoker avec tous ces gens?"
+    "texte_fr": "Tant de monde?[001E][1205] Que veut le\nJoker avec tous ces gens?"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]way[SP]he[SP]panicked...[1205][000F][SP]There[SP]was[SP]something\ndefinitely[SP]off[SP]about[SP]him.[1205][000F][SP]Is[SP]it[SP]because[SP]we\ngot[SP]out...?",
     "nom_fr": "Maya",
-    "texte_fr": "Il a paniqué... [1205][000F][1205][000F]Quelque chose clochait\nvraiment chez lui. C'est parce qu'on est\nsortis...?"
+    "texte_fr": "Il a paniqué... [000F][1205][000F][1205]Quelque chose clochait\nvraiment chez lui. C'est parce qu'on est\nsortis...?"
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "A[SP]masquerade,[SP]huh?[1205][001E][SP]Isn't[SP]this[SP]just[SP]a[SP]fancy[SP]name\nfor[SP]a[SP]party?",
     "nom_fr": "Yukino",
-    "texte_fr": "Une mascarade?[1205][001E] Un nom\nchic pour une fête, non?"
+    "texte_fr": "Une mascarade?[001E][1205] Un nom\nchic pour une fête, non?"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Hm?[SP]Why[SP]would[SP]Joker[SP]throw[SP]a[SP]party?[1205][000F]\nHow[SP]should[SP]I[SP]know?",
     "nom_fr": "Yukino",
-    "texte_fr": "Pourquoi il ferait une fête? [1205][000F]Aucune idée."
+    "texte_fr": "Pourquoi il ferait une fête? [000F][1205]Aucune idée."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "No...[1205][001E][SP]I[SP]don't[SP]think[SP]that's[SP]it.[SP]Aren't[SP]these\nguys[SP]just[SP]plain[SP]happy?",
     "nom_fr": "Yukino",
-    "texte_fr": "Non...[1205][001E] Pas sûr. Ces types ont\njuste l'air heureux, non?"
+    "texte_fr": "Non...[001E][1205] Pas sûr. Ces types ont\njuste l'air heureux, non?"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "That[SP]girl...[SP]Why[SP]was[SP]she[SP]here?[1205][000F][SP]If[SP]she[SP]didn't\ncome[SP]to[SP]dance,[SP]then...[1205][000F][SP]Oh,[SP]no...",
     "nom_fr": "Yukino",
-    "texte_fr": "Cette fille... [1205][000F][1205][000F]Que fait-elle ici?\nPas pour danser, alors... Oh non..."
+    "texte_fr": "Cette fille... [000F][1205][000F][1205]Que fait-elle ici?\nPas pour danser, alors... Oh non..."
   },
   {
     "id": 18,
@@ -312,7 +312,7 @@
     "nom_orig": "Motivated[SP]committee[SP]member",
     "texte_orig": "Huh...?[1205][000F][SP]What[SP]was[SP]I[SP]doing[SP]here...?[1205][000F][SP]Oh[SP]yeah...\nThe[SP]masquerade.[1205][000F][SP]Wait,[SP]was[SP]this[SP]all[SP]the[SP]customers\nwe[SP]had?",
     "nom_fr": "Membre motivé",
-    "texte_fr": "Hein.[1205][000F][1205][000F][1205][000F]..? Que faisais-je ici...? Ah\noui... La mascarade. Attends, c'est\ntout ce qu'on a eu comme clients?"
+    "texte_fr": "Hein.[000F][1205][000F][1205][000F][1205]..? Que faisais-je ici...? Ah\noui... La mascarade. Attends, c'est\ntout ce qu'on a eu comme clients?"
   },
   {
     "id": 21,
@@ -357,7 +357,7 @@
     "nom_orig": "Effeminate[SP]committee[SP]member",
     "texte_orig": "What[SP]was[SP]that[SP]our[SP]president[SP]was[SP]holding...?[1205][000F]\nIt[SP]was[SP]so[SP]shiny[SP]and[SP]pretty.",
     "nom_fr": "Membre efféminé",
-    "texte_fr": "Que tenait notre président...?\n[1205][000F]C'était si joli et brillant."
+    "texte_fr": "Que tenait notre président...?\n[000F][1205]C'était si joli et brillant."
   },
   {
     "id": 24,
@@ -417,7 +417,7 @@
     "nom_orig": "Masquerade[SP]committee[SP]member",
     "texte_orig": "The[SP]president[SP]ran[SP]off[SP]toward[SP]the[SP]school\nbuilding[SP]in[SP]a[SP]big[SP]hurry.[1205][000F][SP]What[SP]happened?",
     "nom_fr": "Comité",
-    "texte_fr": "Le président a couru vers le bâtiment du\nlycée en toute hâte. [1205][000F]Que s'est-il passé?"
+    "texte_fr": "Le président a couru vers le bâtiment du\nlycée en toute hâte. [000F][1205]Que s'est-il passé?"
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Masquerade[SP]committee[SP]member",
     "texte_orig": "Hey,[SP]you[SP]can't[SP]go[SP]in[SP]without[SP]registering[SP]here\nfirst.[SP]Take[SP]a[SP]mask[SP]in[SP]with[SP]you,[SP]too.",
     "nom_fr": "Comité",
-    "texte_fr": "Hé, inscris-toi ici\navant d'entrer. Prends un\nmasque aussi. Ils\npréparent la mascarade..."
+    "texte_fr": "Hé, inscris-toi ici\navant d'entrer. Prends un\nmasque aussi. Ils préparent la mascarade..."
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Masquerade[SP]committee[SP]member",
     "texte_orig": "Hey,[SP]you[SP]can't[SP]go[SP]in[SP]without[SP]registering[SP]here\nfirst.[SP]Take[SP]a[SP]mask[SP]in[SP]with[SP]you,[SP]too.",
     "nom_fr": "Comité",
-    "texte_fr": "Hé, inscris-toi ici\navant d'entrer. Prends un\nmasque aussi. Ils\npréparent la mascarade..."
+    "texte_fr": "Hé, inscris-toi ici\navant d'entrer. Prends un\nmasque aussi. Ils préparent la mascarade..."
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Teacher",
     "texte_orig": "*sniff*[SP]In[SP]my[SP]18[SP]years[SP]of[SP]teaching,[SP]have[SP]the\nstudents[SP]ever[SP]been[SP]so[SP]dedicated[SP]toward[SP]working\non[SP]the[SP]school[SP]festival?[1205][000F][SP]No![SP]They[SP]haven't!",
     "nom_fr": "Prof",
-    "texte_fr": "*sniff* En 18 ans de carrière, les\nélèves ont-ils déjà été aussi dévoués\nà la fête du lycée? [1205][000F]Non! Jamais!"
+    "texte_fr": "*sniff* En 18 ans de carrière, les\nélèves ont-ils déjà été aussi dévoués\nà la fête du lycée? [000F][1205]Non! Jamais!"
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Teacher",
     "texte_orig": "Th-This[SP]can[SP]only[SP]be[SP]the[SP]leadership[SP]of[SP]our[SP]new\nstudent[SP]council[SP]president.[SP]My[SP]students...[SP]Right\nnow,[SP]you[SP]are[SP]beautiful![SP]Just[SP]beautiful![SP]*sniff*",
     "nom_fr": "Prof",
-    "texte_fr": "Ç-Ça ne peut être\nque grâce au leadership de\nnotre nouveau président. Mes élèves... Vous\nêtes magnifiques! Magnifiques! *sniff*"
+    "texte_fr": "Ç-Ça ne peut être\nque grâce au leadership de\nnotre nouveau président. Mes élèves... Vous êtes magnifiques! Magnifiques! *sniff*"
   },
   {
     "id": 32,
@@ -537,7 +537,7 @@
     "nom_orig": "School[SP]nurse",
     "texte_orig": "Huh?[1205][000F][SP]Hey,[SP]you're[SP]hurt.[SP]Let[SP]me[SP]take[SP]a[SP]look.\n[1208][0002]Yes\nNo",
     "nom_fr": "Infirmière",
-    "texte_fr": "Hein? [1205][000F]T'es blessé. Fais voir.\n[1208][0002]OuiNon\n Équipe soignée.[E4][NULL][NULL]",
+    "texte_fr": "Hein? [000F][1205]T'es blessé. Fais voir.\n[1208][0002]OuiNon\n Équipe soignée.[E4][NULL][NULL]",
     "question_orig": "Huh?[1205][000F][SP]Hey,[SP]you're[SP]hurt.[SP]Let[SP]me[SP]take[SP]a[SP]look.",
     "choix_orig": [
       "Yes",
@@ -562,6 +562,6 @@
     "nom_orig": "School[SP]nurse",
     "texte_orig": "Don't[SP]be[SP]reckless[SP]just[SP]'cause[SP]you're[SP]young.[1205][000F]\nYou[SP]won't[SP]be[SP]able[SP]to[SP]enjoy[SP]the[SP]Kasuga[SP]Festival\nif[SP]you're[SP]hurt.",
     "nom_fr": "",
-    "texte_fr": "Sois pas téméraire juste parce que\nt'es jeune.[1205][000F] Tu pourras pas profiter\ndu Festival Kasuga si tu te blesses."
+    "texte_fr": "Sois pas téméraire juste parce que\nt'es jeune.[000F][1205] Tu pourras pas profiter\ndu Festival Kasuga si tu te blesses."
   }
 ]

--- a/traduction/event_scripts/script_302.json
+++ b/traduction/event_scripts/script_302.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Even[SP]these[SP]guys[SP]turned[SP]into[SP]shadowmen...\nIt[SP]makes[SP]no[SP]sense.[SP]Everyone[SP]was[SP]fine[SP]a[SP]few\ndays[SP]ago![SP]Why[SP]is[SP]this[SP]suddenly[SP]happening...?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Même eux sont devenus des Ombres... Ça n'a\naucun sens. Tout allait\nbien il y a quelques\njours! Pourquoi ça arrive soudain?"
+    "texte_fr": "Même eux sont devenus des Ombres... Ça n'a\naucun sens. Tout allait\nbien il y a quelques jours! Pourquoi ça arrive soudain?"
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP][1113],[SP]do[SP]you[SP]have[SP]a[SP]dream?[1205][000F]\nHuh?[SP]Me?[SP]Well...[SP]I...[1205][000F][SP]Um,[SP]I'll[SP]tell[SP]you[SP]someday.",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, [1113], tu as un rêve? [1205][000F][1205][000F]Hein? Moi?\nBen... Je... Je te le dirai un jour."
+    "texte_fr": "Hé, [1113], tu as un rêve? [000F][1205][000F][1205]Hein? Moi?\nBen... Je... Je te le dirai un jour."
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "There[SP]seem[SP]to[SP]be[SP]more[SP]and[SP]more[SP]people[SP]who\ndon't...[1205][000F][SP]or[SP]rather[SP]can't[SP]dream...[1205][000F][SP]It's[SP]kind\nof[SP]sad[SP]if[SP]you[SP]think[SP]about[SP]it.",
     "nom_fr": "Maya",
-    "texte_fr": "De plus en plus de gens ne rêvent\nplus.[1205].[1205][000F][000F]. ou plutôt, n'y arrivent\nplus... C'est triste quand on y pense."
+    "texte_fr": "De plus en plus de gens ne rêvent\nplus.[1205].[000F][1205][000F]. ou plutôt, n'y arrivent\nplus... C'est triste quand on y pense."
   },
   {
     "id": 5,
@@ -132,7 +132,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "There[SP]was...[SP]one[SP]who...[SP]escaped[SP]the[SP]shelter...[1205][000F]\nSomething[SP]about...[SP]a[SP]mirror[SP]he[SP]had...[1205][000F][SP]I[SP]don't\neven[SP]care...",
     "nom_fr": "Élève",
-    "texte_fr": "Un type a... pu s'échapper de l'abri...\n[1205][000F][1205][000F]Une histoire de... miroir qu'il\navait... De toute façon je m'en fous..."
+    "texte_fr": "Un type a... pu s'échapper de l'abri...\n[000F][1205][000F][1205]Une histoire de... miroir qu'il\navait... De toute façon je m'en fous..."
   },
   {
     "id": 9,
@@ -177,7 +177,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I[SP]heard[SP]your[SP]ideals[SP]will[SP]be[SP]granted[SP]if[SP]you[SP]play\nthe[SP]Joker[SP]Game.[SP]But[SP]what're[SP]ideals?[SP]Dreams[SP]for\nyour[SP]future?[SP]I[SP]don't[SP]think[SP]I[SP]have[SP]any.",
     "nom_fr": "Élève",
-    "texte_fr": "Le Jeu du Joker réalise vos idéaux, à ce\nqu'on dit. Mais c'est quoi un idéal? Des\nrêves d'avenir? Je crois que\nje n'en ai pas."
+    "texte_fr": "Le Jeu du Joker réalise vos idéaux, à ce\nqu'on dit. Mais c'est quoi un idéal? Des\nrêves d'avenir? Je crois que je n'en ai pas."
   },
   {
     "id": 12,

--- a/traduction/event_scripts/script_303.json
+++ b/traduction/event_scripts/script_303.json
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What[SP]does[SP]he[SP]mean,[SP]he[SP]was[SP]totally[SP]fine!?[SP]He's\nthe[SP]one[SP]who[SP]charged[SP]straight[SP]into[SP]that[SP]shelter![1205][000F]\nAre[SP]these[SP]guys[SP]blind[SP]or[SP]something?",
     "nom_fr": "Ginko",
-    "texte_fr": "Comment ça, il allait très bien!? C'est\nlui qui a foncé tête baissée dans cet\n[1205][000F]abri! Ils sont aveugles ou quoi?"
+    "texte_fr": "Comment ça, il allait très bien!? C'est\nlui qui a foncé tête baissée dans cet\n[000F][1205]abri! Ils sont aveugles ou quoi?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]business[SP]with[SP]the[SP]new[SP]Leader[SP]must[SP]have\nwoken[SP]Eikichi-kun[SP]up.[1205][000F][SP]He[SP]looks[SP]a[SP]lot[SP]more\nmature[SP]now.",
     "nom_fr": "Maya",
-    "texte_fr": "Ce nouveau Boss a dû secouer Eikichi.\n[1205][000F]Il a l'air bien plus mature maintenant."
+    "texte_fr": "Ce nouveau Boss a dû secouer Eikichi.\n[000F][1205]Il a l'air bien plus mature maintenant."
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Eikichi's[SP]a[SP]Boss[SP]through[SP]and[SP]through.[1205][000F][SP]He's[SP]not\njust[SP]talk--he[SP]really[SP]does[SP]take[SP]good[SP]care[SP]of\nhis[SP]own.",
     "nom_fr": "Yukino",
-    "texte_fr": "Eikichi est un vrai Boss.\n[1205][000F]Ce ne sont pas que\ndes mots, il veille vraiment sur les siens."
+    "texte_fr": "Eikichi est un vrai Boss.\n[000F][1205]Ce ne sont pas que\ndes mots, il veille vraiment sur les siens."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I'm[SP]starting[SP]to[SP]think[SP]it's[SP]a[SP]shame[SP]he's[SP]giving\nup[SP]being[SP]the[SP]Boss.[1205][000F][SP]Guys[SP]like[SP]him[SP]don't[SP]come\naround[SP]too[SP]often[SP]anymore.",
     "nom_fr": "Yukino",
-    "texte_fr": "Je commence à me dire que c'est dommage\nqu'il arrête d'être le Boss. [1205][000F]Les gars\ncomme lui se font rares de nos jours."
+    "texte_fr": "Je commence à me dire que c'est dommage\nqu'il arrête d'être le Boss. [000F][1205]Les gars\ncomme lui se font rares de nos jours."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Man,[SP]the[SP]way[SP]you[SP]could[SP]only[SP]see[SP]the[SP]exit[SP]to\nthat[SP]place[SP]indirectly...[1205][000F][SP]I[SP]guess[SP]sometimes\nyou[SP]have[SP]to[SP]think[SP]outside[SP]the[SP]box.",
     "nom_fr": "Yukino",
-    "texte_fr": "Mince, ne pouvoir voir la sortie de cet\nendroit qu'indirectement.[1205][000F].. Parfois, il\nfaut savoir penser différemment."
+    "texte_fr": "Mince, ne pouvoir voir la sortie de cet\nendroit qu'indirectement.[000F][1205].. Parfois, il\nfaut savoir penser différemment."
   },
   {
     "id": 10,
@@ -207,7 +207,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "The[SP]student[SP]council's[SP]preparing[SP]the[SP]masks...[1205][000F]\nBut[SP]we[SP]can't[SP]go[SP]in[SP]without[SP]one.[1205][000F][SP]Don't[SP]you[SP]think\nthey're[SP]taking[SP]this[SP]a[SP]little[SP]too[SP]far?",
     "nom_fr": "Élève",
-    "texte_fr": "Le conseil des\nélèves prépare les masques.[1205][000F][1205][000F]..\nImpossible d'entrer sans\nça. Vous ne trouvez\npas qu'ils vont un peu trop loin?"
+    "texte_fr": "Le conseil des\nélèves prépare les masques.[000F][1205][000F][1205]..\nImpossible d'entrer sans ça. Vous ne trouvez pas qu'ils vont un peu trop loin?"
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Did[SP]you[SP]guys[SP]fall[SP]into[SP]a[SP]trap[SP]too?[1205][000F][SP]You[SP]should\nwatch[SP]out[SP]for[SP]that[SP]president...[1205][000F][SP]Not[SP]that[SP]it\nmatters[SP]to[SP]me...",
     "nom_fr": "Élève",
-    "texte_fr": "Vous êtes aussi tombés dans un piège?\n[1205][000F][1205][000F]Méfiez-vous de ce président... Même\nsi je m'en fiche..."
+    "texte_fr": "Vous êtes aussi tombés dans un piège?\n[000F][1205][000F][1205]Méfiez-vous de ce président... Même\nsi je m'en fiche..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "No...[SP]If[SP]you[SP]quit[SP]being[SP]Boss...[SP]What's[SP]going[SP]to\nhappen[SP]to[SP]this[SP]school?[SP]To[SP]us?[1205][000F][SP]Who's[SP]going[SP]to\ntake[SP]care[SP]of[SP]everything?",
     "nom_fr": "Élève",
-    "texte_fr": "Non... Si vous n'êtes plus le\nBoss... Que va devenir ce lycée?\n[1205][000F]Et nous? Qui va s'occuper de tout?"
+    "texte_fr": "Non... Si vous n'êtes plus le\nBoss... Que va devenir ce lycée?\n[000F][1205]Et nous? Qui va s'occuper de tout?"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I[SP]understand.[1205][000F][SP]I'm[SP]with[SP]Michel-san[SP]on[SP]this[SP]one.[1205][000F]\nI'll[SP]carry[SP]on[SP]without[SP]needing[SP]anyone's[SP]help\nanymore.",
     "nom_fr": "Élève",
-    "texte_fr": "Je comprends. [1205][000F][1205][000F]Je suis avec Michel\nsur ce coup-là. Je continuerai sans\navoir besoin de l'aide de personne."
+    "texte_fr": "Je comprends. [000F][1205][000F][1205]Je suis avec Michel\nsur ce coup-là. Je continuerai sans\navoir besoin de l'aide de personne."
   },
   {
     "id": 17,
@@ -282,7 +282,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I[SP]understand.[1205][000F][SP]I'm[SP]gonna[SP]try[SP]my[SP]best[SP]too[SP]to\nstay[SP]afloat[SP]without[SP]anyone's[SP]help.",
     "nom_fr": "Élève",
-    "texte_fr": "Je comprends. [1205][000F]Je vais faire de mon mieux\npour m'en sortir sans l'aide de personne."
+    "texte_fr": "Je comprends. [000F][1205]Je vais faire de mon mieux\npour m'en sortir sans l'aide de personne."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "By[SP]the[SP]way,[SP]Michel-san,[SP]you[SP]were[SP]looking[SP]for\nthe[SP]president,[SP]weren't[SP]you?[1205][000F][SP]I[SP]think[SP]he's[SP]in\nClass[SP]3-1[SP]right[SP]now.",
     "nom_fr": "Élève",
-    "texte_fr": "Au fait, Michel, vous cherchiez le\nprésident, n'est-ce pas? [1205][000F]Je crois\nqu'il est dans la classe 3-1."
+    "texte_fr": "Au fait, Michel, vous cherchiez le\nprésident, n'est-ce pas? [000F][1205]Je crois\nqu'il est dans la classe 3-1."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I[SP]understand.[1205][000F][SP]I'm[SP]with[SP]Michel-san[SP]on[SP]this[SP]one.[1205][000F]\nI'll[SP]carry[SP]on[SP]without[SP]needing[SP]anyone's[SP]help\nanymore.",
     "nom_fr": "Élève",
-    "texte_fr": "Je comprends. [1205][000F][1205][000F]Je suis avec Michel\nsur ce coup-là. Je continuerai sans\navoir besoin de l'aide de personne."
+    "texte_fr": "Je comprends. [000F][1205][000F][1205]Je suis avec Michel\nsur ce coup-là. Je continuerai sans\navoir besoin de l'aide de personne."
   },
   {
     "id": 21,
@@ -327,6 +327,6 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "By[SP]the[SP]way,[SP]Michel-san,[SP]you[SP]were[SP]looking[SP]for\nthe[SP]president,[SP]weren't[SP]you?[1205][000F][SP]Looks[SP]like[SP]that\nbastard's[SP]holed[SP]up[SP]in[SP]the[SP]basement.",
     "nom_fr": "",
-    "texte_fr": "Au fait, Michel-san, tu cherchais\nle président, non ?[1205][000F] Il paraît que\nce bâtard s'est terré au sous-sol."
+    "texte_fr": "Au fait, Michel-san, tu cherchais\nle président, non ?[000F][1205] Il paraît que\nce bâtard s'est terré au sous-sol."
   }
 ]

--- a/traduction/event_scripts/script_304.json
+++ b/traduction/event_scripts/script_304.json
@@ -27,7 +27,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "By[SP]the[SP]way,[SP]have[SP]you[SP]heard[SP]of[SP]the[SP]Joker[SP]Game?[1205][000F]\nI[SP]heard[SP]it[SP]can[SP]grant[SP]any[SP]wish.[SP]I[SP]wonder[SP]if\nit'd[SP]help[SP]me[SP]be[SP]more[SP]like[SP]you,[SP]Senpai.",
     "nom_fr": "Élève",
-    "texte_fr": "Au fait, tu connais le Jeu du Joker?\n[1205][000F]Il exauce tous les vœux, dit-on.\nPourrais-je te ressembler, Senpai?"
+    "texte_fr": "Au fait, tu connais le Jeu du Joker?\n[000F][1205]Il exauce tous les vœux, dit-on.\nPourrais-je te ressembler, Senpai?"
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "The[SP]school[SP]festival's[SP]almost[SP]here...[1205][000F][SP]I[SP]heard\nthat[SP]lots[SP]of[SP]girls[SP]go[SP]to[SP]meet[SP]boys.[1205][000F][SP]But[SP]I\nguess[SP]that[SP]won't[SP]happen[SP]this[SP]year...",
     "nom_fr": "Élève blessé",
-    "texte_fr": "La fête approche... [1205][000F][1205][000F]Plein de\nfilles viennent y draguer. Mais\nça n'arrivera pas cette année..."
+    "texte_fr": "La fête approche... [000F][1205][000F][1205]Plein de\nfilles viennent y draguer. Mais\nça n'arrivera pas cette année..."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "After[SP]all,[SP]my[SP]face[SP]is[SP]all[SP]jacked[SP]up.[1205][000F][SP]I[SP]just\nwanted[SP]a[SP]piece[SP]of[SP]the[SP]action...[1205][000F][SP]I[SP]specifically\nchose[SP]a[SP]school[SP]with[SP]a[SP]festival,[SP]too...",
     "nom_fr": "Élève blessé",
-    "texte_fr": "Après tout, mon visage est en sale état. [1205][000F][1205][000F]Je\nvoulais juste un peu d'action... J'avais\npourtant choisi un\nlycée avec un festivalexprès..."
+    "texte_fr": "Après tout, mon visage est en sale état. [000F][1205][000F][1205]Je\nvoulais juste un peu d'action... J'avais\npourtant choisi un lycée avec un festivalexprès..."
   },
   {
     "id": 5,

--- a/traduction/event_scripts/script_305.json
+++ b/traduction/event_scripts/script_305.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "S-Sorry.[1205][000F][SP]It's[SP]nothing.[1205][000F][SP]C-C'mon,[SP]let's[SP]go[SP]look\nfor[SP]the[SP]president.",
     "nom_fr": "Eikichi",
-    "texte_fr": "D-Désolé. [1205][000F][1205][000F]Ce n'est rien.\nA-Allez, cherchons le président."
+    "texte_fr": "D-Désolé. [000F][1205][000F][1205]Ce n'est rien.\nA-Allez, cherchons le président."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "...Er,[SP]wasn't[SP]there[SP]a[SP]transfer[SP]student[SP]here?[1205][000F]\nWould[SP]you[SP]happen[SP]to[SP]know[SP]where[SP]he[SP]is[SP]now?",
     "nom_fr": "Eikichi",
-    "texte_fr": "... Euh, y avait pas un nouvel élève\n[1205][000F]ici? Tu saurais où il est maintenant?"
+    "texte_fr": "... Euh, y avait pas un nouvel élève\n[000F][1205]ici? Tu saurais où il est maintenant?"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Transfer[SP]student?[SP]Oh,[SP]that[SP]guy...[1205][000F][SP]Nah,[SP]he\nhasn't[SP]come[SP]to[SP]school[SP]lately.[1205][000F][SP]Maybe[SP]he's[SP]in\nthe[SP]hospital[SP]or[SP]something,[SP]I[SP]dunno.",
     "nom_fr": "Élève",
-    "texte_fr": "Le nouveau? Ah, lui... [1205][000F][1205][000F]Non, il ne vient\nplus ces temps-ci. Il est p't'être à\nl'hôpital ou autre, j'sais pas."
+    "texte_fr": "Le nouveau? Ah, lui... [000F][1205][000F][1205]Non, il ne vient\nplus ces temps-ci. Il est p't'être à\nl'hôpital ou autre, j'sais pas."
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What's[SP]up,[SP]Eikichi-kun?[1205][000F][SP]Do[SP]you[SP]know[SP]this\ntransfer[SP]student?",
     "nom_fr": "Maya",
-    "texte_fr": "Qu'y a-t-il, Eikichi? [1205][000F]Tu\nconnais ce nouvel élève?"
+    "texte_fr": "Qu'y a-t-il, Eikichi? [000F][1205]Tu\nconnais ce nouvel élève?"
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What[SP]the[SP]hell...?[SP]What's[SP]with[SP]Eikichi?[1205][000F][SP]He's[SP]all\nbroody...",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est quoi son problème? [1205][000F]Il est maussade..."
+    "texte_fr": "C'est quoi son problème? [000F][1205]Il est maussade..."
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Is[SP]Eikichi-kun[SP]looking[SP]for[SP]the[SP]transfer[SP]student?[1205][000F]\nBecause[SP]he[SP]seemed[SP]relieved[SP]that[SP]he[SP]wasn't[SP]here.[1205][000F]\nWhat's[SP]going[SP]on...?",
     "nom_fr": "Maya",
-    "texte_fr": "Eikichi cherche le nouvel élève?\n[1205][000F][1205][000F]Parce qu'il semblait soulagé qu'il ne\nsoit pas là. Que se passe-t-il...?"
+    "texte_fr": "Eikichi cherche le nouvel élève?\n[000F][1205][000F][1205]Parce qu'il semblait soulagé qu'il ne\nsoit pas là. Que se passe-t-il...?"
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "...Er,[SP]wasn't[SP]there[SP]a[SP]transfer[SP]student[SP]here?[1205][000F]\nWould[SP]you[SP]happen[SP]to[SP]know[SP]where[SP]he[SP]is[SP]now?",
     "nom_fr": "Eikichi",
-    "texte_fr": "... Euh, y avait pas un nouvel élève\n[1205][000F]ici? Tu saurais où il est maintenant?"
+    "texte_fr": "... Euh, y avait pas un nouvel élève\n[000F][1205]ici? Tu saurais où il est maintenant?"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Transfer[SP]student?[SP]Oh,[SP]that[SP]guy...[1205][000F][SP]Nah,[SP]he\nhasn't[SP]come[SP]to[SP]school[SP]lately.[1205][000F][SP]Maybe[SP]he's[SP]in\nthe[SP]hospital[SP]or[SP]something,[SP]I[SP]dunno.",
     "nom_fr": "Élève",
-    "texte_fr": "Le nouveau? Ah, lui... [1205][000F][1205][000F]Non, il ne vient\nplus ces temps-ci. Il est p't'être à\nl'hôpital ou autre, j'sais pas."
+    "texte_fr": "Le nouveau? Ah, lui... [000F][1205][000F][1205]Non, il ne vient\nplus ces temps-ci. Il est p't'être à\nl'hôpital ou autre, j'sais pas."
   },
   {
     "id": 13,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What's[SP]up,[SP]Eikichi-kun?[1205][000F][SP]Do[SP]you[SP]know[SP]this\ntransfer[SP]student?",
     "nom_fr": "Maya",
-    "texte_fr": "Qu'y a-t-il, Eikichi? [1205][000F]Tu\nconnais ce nouvel élève?"
+    "texte_fr": "Qu'y a-t-il, Eikichi? [000F][1205]Tu\nconnais ce nouvel élève?"
   },
   {
     "id": 15,
@@ -252,7 +252,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Eikichi's[SP]acting[SP]weird...[1205][000F][SP]and[SP]Lisa[SP]seems[SP]mopey\ntoo,[SP]for[SP]some[SP]reason.[SP]What's[SP]up[SP]with[SP]them?",
     "nom_fr": "Yukino",
-    "texte_fr": "Eikichi est bizarre.[1205][000F].. et Lisa a l'air\ndéprimée aussi, sans raison. Qu'ont-ils?"
+    "texte_fr": "Eikichi est bizarre.[000F][1205].. et Lisa a l'air\ndéprimée aussi, sans raison. Qu'ont-ils?"
   },
   {
     "id": 17,
@@ -297,7 +297,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Are[SP]you[SP]looking[SP]for[SP]the[SP]president?[1205][000F][SP]I-I'm[SP]pretty\nsure[SP]he's[SP]in[SP]Class[SP]2-4.[SP]I[SP]bet[SP]you'll[SP]find[SP]him\nif[SP]you[SP]go[SP]there.",
     "nom_fr": "Élève",
-    "texte_fr": "Vous cherchez le président? [1205][000F]J-Je\ncrois qu'il est en classe 2-4. Je\nparie que vous le trouverez là-bas."
+    "texte_fr": "Vous cherchez le président? [000F][1205]J-Je\ncrois qu'il est en classe 2-4. Je\nparie que vous le trouverez là-bas."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "The[SP]president?[1205][000F][SP]Um...[SP]I[SP]heard[SP]he[SP]was[SP]in[SP]the\nbasement.[1205][000F][SP]H-He's[SP]hiding[SP]out[SP]there...",
     "nom_fr": "Élève",
-    "texte_fr": "Le président? [1205][000F][1205][000F]Euh... J'ai entendu qu'il\nétait au sous-sol. I-Il s'y cache..."
+    "texte_fr": "Le président? [000F][1205][000F][1205]Euh... J'ai entendu qu'il\nétait au sous-sol. I-Il s'y cache..."
   },
   {
     "id": 21,
@@ -342,7 +342,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "...Er,[SP]wasn't[SP]there[SP]a[SP]transfer[SP]student[SP]here?[1205][000F]\nWould[SP]you[SP]happen[SP]to[SP]know[SP]where[SP]he[SP]is[SP]now?",
     "nom_fr": "Eikichi",
-    "texte_fr": "... Euh, y avait pas un nouvel élève\n[1205][000F]ici? Tu saurais où il est maintenant?"
+    "texte_fr": "... Euh, y avait pas un nouvel élève\n[000F][1205]ici? Tu saurais où il est maintenant?"
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Transfer[SP]student?[SP]Oh,[SP]that[SP]guy...[1205][000F][SP]Nah,[SP]he\nhasn't[SP]come[SP]to[SP]school[SP]lately.[1205][000F][SP]Maybe[SP]he's[SP]in\nthe[SP]hospital[SP]or[SP]something,[SP]I[SP]dunno.",
     "nom_fr": "Élève",
-    "texte_fr": "Le nouveau? Ah, lui... [1205][000F][1205][000F]Non, il ne vient\nplus ces temps-ci. Il est p't'être à\nl'hôpital ou autre, j'sais pas."
+    "texte_fr": "Le nouveau? Ah, lui... [000F][1205][000F][1205]Non, il ne vient\nplus ces temps-ci. Il est p't'être à\nl'hôpital ou autre, j'sais pas."
   },
   {
     "id": 24,
@@ -387,7 +387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What's[SP]up,[SP]Eikichi-kun?[1205][000F][SP]Do[SP]you[SP]know[SP]this\ntransfer[SP]student?",
     "nom_fr": "Maya",
-    "texte_fr": "Qu'y a-t-il, Eikichi? [1205][000F]Tu\nconnais ce nouvel élève?"
+    "texte_fr": "Qu'y a-t-il, Eikichi? [000F][1205]Tu\nconnais ce nouvel élève?"
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Transfer[SP]student...[1205][000F][SP]Yeah,[SP]this[SP]class[SP]did[SP]have\none...[1205][000F][SP]But[SP]I[SP]haven't[SP]seen[SP]him[SP]in[SP]forever...[1205][000F]\nDoesn't[SP]matter...[1205][000F][SP]Has[SP]nothing[SP]to[SP]do[SP]with[SP]me...",
     "nom_fr": "Élève",
-    "texte_fr": "Le nouvel élève.[1205][000F][1205][000F][1205][000F][1205][000F].. Ouais, cette classe en\navait un... Mais ça\nfait une éternité que je\nl'ai pas vu... Peu\nimporte... Ça me regardepas..."
+    "texte_fr": "Le nouvel élève.[000F][1205][000F][1205][000F][1205][000F][1205].. Ouais, cette classe en\navait un... Mais ça\nfait une éternité que je l'ai pas vu... Peu importe... Ça me regardepas..."
   },
   {
     "id": 28,
@@ -432,6 +432,6 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "A[SP]transfer[SP]student[SP]in[SP]this[SP]class...?[1205][000F][SP]Think[SP]his\nname[SP]was...[1205][000F][SP]Kuro...[1205][000F][SP]What[SP]was[SP]it...?[1205][000F][SP]Well,[SP]I\nguess[SP]it's[SP]not[SP]important...[E1][E2]\n[E3][E4][NULL][NULL]\"Male[SP]student\nThe[SP]way[SP]Eikichi[SP]beat[SP]up[SP]the[SP]new[SP]Leader[SP]was[SP]the\ntalk[SP]of[SP]the[SP]school.[SP]Looks[SP]like[SP]his[SP]nickname[SP]of\n[1432][NULL][NULL][0014]Death[SP]Boss[1432][NULL][NULL][0014][SP]was[SP]no[SP]joke.",
     "nom_fr": "",
-    "texte_fr": "Un élève transféré dans cette classe... ?[1205][000F]\nJe crois que son nom c'était... Kuro...[1205][000F]\nEnfin bon, c'est pas important...[E1][E2]\n[E3][E4][NULL][NULL]Élève masculin\nLa façon dont Eikichi a mis la pâtée au nouveau leader faisait le\ntour du lycée. Son surnom [1432][NULL][NULL][0014]Boss de la Mort[1432][NULL][NULL][0014] était mérité."
+    "texte_fr": "Un élève transféré dans cette classe... ?[000F][1205]\nJe crois que son nom c'était... Kuro...[000F][1205]\nEnfin bon, c'est pas important...[E1][E2]\n[E3][E4][NULL][NULL]Élève masculin\nLa façon dont Eikichi a mis la pâtée au nouveau leader faisait le\ntour du lycée. Son surnom [1432][NULL][NULL][0014]Boss de la Mort[1432][NULL][NULL][0014] était mérité."
   }
 ]

--- a/traduction/event_scripts/script_306.json
+++ b/traduction/event_scripts/script_306.json
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Dreams...[1205][000F][SP]My[SP]dream[SP]is[SP]to...",
     "nom_fr": "Ginko",
-    "texte_fr": "Rêves.[1205][000F].. Mon rêve est..."
+    "texte_fr": "Rêves.[000F][1205].. Mon rêve est..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Fanna...[SP]Hey,[SP][1113]?[SP]I[SP]keep[SP]thinking[SP]about\nthat[SP]resonance[SP]with[SP]Joker.[1205][000F][SP]I[SP]can't[SP]get[SP]it[SP]out\nof[SP]my[SP]head...[1205][000F][SP]Why[SP]is[SP]that?",
     "nom_fr": "Ginko",
-    "texte_fr": "Fanna... Hé, [1113]? Je repense\n[1205][1205][000F]à cette résonance avec le Joker.\n[000F]Je l'ai en tête... Pourquoi?"
+    "texte_fr": "Fanna... Hé, [1113]? Je repense\n[1205][000F][1205]à cette résonance avec le Joker.\n[000F]Je l'ai en tête... Pourquoi?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Dreams[SP]differ[SP]from[SP]person[SP]to[SP]person...[1205][000F][SP]I[SP]think\nit's[SP]fine[SP]that[SP]not[SP]everyone[SP]has[SP]the[SP]same[SP]one.",
     "nom_fr": "Maya",
-    "texte_fr": "Les rêves varient selon les gens.[1205][000F].. C'est\nbien qu'on n'ait pas tous les mêmes."
+    "texte_fr": "Les rêves varient selon les gens.[000F][1205].. C'est\nbien qu'on n'ait pas tous les mêmes."
   },
   {
     "id": 5,
@@ -117,7 +117,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Does[SP]getting[SP]what[SP]you[SP]want[SP]count[SP]as[SP]an[SP]ideal?[1205][000F]\nThen[SP]if[SP]you[SP]get[SP]it,[SP]does[SP]that[SP]mean[SP]your[SP]ideal's\nbeen[SP]granted?[1205][000F][SP]Kinda[SP]boring.",
     "nom_fr": "Yukino",
-    "texte_fr": "Obtenir ce qu'on veut est un idéal?\n[1205][000F][1205][000F]Alors si on l'obtient, cela signifie que\nl'idéal est exaucé? Un peu ennuyeux."
+    "texte_fr": "Obtenir ce qu'on veut est un idéal?\n[000F][1205][000F][1205]Alors si on l'obtient, cela signifie que\nl'idéal est exaucé? Un peu ennuyeux."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]think[SP]ideals[SP]are[SP]more[SP]than[SP]that.[1205][000F][SP]They're\nsomething[SP]you'll[SP]chase[SP]after[SP]your[SP]whole[SP]life.",
     "nom_fr": "Yukino",
-    "texte_fr": "L'idéal, c'est plus que ça.\n[1205][000F]On le poursuit toute sa vie."
+    "texte_fr": "L'idéal, c'est plus que ça.\n[000F][1205]On le poursuit toute sa vie."
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I'll...[SP]never[SP]forget[SP]it...[1205][000F][SP]A[SP]normal[SP]meeting...[1205][000F]\nNothing[SP]out[SP]of[SP]the[SP]ordinary...[1205][000F][SP]And[SP]then[SP]there\nwas[SP]someone[SP]with[SP]a[SP]blue[SP]skull...",
     "nom_fr": "Élève",
-    "texte_fr": "Je... l'oublierai jamais.[1205][000F][1205][000F][1205][000F].. Une\nréunion normale... Rien d'anormal...\nPuis quelqu'un avec un crâne bleu..."
+    "texte_fr": "Je... l'oublierai jamais.[000F][1205][000F][1205][000F][1205].. Une\nréunion normale... Rien d'anormal...\nPuis quelqu'un avec un crâne bleu..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "A[SP]scorpion...[1205][000F][SP]That's[SP]right...[1205][000F][SP]A[SP]scorpion's...[1205][000F]\nIt[SP]was[SP]a...",
     "nom_fr": "Élève",
-    "texte_fr": "Un scorpion.[1205][000F][1205][000F][1205][000F].. C'est ça...\nDe scorpion... C'était..."
+    "texte_fr": "Un scorpion.[000F][1205][000F][1205][000F][1205].. C'est ça...\nDe scorpion... C'était..."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Huh?[SP]Are[SP]you[SP]the[SP]guys[SP]looking[SP]for[SP]the\npresident?[1205][000F][SP]O-Oh,[SP]well[SP]in[SP]that[SP]case...[1205][000F]\nI[SP]think[SP]he's[SP]in[SP]the[SP]student[SP]council[SP]room.",
     "nom_fr": "Élève",
-    "texte_fr": "Hein? Vous cherchez le président?\n[1205][000F][1205][000F]O-Oh, dans ce cas... Je crois\nqu'il est en salle du conseil."
+    "texte_fr": "Hein? Vous cherchez le président?\n[000F][1205][000F][1205]O-Oh, dans ce cas... Je crois\nqu'il est en salle du conseil."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "You're[SP]looking[SP]for[SP]the[SP]president,[SP]right?[1205][000F][SP]Yeah...\nLooks[SP]like[SP]he's[SP]in[SP]Class[SP]2-4.[1205][000F][SP]Why[SP]not[SP]go[SP]check\nit[SP]out...?",
     "nom_fr": "Élève",
-    "texte_fr": "Vous cherchez le\nprésident, non? [1205][000F][1205][000F]Ouais... Il\nest en classe 2-4.\nPourquoi ne pas y aller...?"
+    "texte_fr": "Vous cherchez le\nprésident, non? [000F][1205][000F][1205]Ouais... Il\nest en classe 2-4. Pourquoi ne pas y aller...?"
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Y-You[SP]still[SP]can't[SP]find[SP]the[SP]president?[1205][000F][SP]H-Huh...?[1205][000F]\nThat's[SP]weird...[1205][000F][SP]Um,[SP]then[SP]he's[SP]probably[SP]in\nClass[SP]3-1....[1205][000F][SP]I[SP]think.",
     "nom_fr": "Élève",
-    "texte_fr": "T-Toujours pas trouvé le président?\n[1205][000F][1205][000F][1205][000F][1205][000F]H-Hein...? Bizarre... Euh, il doit\nêtre en 3-1... Je crois."
+    "texte_fr": "T-Toujours pas trouvé le président?\n[000F][1205][000F][1205][000F][1205][000F][1205]H-Hein...? Bizarre... Euh, il doit\nêtre en 3-1... Je crois."
   },
   {
     "id": 15,
@@ -311,7 +311,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Hmph.[SP]That's[SP]all[SP]fine[SP]and[SP]dandy,[SP]but[SP]how[SP]do[SP]you\nknow[SP]what'll[SP]happen[SP]in[SP]the[SP]future?[1205][000F][SP]How[SP]can[SP]you\nbase[SP]your[SP]dreams[SP]on[SP]that?",
     "nom_fr": "Élève",
-    "texte_fr": "Hmph. C'est bien\nbeau, mais comment connaître\nl'avenir? [1205][000F]Comment baser ses rêves sur ça?"
+    "texte_fr": "Hmph. C'est bien\nbeau, mais comment connaître\nl'avenir? [000F][1205]Comment baser ses rêves sur ça?"
   },
   {
     "id": 20,
@@ -326,7 +326,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I[SP]know,[SP]right?[SP]Right[SP]now[SP]is[SP]all[SP]I[SP]know,[SP]so[SP]why\nplan[SP]ahead[SP]when[SP]it[SP]comes[SP]to[SP]my[SP]dreams?[SP]Besides,\nthat[SP]kind[SP]of[SP]talk[SP]is[SP]totally[SP]lame[SP]nowadays.",
     "nom_fr": "Élève",
-    "texte_fr": "C'est clair. Je ne connais que le présent,\nalors pourquoi planifier\nmes rêves? Et puis,\nce genre de discours est tellement ringard."
+    "texte_fr": "C'est clair. Je ne connais que le présent,\nalors pourquoi planifier\nmes rêves? Et puis, ce genre de discours est tellement ringard."
   },
   {
     "id": 21,

--- a/traduction/event_scripts/script_307.json
+++ b/traduction/event_scripts/script_307.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Something's[SP]not[SP]right...[1205][000F][SP]Why[SP]are[SP]these[SP]guys\nsucking[SP]up[SP]to[SP]me[SP]all[SP]of[SP]a[SP]sudden?[1205][000F][SP]Did[SP]even\nthe[SP]student[SP]council[SP]hate[SP]Yasuo?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Y a un truc qui cloche.[1205][000F][1205][000F].. Pourquoi\nils me fayotent tous soudainement?\nLe conseil déteste Yasuo aussi?"
+    "texte_fr": "Y a un truc qui cloche.[000F][1205][000F][1205].. Pourquoi\nils me fayotent tous soudainement?\nLe conseil déteste Yasuo aussi?"
   },
   {
     "id": 1,
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Alright,[SP]alright![1205][000F][SP]So,[SP]any[SP]ideas[SP]on[SP]just[SP]where\nhe[SP]might[SP]be[SP]hiding?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est bon! [1205][000F]Vous avez une idée\nd'où il pourrait se cacher?"
+    "texte_fr": "C'est bon! [000F][1205]Vous avez une idée\nd'où il pourrait se cacher?"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "This[SP]new[SP]president[SP]had[SP]to[SP]be[SP]elected,[SP]right?\nDoesn't[SP]that[SP]mean[SP]he's[SP]popular[SP]at[SP]Cuss...\nI[SP]mean,[SP]Kasugayama[SP]High?",
     "nom_fr": "Ginko",
-    "texte_fr": "Ce président a dû être\nélu, non? Il est donc\npopulaire au Lycée Kakasu... enfin,\nKasugayama?"
+    "texte_fr": "Ce président a dû être\nélu, non? Il est donc\npopulaire au Lycée Kakasu... enfin, Kasugayama?"
   },
   {
     "id": 12,
@@ -312,7 +312,7 @@
     "nom_orig": "Earnest[SP]student[SP]council[SP]member",
     "texte_orig": "The[SP]president[SP]is[SP]an[SP]amoral[SP]demon[SP]who[SP]doesn't\neven[SP]fear[SP]God.[SP]He[SP]controls[SP]his[SP]hoods[SP]from[SP]the\nshadows[SP]and[SP]has[SP]this[SP]school[SP]under[SP]his[SP]thumb.",
     "nom_fr": "Élève sérieux",
-    "texte_fr": "Le président est un démon amoral qui ne\ncraint même pas Dieu.\nIl contrôle ses voyous\ndans l'ombre et tient\nce lycée sous sa coupe."
+    "texte_fr": "Le président est un démon amoral qui ne\ncraint même pas Dieu.\nIl contrôle ses voyous dans l'ombre et tient ce lycée sous sa coupe."
   },
   {
     "id": 21,
@@ -492,7 +492,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Alright,[SP]alright![1205][000F][SP]So,[SP]any[SP]ideas[SP]on[SP]just[SP]where\nhe[SP]might[SP]be[SP]hiding?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est bon! [1205][000F]Vous avez une idée\nd'où il pourrait se cacher?"
+    "texte_fr": "C'est bon! [000F][1205]Vous avez une idée\nd'où il pourrait se cacher?"
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Glib[SP]student[SP]council[SP]member",
     "texte_orig": "We're[SP]counting[SP]on[SP]you,[SP]Michel-san.[SP]Please[SP]give\nthat[SP]awful[SP]president[SP]a[SP]thrashing.[1205][000F][SP]No[SP]need[SP]to\nhold[SP]back![SP]Really[SP]give[SP]him[SP]the[SP]business!",
     "nom_fr": "Élève bavard",
-    "texte_fr": "On compte sur vous, Michel. Donnez une\nraclée à cet affreux président. [1205][000F]Ne\nvous retenez pas! Faites-lui sa fête!"
+    "texte_fr": "On compte sur vous, Michel. Donnez une\nraclée à cet affreux président. [000F][1205]Ne\nvous retenez pas! Faites-lui sa fête!"
   },
   {
     "id": 34,
@@ -642,7 +642,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Alright,[SP]alright![1205][000F][SP]So,[SP]any[SP]ideas[SP]on[SP]just[SP]where\nhe[SP]might[SP]be[SP]hiding?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est bon! [1205][000F]Vous avez une idée\nd'où il pourrait se cacher?"
+    "texte_fr": "C'est bon! [000F][1205]Vous avez une idée\nd'où il pourrait se cacher?"
   },
   {
     "id": 43,

--- a/traduction/event_scripts/script_308.json
+++ b/traduction/event_scripts/script_308.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]moron...[SP]Then[SP]we'll[SP]just[SP]change[SP]things.[1205][000F]\nWe[SP]gotta[SP]make[SP]this[SP]the[SP]best[SP]school[SP]around!\nAnd[SP]you[SP]better[SP]help[SP]us[SP]do[SP]it,[SP]get[SP]me!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Idiots... Changeons les choses.\n[1205][000F]Faisons-en le meilleur lycée! Et\nvous allez nous aider, pigé!?"
+    "texte_fr": "Idiots... Changeons les choses.\n[000F][1205]Faisons-en le meilleur lycée! Et\nvous allez nous aider, pigé!?"
   },
   {
     "id": 1,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Huh?[1205][000F][SP]I[SP]don't[SP]think[SP]we[SP]talked[SP]about[SP]anything\nspecial,[SP]really...[1205][000F][SP]What's[SP]wrong,[SP]Lisa?",
     "nom_fr": "Maya",
-    "texte_fr": "Hein? [1205][000F][1205][000F]On n'a rien dit de\nspécial... Qu'y a-t-il, Lisa?"
+    "texte_fr": "Hein? [000F][1205][000F][1205]On n'a rien dit de\nspécial... Qu'y a-t-il, Lisa?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Uh-oh...[SP]They[SP]pissed[SP]off[SP]Maya-san.[1205][000F][SP]You[SP]might[SP]not\nthink[SP]so,[SP]but[SP]she[SP]gets[SP]emotional[SP]pretty[SP]easily.[1205][000F]\nBut[SP]then,[SP]if[SP]it[SP]was[SP]me,[SP]I'd[SP]talk[SP]with[SP]my[SP]fists.",
     "nom_fr": "Yukino",
-    "texte_fr": "Oh-oh... Ils ont énervé Maya. [1205][000F][1205][000F]On ne dirait\npas, mais elle est\nplutôt émotive. Mais bon,\nsi c'était moi, je\nparlerais avec mes poings."
+    "texte_fr": "Oh-oh... Ils ont énervé Maya. [000F][1205][000F][1205]On ne dirait\npas, mais elle est\nplutôt émotive. Mais bon, si c'était moi, je parlerais avec mes poings."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Yikes,[SP]Lisa...[1205][000F][SP]There's[SP]no[SP]point[SP]in[SP]trying[SP]to\nrush[SP]Maya-san[SP]like[SP]that.[SP]She's[SP]so[SP]slow[SP]when\nit[SP]comes[SP]to[SP]this[SP]stuff...",
     "nom_fr": "Yukino",
-    "texte_fr": "Oups, Lisa.[1205][000F].. Inutile\nde brusquer Maya. Elle\nest si lente pour ce genre de choses..."
+    "texte_fr": "Oups, Lisa.[000F][1205].. Inutile\nde brusquer Maya. Elle\nest si lente pour ce genre de choses..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "B-Boss...[1205][000F][SP]Maybe[SP]it[SP]was[SP]us[SP]who[SP]was[SP]the[SP]reason\neveryone[SP]calls[SP]our[SP]school[SP]Cuss[SP]High...",
     "nom_fr": "Élève",
-    "texte_fr": "B-Boss.[1205][000F].. C'est peut-être à cause de\nnous qu'on l'appelle le Lycée Kakasu..."
+    "texte_fr": "B-Boss.[000F][1205].. C'est peut-être à cause de\nnous qu'on l'appelle le Lycée Kakasu..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "We[SP]don't[SP]feel[SP]like[SP]doing[SP]anything...[1205][000F][SP]I[SP]get[SP]that\nnow.[1205][000F][SP]But[SP]we[SP]were[SP]only[SP]jealous[SP]of[SP]Sevens[SP]because\nwe[SP]loved[SP]our[SP]school.[1205][000F][SP]That's...[1205][000F][SP]That's[SP]why...",
     "nom_fr": "Élève",
-    "texte_fr": "On ne veut rien faire.[1205][000F][1205][000F][1205][000F][1205].[000F]. Je comprends.\nOn jalousait Seven car on aimait notre\nlycée. C'est... C'est pour ça..."
+    "texte_fr": "On ne veut rien faire.[000F][1205][000F][1205][000F][1205][1205].[000F]. Je comprends.\nOn jalousait Seven car on aimait notre\nlycée. C'est... C'est pour ça..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "I[SP]want[SP]to[SP]make[SP]up[SP]with[SP]you[SP]Sevens[SP]guys...[1205][000F][SP]We've\nhated[SP]you[SP]for[SP]so[SP]long...[1205][000F][SP]I[SP]guess[SP]you[SP]wouldn't\nwant[SP]our[SP]emblem?[1205][000F][SP]Haha...[SP]A[SP]little[SP]late,[SP]huh...",
     "nom_fr": "Élève",
-    "texte_fr": "Je veux faire la paix avec vous, ceux de\n[1205][000F][1205][000F][1205][000F]Seven... On vous a tant haïs... Vous\nrefusez notre emblème? Haha... Trop tard..."
+    "texte_fr": "Je veux faire la paix avec vous, ceux de\n[000F][1205][000F][1205][000F][1205]Seven... On vous a tant haïs... Vous\nrefusez notre emblème? Haha... Trop tard..."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Hehehe,[SP]Sevens[SP]is[SP]for[SP]shit[SP]now,[SP]while[SP]our[SP]school\nfestival[SP]is[SP]rockin'[SP]it.[SP]We'll[SP]get[SP]tons[SP]of[SP]visitors\nfor[SP]sure.[SP]Jealous?[SP]Don't[SP]deny[SP]it!",
     "nom_fr": "Élève",
-    "texte_fr": "Héhéhé, Seven c'est nul\nà présent, alors que\nnotre fête déchire. On aura plein de\nvisiteurs. Vous êtes jaloux?\nNe le niez pas!"
+    "texte_fr": "Héhéhé, Seven c'est nul\nà présent, alors que\nnotre fête déchire. On aura plein de visiteurs. Vous êtes jaloux? Ne le niez pas!"
   },
   {
     "id": 13,

--- a/traduction/event_scripts/script_309.json
+++ b/traduction/event_scripts/script_309.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "These[SP]guys...[1205][000F][SP]They[SP]called[SP][1113][SP]out[SP]for[SP]my\nsake...[1205][000F][SP]For[SP]my[SP]dream...[SP]For[SP]Gas[SP]Chamber...[1205][000F]\nAnd[SP]I[SP]couldn't[SP]save[SP]them.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ces gars.[1205][000F][1205][000F][1205][000F].. Ils ont appelé [1113]\npour moi... Pour mon rêve... Pour Gas\nChamber... Et je n'ai rien pu faire."
+    "texte_fr": "Ces gars.[000F][1205][000F][1205][000F][1205].. Ils ont appelé [1113]\npour moi... Pour mon rêve... Pour Gas\nChamber... Et je n'ai rien pu faire."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "H-Hey,[SP]what?[SP]What're[SP]you[SP]saying!?[SP]C'mon,[SP]you\ngotta[SP]keep[SP]it[SP]together...[1205][000F][SP]Why're[SP]you[SP]guys\ngetting[SP]even[SP]darker[SP]than[SP]before...?",
     "nom_fr": "Eikichi",
-    "texte_fr": "H-Hé, quoi? Que dites-vous!? Allez,\ntenez bon... [1205][000F]Pourquoi devenez-vous\nencore plus sombres qu'avant...?"
+    "texte_fr": "H-Hé, quoi? Que dites-vous!? Allez,\ntenez bon... [000F][1205]Pourquoi devenez-vous\nencore plus sombres qu'avant...?"
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Holeen...[SP]These[SP]three[SP]weren't[SP]very[SP]bright...[1205][000F]\nBut[SP]I[SP]feel[SP]bad[SP]about[SP]what's[SP]happened[SP]to[SP]them.",
     "nom_fr": "Lisa",
-    "texte_fr": "Holeen... Ces trois n'étaient pas malins.[1205][000F]..\nMais je suis triste\npour ce qui leur arrive."
+    "texte_fr": "Holeen... Ces trois n'étaient pas malins.[000F][1205]..\nMais je suis triste\npour ce qui leur arrive."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Holeen...[SP]These[SP]three[SP]weren't[SP]very[SP]bright...[1205][000F]\nBut[SP]I[SP]feel[SP]bad[SP]about[SP]what's[SP]happened[SP]to[SP]them.",
     "nom_fr": "Ginko",
-    "texte_fr": "Holeen... Ces trois n'étaient pas malins.[1205][000F]..\nMais je suis triste\npour ce qui leur arrive."
+    "texte_fr": "Holeen... Ces trois n'étaient pas malins.[000F][1205]..\nMais je suis triste\npour ce qui leur arrive."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "N-No...[1205][000F][SP]They[SP]can't[SP]even[SP]talk[SP]now...\nWhat's[SP]happening[SP]to[SP]them?",
     "nom_fr": "Ginko",
-    "texte_fr": "N-Non.[1205][000F].. Ils ne parlent même\nplus... Que leur arrive-t-il?"
+    "texte_fr": "N-Non.[000F][1205].. Ils ne parlent même\nplus... Que leur arrive-t-il?"
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I'm[SP]sure[SP]Eikichi[SP]remembers[SP]what[SP]happened...[1205][000F]\nThere's[SP]no[SP]way[SP]we'll[SP]ever[SP]forget...",
     "nom_fr": "Ginko",
-    "texte_fr": "Eikichi se souvient de ce qui s'est\n[1205][000F]passé... Jamais on n'oubliera..."
+    "texte_fr": "Eikichi se souvient de ce qui s'est\n[000F][1205]passé... Jamais on n'oubliera..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "They're[SP]gone...[SP]I[SP]can't[SP]find[SP]those[SP]three\nanywhere![1205][000F][SP]They[SP]finally[SP]disappeared...",
     "nom_fr": "Ginko",
-    "texte_fr": "Ils sont partis... Introuvables!\n[1205][000F]Ils ont finis par disparaître..."
+    "texte_fr": "Ils sont partis... Introuvables!\n[000F][1205]Ils ont finis par disparaître..."
   },
   {
     "id": 11,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Eikichi-kun's[SP]a[SP]nice[SP]guy[SP]at[SP]heart.[1205][000F][SP]We[SP]need[SP]to\nhurry[SP]and[SP]catch[SP]Joker,[SP]for[SP]their[SP]sake.",
     "nom_fr": "Maya",
-    "texte_fr": "Eikichi a un bon fond. [1205][000F]On doit se\ndépêcher d'attraper le Joker, pour eux."
+    "texte_fr": "Eikichi a un bon fond. [000F][1205]On doit se\ndépêcher d'attraper le Joker, pour eux."
   },
   {
     "id": 13,
@@ -342,7 +342,7 @@
     "nom_orig": "Ken",
     "texte_orig": "I[SP]wanted...[SP]to[SP]be[SP]a[SP]boxing[SP]champ...[1205][000F][SP]To[SP]prove\nto[SP]those[SP]guys[SP]who[SP]made[SP]fun[SP]of[SP]us...[1205][000F][SP]that[SP]they\nwere[SP]wrong...[SP]with[SP]my[SP]fists...[1205][000F][SP]But[SP]who[SP]cares...",
     "nom_fr": "Ken",
-    "texte_fr": "Je voulais... [1205][000F][1205][1205]être un champion de boxe.[000F][000F]..\nProuver aux moqueurs... qu'ils avaient\ntort... avec mes poings... Mais bref..."
+    "texte_fr": "Je voulais... [000F][1205][1205][1205]être un champion de boxe.[000F][000F]..\nProuver aux moqueurs... qu'ils avaient\ntort... avec mes poings... Mais bref..."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Ken",
     "texte_orig": "I[SP]don't[SP]want[SP]a[SP]dream[SP]that'll[SP]never[SP]come[SP]true...[1205][000F]\nIt[SP]all[SP]seems[SP]so[SP]dumb[SP]now...[SP]We're[SP]so[SP]useless...\nLike[SP]rotten[SP]apples...",
     "nom_fr": "Ken",
-    "texte_fr": "Pas envie d'un rêve qui ne se\nréalisera pas.[1205][000F].. C'est si bête... On\nest inutiles... Des pommes pourries..."
+    "texte_fr": "Pas envie d'un rêve qui ne se\nréalisera pas.[000F][1205].. C'est si bête... On\nest inutiles... Des pommes pourries..."
   },
   {
     "id": 24,
@@ -417,7 +417,7 @@
     "nom_orig": "Shogo",
     "texte_orig": "It's[SP]hard[SP]work...[SP]and[SP]smelly...[SP]and[SP]just\ngenerally[SP]awful.[1205][001E][SP]I[SP]don't[SP]wanna[SP]do[SP]anything\nanymore...",
     "nom_fr": "Shogo",
-    "texte_fr": "C'est dur... ça pue... et c'est affreux\nen général.[1205][001E] Je ne veux plus rien faire..."
+    "texte_fr": "C'est dur... ça pue... et c'est affreux\nen général.[001E][1205] Je ne veux plus rien faire..."
   },
   {
     "id": 28,
@@ -462,7 +462,7 @@
     "nom_orig": "Takeshi",
     "texte_orig": "I[SP]found[SP]out[SP]we[SP]were[SP]poor...[SP]when[SP]open[SP]house\ncame[SP]around...[SP]Other[SP]moms[SP]had[SP]nice[SP]clothes...\nMy[SP]mom[SP]was[SP]the[SP]only[SP]one...[SP]who[SP]looked[SP]dirty...",
     "nom_fr": "Takeshi",
-    "texte_fr": "J'ai su qu'on était pauvres... aux portes\nouvertes... Les autres mères étaient bien\nhabillées... La mienne\nseule... avait l'airsale..."
+    "texte_fr": "J'ai su qu'on était pauvres... aux portes\nouvertes... Les autres mères étaient bien\nhabillées... La mienne seule... avait l'airsale..."
   },
   {
     "id": 31,
@@ -492,7 +492,7 @@
     "nom_orig": "Takeshi",
     "texte_orig": "Mom...[1205][001E][SP]I'm[SP]so[SP]sorry...[1205]([SP]I[SP]can't[SP]do[SP]anything\nanymore...",
     "nom_fr": "Takeshi",
-    "texte_fr": "Maman...[1205][001E] Désolé...[1205]( Je ne\npeux plus rien faire..."
+    "texte_fr": "Maman...[001E][1205] Désolé...[1205]( Je ne\npeux plus rien faire..."
   },
   {
     "id": 33,

--- a/traduction/event_scripts/script_311.json
+++ b/traduction/event_scripts/script_311.json
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey,[SP]don't[SP]let[SP]what[SP]happened[SP]at[SP]Smile[SP]Hirasaka\nget[SP]to[SP]you.[1205][000F][SP]It's[SP]not[SP]your[SP]fault,[SP][1113].",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, oublie ce qui s'est passé à Smile\nHirasaka. [1205][000F]C'est pas ta faute, [1113]."
+    "texte_fr": "Hé, oublie ce qui s'est passé à Smile\nHirasaka. [000F][1205]C'est pas ta faute, [1113]."
   },
   {
     "id": 11,
@@ -237,7 +237,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#3![1205][001E][SP][1432][NULL][NULL][0014]Fanna[1432][NULL][NULL][0014][SP]means\nsomething[SP]like,[SP][1432][NULL][NULL][0014]I[SP]don't[SP]like[SP]this...[1432][NULL][NULL][0014]\nYou[SP]use[SP]it[SP]when[SP]you're[SP]feeling[SP]let[SP]down.",
     "nom_fr": "Ginko",
-    "texte_fr": "Leçon de cantonais n°3![1205][001E] [1432][NULL][NULL][0014]Fanna[1432][NULL][NULL][0014] veut\ndire quelque chose comme [1432][NULL][NULL][0014]J'aime pas\nça...[1432][NULL][NULL][0014] Ça s'utilise quand on est déçu."
+    "texte_fr": "Leçon de cantonais n°3![001E][1205] [1432][NULL][NULL][0014]Fanna[1432][NULL][NULL][0014] veut\ndire quelque chose comme [1432][NULL][NULL][0014]J'aime pas\nça...[1432][NULL][NULL][0014] Ça s'utilise quand on est déçu."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#12![1205][001E][SP][1432][NULL][NULL][0014]Holeen[1432][NULL][NULL][0014][SP]means\n[1432][NULL][NULL][0014]poor[SP]thing,[1432][NULL][NULL][0014][SP]basically,[SP]for[SP]when[SP]you're\nsympathizing[SP]with[SP]someone.",
     "nom_fr": "Ginko",
-    "texte_fr": "Leçon de cantonais n°12![1205][001E] [1432][NULL][NULL][0014]Holeen[1432][NULL][NULL][0014]\nsignifie [1432][NULL][NULL][0014]pauvre chou,[1432][NULL][NULL][0014] pour exprimer\nde la sympathie envers quelqu'un."
+    "texte_fr": "Leçon de cantonais n°12![001E][1205] [1432][NULL][NULL][0014]Holeen[1432][NULL][NULL][0014]\nsignifie [1432][NULL][NULL][0014]pauvre chou,[1432][NULL][NULL][0014] pour exprimer\nde la sympathie envers quelqu'un."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "But[SP]why[SP]was[SP]Anna-san[SP]at[SP]Zodiac?[1205][000F][SP]Could[SP]she\nhave[SP]been[SP]trying[SP]to[SP]go[SP]through[SP]the[SP]initiation\nritual[SP]with[SP]the[SP]Cuss[SP]High[SP]students...?",
     "nom_fr": "Ginko",
-    "texte_fr": "Mais pourquoi Anna-san était au Zodiac?\n[1205][000F]Elle voulait peut-être faire le rituel\navec les élèves du Lycée Kakasu...?"
+    "texte_fr": "Mais pourquoi Anna-san était au Zodiac?\n[000F][1205]Elle voulait peut-être faire le rituel\navec les élèves du Lycée Kakasu...?"
   },
   {
     "id": 18,
@@ -297,7 +297,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Are[SP]you[SP]still[SP]moaning[SP]about[SP]my[SP]debut?[SP]Will[SP]you\nlet[SP]it[SP]go[SP]already?[1205][000F][SP]I[SP]got[SP]roped[SP]into[SP]that...!",
     "nom_fr": "Ginko",
-    "texte_fr": "Tu râles encore pour mes débuts? Laisse\ntomber, s'il te plaît! [1205][000F]On m'a forcé la\nmain...!"
+    "texte_fr": "Tu râles encore pour mes débuts? Laisse\ntomber, s'il te plaît! [000F][1205]On m'a forcé la\nmain...!"
   },
   {
     "id": 20,
@@ -357,7 +357,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "That[SP]can't[SP]be...[1205][000F][SP]If[SP]they're[SP]Joker...[1205][000F][SP]there's[SP]no\nway[SP]they'd[SP]want[SP]to[SP]destroy[SP]everything...",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est impossible.[1205][000F][1205][000F].. Si c'est Joker... ils\nne voudraient jamais tout détruire..."
+    "texte_fr": "C'est impossible.[000F][1205][000F][1205].. Si c'est Joker... ils\nne voudraient jamais tout détruire..."
   },
   {
     "id": 24,
@@ -552,7 +552,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That's[SP]the[SP]best[SP]attitude[SP]to[SP]take.[1205][000F][SP]Things[SP]have\ngone[SP]too[SP]far[SP]for[SP]us[SP]to[SP]stop[SP]now.[SP]Regret[SP]won't\nhelp[SP]anyone,[SP]after[SP]all.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est la bonne attitude. [1205][000F]Trop loin pour\ns'arrêter maintenant. Les regrets n'aident\npersonne."
+    "texte_fr": "C'est la bonne attitude. [000F][1205]Trop loin pour\ns'arrêter maintenant. Les regrets n'aident\npersonne."
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Crises[SP]are[SP]prerequisites[SP]for[SP]the[SP]evolution[SP]of\nany[SP]species.[SP]Only[SP]those[SP]who[SP]overcome[SP]the[SP]crisis\nwill[SP]greet[SP]the[SP]new[SP]era.[SP]Those[SP]that[SP]don't,[SP]die.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nAren't[SP]humans[SP]the[SP]contradictory[SP]ones,[SP]thinking\nthat[SP]prosperity[SP]and[SP]survival[SP]are[SP]all?[SP]Have[SP]they\nforgotten[SP]the[SP]laws[SP]of[SP]evolution?[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nI[SP]think[SP]Jun-kun's[SP]objective[SP]has[SP]been[SP]twisted\nby[SP]the[SP]power[SP]of[SP]rumors,[SP]too...[1205][000F][SP]But[SP]is[SP]that[SP]also\nthe[SP]reason[SP]they[SP]went[SP]public[SP]with[SP]that[SP]book...?",
     "nom_fr": "Maya",
-    "texte_fr": "Les crises sont des\nprérequis à l'évolution de\ntoute espèce. Seuls ceux qui les surmontent\naccèdent à la nouvelle ère.[E1][E2] [E3][E4][NULL][NULL]\"Maya\nLes humains\nne sont-ils pas contradictoires à\npenser queprospérité et survie sont tout? Auraient-ils\noublié les lois de l'évolution?[E1][E2] [E3][E4][NULL][NULL]\"Maya\n Je pense\nque l'objectif de Jun-kun a été déformé\n[1205][000F]par lepouvoir des rumeurs... Mais est-ce pour ça\nqu'ils ont publié ce livre...?"
+    "texte_fr": "Les crises sont des\nprérequis à l'évolution de\ntoute espèce. Seuls ceux qui les surmontent\naccèdent à la nouvelle ère.[E1][E2] [E3][E4][NULL][NULL]\"Maya\nLes humains\nne sont-ils pas contradictoires à\npenser queprospérité et survie sont tout? Auraient-ils\noublié les lois de l'évolution?[E1][E2] [E3][E4][NULL][NULL]\"Maya\n Je pense\nque l'objectif de Jun-kun a été déformé\n[000F][1205]par lepouvoir des rumeurs... Mais est-ce pour ça\nqu'ils ont publié ce livre...?"
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Thinking[SP]ahead,[SP]part[SP]1![1205][001E][SP]You[SP]should[SP]outfit\nyourself[SP]with[SP]the[SP]best[SP]gear[SP]you[SP]can[SP]find\nbefore[SP]a[SP]battle.",
     "nom_fr": "Yukino",
-    "texte_fr": "Penser à l'avance, partie 1![1205][001E] Équipe-toi du\nmeilleur matériel possible\navant une bataille."
+    "texte_fr": "Penser à l'avance, partie 1![001E][1205] Équipe-toi du\nmeilleur matériel possible\navant une bataille."
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "You[SP]can't[SP]keep[SP]summoning[SP]a[SP]Persona[SP]forever,\nso[SP]it's[SP]important[SP]to[SP]have[SP]a[SP]good[SP]weapon[SP]as\na[SP]fallback.",
     "nom_fr": "Yukino",
-    "texte_fr": "On ne peut pas invoquer un Persona\nindéfiniment, donc avoir\nune arme en réserve\nest crucial."
+    "texte_fr": "On ne peut pas invoquer un Persona\nindéfiniment, donc avoir\nune arme en réserve est crucial."
   },
   {
     "id": 40,
@@ -717,7 +717,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Seriously,[SP]setting[SP]off[SP]the[SP]fire[SP]alarm[SP]to[SP]get\neveryone[SP]out[SP]of[SP]the[SP]building?[1205][000F][SP]Never[SP]let[SP]it[SP]be\nsaid[SP]Maya-san[SP]is[SP]scared[SP]to[SP]make[SP]bold[SP]moves.",
     "nom_fr": "Yukino",
-    "texte_fr": "Sérieusement, déclencher l'alarme\nincendie pour vider le bâtiment? [1205][000F]Maya-san\nn'a jamais peur des grands gestes."
+    "texte_fr": "Sérieusement, déclencher l'alarme\nincendie pour vider le bâtiment? [000F][1205]Maya-san\nn'a jamais peur des grands gestes."
   },
   {
     "id": 48,
@@ -1084,7 +1084,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Such[SP]a[SP]miserable[SP]fate[SP]the[SP]Nomanov[SP]Dynasty's\nlast[SP]Imperial[SP]princess[SP]came[SP]to...[1205][000F][SP]Ahhh,[SP]what\na[SP]tearjerker[SP]of[SP]a[SP]story.",
     "nom_fr": "Patronne",
-    "texte_fr": "Quel destin tragique pour la dernière\nprincesse impériale des Nomanov.[1205][000F]..\nAhhh, quelle histoire déchirante."
+    "texte_fr": "Quel destin tragique pour la dernière\nprincesse impériale des Nomanov.[000F][1205]..\nAhhh, quelle histoire déchirante."
   },
   {
     "id": 67,
@@ -1129,7 +1129,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "*sigh*[1205][000F][SP]I[SP]miss[SP]the[SP]days[SP]when[SP]I'd[SP]wear[SP]personally\ntailored[SP]Juan[SP]Galliano[SP]and[SP]Alexandra[SP]McQueen\noutfits,[SP]strutting[SP]down[SP]the[SP]runway...",
     "nom_fr": "Patronne",
-    "texte_fr": "*soupir* Ces jours où je portais du\n[1205][000F]Juan Galliano et Alexander McQueen sur\nmesure, en défilant sur le podium..."
+    "texte_fr": "*soupir* Ces jours où je portais du\n[000F][1205]Juan Galliano et Alexander McQueen sur\nmesure, en défilant sur le podium..."
   },
   {
     "id": 70,
@@ -1144,7 +1144,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Yeah,[SP]yeah,[SP]let's[SP]put[SP]stories[SP]of[SP]the[SP]old[SP]days\naside[SP]for[SP]a[SP]bit.[1205][000F][SP]I[SP]got[SP]some[SP]new[SP]goods[SP]in.[1205][000F]\nThey[SP]sell[SP]out[SP]pretty[SP]quick,[SP]so[SP]look[SP]now.",
     "nom_fr": "Patronne",
-    "texte_fr": "Bon, bon, laissons les histoires du passé\nde côté. [1205][000F][1205][000F]J'ai reçu de nouveaux articles.\nÇa part vite, alors regardez maintenant."
+    "texte_fr": "Bon, bon, laissons les histoires du passé\nde côté. [000F][1205][000F][1205]J'ai reçu de nouveaux articles.\nÇa part vite, alors regardez maintenant."
   },
   {
     "id": 71,
@@ -1159,7 +1159,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Thinking[SP]back,[SP]I[SP]must[SP]have[SP]been[SP]18[SP]when[SP]I[SP]made\nmy[SP]Hollywood[SP]debut...[SP]I[SP]worked[SP]with[SP]John,[SP]Tom,\nall[SP]those[SP]guys...[SP]I[SP]was[SP]the[SP]Queen[SP]of[SP]Movies.",
     "nom_fr": "Patronne",
-    "texte_fr": "En y repensant, j'avais 18 ans quand j'ai\nfait mes débuts\nà Hollywood... J'ai travaillé\navec John, Tom... J'étais la Reine du film."
+    "texte_fr": "En y repensant, j'avais 18 ans quand j'ai\nfait mes débuts\nà Hollywood... J'ai travaillé avec John, Tom... J'étais la Reine du film."
   },
   {
     "id": 72,
@@ -1174,7 +1174,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "I[SP]still[SP]remember...[1205][000F][SP]That[SP]scene[SP]where[SP]he[SP]embraced\nme[SP]at[SP]the[SP]prow[SP]of[SP]the[SP]luxury[SP]liner...[1205][000F][SP]We'd[SP]gone\nbeyond[SP]acting[SP]in[SP]that[SP]moment.",
     "nom_fr": "Patronne",
-    "texte_fr": "Je m'en souviens encore.[1205][000F][1205][000F].. Cette scène où\nil me serrait à la proue du paquebot...\nOn avait dépassé les limites du jeu."
+    "texte_fr": "Je m'en souviens encore.[000F][1205][000F][1205].. Cette scène où\nil me serrait à la proue du paquebot...\nOn avait dépassé les limites du jeu."
   },
   {
     "id": 73,
@@ -1219,7 +1219,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Alrighty.[1205][000A][SP]Hope[SP]you[SP]come[SP]again.",
     "nom_fr": "Patronne",
-    "texte_fr": "Voilà![1205][000A] À bientôt!"
+    "texte_fr": "Voilà![000A][1205] À bientôt!"
   },
   {
     "id": 76,
@@ -1234,7 +1234,7 @@
     "nom_orig": "Washout[SP]student",
     "texte_orig": "Well,[SP]don't[SP]that[SP]beat[SP]all?[SP]Ma'am[SP]really[SP]was[SP]an\nex-spy.[SP]City[SP]folk[SP]never[SP]fail[SP]to[SP]surprise[SP]me.[E1][E2]\n[E3][E4][NULL][NULL]\"Washout[SP]student\nMa'am's[SP]stories[SP]are[SP]always[SP]so[SP]interesting.[1205][000F]\nEspecially[SP]lately,[SP]they[SP]seem[SP]to[SP]be[SP]even[SP]more\nplausible!",
     "nom_fr": "Lycéen raté",
-    "texte_fr": "Ben ça alors! La patronne était espionne.\nLes gens de la ville m'étonneront\ntoujours.[E1][E2]\n[E3][E4][NULL][NULL]\"Étudiant raté\nSes histoires\nsont fascinantes. [1205][000F]Ces derniers temps,\nelles semblent de plus en plus crédibles!"
+    "texte_fr": "Ben ça alors! La patronne était espionne.\nLes gens de la ville m'étonneront\ntoujours.[E1][E2]\n[E3][E4][NULL][NULL]\"Étudiant raté\nSes histoires\nsont fascinantes. [000F][1205]Ces derniers temps,\nelles semblent de plus en plus crédibles!"
   },
   {
     "id": 77,
@@ -1279,7 +1279,7 @@
     "nom_orig": "Washout[SP]student",
     "texte_orig": "The[SP]city's[SP]in[SP]chaos[SP]because[SP]of[SP]the[SP]terrorist\nattacks,[SP]but[SP]Ma'am[SP]doesn't[SP]so[SP]much[SP]as[SP]blink[SP]an\neye[SP]at[SP]it.[SP]It's[SP]like[SP]time's[SP]stopped[SP]in[SP]here.",
     "nom_fr": "Lycéen raté",
-    "texte_fr": "La ville est en\nchaos à cause des attentats,\nmais la patronne ne sourcille pas. C'est\ncomme si le temps s'était arrêté."
+    "texte_fr": "La ville est en\nchaos à cause des attentats,\nmais la patronne ne sourcille pas. C'est comme si le temps s'était arrêté."
   },
   {
     "id": 80,
@@ -1309,7 +1309,7 @@
     "nom_orig": "Washout[SP]student",
     "texte_orig": "I[SP]watched[SP]the[SP]news[SP]and[SP]it[SP]got[SP]me[SP]all[SP]confused.\nSo[SP]those[SP]five[SP]guys[SP]weren't[SP]the[SP]terrorists?[1205][000F]\nIt[SP]was[SP]actually[SP]the[SP]Last[SP]Battalion?",
     "nom_fr": "Lycéen raté",
-    "texte_fr": "J'ai regardé les infos et j'y comprends\nrien. Ces cinq types n'étaient pas les\n[1205][000F]terroristes? C'était le Bataillon?"
+    "texte_fr": "J'ai regardé les infos et j'y comprends\nrien. Ces cinq types n'étaient pas les\n[000F][1205]terroristes? C'était le Bataillon?"
   },
   {
     "id": 82,
@@ -1354,7 +1354,7 @@
     "nom_orig": "Bodyguard",
     "texte_orig": "I[SP]get[SP]the[SP]feeling[SP]that[SP]something's[SP]not[SP]quite\nright,[SP]but[SP]I'm[SP]the[SP]bodyguard[SP]here![SP]Don't[SP]tell\nanyone,[SP]though,[SP]okay?",
     "nom_fr": "Garde du corps",
-    "texte_fr": "J'ai l'impression que ça\ncloche, mais je suis\nle garde du corps!\nN'en parlez à personne, ok?"
+    "texte_fr": "J'ai l'impression que ça\ncloche, mais je suis\nle garde du corps! N'en parlez à personne, ok?"
   },
   {
     "id": 85,
@@ -1369,7 +1369,7 @@
     "nom_orig": "Bodyguard",
     "texte_orig": "I'm[SP]Ma'am's[SP]bodyguard,[SP]but...[SP]When[SP]did[SP]I[SP]take\nthis[SP]job?[1205][000F][SP]I[SP]can't[SP]remember...[SP]But[SP]the[SP]important\nthing[SP]is,[SP]I'm[SP]her[SP]bodyguard.",
     "nom_fr": "Garde du corps",
-    "texte_fr": "Je suis le garde de la patronne,\nmais... [1205][000F]Quand ai-je pris ce poste?\nJe sais plus... Mais je le suis."
+    "texte_fr": "Je suis le garde de la patronne,\nmais... [000F][1205]Quand ai-je pris ce poste?\nJe sais plus... Mais je le suis."
   },
   {
     "id": 86,
@@ -1429,7 +1429,7 @@
     "nom_orig": "Bodyguard",
     "texte_orig": "Looks[SP]like[SP]they[SP]even[SP]set[SP]bombs[SP]at[SP]Smile\nHirasaka.[SP]But[SP]this[SP]place[SP]is[SP]safe.[SP]Especially\nwith[SP]a[SP]bodyguard[SP]like[SP]me[SP]around!",
     "nom_fr": "Garde du corps",
-    "texte_fr": "Des bombes à\nSmile Hirasaka, paraît-il. Mais\nici c'est sûr. Surtout avec un garde comme\nmoi!"
+    "texte_fr": "Des bombes à\nSmile Hirasaka, paraît-il. Mais\nici c'est sûr. Surtout avec un garde comme moi!"
   },
   {
     "id": 90,
@@ -1444,7 +1444,7 @@
     "nom_orig": "Bodyguard",
     "texte_orig": "Looks[SP]like[SP]they[SP]even[SP]set[SP]bombs[SP]at[SP]Smile\nHirasaka.[SP]But[SP]this[SP]place[SP]is[SP]safe.[SP]Especially\nwith[SP]a[SP]bodyguard[SP]like[SP]me[SP]around!",
     "nom_fr": "Garde du corps",
-    "texte_fr": "Des bombes à\nSmile Hirasaka, paraît-il. Mais\nici c'est sûr. Surtout avec un garde comme\nmoi!"
+    "texte_fr": "Des bombes à\nSmile Hirasaka, paraît-il. Mais\nici c'est sûr. Surtout avec un garde comme moi!"
   },
   {
     "id": 91,
@@ -1474,7 +1474,7 @@
     "nom_orig": "Bodyguard",
     "texte_orig": "Rumor[SP]has[SP]it[SP]the[SP][1432][NULL][NULL][0014]lion's[SP]roar[1432][NULL][NULL][0014][SP]the[SP]In[SP]Lak'ech\ntalks[SP]about[SP]is[SP]the[SP]Leonids.[1205][000F][SP]What[SP]do[SP]you[SP]think?",
     "nom_fr": "Garde du corps",
-    "texte_fr": "Selon l'In Lak'ech, le [1432][NULL][NULL][0014]rugissement du\nlion[1432][NULL][NULL][0014] serait les Léonides. [1205][000F]Et vous?"
+    "texte_fr": "Selon l'In Lak'ech, le [1432][NULL][NULL][0014]rugissement du\nlion[1432][NULL][NULL][0014] serait les Léonides. [000F][1205]Et vous?"
   },
   {
     "id": 93,
@@ -1534,7 +1534,7 @@
     "nom_orig": "Maniac",
     "texte_orig": "I[SP]mean,[SP]you've[SP]heard[SP]the[SP]rumors[SP]about[SP]how[SP]the\nflowers[SP]bewitch[SP]people[SP]there[SP]and[SP]make[SP]them[SP]lose\ntheir[SP]way,[SP]right?",
     "nom_fr": "Fan obsédé",
-    "texte_fr": "Les rumeurs sur les\nfleurs qui envoûtent les\ngens là-bas et les\nfont se perdre, vous savez?"
+    "texte_fr": "Les rumeurs sur les\nfleurs qui envoûtent les\ngens là-bas et les font se perdre, vous savez?"
   },
   {
     "id": 97,
@@ -1594,7 +1594,7 @@
     "nom_orig": "Maniac",
     "texte_orig": "No,[SP]I[SP]shouldn't[SP]ask.[SP]I[SP]shouldn't...[1205][000F][SP]But[SP]I[SP]really\ndo[SP]want[SP]it...[SP][E4][NULL][NULL][0006]Linda's[SP]Bra[E4][NULL][NULL][0002]...[1205][000F][SP]Her[SP]ghost[SP]shows[SP]up\nin[SP]Aoba[SP]Park,[SP]I[SP]hear...",
     "nom_fr": "Fan obsédé",
-    "texte_fr": "Non, je ne devrais pas demander.[1205][000F][1205][000F].. Mais\nje le veux tellement... Le [E4][NULL][NULL][0006]soutien-gorge\nde Linda[E4][NULL][NULL][0002]... Son fantôme..."
+    "texte_fr": "Non, je ne devrais pas demander.[000F][1205][000F][1205].. Mais\nje le veux tellement... Le [E4][NULL][NULL][0006]soutien-gorge\nde Linda[E4][NULL][NULL][0002]... Son fantôme..."
   },
   {
     "id": 101,
@@ -1679,7 +1679,7 @@
     "nom_orig": "Maniac",
     "texte_orig": "N-No...[1205][000F][SP]Look,[SP]I'll[SP]give[SP]you[SP]something[SP]rare\nfrom[SP]my[SP]collection,[SP]too![SP]How[SP]about[SP]a[SP]trade?",
     "nom_fr": "Fan obsédé",
-    "texte_fr": "N-Non.[1205][000F].. Je vous donne quelque\nchose de rare! Et si on échangeait?"
+    "texte_fr": "N-Non.[000F][1205].. Je vous donne quelque\nchose de rare! Et si on échangeait?"
   },
   {
     "id": 106,
@@ -1694,7 +1694,7 @@
     "nom_orig": "Maniac",
     "texte_orig": "Hehahahahaha![SP]So[SP]this[SP]is[SP]her...[1205][000F][SP]Wow,[SP]this[SP]is\nsuch[SP]a[SP]rarity![SP]Hehaha...[1205][000F][SP]I'm[SP]gonna[SP]take[SP]it[SP]home\nand[SP]put[SP]it[SP]on[SP]the[SP]wall[SP]right[SP]now!",
     "nom_fr": "Fan obsédé",
-    "texte_fr": "Hehahahahaha! [1205][000F][1205][000F]C'est donc elle...\nQuelle rareté! Hehaha... Je rentre\nmaintenant et l'accroche au mur!"
+    "texte_fr": "Hehahahahaha! [000F][1205][000F][1205]C'est donc elle...\nQuelle rareté! Hehaha... Je rentre\nmaintenant et l'accroche au mur!"
   },
   {
     "id": 107,

--- a/traduction/event_scripts/script_312.json
+++ b/traduction/event_scripts/script_312.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Don't[SP]they[SP]give[SP]a[SP]damn[SP]about[SP]the[SP]people[SP]still\ndown[SP]there!?[SP]Tch,[SP]I'm[SP]starting[SP]to[SP]have[SP]second\nthoughts[SP]about[SP]fighting[SP]for[SP]these[SP]creeps.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ils en ont rien à foutre de ceux restés en\nbas!? Tch, j'commence à\nme demander si ça vaut\nle coup de se battre pour ces sales types."
+    "texte_fr": "Ils en ont rien à foutre de ceux restés en\nbas!? Tch, j'commence à\nme demander si ça vaut le coup de se battre pour ces sales types."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Heh...[SP]Heh[SP]heh...[SP]Don't[SP]worry[SP]about[SP]me...[1205][000F]\nOne[SP]for[SP]all...[1205][000F][SP]and[SP]all[SP]for[SP]one...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé... Hé Hé... Te bile pas pour moi.[1205][000F][1205][000F]..\nUn pour tous... et tous pour un..."
+    "texte_fr": "Hé... Hé Hé... Te bile pas pour moi.[000F][1205][000F][1205]..\nUn pour tous... et tous pour un..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Is[SP]that[SP]woman[SP]so[SP]calm[SP]because[SP]the[SP]rumors[SP]really\ndid[SP]turn[SP]her[SP]into[SP]a[SP]spy?[1205][000F][SP]Or[SP]did[SP]she[SP]have[SP]nerves\nof[SP]steel[SP]to[SP]begin[SP]with?",
     "nom_fr": "Ginko",
-    "texte_fr": "Si cette femme garde son calme, c'est\ncar la rumeur l'a faite espion? [1205][000F]Ou bien\nelle a toujours eu des nerfs d'acier?"
+    "texte_fr": "Si cette femme garde son calme, c'est\ncar la rumeur l'a faite espion? [000F][1205]Ou bien\nelle a toujours eu des nerfs d'acier?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]no[SP]one's[SP]fault[SP]that[SP]the[SP]city[SP]is[SP]so[SP]far\ngone[SP]now.[1205][000A][SP]Rumors[SP]are[SP]becoming[SP]reality...\nI[SP]think[SP]everyone[SP]was[SP]wrong[SP]in[SP]some[SP]way.",
     "nom_fr": "Maya",
-    "texte_fr": "L'état de la ville n'est la faute de\npersonne.[1205][000A] Les rumeurs deviennent réalité...\nChacun y a sa part de responsabilité."
+    "texte_fr": "L'état de la ville n'est la faute de\npersonne.[000A][1205] Les rumeurs deviennent réalité...\nChacun y a sa part de responsabilité."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Rumors[SP]are[SP]the[SP]desire[SP]lurking[SP]in[SP]human[SP]hearts\ngiven[SP]form.[1205][000F][SP]Man[SP]has[SP]a[SP]dark[SP]side,[SP]alas...[1205][000F][SP]But\nhe[SP]is[SP]also[SP]capable[SP]of[SP]kindness[SP]and[SP]empathy.",
     "nom_fr": "Jun",
-    "texte_fr": "Les désirs cachés du coeur humain donnent\n[1205][000F][1205][000F]forme aux rumeurs. L'humain a une part\nsombre... Mais aussi de\nla bonté et del'empathie."
+    "texte_fr": "Les désirs cachés du coeur humain donnent\n[000F][1205][000F][1205]forme aux rumeurs. L'humain a une part\nsombre... Mais aussi de la bonté et del'empathie."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]want[SP]to[SP]believe[SP]that's[SP]the[SP]dominant[SP]side.[1205][000A]\nAnd[SP]it's[SP]because[SP]I'm[SP]with[SP]you[SP]all[SP]that[SP]I[SP]can\nbelieve[SP]that.[1205][000F][SP]Let's[SP]stay[SP]together[SP]to[SP]the[SP]end...",
     "nom_fr": "Jun",
-    "texte_fr": "Je veux croire que c'est cette part qui\n[1205]domine.[1205][000A] C'est d'être avec\nvous qui me fait y\ncroire. [000F]Restons ensemble jusqu'à la fin..."
+    "texte_fr": "Je veux croire que c'est cette part qui\n[1205]domine.[000A][1205] C'est d'être avec\nvous qui me fait y croire. [000F]Restons ensemble jusqu'à la fin..."
   },
   {
     "id": 8,
@@ -304,7 +304,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "We're[SP]in[SP]a[SP]real[SP]fix.[1205][000A][SP]I[SP]mean,[SP]the[SP]damn[SP]city's\nflyin',[SP]right?",
     "nom_fr": "Cheffe",
-    "texte_fr": "On est dans la mouise.[1205][000A] Enfin,\nla ville a disparu, non?"
+    "texte_fr": "On est dans la mouise.[000A][1205] Enfin,\nla ville a disparu, non?"
   },
   {
     "id": 15,
@@ -334,7 +334,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Best[SP]to[SP]stay[SP]calm[SP]at[SP]times[SP]like[SP]this.[1205][000A][SP]Sometimes\nall[SP]you[SP]can[SP]do[SP]is[SP]let[SP]luck[SP]run[SP]its[SP]course.[1205][000F]\nNo[SP]sense[SP]in[SP]gettin'[SP]panicky,[SP]after[SP]all.",
     "nom_fr": "Cheffe",
-    "texte_fr": "Dans ces périodes, il\nvaut mieux rester calme.[1205][1205][000A]\nParfois on doit juste laisser la chance \n[000F]suivre son cours. Paniquer est inutile."
+    "texte_fr": "Dans ces périodes, il\nvaut mieux rester calme.[1205][000A][1205]\nParfois on doit juste laisser la chance [000F]suivre son cours. Paniquer est inutile."
   },
   {
     "id": 17,
@@ -349,7 +349,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Huh?[1205][000F][SP]Legendary[SP]case?[1205][000F][SP]Yikes,[SP]you[SP]kids[SP]heard[SP]the\nrumor[SP]too?",
     "nom_fr": "Cheffe",
-    "texte_fr": "Que? [1205][000F][1205][000F]L'étui légendaire?\nVous la connaissez aussi?"
+    "texte_fr": "Que? [000F][1205][000F][1205]L'étui légendaire?\nVous la connaissez aussi?"
   },
   {
     "id": 18,
@@ -364,7 +364,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Some[SP]people[SP]been[SP]sayin'[SP][E4][NULL][NULL][0006]I[SP]sell[SP]a[SP]legendary\ncase[SP]here[E4][NULL][NULL][0002],[SP]right?[1205][000F][SP]Who'd[SP]go[SP]startin'[SP]a[SP]rumor\nlike[SP]that?",
     "nom_fr": "Cheffe",
-    "texte_fr": "Certains disent [E4][NULL][NULL][0006]que je vends un étui\nlégendaire[E4][NULL][NULL][0002], pas vrai? [1205][000F]Qui a pu lancer une\ntelle rumeur?"
+    "texte_fr": "Certains disent [E4][NULL][NULL][0006]que je vends un étui\nlégendaire[E4][NULL][NULL][0002], pas vrai? [000F][1205]Qui a pu lancer une\ntelle rumeur?"
   },
   {
     "id": 19,
@@ -379,7 +379,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Well,[SP]whoever[SP]it[SP]is,[SP]it's[SP]bull[SP]puckey.[1205][000F][SP]I[SP]don't\nhave[SP]anything[SP]like[SP]that[SP]here.",
     "nom_fr": "Cheffe",
-    "texte_fr": "Qui que ce soit, ce sont des\n[1205][000F]conneries. J'ai rien comme ça ici."
+    "texte_fr": "Qui que ce soit, ce sont des\n[000F][1205]conneries. J'ai rien comme ça ici."
   },
   {
     "id": 20,
@@ -409,7 +409,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Sure,[SP]I[SP]sell[SP]weapons...[1205][000F][SP]But[SP]ramen[SP]is[SP]my[SP]main\nbusiness.[1205][000F][SP]And[SP]why[SP]a[SP]guitar[SP]case,[SP]anyway?",
     "nom_fr": "Cheffe",
-    "texte_fr": "J'vends des armes, mais mon vrai job,\n[1205][000F][1205][000F]les ramen. Pourquoi un étui à guitare?"
+    "texte_fr": "J'vends des armes, mais mon vrai job,\n[000F][1205][000F][1205]les ramen. Pourquoi un étui à guitare?"
   },
   {
     "id": 22,
@@ -424,7 +424,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Alrighty.[1205][000A][SP]Hope[SP]you[SP]come[SP]again.",
     "nom_fr": "Cheffe",
-    "texte_fr": "Ok.[1205][000A] J'espère vous revoir."
+    "texte_fr": "Ok.[000A][1205] J'espère vous revoir."
   },
   {
     "id": 23,
@@ -439,7 +439,7 @@
     "nom_orig": "Washout[SP]student",
     "texte_orig": "Man,[SP]I[SP]just[SP]saw[SP]something[SP]that[SP]scared[SP]the[SP]life\nout[SP]of[SP]me.[1205][000F][SP]You[SP]know[SP]how[SP]that[SP]weird[SP]building\nshowed[SP]up[SP]where[SP]Smile[SP]Hirasaka[SP]was?[E1][E2]\n[E3][E4][NULL][NULL]\"Washout[SP]student\nTons[SP]of[SP]those[SP]soldiers[SP]from[SP]the[SP]Last[SP]Whatever\nwent[SP]in[SP]there.[1205][000F][SP]Then[SP]the[SP]Masked[SP]Circle[SP]guys\nrushed[SP]in[SP]to[SP]follow[SP]them.",
     "nom_fr": "Lycéen en échec",
-    "texte_fr": "Mec, j'ai vu un\ntruc terrifiant. Tu vois cet\n[1205][000F][1205][000F]immeuble bizarre là où était le Smile\nHirasaka?[E1][E2]\n[E3][E4][NULL][NULL]\"Lycéen en échec\nPleins de soldats\ndu Bata-truc y sont entrés. Et juste après\nlesgars du Cercle Masqué les ont suivis dedans."
+    "texte_fr": "Mec, j'ai vu un\ntruc terrifiant. Tu vois cet\n[000F][1205][000F][1205]immeuble bizarre là où était le Smile\nHirasaka?[E1][E2]\n[E3][E4][NULL][NULL]\"Lycéen en échec\nPleins de soldats\ndu Bata-truc y sont entrés. Et juste après\nlesgars du Cercle Masqué les ont suivis dedans."
   },
   {
     "id": 24,
@@ -529,7 +529,7 @@
     "nom_orig": "Bodyguard",
     "texte_orig": "There's[SP]a[SP]line[SP]in[SP]the[SP]Oracle[SP]about[SP]a[SP]star[SP]coming\nto[SP]a[SP]halt,[SP]right?[1205][000F][SP]Maybe[SP]that's[SP]talking[SP]about\nthe[SP]Earth's[SP]destruction.",
     "nom_fr": "Garde du corps",
-    "texte_fr": "Un passage de l'Oracle parle d'une\nétoile qui s'arrêterait, hein? [1205][000F]C'est\npeut-être ça la destruction de la Terre."
+    "texte_fr": "Un passage de l'Oracle parle d'une\nétoile qui s'arrêterait, hein? [000F][1205]C'est\npeut-être ça la destruction de la Terre."
   },
   {
     "id": 30,
@@ -544,7 +544,7 @@
     "nom_orig": "Bodyguard",
     "texte_orig": "Seriously,[SP]how[SP]much[SP]worse[SP]can[SP]things[SP]get?[1205][000A][SP]When\nthe[SP]Grand[SP]Cross[SP]happens,[SP]some[SP]gravity[SP]warp[SP]is\ngonna[SP]stop[SP]the[SP]Earth's[SP]rotation.",
     "nom_fr": "Garde du corps",
-    "texte_fr": "À quel point ça peut empirer?[1205][000A] Quand la\nCroix Cosmique arrivera, une distorsion\nde gravité figera la rotation terrestre."
+    "texte_fr": "À quel point ça peut empirer?[000A][1205] Quand la\nCroix Cosmique arrivera, une distorsion\nde gravité figera la rotation terrestre."
   },
   {
     "id": 31,
@@ -589,7 +589,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Heh,[SP]I[SP]think[SP]you[SP]do.[1205][000F][SP]After[SP]all,[SP]we[SP]spread[SP]the--[1205][000F]\nUh,[SP]I[SP]mean...[1205][000F][SP]Well...[1205][000F][SP]I[SP]know[SP]you[SP]really[SP]do[SP]have\nit,[SP]don't[SP]you?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, je pense que si. [1205][000F][1205][000F][1205][000F][1205][000F]Car on a répandu\nla-- Heu, je veux dire... Je... sais\nque vous l'avez vraiment, pas vrai?"
+    "texte_fr": "Hé, je pense que si. [000F][1205][000F][1205][000F][1205][000F][1205]Car on a répandu\nla-- Heu, je veux dire... Je... sais\nque vous l'avez vraiment, pas vrai?"
   },
   {
     "id": 34,
@@ -619,7 +619,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Even[SP]that[SP]spy[SP]stuff[SP]was[SP]a[SP]rumor[SP]before--[1205][000F]\nUm,[SP]I[SP]mean...[1205][000F][SP]It[SP]doesn't[SP]matter!",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est aussi une rumeur le truc d'espion\n[1205][000F][1205][000F]et-- C'est, je... On s'en fiche!"
+    "texte_fr": "C'est aussi une rumeur le truc d'espion\n[000F][1205][000F][1205]et-- C'est, je... On s'en fiche!"
   },
   {
     "id": 36,
@@ -634,7 +634,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]just[SP]want[SP]you[SP]to[SP]help[SP]me[SP]out.[1205][000F][SP]For[SP]old[SP]time's\nsake?[1205][000F][SP]The[SP]guitar[SP]case[SP]is[SP]here,[SP]isn't[SP]it?\nC'mon,[SP]don't[SP]make[SP]me[SP]beg...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je veux que vous m'aidiez. [1205][000F][1205][000F]Pour le bon\nvieux temps? L'étui légendaire est là,\nhein? Me faites pas vous supplier..."
+    "texte_fr": "Je veux que vous m'aidiez. [000F][1205][000F][1205]Pour le bon\nvieux temps? L'étui légendaire est là,\nhein? Me faites pas vous supplier..."
   },
   {
     "id": 37,
@@ -649,7 +649,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Sheesh...[1205][000F][SP]It'd[SP]be[SP]pretty[SP]sad[SP]to[SP]go[SP]around[SP]with\nyou[SP]holdin'[SP]a[SP]grudge.[1205][000F][SP]Alright.[1205][000F][SP]You[SP]want[SP]the\nlegendary[SP]case?[1205][000F][SP]I[SP]got[SP]it[SP]right[SP]here.",
     "nom_fr": "Cheffe",
-    "texte_fr": "Tch.[1205][000F][1205][000F][1205][000F][1205].[000F]. Ça serait triste que tu restes\ntoujours rancunier après ça. Très bien. Tu\nveux l'étui légendaire? Je l'ai juste là."
+    "texte_fr": "Tch.[000F][1205][000F][1205][000F][1205][1205].[000F]. Ça serait triste que tu restes\ntoujours rancunier après ça. Très bien. Tu\nveux l'étui légendaire? Je l'ai juste là."
   },
   {
     "id": 38,
@@ -679,7 +679,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Heh,[SP]that's[SP]the[SP]spirit![1205][000F][SP]Lay[SP]it[SP]on[SP]me![1205][000F]\nI'll[SP]agree[SP]to[SP]anything!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Voilà, là on parle! [1205][000F][1205][000F]Allez-y!\nJ'accepterai n'importe quoi!"
+    "texte_fr": "Voilà, là on parle! [000F][1205][000F][1205]Allez-y!\nJ'accepterai n'importe quoi!"
   },
   {
     "id": 40,
@@ -739,7 +739,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "[1114]![SP]We're[SP]friends,[SP]right!?[SP]You[SP]wouldn't\nsacrifice[SP]your[SP]best[SP]buddy[SP]just[SP]for[SP]a[SP]weapon,\nwould[SP]you?",
     "nom_fr": "Eikichi",
-    "texte_fr": "[1114]! On est potes,\nhein? Tu sacrifierais pas ton\nmeilleur ami pour une\npauvre arme, pas vrai?"
+    "texte_fr": "[1114]! On est potes,\nhein? Tu sacrifierais pas ton\nmeilleur ami pour une pauvre arme, pas vrai?"
   },
   {
     "id": 44,
@@ -780,7 +780,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Tch![SP]Fine![1205][000F][SP]You[SP]want[SP]me[SP]to[SP]eat[SP]it![1205][000F][SP]I'll[SP]eat[SP]it!\nI'll[SP]show[SP]you[SP]the[SP]Great[SP]Michel's[SP]iron[SP]stomach!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tss! [1205][000F][1205][000F]Bien! Si vous\nvoulez! Je vais le manger!\nAdmirez l'estomac d'acier du Grand Michel!"
+    "texte_fr": "Tss! [000F][1205][000F][1205]Bien! Si vous\nvoulez! Je vais le manger!\nAdmirez l'estomac d'acier du Grand Michel!"
   },
   {
     "id": 46,
@@ -810,7 +810,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Hah![1205][000F][SP]That's[SP]the[SP]spirit,[SP]kid.[1205][000F][SP]I'll[SP]whip[SP]some\nup[SP]right[SP]now.[SP]Just[SP]give[SP]me[SP]a[SP]sec...",
     "nom_fr": "Cheffe",
-    "texte_fr": "Hah! [1205][000F][1205][000F]J'aime mieux ça, gamin. Je te\nprépare ça. Patiente juste un peu..."
+    "texte_fr": "Hah! [000F][1205][000F][1205]J'aime mieux ça, gamin. Je te\nprépare ça. Patiente juste un peu..."
   },
   {
     "id": 48,
@@ -855,7 +855,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Relax,[SP]relax.[1205][000F][SP]It[SP]ain't[SP]hot[SP]or[SP]anything.",
     "nom_fr": "Cheffe",
-    "texte_fr": "Relax, relax. [1205][000F]C'est même pas chaud."
+    "texte_fr": "Relax, relax. [000F][1205]C'est même pas chaud."
   },
   {
     "id": 51,
@@ -900,7 +900,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Well?[1205][000F][SP]How[SP]was[SP]it?",
     "nom_fr": "Cheffe",
-    "texte_fr": "Alors? [1205][000F]Un avis?"
+    "texte_fr": "Alors? [000F][1205]Un avis?"
   },
   {
     "id": 54,
@@ -915,7 +915,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Haha...[1205][000F][SP]It[SP]was[SP]delicious...[1205][000F][SP]So[SP]good,[SP]I[SP]can[SP]feel\nmy[SP]organs[SP]shutting[SP]down...[1205][000F][SP]Adieu...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Haha.[1205][000F][1205][000F][1205][000F].. Délicieux... Tellement que je\nsens mes organes me lâcher... Adieu..."
+    "texte_fr": "Haha.[000F][1205][000F][1205][000F][1205].. Délicieux... Tellement que je\nsens mes organes me lâcher... Adieu..."
   },
   {
     "id": 55,
@@ -975,7 +975,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Pff...[SP]What's[SP]with[SP]the[SP]cold[SP]shoulder?[1205][000F][SP]Fine.\nI[SP]won't[SP]ask[SP]you[SP]twice.[1205][000F][SP]The[SP]deal's[SP]off.",
     "nom_fr": "Cheffe",
-    "texte_fr": "Pff... Tu te dégonfles? [1205]Bien. [1205][000F][000F]Je ne le\nredemanderai pas. Je retire mon offre."
+    "texte_fr": "Pff... Tu te dégonfles? [1205]Bien. [000F][1205][000F]Je ne le\nredemanderai pas. Je retire mon offre."
   },
   {
     "id": 59,

--- a/traduction/event_scripts/script_313.json
+++ b/traduction/event_scripts/script_313.json
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]guys[SP]who[SP]didn't[SP]go[SP]to[SP]the[SP]masquerade[SP]don't\nknow[SP]what[SP]happened[SP]in[SP]the[SP]gym...[1205][000F][SP]At[SP]least,[SP]they\ndon't[SP]realize[SP]it[SP]yet...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ceux qui sont pas allés au bal masqué ne\nsavent rien de l'incident du gymnase.[1205][000F]..\nOu ils ne l'ont pas encore réalisé."
+    "texte_fr": "Ceux qui sont pas allés au bal masqué ne\nsavent rien de l'incident du gymnase.[000F][1205]..\nOu ils ne l'ont pas encore réalisé."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That[SP]guy's[SP]nuts,[SP]isn't[SP]he?[SP]I[SP]don't[SP]know[SP]if[SP]it's\nbecause[SP]of[SP]this[SP]Oracle[SP]or[SP]whatever,[SP]but[SP]starting\nfires[SP]based[SP]on[SP]some[SP]prophecy[SP]is[SP]total[SP]BS.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ce mec est fou, hein?\nJe sais pas si c'est à\ncause de l'Oracle ou quoi, mais devenir\npyromane pour une\nprophétie c'est vraimenttrès con."
+    "texte_fr": "Ce mec est fou, hein?\nJe sais pas si c'est à\ncause de l'Oracle ou quoi, mais devenir pyromane pour une prophétie c'est vraimenttrès con."
   },
   {
     "id": 5,
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I'd[SP]like[SP]to[SP]see[SP]the[SP]looks[SP]on[SP]people's[SP]faces[SP]if\nwe[SP]told[SP]them[SP]the[SP]Last[SP]Battalion[SP]only[SP]showed[SP]up\nbecause[SP]people[SP]kept[SP]talking[SP]about[SP]them.",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'aimerais voir les visages de ces gens\naprès leur avoir dit\nque le Bataillon s'est \npointé car ils\nn'arrêtaient pas d'en parler."
+    "texte_fr": "J'aimerais voir les visages de ces gens\naprès leur avoir dit\nque le Bataillon s'est pointé car ils n'arrêtaient pas d'en parler."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "But[SP]they'd[SP]never[SP]believe[SP]it...[1205][000F][SP]If[SP]they[SP]did,\nthat[SP]stupid[SP]rumor[SP]would[SP]have[SP]never[SP]gotten[SP]off\nthe[SP]ground.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mais ils le croiraient pas.[1205][000F]..\nSinon, cette rumeur débile aurait\njamais pris autant d'ampleur."
+    "texte_fr": "Mais ils le croiraient pas.[000F][1205]..\nSinon, cette rumeur débile aurait\njamais pris autant d'ampleur."
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "I'm[SP]totally[SP]into[SP]Bruce[SP]Lee[SP]now,[SP]so[SP]I'm[SP]studying\nkung[SP]fu[SP]and[SP]Cantonese[SP]in[SP]my[SP]spare[SP]time.[1205][001E][SP]Hwataaa!\nIt's[SP]so[SP]cool!",
     "nom_fr": "Lisa",
-    "texte_fr": "Je suis en période Bruce Lee, donc\nj'étudie le kung fu et le Cantonais sur\nmon temps libre.[1205][001E] Hwata! Trop cool!"
+    "texte_fr": "Je suis en période Bruce Lee, donc\nj'étudie le kung fu et le Cantonais sur\nmon temps libre.[001E][1205] Hwata! Trop cool!"
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I'm[SP]totally[SP]into[SP]Bruce[SP]Lee[SP]now,[SP]so[SP]I'm[SP]studying\nkung[SP]fu[SP]and[SP]Cantonese[SP]in[SP]my[SP]spare[SP]time.[1205][001E][SP]Hwataaa!\nIt's[SP]so[SP]cool!",
     "nom_fr": "Ginko",
-    "texte_fr": "Je suis en période Bruce Lee, donc\nj'étudie le kung fu et le Cantonais sur\nmon temps libre.[1205][001E] Hwata! Trop cool!"
+    "texte_fr": "Je suis en période Bruce Lee, donc\nj'étudie le kung fu et le Cantonais sur\nmon temps libre.[001E][1205] Hwata! Trop cool!"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Lisa's[SP]Cantonese[SP]lesson[SP]#17![1205][001E][SP][1432][NULL][NULL][0014]Baaibaai[1432][NULL][NULL][0014][SP]means\n[1432][NULL][NULL][0014]Goodbye.[1432][NULL][NULL][0014][SP]That[SP]one's[SP]pretty[SP]easy.",
     "nom_fr": "Ginko",
-    "texte_fr": "Lesson de Cantonais #17![1205][001E] [1432][NULL][NULL][0014]Baaibaai[1432][NULL][NULL][0014]\nsignifie [1432][NULL][NULL][0014]Au revoir.[1432][NULL][NULL][0014] Facile, celui-là."
+    "texte_fr": "Lesson de Cantonais #17![001E][1205] [1432][NULL][NULL][0014]Baaibaai[1432][NULL][NULL][0014]\nsignifie [1432][NULL][NULL][0014]Au revoir.[1432][NULL][NULL][0014] Facile, celui-là."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Even[SP]if[SP]they[SP]did[SP]realize,[SP]it[SP]wouldn't[SP]make[SP]much\nof[SP]an[SP]impression[SP]on[SP]them,[SP]huh?[SP]I[SP]bet[SP]they[SP]won't\neven[SP]look[SP]around[SP]them...[SP]Holeen...",
     "nom_fr": "Ginko",
-    "texte_fr": "Même s'ils réalisaient, ça les ferait pas\nbeaucoup réagir, hein?\nIls feraient même pas\ngaffe à ce qui a autour d'eux... Holeen..."
+    "texte_fr": "Même s'ils réalisaient, ça les ferait pas\nbeaucoup réagir, hein?\nIls feraient même pas gaffe à ce qui a autour d'eux... Holeen..."
   },
   {
     "id": 18,
@@ -312,7 +312,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Yeah...[1205][000F][SP]I[SP]know[SP]it's[SP]not[SP]their[SP]fault,[SP]but[SP]it\nstill[SP]hurts[SP]to[SP]see[SP]them[SP]like[SP]this.",
     "nom_fr": "Ginko",
-    "texte_fr": "Oui, je sais qu'ils sont pas fautifs,\n[1205][000F]mais ça fait mal de les voir comme ça."
+    "texte_fr": "Oui, je sais qu'ils sont pas fautifs,\n[000F][1205]mais ça fait mal de les voir comme ça."
   },
   {
     "id": 21,
@@ -357,7 +357,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah,[SP]my[SP]sinking[SP]feeling[SP]came[SP]true...[1205][000F][SP]I[SP]can't\nbelieve[SP]the[SP]Last[SP]Battalion[SP]is[SP]real[SP]now...[SP]This\nis[SP]so[SP]not[SP]fair!",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiyah, mes craintes se sont réalisées.[1205][000F]..\nJe peux pas croire que le Bataillon soit\nréel... C'est si injuste!"
+    "texte_fr": "Aiyah, mes craintes se sont réalisées.[000F][1205]..\nJe peux pas croire que le Bataillon soit\nréel... C'est si injuste!"
   },
   {
     "id": 24,
@@ -387,7 +387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Th-That[SP]woman[SP]over[SP]there...[1205][001E][SP]Did[SP]she[SP]have[SP]Joker\ngive[SP]her...[SP]man[SP]parts...?",
     "nom_fr": "Maya",
-    "texte_fr": "Cette personne...[1205][001E] a demandée à Joker\nde lui donner des parties d'homme?"
+    "texte_fr": "Cette personne...[001E][1205] a demandée à Joker\nde lui donner des parties d'homme?"
   },
   {
     "id": 26,
@@ -507,7 +507,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Can[SP]you[SP]deny[SP]Ms.[SP]Ideal's[SP]line[SP]of[SP]thought?[1205][000F]\nAfter[SP]all,[SP]you're[SP]switching[SP]out[SP]dreams[SP]and\nreality[SP]for[SP]your[SP]own[SP]convenience...[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nEveryone[SP]says[SP]they[SP]want[SP]peace,[SP]but[SP]maybe[SP]deep\ndown,[SP]they[SP]want[SP]to[SP]tear[SP]it[SP]all[SP]down[SP]and[SP]start\nover[SP]from[SP]the[SP]rubble.",
     "nom_fr": "Maya",
-    "texte_fr": "Peut-on réfuter la logique de Mme Ideal?\n[1205][000F]Vous aussi vous intervertissez rêves et\nréalité à votre avantage...[E1][E2] [E3][E4][NULL][NULL]\"Maya\nChacun\nprétend souhaiter la paix, mais\n peut-êtrequ'inconsciemment on souhaite tout\ndétruire pour pouvoir repartir de zéro."
+    "texte_fr": "Peut-on réfuter la logique de Mme Ideal?\n[000F][1205]Vous aussi vous intervertissez rêves et\nréalité à votre avantage...[E1][E2] [E3][E4][NULL][NULL]\"Maya\nChacun\nprétend souhaiter la paix, mais\n peut-êtrequ'inconsciemment on souhaite tout\ndétruire pour pouvoir repartir de zéro."
   },
   {
     "id": 34,
@@ -522,7 +522,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]reason[SP]the[SP]Last[SP]Battalion[SP]caught[SP]on[SP]so[SP]fast\nmight[SP]be[SP]because[SP]man[SP]secretly[SP]wishes[SP]this[SP]world\nto[SP]be[SP]destroyed...[1205][000F][SP]Is[SP]the[SP]same[SP]true[SP]of[SP]us?",
     "nom_fr": "Maya",
-    "texte_fr": "Si le Bataillon s'est montré si vite, c'est\npeut-être qu'au fond\nles humains souhaitent\nla fin du monde.[1205].[000F].\nEn est-il de même pournous?"
+    "texte_fr": "Si le Bataillon s'est montré si vite, c'est\npeut-être qu'au fond\nles humains souhaitent la fin du monde.[1205].[000F]. En est-il de même pournous?"
   },
   {
     "id": 35,
@@ -672,7 +672,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]know[SP]that[SP]book[SP]is[SP]the[SP]cause[SP]of[SP]all[SP]this...[1205][000F]\nBut[SP]frankly,[SP]it's[SP]the[SP]people[SP]of[SP]Sumaru[SP]who[SP]are\nto[SP]blame.[1205][000F][SP]I[SP]don't[SP]know[SP]how[SP]to[SP]feel[SP]about[SP]that.",
     "nom_fr": "Yukino",
-    "texte_fr": "Je sais que ce livre est la cause de tout\n[1205][000F][1205][000F]ça... Mais honnêtement c'est les habitants\nqu'il faut blâmer. Je\nsais pas trop quoi enpenser."
+    "texte_fr": "Je sais que ce livre est la cause de tout\n[000F][1205][000F][1205]ça... Mais honnêtement c'est les habitants\nqu'il faut blâmer. Je sais pas trop quoi enpenser."
   },
   {
     "id": 45,
@@ -687,7 +687,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Rumors[SP]spread[SP]because[SP]people[SP]unconsciously[SP]want\nthem[SP]to.[SP]I[SP]remember[SP]someone[SP]saying[SP]that...\nGuess[SP]I[SP]can't[SP]blame[SP]it[SP]all[SP]on[SP]Ms.[SP]Okamura.",
     "nom_fr": "Yukino",
-    "texte_fr": "L'inconscient des gens veut que les rumeurs\nse propagent. Quelqu'un\ndisait ça... Je peux\npas blâmer Mme Okamura pour tout j'imagine."
+    "texte_fr": "L'inconscient des gens veut que les rumeurs\nse propagent. Quelqu'un\ndisait ça... Je peux pas blâmer Mme Okamura pour tout j'imagine."
   },
   {
     "id": 46,
@@ -906,7 +906,7 @@
     "nom_orig": "Whistler",
     "texte_orig": "It's[SP]dangerous[SP]out[SP]there.[1205][000F][SP]Make[SP]sure[SP]you[SP]get\nyourself[SP]some[SP]armor.",
     "nom_fr": "Siffleur",
-    "texte_fr": "C'est dangereux là-dehors. [1205][000F]Sois\nsûr d'avoir un peu d'armure."
+    "texte_fr": "C'est dangereux là-dehors. [000F][1205]Sois\nsûr d'avoir un peu d'armure."
   },
   {
     "id": 58,
@@ -1011,7 +1011,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "I[SP]never[SP]had[SP]a[SP]girlfriend.[SP]I[SP]assumed[SP]it[SP]was\nbecause[SP]my[SP]legs[SP]were[SP]so[SP]short.[1205][000F][SP]That's[SP]why[SP]I\nhad[SP]them[SP]lengthened...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Jamais eu de copine, je pensais que\nla cause était mes jambes courtes.\n[1205][000F]Donc je les ai faites allonger..."
+    "texte_fr": "Jamais eu de copine, je pensais que\nla cause était mes jambes courtes.\n[000F][1205]Donc je les ai faites allonger..."
   },
   {
     "id": 65,
@@ -1086,7 +1086,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Looks[SP]like[SP]it[SP]was[SP]a[SP]cell[SP]of[SP]five[SP]terrorists\nsetting[SP]fires.[SP]Heheh,[SP]sounds[SP]like[SP]my[SP]kind[SP]of\npeople.[SP]I[SP]hope[SP]they[SP]burn[SP]the[SP]whole[SP]city[SP]down.",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Apparement ce sont cinq terroristes qui ont\nmis le feu. Héhé, j'aime bien ces gens.\nJ'espère qu'ils réduiront\nSumaru en cendres."
+    "texte_fr": "Apparement ce sont cinq terroristes qui ont\nmis le feu. Héhé, j'aime bien ces gens.\nJ'espère qu'ils réduiront Sumaru en cendres."
   },
   {
     "id": 70,
@@ -1131,7 +1131,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Uuunghhh..[SP]Aaaaagh...[1205][000A][SP]Uaaagh...[E1][E2]\n[E3][E4][NULL][NULL]\"Weird[SP]woman\nHahahah...[SP]I've[SP]been[SP]mocked[SP]all[SP]my[SP]life[SP]for\nbeing[SP]butch,[SP]but[SP]that[SP]ends[SP]today![SP]I've[SP]finally\nbecome[SP]a[SP]man!",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Ggggn... Aaagh...[1205][000A] Uaagh...[E1][E2] [E3][E4][NULL][NULL]\"Pas une\nfemme Haha... Toute ma vie on m'a\ndénigré car j'étais trop masculin, maisc'est\nfini! Je suis enfin un homme!"
+    "texte_fr": "Ggggn... Aaagh...[000A][1205] Uaagh...[E1][E2] [E3][E4][NULL][NULL]\"Pas une\nfemme Haha... Toute ma vie on m'a\ndénigré car j'étais trop masculin, maisc'est\nfini! Je suis enfin un homme!"
   },
   {
     "id": 73,
@@ -1176,7 +1176,7 @@
     "nom_orig": "Weird[SP]woman",
     "texte_orig": "Like[SP]this[SP]guy[SP]a[SP]moment[SP]ago.[SP]He[SP]didn't[SP]believe\nI[SP]was[SP]a[SP]man,[SP]so[SP]I[SP]showed[SP]him[SP]the[SP]goods![SP]Bastard\nran[SP]off[SP]screaming[SP]to[SP]the[SP]detective[SP]agency.",
     "nom_fr": "Pas une femme",
-    "texte_fr": "Genre ce mec avant.\nIl croyait pas que j'étais\nun gars, donc je lui\nai montré! Ce con a hurlé\net fui vers l'agence de détective."
+    "texte_fr": "Genre ce mec avant.\nIl croyait pas que j'étais\nun gars, donc je lui ai montré! Ce con a hurlé et fui vers l'agence de détective."
   },
   {
     "id": 76,
@@ -1206,7 +1206,7 @@
     "nom_orig": "Weird[SP]woman",
     "texte_orig": "I[SP]never[SP]had[SP]any[SP]interest[SP]in[SP]men.[1205][000A][SP]Women,[SP]either.[1205][000F]\nI[SP]never[SP]had[SP]a[SP]relationship[SP]and[SP]I[SP]never[SP]wanted\none.[SP]But[SP]men[SP]just[SP]see[SP]me[SP]as[SP]meat.",
     "nom_fr": "Pas une femme",
-    "texte_fr": "Jamais un homme ou une femme ne m'a attiré.[1205][1205][000A]\n[000F]J'ai jamais eu ou voulu de relation. Mais\npour les mecs je suis de la viande."
+    "texte_fr": "Jamais un homme ou une femme ne m'a attiré.[1205][000A][1205]\n[000F]J'ai jamais eu ou voulu de relation. Mais\npour les mecs je suis de la viande."
   },
   {
     "id": 78,
@@ -1221,7 +1221,7 @@
     "nom_orig": "Weird[SP]woman",
     "texte_orig": "Just[SP]when[SP]I[SP]think[SP]we'd[SP]be[SP]getting[SP]to[SP]be[SP]good\nfriends,[SP]they'd[SP]let[SP]their[SP]dicks[SP]take[SP]over[SP]and\nmake[SP]a[SP]pass[SP]at[SP]me.\n[1205][000F]\n[E4][NULL][NULL]\"Weird[SP]woman\nWhen[SP]I[SP]said[SP]no,[SP]these[SP][1432][NULL][NULL][0014]friends[1432][NULL][NULL][0014][SP]of[SP]mine[SP]turned\nreal[SP]cold...[1205][000F][SP]That's[SP]the[SP]part[SP]I[SP]hated[SP]most.",
     "nom_fr": "Pas une femme",
-    "texte_fr": "Quand je pense avoir trouvé de bons amis,\nleur bite prend le contrôle et ils me font\ndes avances. [E4][NULL][NULL]\"Femme bizarre\n[1205][000F][1205][000F]Pas une femmePuis quand j'ai\ndit non, ces [1432][NULL][NULL][0014]amis[1432][NULL][NULL][0014] sont devenus distants...\nC'est ce qui me débectais le plus."
+    "texte_fr": "Quand je pense avoir trouvé de bons amis,\nleur bite prend le contrôle et ils me font\ndes avances. [E4][NULL][NULL]\"Femme bizarre [000F][1205][000F][1205]Pas une femmePuis quand j'ai dit non, ces [1432][NULL][NULL][0014]amis[1432][NULL][NULL][0014] sont devenus distants... C'est ce qui me débectais le plus."
   },
   {
     "id": 79,
@@ -1251,7 +1251,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "The[SP]attacks[SP]must[SP]be[SP]the[SP]Masked[SP]Circle's[SP]doing!\nI[SP]mean,[SP]why[SP]not?[SP]Who[SP]but[SP]we[SP]of[SP]the[SP]Masked[SP]Circle\nwould[SP]pull[SP]off[SP]something[SP]so[SP]amazing?",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Ces attaques doivent\nêtre l'oeuvre du Cercle\nMasqué! Pourquoi pas? Qui à part nous\npourrait faire quelque chose de si fou?"
+    "texte_fr": "Ces attaques doivent\nêtre l'oeuvre du Cercle\nMasqué! Pourquoi pas? Qui à part nous pourrait faire quelque chose de si fou?"
   },
   {
     "id": 81,
@@ -1326,7 +1326,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "The[SP]Masked[SP]Circle[SP]will[SP]grant[SP]my[SP]ideals[SP]again!\nEvery[SP]foolish[SP]human[SP]across[SP]the[SP]globe[SP]will[SP]burn,\nleaving[SP]only[SP]we[SP]whose[SP]dreams[SP]are[SP]fulfilled!",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Le Cercle Masqué\naccomplira mon idéal! Chaque\nhumain idiot sur le globe brûlera, nous \népargnant nous dont les\nrêves ont été exaucés!"
+    "texte_fr": "Le Cercle Masqué\naccomplira mon idéal! Chaque\nhumain idiot sur le globe brûlera, nous épargnant nous dont les rêves ont été exaucés!"
   },
   {
     "id": 86,
@@ -1341,7 +1341,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Those[SP]guys[SP]in[SP]the[SP]composite[SP]sketches[SP]seem[SP]to[SP]be\nheroes[SP]fighting[SP]against[SP]the[SP]Masked[SP]Circle...\nThey're[SP]morons[SP]to[SP]try[SP]and[SP]challenge[SP]us...",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Ces gens sur les portraits robots seraient\ndes héros qui combattent le Cercle Masqué.\nCes idiots pensent\npouvoir nous affronter..."
+    "texte_fr": "Ces gens sur les portraits robots seraient\ndes héros qui combattent le Cercle Masqué.\nCes idiots pensent pouvoir nous affronter..."
   },
   {
     "id": 87,
@@ -1356,7 +1356,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "I[SP]heard[SP]a[SP]rumor[SP]that[SP]both[SP]we[SP]and[SP]the[SP]Last\nBattalion[SP]are[SP]after[SP]Xibalba.[SP]But[SP]what's[SP]it\nmean?[1205][000F][SP]I[SP]didn't[SP]know[SP]about[SP]this[SP]Xibalba[SP]thing.",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "La rumeur dit que nous et le Bataillon\nnous cherchons Xibalba. Mais ça veut dire\n[1205][000F]quoi? Je savais rien de ce Xibalba moi."
+    "texte_fr": "La rumeur dit que nous et le Bataillon\nnous cherchons Xibalba. Mais ça veut dire\n[000F][1205]quoi? Je savais rien de ce Xibalba moi."
   },
   {
     "id": 88,
@@ -1371,7 +1371,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Joker[SP]ordered[SP]us[SP]to[SP]protect[SP]the[SP]people[SP]of[SP]the\ncity.[SP]Fine[SP]with[SP]me![SP]A[SP]man's[SP]place[SP]is[SP]on[SP]the\nbattlefield![SP]I'll[SP]show[SP]them[SP]how[SP]fierce[SP]we[SP]are!",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Joker nous a ordonné de protéger les\nhabitants. Ça me va!\nUn homme doit se battre!\nOn va leur montrer comme on est féroces!"
+    "texte_fr": "Joker nous a ordonné de protéger les\nhabitants. Ça me va!\nUn homme doit se battre! On va leur montrer comme on est féroces!"
   },
   {
     "id": 89,
@@ -1401,7 +1401,7 @@
     "nom_orig": "Whistler",
     "texte_orig": "I'm[SP]still[SP]getting[SP]ready.[1205][000F][SP]Take[SP]a[SP]hike.",
     "nom_fr": "Siffleur",
-    "texte_fr": "J'suis pas encore prêt. [1205][000F]Va ailleurs."
+    "texte_fr": "J'suis pas encore prêt. [000F][1205]Va ailleurs."
   },
   {
     "id": 91,

--- a/traduction/event_scripts/script_314.json
+++ b/traduction/event_scripts/script_314.json
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP]this[SP]guy[SP]says[SP]he's[SP]in[SP]the[SP]Masked[SP]Circle.\nShould[SP]we[SP]tell[SP]him[SP]that[SP]even[SP]with[SP]the[SP]best\narmor,[SP]he's[SP]screwed[SP]if[SP]he[SP]messes[SP]with[SP]us?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, ce gars dit\nêtre membre du Cercle Masqué.\nOn le prévient que même avec la meilleure \narmure, on l'explosera s'il nous cherche?"
+    "texte_fr": "Hé, ce gars dit\nêtre membre du Cercle Masqué.\nOn le prévient que même avec la meilleure armure, on l'explosera s'il nous cherche?"
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Umm...[1205][000A][SP]A-Are[SP]you[SP]the[SP]owner's[SP]son?[1205][000F][SP]H-Hello...",
     "nom_fr": "Maya",
-    "texte_fr": "Hum,[1205][000A] Êtes-vous le fils du gérant? [1205][000F]Salut..."
+    "texte_fr": "Hum,[000A][1205] Êtes-vous le fils du gérant? [000F][1205]Salut..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]boy's[SP]good...[1205][001E][SP]He[SP]even[SP]deflected[SP]my[SP]smile\nguaranteed[SP]to[SP]make[SP]a[SP]crying[SP]baby[SP]giggle.",
     "nom_fr": "Maya",
-    "texte_fr": "Ce garçon est doué,[1205][001E] il repousse mon sourire\nauquel aucun bébé en pleurs ne résiste."
+    "texte_fr": "Ce garçon est doué,[001E][1205] il repousse mon sourire\nauquel aucun bébé en pleurs ne résiste."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Try[SP]not[SP]to[SP]pick[SP]on[SP]them[SP]too[SP]much,[SP]Lisa...[1205][001E]\nThey[SP]are[SP]in[SP]the[SP]Masked[SP]Circle,[SP]but[SP]apart[SP]from\nthat,[SP]they're[SP]no[SP]different[SP]from[SP]anyone[SP]else...",
     "nom_fr": "Jun",
-    "texte_fr": "Ne sois pas trop rude avec eux, Lisa...[1205][001E]\nIls ont beau être dans le Cercle Masqué,\nce sont des gens comme les autres..."
+    "texte_fr": "Ne sois pas trop rude avec eux, Lisa...[001E][1205]\nIls ont beau être dans le Cercle Masqué,\nce sont des gens comme les autres..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Jun",
     "texte_orig": "My[SP]younger[SP]days...[1205][001E][SP]They're[SP]nostalgic,[SP]and[SP]sad\nas[SP]well...[1205][001E][SP]But[SP]I[SP]can't[SP]keep[SP]dwelling[SP]on[SP]the\npast[SP]forever.",
     "nom_fr": "Jun",
-    "texte_fr": "Mon enfance...[1205][001E] Me rend nostalgique,\net triste aussi...[1205][001E] Mais je dois\ncesser d'être bloqué dans le passé."
+    "texte_fr": "Mon enfance...[001E][1205] Me rend nostalgique,\net triste aussi...[001E][1205] Mais je dois\ncesser d'être bloqué dans le passé."
   },
   {
     "id": 8,
@@ -261,7 +261,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Looks[SP]like[SP]our[SP]comrades[SP]are[SP]fighting[SP]against\nthe[SP]Last[SP]Battalion[SP]inside[SP]that[SP]temple[SP]as[SP]we\nspeak.[1205][000F][SP]I[SP]better[SP]hurry[SP]and[SP]help[SP]them!",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Nos camarades semblent encore se battre\ncontre le Bataillon dans le temple. Je\n[1205][000F]dois me dépêcher d'aller les aider!"
+    "texte_fr": "Nos camarades semblent encore se battre\ncontre le Bataillon dans le temple. Je\n[000F][1205]dois me dépêcher d'aller les aider!"
   },
   {
     "id": 15,
@@ -276,7 +276,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "...But[SP]the[SP]armor[SP]here[SP]is[SP]a[SP]little[SP]pricey...[1205][000F]\nAnd[SP]going[SP]into[SP]battle[SP]without[SP]it[SP]is[SP]suicide...[1205][000F]\nI've[SP]gotta[SP]do[SP]something[SP]about[SP]that[SP]first...",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "... Mais les armures ici ne sont pas\n[1205][000F][1205][000F]données... Et aller au front sans serait du\nsuicide... Je dois\nd'abord m'occuper de ça..."
+    "texte_fr": "... Mais les armures ici ne sont pas\n[000F][1205][000F][1205]données... Et aller au front sans serait du\nsuicide... Je dois d'abord m'occuper de ça..."
   },
   {
     "id": 16,

--- a/traduction/event_scripts/script_315.json
+++ b/traduction/event_scripts/script_315.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "No[SP]one[SP]at[SP]my[SP]school[SP]smokes![SP]I[SP]have[SP]a[SP]strict\nrule[SP]against[SP]it.[1205][001E][SP]The[SP]same[SP]goes[SP]for[SP]Ken,[SP]Shogo,\nand[SP]Takeshi,[SP]too...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Zéro fumeur chez moi! C'est ma règle.[1205][001E]\nPareil pour Ken, Shogo et Takeshi..."
+    "texte_fr": "Zéro fumeur chez moi! C'est ma règle.[001E][1205]\nPareil pour Ken, Shogo et Takeshi..."
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yeah![SP]Mission[SP]accomplished![1205][000F][SP]Elly-san[SP]was[SP]right\non[SP]the[SP]money.[SP]Guess[SP]there's[SP]something[SP]to[SP]this\nastrology[SP]stuff[SP]after[SP]all.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ouais! Mission accomplie! [1205][000F]Elly a\nvu juste. Faut croire qu'il y a du\nvrai dans ces trucs d'astrologie."
+    "texte_fr": "Ouais! Mission accomplie! [000F][1205]Elly a\nvu juste. Faut croire qu'il y a du\nvrai dans ces trucs d'astrologie."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Tch,[SP]I[SP]hate[SP]this...[1205][000F][SP]That[SP]lion[SP]bastard[SP]just\nmoved[SP]up[SP]to[SP]the[SP]top[SP]of[SP]my[SP]list![SP]I'll[SP]tear\nhim[SP]to[SP]pieces[SP]with[SP]my[SP]own[SP]hands!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tch, je déteste ça.[1205][000F].. Ce lion de\nmalheur est en haut de ma liste! Je\nle mettrai en pièces à mains nues!"
+    "texte_fr": "Tch, je déteste ça.[000F][1205].. Ce lion de\nmalheur est en haut de ma liste! Je\nle mettrai en pièces à mains nues!"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "No...[SP]Playing[SP]Masked[SP]Circle...[1205][000F][SP]It[SP]was[SP]just[SP]a\ndream...[SP]H-Hey,[SP]c'mon,[SP]it[SP]was[SP]just[SP]a[SP]dream!\nTell[SP]me[SP]it[SP]was[SP]only[SP]a[SP]dream,[SP][1113]!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Non... Le Cercle masqué.[1205][000F].. C'était\nqu'un rêve... Hé, dis-moi que\nc'était juste un rêve, [1113]!"
+    "texte_fr": "Non... Le Cercle masqué.[000F][1205].. C'était\nqu'un rêve... Hé, dis-moi que\nc'était juste un rêve, [1113]!"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey,[SP][1114]...[1205][000F][SP]We[SP]did[SP]play[SP]Masked[SP]Circle,\nbut[SP]I[SP]don't[SP]think[SP]we[SP]ever[SP]played[SP]drugstore.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, [1114].[1205][000F].. On a joué au Cercle, mais\npas à la pharmacie, je crois."
+    "texte_fr": "Hé, [1114].[000F][1205].. On a joué au Cercle, mais\npas à la pharmacie, je crois."
   },
   {
     "id": 7,
@@ -192,7 +192,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Weren't[SP]there[SP]still[SP]people[SP]inside[SP]Smile\nHirasaka?[1205][000F][SP]We[SP]couldn't[SP]do[SP]anything...[1205][000F]\nSorry-ia...[SP]*sniff*",
     "nom_fr": "Ginko",
-    "texte_fr": "Y'avait des gens au Smile Hirasaka? [1205][000F][1205][000F]On\nn'a rien pu faire... Pardon... *sniff*"
+    "texte_fr": "Y'avait des gens au Smile Hirasaka? [000F][1205][000F][1205]On\nn'a rien pu faire... Pardon... *sniff*"
   },
   {
     "id": 13,
@@ -237,7 +237,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "If...[1205][000F][SP]If[SP]they're[SP]Joker,[SP]then[SP]we[SP]have[SP]to[SP]clear\nup[SP]what[SP]happened[SP]10[SP]years[SP]ago...[1205][000F][SP]That'll[SP]help\nus[SP]figure[SP]everything[SP]out...",
     "nom_fr": "Ginko",
-    "texte_fr": "Si c'est eux le Joker, il faut\n[1205][000F][1205][000F]clarifier ce qui s'est passé il\ny a 10 ans... Ça nous aidera..."
+    "texte_fr": "Si c'est eux le Joker, il faut\n[000F][1205][000F][1205]clarifier ce qui s'est passé il\ny a 10 ans... Ça nous aidera..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey[SP][1113],[SP]once[SP]this[SP]is[SP]all[SP]settled,[SP]let's\nplay[SP]Masked[SP]Circle[SP]again.[1205][000F][SP]It[SP]might[SP]actually\nbe[SP]fun!",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé [1113], une fois que ce sera\nréglé, rejouons au Cercle masqué.\n[1205][000F]Ce sera peut-être amusant!"
+    "texte_fr": "Hé [1113], une fois que ce sera\nréglé, rejouons au Cercle masqué.\n[000F][1205]Ce sera peut-être amusant!"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Nothing[SP]wrong[SP]with[SP]carrying[SP]a[SP]lighter,[SP]but,\numm...[1205][001E][SP]Just[SP]be[SP]careful![SP]Ahahah.[SP]It[SP]would[SP]be\nawful[SP]if[SP]anything[SP]caught[SP]fire,[SP]right?",
     "nom_fr": "Maya",
-    "texte_fr": "Y'a pas de mal à avoir un briquet, mais,\neuh...[1205][001E] Sois prudent! Ahahah. Ce serait\naffreux si quelque chose prenait feu, non?"
+    "texte_fr": "Y'a pas de mal à avoir un briquet, mais,\neuh...[001E][1205] Sois prudent! Ahahah. Ce serait\naffreux si quelque chose prenait feu, non?"
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Huh,[SP]so[SP]Satomi[SP]Tadashi[SP]uses[SP]different[SP]remixes\nin[SP]each[SP]branch.[1205][000F][SP]I[SP]like[SP]the[SP]version[SP]at[SP]this\nplace[SP]too.",
     "nom_fr": "Maya",
-    "texte_fr": "Satomi Tadashi remixe selon la boutique.\n[1205][000F]J'aime bien la version d'ici aussi."
+    "texte_fr": "Satomi Tadashi remixe selon la boutique.\n[000F][1205]J'aime bien la version d'ici aussi."
   },
   {
     "id": 19,
@@ -327,7 +327,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]know[SP]this[SP]is[SP]tough...[SP]But[SP]we[SP]can't[SP]allow[SP]any\nmore[SP]casualties,[SP]for[SP]the[SP]sake[SP]of[SP]the[SP]ones[SP]who\ngot[SP]dragged[SP]into[SP]this.[SP]Let's[SP]go[SP]stop[SP]him!",
     "nom_fr": "Maya",
-    "texte_fr": "C'est dur, je sais... Mais on ne peut pas\npermettre d'autres victimes,\npour ceux qui ont\nété entraînés là-dedans. Allons l'arrêter!"
+    "texte_fr": "C'est dur, je sais... Mais on ne peut pas\npermettre d'autres victimes,\npour ceux qui ont été entraînés là-dedans. Allons l'arrêter!"
   },
   {
     "id": 22,
@@ -372,7 +372,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Frightened[SP]of[SP]his[SP]memory[SP]from[SP]ten[SP]years[SP]ago...[1205][000F]\nOr[SP]rather,[SP]frightened[SP]to[SP]admit[SP]that[SP]it[SP]really\nhappened.[SP]Isn't[SP]it[SP]the[SP]same[SP]for[SP]you,[SP]too?",
     "nom_fr": "Maya",
-    "texte_fr": "Effrayé par son souvenir d'il y a 10 ans.[1205].[000F].\nOu plutôt, effrayé d'admettre que c'est\nvraiment arrivé. Pas\npareil pour toi, aussi?"
+    "texte_fr": "Effrayé par son souvenir d'il y a 10 ans.[1205].[000F].\nOu plutôt, effrayé d'admettre que c'est\nvraiment arrivé. Pas pareil pour toi, aussi?"
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Did[SP]you[SP]hear[SP]Lisa's[SP]idea?[SP]Let's[SP]play[SP]Masked\nCircle[SP]again.[SP]This[SP]time,[SP]we'll[SP]do[SP]a[SP]drugstore![1205][000F]\nHehe...[SP]I[SP]should[SP]ask[SP]Yukki[SP]to[SP]join[SP]us.",
     "nom_fr": "Maya",
-    "texte_fr": "L'idée de Lisa? Rejouer au Cercle masqué,\nversion pharmacie! [1205][000F]Héhé... Je vais inviter\nYukki."
+    "texte_fr": "L'idée de Lisa? Rejouer au Cercle masqué,\nversion pharmacie! [000F][1205]Héhé... Je vais inviter\nYukki."
   },
   {
     "id": 26,
@@ -477,7 +477,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]know[SP]how[SP]you[SP]guys[SP]feel.[SP]I'm[SP]angry[SP]at[SP]myself\ntoo,[SP]but[SP]it's[SP]at[SP]times[SP]like[SP]these[SP]that[SP]we[SP]need\nto[SP]keep[SP]calm.[SP]Consider[SP]it[SP]advice[SP]from[SP]a[SP]senpai.",
     "nom_fr": "Yukino",
-    "texte_fr": "Je vous comprends. Je\nm'en veux, mais on doit\nrester calmes. C'est\nle conseil d'une senpai."
+    "texte_fr": "Je vous comprends. Je\nm'en veux, mais on doit\nrester calmes. C'est le conseil d'une senpai."
   },
   {
     "id": 32,
@@ -507,7 +507,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Maya-san...[SP]I[SP]can[SP]hear[SP]you.[1205][000F][SP]Honestly,[SP]you're\ntoo[SP]old[SP]for[SP]that...[1205][000F][SP]Count[SP]me[SP]out.",
     "nom_fr": "Yukino",
-    "texte_fr": "Maya... Je t'entends. [1205][000F][1205][000F]T'es trop\nvieille pour ça... Sans moi."
+    "texte_fr": "Maya... Je t'entends. [000F][1205][000F][1205]T'es trop\nvieille pour ça... Sans moi."
   },
   {
     "id": 34,
@@ -622,7 +622,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Leave[SP]it[SP]to[SP]us[SP]Seven[SP]Satomi[SP]Sisters[SP]to\nbrainwash--[1205][001E]I[SP]mean,[SP]take[SP]over[SP]this[SP]city!\nHeeheehee!",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Les sœurs Satomi vont laver le cerveau--[1205][001E]\neuh, diriger la ville! Héhéhé!"
+    "texte_fr": "Les sœurs Satomi vont laver le cerveau--[001E][1205]\neuh, diriger la ville! Héhéhé!"
   },
   {
     "id": 39,
@@ -637,7 +637,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Our[SP]medicine[SP]was[SP]a[SP]hot[SP]seller[SP]until[SP]recently.[1205][000F]\nYou[SP]know[SP]how[SP]Cuss[SP]High[SP]is[SP]close[SP]by?[1205][000F][SP]Those[SP]kids\nare[SP]so[SP]hot-blooded,[SP]sales[SP]were[SP]sky-high.",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Ça se vendait bien avant. Le Lycée\n[1205][000F][1205][000F]Kakasu est près. Leurs ados au sang\nchaud faisaient exploser les ventes."
+    "texte_fr": "Ça se vendait bien avant. Le Lycée\n[000F][1205][000F][1205]Kakasu est près. Leurs ados au sang\nchaud faisaient exploser les ventes."
   },
   {
     "id": 40,
@@ -652,7 +652,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "But[SP]it's[SP]really[SP]dropped[SP]off.[1205][000F][SP]The[SP]Cuss[SP]High[SP]kids\nhave[SP]suddenly[SP]calmed[SP]down.[SP]It's[SP]ruining[SP]our\nbusiness...[SP]*sniff*",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Mais ça a chuté. [1205][000F]Les jeunes de\nKakasu se sont soudain calmés. Ça\nruine notre affaire... *sniff*"
+    "texte_fr": "Mais ça a chuté. [000F][1205]Les jeunes de\nKakasu se sont soudain calmés. Ça\nruine notre affaire... *sniff*"
   },
   {
     "id": 41,
@@ -667,7 +667,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "That[SP]reminds[SP]me,[SP]how[SP]did[SP]the[SP]masquerade[SP]go?\nKasuga[SP]Festival[SP]was[SP]the[SP]talk[SP]of[SP]the[SP]city,\nbut[SP]it[SP]ended[SP]without[SP]a[SP]bang,[SP]so[SP]to[SP]speak.",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Ça me rappelle, comment s'est passée la\nmascarade? Tout le\nmonde parlait du festival\nKasuga, mais ça a fini sans étincelle."
+    "texte_fr": "Ça me rappelle, comment s'est passée la\nmascarade? Tout le\nmonde parlait du festival Kasuga, mais ça a fini sans étincelle."
   },
   {
     "id": 42,
@@ -697,7 +697,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "I[SP]heard[SP]the[SP]terrorists[SP]targeted[SP]Smile[SP]Hirasaka.[1205][000F]\nThank[SP]goodness[SP]it[SP]was[SP]prevented,[SP]but[SP]maybe[SP]the\nrumors[SP]of[SP]random[SP]acts[SP]of[SP]violence[SP]are[SP]true...",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Les terroristes visaient le Smile\n[1205][000F]Hirasaka. On l'a évité, mais les rumeurs\nde violences aléatoires sont vraies..."
+    "texte_fr": "Les terroristes visaient le Smile\n[000F][1205]Hirasaka. On l'a évité, mais les rumeurs\nde violences aléatoires sont vraies..."
   },
   {
     "id": 44,
@@ -727,7 +727,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "This[SP]strangely[SP]dressed[SP]girl[SP]just[SP]came[SP]by.[1205][000F]\nShe[SP]said[SP]something[SP]about[SP]those[SP]five[SP]actually\nbeing[SP]heroes...[1205][000F][SP]Well,[SP]I[SP]don't[SP]care[SP]much.",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Une fille bizarrement vêtue est passée.\n[1205][000F][1205][000F]Elle a dit que ces cinq-là étaient en fait\ndes héros... Bref, je m'en fiche un peu."
+    "texte_fr": "Une fille bizarrement vêtue est passée.\n[000F][1205][000F][1205]Elle a dit que ces cinq-là étaient en fait\ndes héros... Bref, je m'en fiche un peu."
   },
   {
     "id": 46,
@@ -772,7 +772,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Satomi[SP]Tadashi[SP]is[SP]open[SP]all[SP]year[SP]'round![1205][000A]\nCome[SP]back[SP]soon![SP]Heeheehee!",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Satomi Tadashi est ouvert toute\nl'année![1205][000A] Revenez vite! Héhéhé!"
+    "texte_fr": "Satomi Tadashi est ouvert toute\nl'année![000A][1205] Revenez vite! Héhéhé!"
   },
   {
     "id": 49,
@@ -787,7 +787,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Tum[SP]te[SP]duuuum...[1205][001E][SP]*gasp*[SP]The[SP]song![SP]I[SP]can't[SP]get\nit[SP]out[SP]of[SP]my[SP]head![SP]Hmm[SP]hmmmm[SP]hm[SP]hmmmmm...",
     "nom_fr": "Employé",
-    "texte_fr": "Tou dou doum...[1205][001E]\n*gasp* La chanson! Impossible\nde l'oublier! Hmm hmmmm hm hmmmmm..."
+    "texte_fr": "Tou dou doum...[001E][1205]\n*gasp* La chanson! Impossible\nde l'oublier! Hmm hmmmm hm hmmmmm..."
   },
   {
     "id": 50,
@@ -802,7 +802,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Noooo![SP]The[SP]song[SP]won't[SP]leave[SP]my[SP]brain![1205][000F][SP]I[SP]should\nget[SP]out[SP]of[SP]this[SP]store...[1205][000F][SP]but[SP]I[SP]can't![SP]And[SP]I\ndon't[SP]know[SP]why!",
     "nom_fr": "Employé",
-    "texte_fr": "Non! La chanson me hante! [1205][000F][1205][000F]Je dois\nfuir ce magasin... Mais je n'y\narrive pas! Et j'ignore pourquoi!"
+    "texte_fr": "Non! La chanson me hante! [000F][1205][000F][1205]Je dois\nfuir ce magasin... Mais je n'y\narrive pas! Et j'ignore pourquoi!"
   },
   {
     "id": 51,
@@ -817,7 +817,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Noooo![SP]I[SP]was[SP]so[SP]excited[SP]about[SP]that[SP]idol[SP]trio,\nbut[SP]I[SP]can't[SP]listen[SP]to[SP]anything[SP]besides[SP]this\nsong![1205][000F][SP]Someone[SP]stop[SP]it--wait,[SP]no,[SP]don't!",
     "nom_fr": "Employé",
-    "texte_fr": "Noooon! J'aimais ce trio d'idoles, mais\nje n'écoute plus que cette chanson! Que\n[1205][000F]quelqu'un l'arrête--non, attendez!"
+    "texte_fr": "Noooon! J'aimais ce trio d'idoles, mais\nje n'écoute plus que cette chanson! Que\n[000F][1205]quelqu'un l'arrête--non, attendez!"
   },
   {
     "id": 52,
@@ -832,7 +832,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "No[SP]more![1205][000F][SP]I've[SP]hit[SP]my[SP]limit![1205][000F][SP]How[SP]much[SP]longer\ndo[SP]I[SP]have[SP]to[SP]keep[SP]listening[SP]to[SP]this[SP]song!?\nI've[SP]had[SP]enough![SP]Stooooooop!",
     "nom_fr": "Employé",
-    "texte_fr": "Assez! [1205][000F][1205][000F]Je suis à bout! Combien de\ntemps vais-je encore subir cette\nchanson!? J'en ai marre! Stop!"
+    "texte_fr": "Assez! [000F][1205][000F][1205]Je suis à bout! Combien de\ntemps vais-je encore subir cette\nchanson!? J'en ai marre! Stop!"
   },
   {
     "id": 53,
@@ -892,7 +892,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Huh?[SP]Have[SP]any[SP]kids[SP]been[SP]here?[1205][000F][SP]Yeah,[SP]I[SP]saw\na[SP]couple[SP]of[SP]'em...[1205][000F][SP]But[SP]I[SP]was[SP]paying[SP]more\nattention[SP]to[SP]the[SP]song...",
     "nom_fr": "Employé",
-    "texte_fr": "Hein? Des jeunes sont venus? [1205][000F][1205][000F]Ouais,\nj'en ai vu quelques-uns... Mais je\nfaisais plus attention à la chanson..."
+    "texte_fr": "Hein? Des jeunes sont venus? [000F][1205][000F][1205]Ouais,\nj'en ai vu quelques-uns... Mais je\nfaisais plus attention à la chanson..."
   },
   {
     "id": 57,
@@ -952,7 +952,7 @@
     "nom_orig": "Composer",
     "texte_orig": "Sometimes[SP]this[SP]causes[SP]me[SP]to[SP]see[SP]things[SP]that\nordinary[SP]people[SP]can't.[SP]Such[SP]as[SP]the[SP]blue[SP]door[SP]to\nthe[SP]Velvet[SP]Room...[1205][001E][SP]Hmm,[SP]that[SP]gives[SP]me[SP]an[SP]idea!",
     "nom_fr": "Compositeur",
-    "texte_fr": "Ça me fait voir des choses invisibles aux\nautres. Comme la porte bleue de la Chambre\nde Velours...[1205][001E] Hmm, ça me donne une idée!"
+    "texte_fr": "Ça me fait voir des choses invisibles aux\nautres. Comme la porte bleue de la Chambre\nde Velours...[001E][1205] Hmm, ça me donne une idée!"
   },
   {
     "id": 61,
@@ -1042,7 +1042,7 @@
     "nom_orig": "Composer",
     "texte_orig": "I[SP]went[SP]to[SP]see[SP]the[SP]composite[SP]sketches,[SP]and[SP]I[SP]was\nsurprised[SP]to[SP]find[SP]they[SP]were[SP]much[SP]younger[SP]than[SP]I\nexpected.[SP]They[SP]were[SP]around[SP]your[SP]age,[SP]in[SP]fact.",
     "nom_fr": "Compositeur",
-    "texte_fr": "J'ai vu les portraits-robots, et j'ai été\nsurpris de voir qu'ils étaient bien plus\njeunes que prévu. Ils\navaient votre âge, enfait."
+    "texte_fr": "J'ai vu les portraits-robots, et j'ai été\nsurpris de voir qu'ils étaient bien plus\njeunes que prévu. Ils avaient votre âge, enfait."
   },
   {
     "id": 67,
@@ -1057,7 +1057,7 @@
     "nom_orig": "Composer",
     "texte_orig": "Hmmm...[SP]Evildoers...[SP]or[SP]agents[SP]of[SP]justice...?[1205][000F]\nThis[SP]may[SP]be[SP]quite[SP]a[SP]promising[SP]theme...[SP]Aha!\nI've[SP]got[SP]it!",
     "nom_fr": "Compositeur",
-    "texte_fr": "Hmmm... Malfaiteurs... ou agents\n[1205][000F]de la justice...? C'est un thème\nprometteur... Aha! Je l'ai!"
+    "texte_fr": "Hmmm... Malfaiteurs... ou agents\n[000F][1205]de la justice...? C'est un thème\nprometteur... Aha! Je l'ai!"
   },
   {
     "id": 68,
@@ -1102,7 +1102,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Welcome[SP]to[SP]Satomi[SP]Tadashi.[1205][000F][SP]I'm[SP]sorry,[SP]but[SP]we're\nnot[SP]quite[SP]open[SP]for[SP]business[SP]yet.[1205][000F][SP]Please[SP]come\nback[SP]in[SP]a[SP]while.",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Bienvenue chez Satomi Tadashi.\n[1205][000F][1205][000F]Désolée, on n'est pas encore tout\nà fait ouverts. Revenez plus tard."
+    "texte_fr": "Bienvenue chez Satomi Tadashi.\n[000F][1205][000F][1205]Désolée, on n'est pas encore tout\nà fait ouverts. Revenez plus tard."
   },
   {
     "id": 71,
@@ -1117,7 +1117,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Ah,[SP]yes,[SP]welcome![1205][000A][SP]We[SP]work[SP]hard[SP]to[SP]spread[SP]our\nchain[SP]throughout[SP]the[SP]country![1205][000F][SP]What[SP]is[SP]it\nyou're[SP]here[SP]for[SP]today?\n[1208][0006]Buy[SP]items\nSell[SP]items\nTalk[SP]to[SP]Sister[SP]#5\n[1210][B_00][U+5601][B_00]iew[SP]items\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Ah, oui, bienvenue! [1205][000A][1205]On travaille dur pour\nétendre notre chaîne dans tout le pays!\n[000F]Que viens-tu chercher?\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°5\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
+    "texte_fr": "Ah, oui, bienvenue! [000A][1205][1205]On travaille dur pour\nétendre notre chaîne dans tout le pays!\n[000F]Que viens-tu chercher?\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°5\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
     "question_orig": "Ah,[SP]yes,[SP]welcome![1205][000A][SP]We[SP]work[SP]hard[SP]to[SP]spread[SP]our\nchain[SP]throughout[SP]the[SP]country![1205][000F][SP]What[SP]is[SP]it\nyou're[SP]here[SP]for[SP]today?",
     "choix_orig": [
       "Buy[SP]items",
@@ -1217,7 +1217,7 @@
     "nom_orig": "Hanako's[SP]mother",
     "texte_orig": "I[SP]know[SP]she's[SP]an[SP]inquisitive[SP]child,[SP]but[SP]for[SP]a[SP]girl\nto[SP]sneak[SP]into[SP]an[SP]all-male[SP]high[SP]school[SP]like[SP]that...[1205][000F]\nWell,[SP]at[SP]least[SP]I[SP]admire[SP]her[SP]fearlessness.",
     "nom_fr": "Mère d'Hanako",
-    "texte_fr": "Elle est curieuse, mais qu'une fille\ns'infiltre dans un\nlycée pour garçons ainsi...\n[1205][000F]Eh bien, j'admire au moins son intrépidité."
+    "texte_fr": "Elle est curieuse, mais qu'une fille\ns'infiltre dans un\nlycée pour garçons ainsi... [000F][1205]Eh bien, j'admire au moins son intrépidité."
   },
   {
     "id": 76,

--- a/traduction/event_scripts/script_316.json
+++ b/traduction/event_scripts/script_316.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey,[SP][1114]...[1205][000F][SP]We[SP]did[SP]play[SP]Masked[SP]Circle,\nbut[SP]I[SP]don't[SP]think[SP]we[SP]ever[SP]played[SP]drugstore.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, [1114].[1205][000F].. On a joué au Cercle masqué,\nmais jamais à la pharmacie."
+    "texte_fr": "Hé, [1114].[000F][1205].. On a joué au Cercle masqué,\nmais jamais à la pharmacie."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey[SP][1113],[SP]once[SP]this[SP]is[SP]all[SP]settled,[SP]let's\nplay[SP]Masked[SP]Circle[SP]again.[1205][000F][SP]It[SP]might[SP]actually\nbe[SP]fun!",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé [1113], quand tout ça sera réglé, rejouons\nau Cercle masqué. [1205][000F]Ça pourrait être amusant!"
+    "texte_fr": "Hé [1113], quand tout ça sera réglé, rejouons\nau Cercle masqué. [000F][1205]Ça pourrait être amusant!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Did[SP]you[SP]hear[SP]Lisa's[SP]idea?[SP]Let's[SP]play[SP]Masked\nCircle[SP]again.[SP]This[SP]time,[SP]we'll[SP]do[SP]a[SP]drugstore![1205][000F]\nI'll[SP]get[SP]Jun-kun[SP]to[SP]join[SP]in[SP]too,[SP]of[SP]course!",
     "nom_fr": "Maya",
-    "texte_fr": "Tu as entendu l'idée de Lisa? Jouons au\nCercle masqué! Cette fois, la pharmacie.\n[1205][000F]Jun-kun se joindra à nous aussi, bien sûr !"
+    "texte_fr": "Tu as entendu l'idée de Lisa? Jouons au\nCercle masqué! Cette fois, la pharmacie.\n[000F][1205]Jun-kun se joindra à nous aussi, bien sûr !"
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Heeheehee![1205][000A][SP]But...[SP]*sniiiiiff*[SP]Anything[SP]else?\n[1208][0006]Buy[SP]items\nSell[SP]items\nTalk[SP]to[SP]Sister[SP]#5\n[1210][B_00][U+5601][B_00]iew[SP]items\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Hihihi![1205][000A] Mais... *sniiiif* Autre chose?\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°5\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
+    "texte_fr": "Hihihi![000A][1205] Mais... *sniiiif* Autre chose?\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°5\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
     "question_orig": "Heeheehee![1205][000A][SP]But...[SP]*sniiiiiff*[SP]Anything[SP]else?",
     "choix_orig": [
       "Buy[SP]items",
@@ -172,7 +172,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "*sniff*[SP]What[SP]good[SP]is[SP]a[SP]city[SP]that[SP]flies[SP]through\nthe[SP]air!?[1205][000F][SP]And[SP]they[SP]say[SP]the[SP]Earth[SP]down[SP]below\nis[SP]going[SP]to[SP]be[SP]annihilated,[SP]right?",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "*renifle* À quoi ça sert une ville dans\nles airs![1205][000F]? Ils disent que la Terre\nlà-bas va être anéantie, c'est ça?"
+    "texte_fr": "*renifle* À quoi ça sert une ville dans\nles airs![000F][1205]? Ils disent que la Terre\nlà-bas va être anéantie, c'est ça?"
   },
   {
     "id": 9,
@@ -202,7 +202,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "I[SP]wonder[SP]what[SP]my[SP]sisters[SP]plan[SP]to[SP]do...[SP]I'm[SP]not\ngiving[SP]up[SP]yet,[SP]anyway.[1205][000F][SP]But[SP]the[SP]future[SP]is[SP]full\nof[SP]problems...[1205][000F][SP]*sniff*",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Je me demande ce que mes sœurs font...\nJe n'abandonne pas encore. [1205][000F][1205][000F]Mais l'avenir\nest plein de soucis... *renifle*"
+    "texte_fr": "Je me demande ce que mes sœurs font...\nJe n'abandonne pas encore. [000F][1205][000F][1205]Mais l'avenir\nest plein de soucis... *renifle*"
   },
   {
     "id": 11,
@@ -217,7 +217,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Satomi[SP]Tadashi[SP]is[SP]open[SP]all[SP]year[SP]'round!\nCome[SP]back[SP]soon![1205][000A][SP]Heeheehee![SP]Also,[SP]*sniff*!",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Satomi Tadashi, ouvert toute\nl'année! Revenez![1205][000A] Héhéhé! *renifle*!"
+    "texte_fr": "Satomi Tadashi, ouvert toute\nl'année! Revenez![000A][1205] Héhéhé! *renifle*!"
   },
   {
     "id": 12,
@@ -232,7 +232,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "*sniff*[SP]My[SP]company[SP]went[SP]under[SP]while[SP]I[SP]was[SP]here\nlistening[SP]to[SP]this[SP]song...[1205][000F][SP]Well,[SP]more[SP]like[SP]it\ngot[SP]destroyed[SP]by[SP]those[SP]huge[SP]rings...",
     "nom_fr": "Employé",
-    "texte_fr": "*renifle* Mon entreprise a coulé\npendant que j'écoutais cette chanson.[1205][000F]..\nDétruite par ces immenses anneaux..."
+    "texte_fr": "*renifle* Mon entreprise a coulé\npendant que j'écoutais cette chanson.[000F][1205]..\nDétruite par ces immenses anneaux..."
   },
   {
     "id": 13,
@@ -262,7 +262,7 @@
     "nom_orig": "Composer",
     "texte_orig": "But[SP]the[SP]only[SP]songs[SP]I[SP]can[SP]think[SP]of[SP]now[SP]are[SP]dirges\nof[SP]destruction[SP]and[SP]preludes[SP]to[SP]annihilation...[1205][000F]\nMuch,[SP]much[SP]too[SP]depressing.",
     "nom_fr": "Compositeur",
-    "texte_fr": "Seules des marches funèbres et des préludes\nà la destruction...\n[1205][000F]Vraiment trop déprimant."
+    "texte_fr": "Seules des marches funèbres et des préludes\nà la destruction...\n[000F][1205]Vraiment trop déprimant."
   },
   {
     "id": 15,
@@ -277,7 +277,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Ah,[SP]yes,[SP]welcome![1205][000A][SP]We[SP]work[SP]hard[SP]to[SP]spread[SP]our\nchain[SP]throughout[SP]the[SP]country![1205][000F][SP]But[SP]that[SP]will\nnever[SP]happen[SP]now![SP]*sniff*\n[1208][0006]Buy[SP]items\nSell[SP]items\nTalk[SP]to[SP]Sister[SP]#5\n[1210][B_00][U+5601][B_00]iew[SP]items\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Ah, oui, bienvenue![1205][1205][000A] On travaille dur pour\nétendre notre chaîne dans tout le pays!\n[000F]Mais c'est fichu maintenant! *snif*\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°5\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
+    "texte_fr": "Ah, oui, bienvenue![1205][000A][1205] On travaille dur pour\nétendre notre chaîne dans tout le pays!\n[000F]Mais c'est fichu maintenant! *snif*\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°5\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
     "question_orig": "Ah,[SP]yes,[SP]welcome![1205][000A][SP]We[SP]work[SP]hard[SP]to[SP]spread[SP]our\nchain[SP]throughout[SP]the[SP]country![1205][000F][SP]But[SP]that[SP]will\nnever[SP]happen[SP]now![SP]*sniff*",
     "choix_orig": [
       "Buy[SP]items",
@@ -462,7 +462,7 @@
     "nom_orig": "Sister[SP]#5",
     "texte_orig": "Our[SP]resale[SP]prices[SP]are[SP]around[SP]half[SP]the[SP]original\nprice.[SP]You[SP]can't[SP]sell[SP]anything[SP]you[SP]have[SP]equipped,\nand[SP]some[SP]special[SP]items[SP]are[SP]off-limits[SP]too.",
     "nom_fr": "Sœur n°5",
-    "texte_fr": "Revente à moitié prix\nenviron. Vous ne pouvez\npas vendre ce qui\nest équipé ni les spéciaux."
+    "texte_fr": "Revente à moitié prix\nenviron. Vous ne pouvez\npas vendre ce qui est équipé ni les spéciaux."
   },
   {
     "id": 25,

--- a/traduction/event_scripts/script_317.json
+++ b/traduction/event_scripts/script_317.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Making[SP]beautiful[SP]poses[SP]is[SP]a[SP]strain[SP]on[SP]the[SP]body.\nOwww...[1205][001E][SP]My[SP]shoulders[SP]are[SP]stiff...[1205][001E][SP]I[SP]should[SP]have\nthis[SP]checked[SP]out.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Prendre des poses artistiques est\nfatiguant. Aïe...[1205][001E] J'ai les épaules\nraides...[1205][001E] Faut que je consulte."
+    "texte_fr": "Prendre des poses artistiques est\nfatiguant. Aïe...[001E][1205] J'ai les épaules\nraides...[001E][1205] Faut que je consulte."
   },
   {
     "id": 1,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Looks[SP]like[SP]there's[SP]more[SP]guys[SP]around[SP]who\nbelieve[SP]the[SP]In[SP]Lak'ech...[1205][001E][SP]Seriously,[SP]how\ndumb[SP]can[SP]you[SP]be?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Il y a plus de gens qui croient à l'In\nLak'ech...[1205][001E] Sérieux, peut-on\nêtre aussi bête?"
+    "texte_fr": "Il y a plus de gens qui croient à l'In\nLak'ech...[001E][1205] Sérieux, peut-on\nêtre aussi bête?"
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Ngh[SP]Hoh[SP]Yi![SP]No[SP]no[SP]no![SP]I'm[SP]not[SP]letting[SP]that\npervert[SP]touch[SP]me![1205][001E][SP]I[SP]bet[SP]he'll[SP]get[SP]fresh[SP]and\nclaim[SP]it's[SP]part[SP]of[SP]the[SP]treatment!",
     "nom_fr": "Lisa",
-    "texte_fr": "Ngh Hoh Yi! Non! Je laisse pas ce\npervers me toucher![1205][001E] Il va agir\nmal et dire que c'est le soin!"
+    "texte_fr": "Ngh Hoh Yi! Non! Je laisse pas ce\npervers me toucher![001E][1205] Il va agir\nmal et dire que c'est le soin!"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Ngh[SP]Hoh[SP]Yi![SP]No[SP]no[SP]no![SP]I'm[SP]not[SP]letting[SP]that\npervert[SP]touch[SP]me![1205][001E][SP]I[SP]bet[SP]he'll[SP]get[SP]fresh[SP]and\nclaim[SP]it's[SP]part[SP]of[SP]the[SP]treatment!",
     "nom_fr": "Ginko",
-    "texte_fr": "Ngh Hoh Yi! Non! Je laisse pas ce\npervers me toucher![1205][001E] Il va agir\nmal et dire que c'est le soin!"
+    "texte_fr": "Ngh Hoh Yi! Non! Je laisse pas ce\npervers me toucher![001E][1205] Il va agir\nmal et dire que c'est le soin!"
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Ng[SP]Hoh[SP]Yi![SP]There[SP]are[SP]plenty[SP]of[SP]other[SP]places[SP]we\ncan[SP]go[SP]for[SP]healing![1205][000F][SP]What[SP]if[SP]he[SP]gives[SP]us[SP]the\nbad[SP]touch[SP]while[SP]we're[SP]asleep!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Ng Hoh Yi! Il y a plein d'autres\nlieux pour se soigner! [1205][000F]Et s'il nous\ntouche mal pendant qu'on dort!?"
+    "texte_fr": "Ng Hoh Yi! Il y a plein d'autres\nlieux pour se soigner! [000F][1205]Et s'il nous\ntouche mal pendant qu'on dort!?"
   },
   {
     "id": 11,
@@ -282,7 +282,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Nnngh,[SP]your[SP]shoulders[SP]get[SP]so[SP]stiff[SP]when[SP]your\nbreasts[SP]are[SP]this[SP]big.[SP]I[SP]wish[SP]they[SP]were[SP]more\naverage-sized.[1205][001E][SP]Right,[SP][1113]-kun?",
     "nom_fr": "Maya",
-    "texte_fr": "Nnngh, avoir une si grosse poitrine\nraidit les épaules. J'aimerais qu'elles\nsoient normales.[1205][001E] Pas vrai, [1113]-kun?"
+    "texte_fr": "Nnngh, avoir une si grosse poitrine\nraidit les épaules. J'aimerais qu'elles\nsoient normales.[001E][1205] Pas vrai, [1113]-kun?"
   },
   {
     "id": 19,
@@ -326,7 +326,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmmm.[SP]If[SP]you[SP]say[SP]so,[SP]I[SP]guess[SP]I[SP]can[SP]live[SP]with\nthese.[1205][001E][SP]Hey,[SP]wait[SP]a[SP]sec...[1205][001E][SP]Eyes[SP]up,[SP]mister!",
     "nom_fr": "Maya",
-    "texte_fr": "Hmmm. Si tu le dis, je fais avec. [1205][001E] Hé,\nattends...[1205][001E] Regarde haut, monsieur!"
+    "texte_fr": "Hmmm. Si tu le dis, je fais avec. [001E][1205] Hé,\nattends...[001E][1205] Regarde haut, monsieur!"
   },
   {
     "id": 21,
@@ -341,7 +341,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]thought[SP]so.[SP]Can't[SP]I[SP]get[SP]rid[SP]of[SP]some[SP]of[SP]these?[1205][001E]\nDo[SP]you[SP]want[SP]some?[1205][001E][SP]Hahahaha![SP]Just[SP]teasing...\nAwww,[SP]you're[SP]all[SP]red.[SP]You[SP]can[SP]be[SP]so[SP]cute!",
     "nom_fr": "Maya",
-    "texte_fr": "Je me disais aussi. On peut pas en\nenlever?[1205][001E] Tu en veux? [1205][001E] Hahahaha! Je\nplaisante... Oh, t'es rouge. T'es mignon!"
+    "texte_fr": "Je me disais aussi. On peut pas en\nenlever?[001E][1205] Tu en veux? [001E][1205] Hahahaha! Je\nplaisante... Oh, t'es rouge. T'es mignon!"
   },
   {
     "id": 22,
@@ -356,7 +356,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm...[1205][001E][SP]They[SP]used[SP]to[SP]be[SP]tiny,[SP]years[SP]ago.[SP]But\nwith[SP]my[SP]personality,[SP]people[SP]might[SP]think[SP]I[SP]was\na[SP]guy[SP]if[SP]they[SP]couldn't[SP]see[SP]'em.[SP]Ahahaha!",
     "nom_fr": "Maya",
-    "texte_fr": "Hmm...[1205][001E] Avant c'était minuscule. Mais\nvu ma personnalité, on me prendrait\npour un mec sans ça. Ahahaha!"
+    "texte_fr": "Hmm...[001E][1205] Avant c'était minuscule. Mais\nvu ma personnalité, on me prendrait\npour un mec sans ça. Ahahaha!"
   },
   {
     "id": 23,
@@ -461,7 +461,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hahaha...[1205][000F][SP]No[SP]need[SP]to[SP]worry.[SP]Everyone[SP]in[SP]Sumaru\nwill[SP]believe[SP]in[SP]the[SP]In[SP]Lak'ech[SP]soon.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nIn[SP]due[SP]time,[SP]that[SP]book's[SP]prophecies[SP]will\nbecome[SP]reality.",
     "nom_fr": "Maya",
-    "texte_fr": "Hahaha.[1205][000F].. Pas de soucis. Sumaru croira en\nl'In Lak'ech bientôt.[E1][E2] [E3][E4][NULL][NULL]\"Maya\n Bientôt, les\nprophéties de ce livre deviendront réalité."
+    "texte_fr": "Hahaha.[000F][1205].. Pas de soucis. Sumaru croira en\nl'In Lak'ech bientôt.[E1][E2] [E3][E4][NULL][NULL]\"Maya\n Bientôt, les\nprophéties de ce livre deviendront réalité."
   },
   {
     "id": 30,
@@ -491,7 +491,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Not[SP]too[SP]bad,[SP][1113].[1205][001E][SP]I[SP]wonder[SP]what\nhe[SP]thinks...",
     "nom_fr": "Yukino",
-    "texte_fr": "Pas mal, [1113].[1205][001E] Il en pense quoi?"
+    "texte_fr": "Pas mal, [1113].[001E][1205] Il en pense quoi?"
   },
   {
     "id": 32,
@@ -506,7 +506,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Aha![1205][001E][SP]You[SP]know[SP]the[SP]score![SP]You're[SP]right,[SP]there's\nmore[SP]to[SP]a[SP]woman[SP]than[SP]her[SP]cup[SP]size![1205][001E][SP]I'm[SP]sure[SP]he\nthinks[SP]so[SP]too...[SP]I[SP]hope...",
     "nom_fr": "Yukino",
-    "texte_fr": "Aha![1205][001E] Tu as compris! Il y a plus\nqu'une poitrine chez une femme![1205][001E] Il\ndoit penser pareil... J'espère..."
+    "texte_fr": "Aha![001E][1205] Tu as compris! Il y a plus\nqu'une poitrine chez une femme![001E][1205] Il\ndoit penser pareil... J'espère..."
   },
   {
     "id": 33,
@@ -521,7 +521,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Well,[SP]excuse[SP]me[SP]and[SP]my[SP]mosquito[SP]bites!\nAre[SP]sweater[SP]puppies[SP]all[SP]men[SP]care[SP]about!?[1205][001E]\nI[SP]wonder[SP]if[SP]he's[SP]the[SP]same[SP]way...",
     "nom_fr": "Yukino",
-    "texte_fr": "Pardon pour mes piqûres de moustique!\nY a que la poitrine qui compte pour\nles hommes!?[1205][001E] Il est pareil?"
+    "texte_fr": "Pardon pour mes piqûres de moustique!\nY a que la poitrine qui compte pour\nles hommes!?[001E][1205] Il est pareil?"
   },
   {
     "id": 34,
@@ -566,7 +566,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "What[SP]was[SP]it[SP]that[SP]teacher[SP]mistook[SP]us[SP]for?[1205][000A]\nI[SP]heard[SP]her[SP]say[SP][1432][NULL][NULL][0014]Last[1432][NULL][NULL][0014][SP]something...[1205][000F][SP]Didn't\nring[SP]any[SP]bells.",
     "nom_fr": "Yukino",
-    "texte_fr": "Pourquoi la prof nous a-t-elle pris?[1205][1205][000A] Elle a\ndit [1432][NULL][NULL][0014]Last[1432][NULL][NULL][0014] un truc.[000F].. Ça me dit rien du tout."
+    "texte_fr": "Pourquoi la prof nous a-t-elle pris?[1205][000A][1205] Elle a\ndit [1432][NULL][NULL][0014]Last[1432][NULL][NULL][0014] un truc.[000F].. Ça me dit rien du tout."
   },
   {
     "id": 37,
@@ -641,7 +641,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Welcome[SP]to[SP]Tominaga[SP]Chiropractic![1205][001E]\nI[SP]am[SP]Mr.[SP]Tomi,[SP]the[SP]man[SP]with[SP]the[SP]magic[SP]fingers.",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Bienvenue chez Tominaga![1205][001E] Je suis M.\nTomi, l'homme aux doigts magiques."
+    "texte_fr": "Bienvenue chez Tominaga![001E][1205] Je suis M.\nTomi, l'homme aux doigts magiques."
   },
   {
     "id": 42,
@@ -768,7 +768,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Hm?[SP]But[SP]you're[SP]all[SP]in[SP]perfect[SP]health.[1205][000F][SP]Overdoing\nit[SP]is[SP]worse[SP]than[SP]underdoing[SP]it.[1205][000A][SP]There's[SP]no[SP]need\nfor[SP]me[SP]to[SP]treat[SP]you.",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Hm? Mais vous êtes en parfaite\n[1205][000F]santé. En faire trop est pire que\npas assez.[1205][000A] Inutile de vous traiter."
+    "texte_fr": "Hm? Mais vous êtes en parfaite\n[000F][1205]santé. En faire trop est pire que\npas assez.[000A][1205] Inutile de vous traiter."
   },
   {
     "id": 49,
@@ -783,7 +783,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Oh[SP]my,[SP]this[SP]is[SP]terrible.[1205][000A][SP]Your[SP]spine's[SP]extremely\ncrooked.[1205][000A][SP]You'll[SP]need[SP]that[SP]straightened[SP]out.",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Oh là là, c'est terrible.[1205][000A] Votre colonne\nest très tordue. [1205][000A] Il faut redresser ça."
+    "texte_fr": "Oh là là, c'est terrible.[000A][1205] Votre colonne\nest très tordue. [000A][1205] Il faut redresser ça."
   },
   {
     "id": 50,
@@ -823,7 +823,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Hm?[SP]But[SP]I[SP]just[SP]treated[SP]you.[SP]You're[SP]all[SP]in\nperfect[SP]health.[1205][000A][SP]There's[SP]no[SP]need[SP]for[SP]me[SP]to\ndo[SP]it[SP]again.",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Hm? Mais je viens\nde vous soigner. Vous êtes\nen parfaite santé.[1205][000A] Inutile de recommencer."
+    "texte_fr": "Hm? Mais je viens\nde vous soigner. Vous êtes\nen parfaite santé.[000A][1205] Inutile de recommencer."
   },
   {
     "id": 52,
@@ -838,7 +838,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Oh[SP]dear...[1205][000A][SP]But[SP]those[SP]wounds[SP]will[SP]be[SP]healed[SP]in\nan[SP]instant[SP]once[SP]my[SP]magic[SP]fingers[SP]do[SP]their[SP]work![1205][000F]\nDon't[SP]overexert[SP]yourself,[SP]now.",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Oh dieu.[1205]..[1205][000A] Mais ces blessures seront\nsoignées en un instant grâce à mes\n[000F]doigts magiques! Ne forcez pas."
+    "texte_fr": "Oh dieu.[1205]..[000A][1205] Mais ces blessures seront\nsoignées en un instant grâce à mes\n[000F]doigts magiques! Ne forcez pas."
   },
   {
     "id": 53,
@@ -853,7 +853,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Right[SP]away![1205][000A][SP]Let[SP]me[SP]just[SP]make[SP]some[SP]markings[SP]with\nthis[SP]pen,[SP]and[SP]then...[1205][000F][SP]Here[SP]goes![1205][000A][SP]My[SP]trump[SP]card![1205][000A]\nThe[SP]MAGIC[SP]FINGERRRRS!",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Tout de suite![1205][1205][000A] Laissez-moi faire des\nmarques au stylo, et puis... [000F]C'est\nparti![1205][000A] Mon atout! [1205][000A] LES DOIGTS MAGIQUES!"
+    "texte_fr": "Tout de suite![1205][000A][1205] Laissez-moi faire des\nmarques au stylo, et puis... [000F]C'est\nparti![000A][1205] Mon atout! [000A][1205] LES DOIGTS MAGIQUES!"
   },
   {
     "id": 54,
@@ -883,7 +883,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Magic[SP]fingers![1205][001E][SP]I[SP]trained[SP]in[SP]America[SP]to[SP]master\nthe[SP]chiropractic[SP]arts!",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Doigts magiques![1205][001E] J'ai appris\nl'art chiropraxique aux USA!"
+    "texte_fr": "Doigts magiques![001E][1205] J'ai appris\nl'art chiropraxique aux USA!"
   },
   {
     "id": 56,
@@ -898,7 +898,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "There's[SP]no[SP]disease[SP]or[SP]injury[SP]I[SP]can't[SP]cure!\nBe[SP]at[SP]ease[SP]and[SP]trust[SP]your[SP]back[SP]to[SP]my...[1205][001E]\nmagic[SP]fingers!",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Aucune maladie ne résiste à mes doigts!\nFaites confiance à mes...[1205][001E] doigts magiques!"
+    "texte_fr": "Aucune maladie ne résiste à mes doigts!\nFaites confiance à mes...[001E][1205] doigts magiques!"
   },
   {
     "id": 57,
@@ -1205,7 +1205,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Come[SP]again[SP]if[SP]you[SP]ever[SP]get[SP]tired.[1205][000A]\nThere's[SP]nothing[SP]these[SP]fingers[SP]can't[SP]cure![1205][000F]\nMagic[SP]fingers!",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Revenez si vous êtes fatigué. [1205][1205][000A] Rien ne\nrésiste à mes doigts! [000F]Doigts magiques!"
+    "texte_fr": "Revenez si vous êtes fatigué. [1205][000A][1205] Rien ne\nrésiste à mes doigts! [000F]Doigts magiques!"
   },
   {
     "id": 76,
@@ -1220,7 +1220,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Hmmm![1205][000A][SP]Unfortunately,[SP]you're[SP]lacking[SP]in[SP]funds.[1205][000F]\nI[SP]can't[SP]treat[SP]you[SP]without[SP]proper[SP]payment.",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Hmmm![1205][1205][000A] Hélas, manque de fonds. [000F]Je\nne peux vous soigner sans paiement."
+    "texte_fr": "Hmmm![1205][000A][1205] Hélas, manque de fonds. [000F]Je\nne peux vous soigner sans paiement."
   },
   {
     "id": 77,
@@ -1235,7 +1235,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Come[SP]again[SP]if[SP]you[SP]ever[SP]get[SP]tired.[1205][000A]\nThere's[SP]nothing[SP]these[SP]fingers[SP]can't[SP]cure![1205][000F]\nMagic[SP]fingers!",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Revenez si vous êtes fatigué. [1205][1205][000A] Rien ne\nrésiste à mes doigts! [000F]Doigts magiques!"
+    "texte_fr": "Revenez si vous êtes fatigué. [1205][000A][1205] Rien ne\nrésiste à mes doigts! [000F]Doigts magiques!"
   },
   {
     "id": 78,
@@ -1370,7 +1370,7 @@
     "nom_orig": "Old[SP]man",
     "texte_orig": "They[SP]posted[SP]those[SP]composite[SP]sketches[SP]of[SP]the\nculprits,[SP]didn't[SP]they?[1205][000F][SP]They're[SP]supposedly[SP]mere\ntykes...[SP]*sigh*[SP]Children[SP]these[SP]days[SP]scare[SP]me.",
     "nom_fr": "Vieil homme",
-    "texte_fr": "Ils ont affiché les portraits-robots\ndes coupables, non? [1205][000F]Ce seraient des\ngosses... *soupir* Ça me fait peur."
+    "texte_fr": "Ils ont affiché les portraits-robots\ndes coupables, non? [000F][1205]Ce seraient des\ngosses... *soupir* Ça me fait peur."
   },
   {
     "id": 87,
@@ -1520,7 +1520,7 @@
     "nom_orig": "Cured[SP]old[SP]man",
     "texte_orig": "I[SP]knew[SP]before[SP]I[SP]switched[SP]on[SP]the[SP]news[SP]that[SP]those\nfive[SP]young'uns[SP]were[SP]fighting[SP]the[SP]Masked[SP]Circle.\nThe[SP]girl[SP]over[SP]there[SP]told[SP]me[SP]so.",
     "nom_fr": "Vieil homme guéri",
-    "texte_fr": "Je savais déjà que\nces jeunes luttaient contre\nle Cercle. La jeune\nfille là-bas me l'a dit."
+    "texte_fr": "Je savais déjà que\nces jeunes luttaient contre\nle Cercle. La jeune fille là-bas me l'a dit."
   },
   {
     "id": 97,
@@ -1550,6 +1550,6 @@
     "nom_orig": "Cured[SP]old[SP]man",
     "texte_orig": "Wait,[SP]are[SP]those[SP]soldiers[SP]not[SP]part[SP]of[SP]the\nMasked[SP]Circle?[1205][000F][SP]That[SP]might[SP]be[SP]bad...[1205][000F]\nMaybe[SP]we[SP]are[SP]in[SP]trouble[SP]after[SP]all.",
     "nom_fr": "",
-    "texte_fr": "Attendez, ces soldats ne font pas\npartie du Cercle Masqué ?[1205][000F] Ça pourrait\nposer problème...[1205][000F] On est peut-être dans le pétrin."
+    "texte_fr": "Attendez, ces soldats ne font pas\npartie du Cercle Masqué ?[000F][1205] Ça pourrait\nposer problème...[000F][1205] On est peut-être dans le pétrin."
   }
 ]

--- a/traduction/event_scripts/script_318.json
+++ b/traduction/event_scripts/script_318.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]think[SP]the[SP]old[SP]guy's[SP]right.[1205][000A][SP]Being[SP]happy[SP]and\nbeing[SP]an[SP]Idealian[SP]are[SP]two[SP]different[SP]things.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je crois que le\nvieux a raison.[1205][000A] Être heureux\net être un Idéalien, c'est pas pareil."
+    "texte_fr": "Je crois que le\nvieux a raison.[000A][1205] Être heureux\net être un Idéalien, c'est pas pareil."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "It[SP]does[SP]seem[SP]weird,[SP]not[SP]having[SP]any[SP]problems[SP]at\nall...[1205][000F][SP]It's[SP]like[SP]being[SP]dead...[1205][000F][SP]Or[SP]not[SP]human,\nat[SP]the[SP]very[SP]least.",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est étrange, n'avoir aucun\nproblème..[1205]. [1205][000F][000F]C'est comme être mort...\nOu du moins pas vraiment humain."
+    "texte_fr": "C'est étrange, n'avoir aucun\nproblème..[1205]. [000F][1205][000F]C'est comme être mort...\nOu du moins pas vraiment humain."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "As[SP]long[SP]as[SP]man[SP]lives,[SP]he'll[SP]suffer[SP]and[SP]face\nhardships.[1205][000F][SP]But[SP]life[SP]goes[SP]on...[SP]I[SP]think[SP]that's\nhow[SP]we[SP]can[SP]find[SP]our[SP]true[SP]reasons[SP]for[SP]living...",
     "nom_fr": "Maya",
-    "texte_fr": "Tant que l'homme vivra, il souffrira et\n[1205][000F]affrontera des épreuves. La vie continue...\nC'est ainsi qu'on trouve\nses raisons de vivre."
+    "texte_fr": "Tant que l'homme vivra, il souffrira et\n[000F][1205]affrontera des épreuves. La vie continue...\nC'est ainsi qu'on trouve ses raisons de vivre."
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Jun",
     "texte_orig": "But...[SP]Is[SP]happiness[SP]just[SP]the[SP]absence[SP]of[SP]sadness?[1205][000F]\nIf[SP]one[SP]doesn't[SP]face[SP]sadness,[SP]can[SP]one[SP]laugh...?[1205][000F]\nIn[SP]all[SP]honesty,[SP]I[SP]haven't[SP]found[SP]the[SP]answer[SP]yet.",
     "nom_fr": "Jun",
-    "texte_fr": "Mais... Le bonheur, c'est l'absence de\n[1205][000F][1205][000F]tristesse? Sans jamais\nla connaître, peut-on\nrire? Franchement, je n'ai pas la réponse."
+    "texte_fr": "Mais... Le bonheur, c'est l'absence de\n[000F][1205][000F][1205]tristesse? Sans jamais\nla connaître, peut-on rire? Franchement, je n'ai pas la réponse."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Jun",
     "texte_orig": "All[SP]I[SP]know[SP]is[SP]that[SP]I'm[SP]happy[SP]right[SP]now.[1205][000F][SP]I[SP]want\nthis[SP]to[SP]go[SP]on[SP]forever...[1205][000F][SP]I'm[SP]sure[SP]I[SP]can[SP]find[SP]the\nanswer[SP]I[SP]yearn[SP]for[SP]someday.",
     "nom_fr": "Jun",
-    "texte_fr": "Ce que je sais, c'est que je suis\n[1205][000F][1205][000F]heureux maintenant. Je veux que ça dure\ntoujours... Je trouverai ma réponse."
+    "texte_fr": "Ce que je sais, c'est que je suis\n[000F][1205][000F][1205]heureux maintenant. Je veux que ça dure\ntoujours... Je trouverai ma réponse."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Welcome[SP]to[SP]Tominaga[SP]Chiropractic![1205][001E]\nI[SP]am[SP]Mr.[SP]Tomi,[SP]the[SP]man[SP]with[SP]the[SP]magic[SP]fingers.",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Bienvenue chez Tominaga Chiropractie![1205][001E]\nJe suis M. Tomi, aux doigts magiques."
+    "texte_fr": "Bienvenue chez Tominaga Chiropractie![001E][1205]\nJe suis M. Tomi, aux doigts magiques."
   },
   {
     "id": 8,
@@ -244,7 +244,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Come[SP]again[SP]if[SP]you[SP]ever[SP]get[SP]tired.[1205][000A]\nThere's[SP]nothing[SP]these[SP]fingers[SP]can't[SP]cure![1205][000F]\nMagic[SP]fingers!",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Revenez si vous êtes fatigués.[1205][1205][000A] Ces doigts\npeuvent tout guérir! [000F]Doigts magiques!"
+    "texte_fr": "Revenez si vous êtes fatigués.[1205][000A][1205] Ces doigts\npeuvent tout guérir! [000F]Doigts magiques!"
   },
   {
     "id": 15,
@@ -259,7 +259,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Hm?[SP]But[SP]you're[SP]all[SP]in[SP]perfect[SP]health.[1205][000F][SP]Overdoing\nit[SP]is[SP]worse[SP]than[SP]underdoing[SP]it.[1205][000A][SP]There's[SP]no[SP]need\nfor[SP]me[SP]to[SP]treat[SP]you.",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Hm? Mais vous êtes tous en parfaite\n[1205][000F]santé. Trop de soins nuit autant que\npas assez.[1205][000A] Pas lieu de vous traiter."
+    "texte_fr": "Hm? Mais vous êtes tous en parfaite\n[000F][1205]santé. Trop de soins nuit autant que\npas assez.[000A][1205] Pas lieu de vous traiter."
   },
   {
     "id": 16,
@@ -274,7 +274,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Oh[SP]my,[SP]this[SP]is[SP]terrible.[1205][000A][SP]Your[SP]spine's[SP]extremely\ncrooked.[1205][000A][SP]You'll[SP]need[SP]that[SP]straightened[SP]out.",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Oh là là, c'est grave.[1205][000A] Votre colonne est\nterriblement courbée.[1205][000A] Il faut redresser ça."
+    "texte_fr": "Oh là là, c'est grave.[000A][1205] Votre colonne est\nterriblement courbée.[000A][1205] Il faut redresser ça."
   },
   {
     "id": 17,
@@ -314,7 +314,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Hm?[SP]But[SP]I[SP]just[SP]treated[SP]you.[SP]You're[SP]all[SP]in\nperfect[SP]health.[1205][000A][SP]There's[SP]no[SP]need[SP]for[SP]me[SP]to\ndo[SP]it[SP]again.",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Hm? Mais je viens\nde vous soigner. Vous êtes\ntous en parfaite santé.[1205][000A] Inutile de\nrecommencer."
+    "texte_fr": "Hm? Mais je viens\nde vous soigner. Vous êtes\ntous en parfaite santé.[000A][1205] Inutile de recommencer."
   },
   {
     "id": 19,
@@ -329,7 +329,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Oh[SP]dear...[1205][000A][SP]But[SP]those[SP]wounds[SP]will[SP]be[SP]healed[SP]in\nan[SP]instant[SP]once[SP]my[SP]magic[SP]fingers[SP]do[SP]their[SP]work![1205][000F]\nDon't[SP]overexert[SP]yourself,[SP]now.",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Oh là...[1205][1205][000A] Mais ces blessures seront guéries\nen un instant avec mes doigts magiques! Ne\n[000F]vous surmenez pas, quand même."
+    "texte_fr": "Oh là...[1205][000A][1205] Mais ces blessures seront guéries\nen un instant avec mes doigts magiques! Ne\n[000F]vous surmenez pas, quand même."
   },
   {
     "id": 20,
@@ -344,7 +344,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Right[SP]away![1205][000A][SP]Let[SP]me[SP]just[SP]make[SP]some[SP]markings[SP]with\nthis[SP]pen,[SP]and[SP]then...[1205][000F][SP]Here[SP]goes![1205][000A][SP]My[SP]trump[SP]card![1205][000A]\nThe[SP]MAGIC[SP]FINGERRRRS!",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Tout de suite![1205][1205][000A] Laissez-moi faire quelques\nmarques avec ce stylo, et.[000F].. Voilà![1205][000A] Mon\natout maître![1205][000A] Les DOIGTS MAGIQUES!"
+    "texte_fr": "Tout de suite![1205][000A][1205] Laissez-moi faire quelques\nmarques avec ce stylo, et.[000F].. Voilà![000A][1205] Mon\natout maître![000A][1205] Les DOIGTS MAGIQUES!"
   },
   {
     "id": 21,
@@ -374,7 +374,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Magic[SP]fingers![1205][000A][SP]They[SP]say[SP]everyone's[SP]troubles\nwill[SP]be[SP]over[SP]once[SP]they[SP]become[SP]Idealians...",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Doigts magiques![1205][000A] On dit\nque tous les problèmes\ndisparaissent en devenant Idéaliens..."
+    "texte_fr": "Doigts magiques![000A][1205] On dit\nque tous les problèmes\ndisparaissent en devenant Idéaliens..."
   },
   {
     "id": 23,
@@ -404,7 +404,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Then[SP]I'm[SP]against[SP]it![1205][000F][SP]It's[SP]that[SP]ache[SP]in[SP]your\nmuscles[SP]you[SP]get[SP]after[SP]a[SP]hard[SP]day's[SP]work[SP]that\nproves[SP]you're[SP]alive.",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Alors je suis contre! [1205][000F]C'est cette\ndouleur musculaire après une longue\njournée qui prouve qu'on est en vie."
+    "texte_fr": "Alors je suis contre! [000F][1205]C'est cette\ndouleur musculaire après une longue\njournée qui prouve qu'on est en vie."
   },
   {
     "id": 25,
@@ -419,7 +419,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Without[SP]that,[SP]there[SP]won't[SP]be[SP]much[SP]satisfaction\nin[SP]a[SP]job[SP]well[SP]done.[1205][000F][SP]There[SP]won't[SP]be[SP]much\nsatisfaction[SP]in[SP]my[SP]job,[SP]either...",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Sans ça, il n'y a guère de satisfaction\naprès un travail bien fait. [1205][000F]Et mon\npropre travail n'aurait plus grand sens."
+    "texte_fr": "Sans ça, il n'y a guère de satisfaction\naprès un travail bien fait. [000F][1205]Et mon\npropre travail n'aurait plus grand sens."
   },
   {
     "id": 26,
@@ -486,7 +486,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Hmmm![1205][000A][SP]Unfortunately,[SP]you're[SP]lacking[SP]in[SP]funds.[1205][000F]\nI[SP]can't[SP]treat[SP]you[SP]without[SP]proper[SP]payment.",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Hmm![1205][1205][000A] Malheureusement, vous n'avez pas\n[000F]assez d'argent. Pas de soin sans paiement."
+    "texte_fr": "Hmm![1205][000A][1205] Malheureusement, vous n'avez pas\n[000F]assez d'argent. Pas de soin sans paiement."
   },
   {
     "id": 29,
@@ -501,7 +501,7 @@
     "nom_orig": "Mr.[SP]Tomi",
     "texte_orig": "Come[SP]again[SP]if[SP]you[SP]ever[SP]get[SP]tired.[1205][000A]\nThere's[SP]nothing[SP]these[SP]fingers[SP]can't[SP]cure![1205][000F]\nMagic[SP]fingers!",
     "nom_fr": "M. Tomi",
-    "texte_fr": "Revenez si vous êtes fatigués.[1205][1205][000A] Ces doigts\npeuvent tout guérir! [000F]Doigts magiques!"
+    "texte_fr": "Revenez si vous êtes fatigués.[1205][000A][1205] Ces doigts\npeuvent tout guérir! [000F]Doigts magiques!"
   },
   {
     "id": 30,
@@ -561,6 +561,6 @@
     "nom_orig": "Cured[SP]old[SP]man",
     "texte_orig": "Everyone[SP]finds[SP]happiness[SP]in[SP]something[SP]different.[1205][000F]\nEven[SP]if[SP]they[SP]do[SP]become[SP]these[SP]Ide...[SP]things,[SP]I\ndoubt[SP]that'll[SP]do[SP]it[SP]for[SP]everyone.",
     "nom_fr": "",
-    "texte_fr": "Tout le monde trouve le bonheur\ndans quelque chose de différent.[1205][000F] Même\nsi on devient ces Ide..., ça plaira pas à tout le monde."
+    "texte_fr": "Tout le monde trouve le bonheur\ndans quelque chose de différent.[000F][1205] Même\nsi on devient ces Ide..., ça plaira pas à tout le monde."
   }
 ]

--- a/traduction/event_scripts/script_319.json
+++ b/traduction/event_scripts/script_319.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Man,[SP]rumors[SP]coming[SP]true...[1205][000A][SP]I[SP]wouldn't[SP]have\nbelieved[SP]it[SP]under[SP]normal[SP]circumstances.[1205][000F]\nWould[SP]you[SP]have,[SP][1113]?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Les rumeurs se réalisent.[1205]..[1205][000A] Incroyable\nen temps normal. [000F]Et toi, [1113]?"
+    "texte_fr": "Les rumeurs se réalisent.[1205]..[000A][1205] Incroyable\nen temps normal. [000F]Et toi, [1113]?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]know,[SP]I've[SP]been[SP]thinking...[1205][001E][SP]If[SP]Joker[SP]shows\nup[SP]when[SP]anyone[SP]calls,[SP]why[SP]don't[SP]we[SP]just[SP]call\nhim[SP]up[SP]again?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je me disais...[1205][001E] Si le Joker vient quand on\nl'appelle, pourquoi ne pas le rappeler?"
+    "texte_fr": "Je me disais...[001E][1205] Si le Joker vient quand on\nl'appelle, pourquoi ne pas le rappeler?"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We've[SP]got[SP]Maya-san[SP]and[SP]Yukino-san[SP]on[SP]our[SP]side\nnow.[1205][001E][SP]Don't[SP]you[SP]think[SP]we[SP]can[SP]take[SP]him[SP]if[SP]it's\nfive[SP]to[SP]one?",
     "nom_fr": "Eikichi",
-    "texte_fr": "On a Maya et Yukino avec nous.[1205][001E] À cinq\ncontre un, on peut se le faire, non ?"
+    "texte_fr": "On a Maya et Yukino avec nous.[001E][1205] À cinq\ncontre un, on peut se le faire, non ?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Huh?[SP]That[SP]Todoroki[SP]guy[SP]and[SP]Tamaki-san[SP]are[SP]both\nout?[1205][000F][SP]Then[SP]let's[SP]go[SP]somewhere[SP]else.[SP]We're[SP]not\ngonna[SP]get[SP]much[SP]out[SP]of[SP]this[SP]guy...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hein? Todoroki et\nTamaki sont sortis? [1205][000F]Allons\nailleurs. On ne tirera rien de ce gars..."
+    "texte_fr": "Hein? Todoroki et\nTamaki sont sortis? [000F][1205]Allons\nailleurs. On ne tirera rien de ce gars..."
   },
   {
     "id": 5,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Even[SP]if[SP]that[SP]producer[SP]has[SP]a[SP]Persona,[SP]he's[SP]no\nkung[SP]fu[SP]expert,[SP]right?[1205][000F][SP]Then[SP]we're[SP]fine.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Même si ce producteur a une Persona,\nce n'est pas un pro du kung-fu. [1205][000F]Ça va."
+    "texte_fr": "Même si ce producteur a une Persona,\nce n'est pas un pro du kung-fu. [000F][1205]Ça va."
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What[SP]was[SP]her[SP]name?[SP]Ixquic?[1205][000F][SP]I[SP]can't[SP]believe[SP]they\nlet[SP]a[SP]kid[SP]like[SP]her[SP]in...[SP]I[SP]guess[SP]the[SP]Masked\nCircle[SP]will[SP]take[SP]anybody.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Son nom? Ixquic? [1205][000F]Accueillir une gamine...\nLe Cercle masqué prend n'importe qui."
+    "texte_fr": "Son nom? Ixquic? [000F][1205]Accueillir une gamine...\nLe Cercle masqué prend n'importe qui."
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "N-No,[SP]that[SP]was[SP]a[SP]dream...[1205][000F][SP]It[SP]was[SP]a[SP]dream...[1205][000F]\nBecause[SP]if[SP]it[SP]wasn't,[SP]we...",
     "nom_fr": "Eikichi",
-    "texte_fr": "N-Non, c'était un rêve.[1205][000F][1205][000F]..\nUn rêve... Car sinon, on..."
+    "texte_fr": "N-Non, c'était un rêve.[000F][1205][000F][1205]..\nUn rêve... Car sinon, on..."
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Oh[SP]yeah,[SP]there[SP]was[SP]that[SP]rumor[SP]that[SP]the\nprincipal's[SP]statue[SP]at[SP]Sevens[SP]was[SP]walking\naround.[1205][000F][SP]Could[SP]that[SP]come[SP]true[SP]too?",
     "nom_fr": "Lisa",
-    "texte_fr": "Ah oui, on dit que la statue du directeur\nse balade. [1205][000F]Ça va se réaliser aussi?"
+    "texte_fr": "Ah oui, on dit que la statue du directeur\nse balade. [000F][1205]Ça va se réaliser aussi?"
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Should[SP]we[SP]try[SP]the[SP]Undie[SP]Boss'[SP]plan?[1205][001E][SP]Hey,[SP]maybe\nif[SP]we[SP]spread[SP]the[SP]rumor[SP]that[SP]Joker[SP]is[SP]really\nweak,[SP]it[SP]might[SP]come[SP]true[SP]and[SP]help[SP]us[SP]win...",
     "nom_fr": "Ginko",
-    "texte_fr": "On tente le plan d'Boss des calbutes?[1205][001E] Si\non dit partout que le Joker est\nfaible, on pourrait gagner..."
+    "texte_fr": "On tente le plan d'Boss des calbutes?[001E][1205] Si\non dit partout que le Joker est\nfaible, on pourrait gagner..."
   },
   {
     "id": 16,
@@ -282,7 +282,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "But...[1205][000F][SP]Were[SP]Sheba[SP]and[SP]Mee-ho[SP]such[SP]good[SP]singers\nthey[SP]lined[SP]up[SP]a[SP]debut?[SP]I've[SP]never[SP]heard[SP]them\nbefore,[SP]so[SP]I[SP]couldn't[SP]say...",
     "nom_fr": "Ginko",
-    "texte_fr": "Mais.[1205][000F].. Sheba et Mee-ho chantent si bien\nqu'elles vont débuter? Je ne sais pas..."
+    "texte_fr": "Mais.[000F][1205].. Sheba et Mee-ho chantent si bien\nqu'elles vont débuter? Je ne sais pas..."
   },
   {
     "id": 19,
@@ -342,7 +342,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "There[SP]had[SP]to[SP]have[SP]been[SP]tons[SP]of[SP]people[SP]in[SP]there...[1205][000F]\nHoushounah...[1205][000F][SP]I'm[SP]so[SP]sorry...",
     "nom_fr": "Ginko",
-    "texte_fr": "Il devait y avoir tant de monde...\n[1205][1205][000F]Houshounah.[000F].. Je suis désolée..."
+    "texte_fr": "Il devait y avoir tant de monde...\n[1205][000F][1205]Houshounah.[000F].. Je suis désolée..."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We...[1205][000F][SP]changed[SP]them[SP]into[SP]Joker...[1205][000F][SP]I[SP]remember[SP]them\nbeing[SP]so[SP]kind,[SP]too...",
     "nom_fr": "Ginko",
-    "texte_fr": "On.[1205][000F][1205][000F].. les a changés en Joker...\nIls étaient si gentils..."
+    "texte_fr": "On.[000F][1205][000F][1205].. les a changés en Joker...\nIls étaient si gentils..."
   },
   {
     "id": 24,
@@ -387,7 +387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]think[SP]Lisa's[SP]plan[SP]would[SP]be[SP]hard[SP]to[SP]pull[SP]off.[1205][001E]\nRumors[SP]don't[SP]spread[SP]unless[SP]they[SP]get[SP]at[SP]people's\nfears[SP]or[SP]desires.",
     "nom_fr": "Maya",
-    "texte_fr": "Le plan de Lisa sera dur.[1205][001E] Les rumeurs\nont besoin de peurs ou de désirs."
+    "texte_fr": "Le plan de Lisa sera dur.[001E][1205] Les rumeurs\nont besoin de peurs ou de désirs."
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Maya",
     "texte_orig": "And[SP]I[SP]don't[SP]have[SP]much[SP]hope[SP]for[SP]Eikichi-kun's\nidea[SP]either.[1205][001E][SP]We're[SP]not[SP]dealing[SP]with[SP]someone\nwho'd[SP]fall[SP]for[SP]such[SP]a[SP]simple[SP]trick.",
     "nom_fr": "Maya",
-    "texte_fr": "Je n'y crois pas trop non plus.[1205][001E] Il ne\ntombera pas dans un piège si bête."
+    "texte_fr": "Je n'y crois pas trop non plus.[001E][1205] Il ne\ntombera pas dans un piège si bête."
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Is[SP]someone[SP]intentionally[SP]turning[SP]rumors[SP]into\nreality...?[1205][000F][SP]Could[SP]that[SP]be[SP]Joker?[SP]Hmm...[SP]I[SP]don't\nknow...",
     "nom_fr": "Maya",
-    "texte_fr": "Quelqu'un rend les rumeurs vraies\n[1205][000F]exprès...? Est-ce le Joker? Hmm..."
+    "texte_fr": "Quelqu'un rend les rumeurs vraies\n[000F][1205]exprès...? Est-ce le Joker? Hmm..."
   },
   {
     "id": 29,
@@ -462,7 +462,7 @@
     "nom_orig": "Maya",
     "texte_orig": "An[SP]idol's[SP]debut...[1205][000F][SP]Is[SP]the[SP]Masked[SP]Circle\nbranching[SP]out[SP]into[SP]showbiz?[SP]Now[SP]I'm[SP]even\nmore[SP]confused[SP]about[SP]their[SP]nature...",
     "nom_fr": "Maya",
-    "texte_fr": "Un début d'idole.[1205][000F].. Le Cercle masqué se\nlance dans le showbiz? Je suis perdue..."
+    "texte_fr": "Un début d'idole.[000F][1205].. Le Cercle masqué se\nlance dans le showbiz? Je suis perdue..."
   },
   {
     "id": 31,
@@ -492,7 +492,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I'm[SP]sure[SP]Lisa's[SP]Persona[SP]must[SP]have[SP]tipped[SP]her\noff[SP]that[SP]the[SP]producer[SP]is[SP]a[SP]Persona-user[SP]too...[1205][000F]\nBut[SP]I[SP]hope[SP]she's[SP]okay...",
     "nom_fr": "Maya",
-    "texte_fr": "Sa Persona a dû l'avertir que le producteur\nen a une aussi...\n[1205][000F]J'espère qu'elle va bien..."
+    "texte_fr": "Sa Persona a dû l'avertir que le producteur\nen a une aussi...\n[000F][1205]J'espère qu'elle va bien..."
   },
   {
     "id": 33,
@@ -522,7 +522,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We're[SP]partly[SP]to[SP]blame[SP]for[SP]the[SP]Masked[SP]Circle\nmembers[SP]acting[SP]that[SP]way.[1205][000F][SP]I[SP]can't[SP]believe[SP]it's\nall[SP]gone[SP]this[SP]far...",
     "nom_fr": "Maya",
-    "texte_fr": "Nous sommes en partie responsables du\n[1205][000F]Cercle masqué. C'est allé si loin..."
+    "texte_fr": "Nous sommes en partie responsables du\n[000F][1205]Cercle masqué. C'est allé si loin..."
   },
   {
     "id": 35,
@@ -537,7 +537,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That[SP]girl's[SP]repressed[SP]emotions[SP]are[SP]just[SP]coming\nout[SP]in[SP]an[SP]ugly[SP]way.[1205][000F][SP]I'm[SP]sure[SP]she's[SP]not[SP]really\na[SP]bad[SP]person.",
     "nom_fr": "Maya",
-    "texte_fr": "Ses émotions refoulées sortent mal.\n[1205][000F]Elle n'est pas méchante au fond."
+    "texte_fr": "Ses émotions refoulées sortent mal.\n[000F][1205]Elle n'est pas méchante au fond."
   },
   {
     "id": 36,
@@ -567,7 +567,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Repressed[SP]emotions[SP]are[SP]like[SP]a[SP]dammed-up[SP]river.[1205][000F]\nThe[SP]water[SP]muddies,[SP]overflows,[SP]and[SP]in[SP]the[SP]end,\ndestroys[SP]the[SP]dam...[1205][000F][SP]Heh.",
     "nom_fr": "Maya",
-    "texte_fr": "Les émotions refoulées sont un barrage.\n[1205][000F][1205][000F]L'eau déborde et détruit tout... Hé."
+    "texte_fr": "Les émotions refoulées sont un barrage.\n[000F][1205][000F][1205]L'eau déborde et détruit tout... Hé."
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Don't[SP]worry![SP]It'll[SP]take[SP]a[SP]lot[SP]more[SP]than[SP]that\nto[SP]kill[SP]Fujii-san![1205][000F][SP]I'm[SP]sure[SP]he'll[SP]be[SP]safe!",
     "nom_fr": "Maya",
-    "texte_fr": "T'en fais pas! Il en faut plus pour\ntuer Fujii! [1205][000F]Il est en sécurité!"
+    "texte_fr": "T'en fais pas! Il en faut plus pour\ntuer Fujii! [000F][1205]Il est en sécurité!"
   },
   {
     "id": 39,
@@ -612,7 +612,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "This[SP]really[SP]takes[SP]me[SP]back...[1205][000F][SP]Tamaki's[SP]a[SP]fellow\nSt.[SP]Hermelin[SP]grad.[SP]I[SP]didn't[SP]think[SP]I'd[SP]find[SP]her\nworking[SP]as[SP]a[SP]detective[SP]here!",
     "nom_fr": "Yukino",
-    "texte_fr": "Souvenirs... [1205][000F]Tamaki était à St. Hermelin.\nIncroyable de la voir détective!"
+    "texte_fr": "Souvenirs... [000F][1205]Tamaki était à St. Hermelin.\nIncroyable de la voir détective!"
   },
   {
     "id": 41,
@@ -627,7 +627,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Oh,[SP]and[SP]I[SP]might[SP]as[SP]well[SP]add[SP]that[SP]this[SP]Tadashi\nguy[SP]went[SP]to[SP]St.[SP]Hermelin[SP]too.[1205][000F][SP]I'm[SP]surprised\nthose[SP]two[SP]are[SP]still[SP]an[SP]item...",
     "nom_fr": "Yukino",
-    "texte_fr": "Tadashi était aussi à St. Hermelin.\n[1205][000F]Étonnant qu'ils soient encore ensemble..."
+    "texte_fr": "Tadashi était aussi à St. Hermelin.\n[000F][1205]Étonnant qu'ils soient encore ensemble..."
   },
   {
     "id": 42,
@@ -642,7 +642,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Looks[SP]like[SP]that[SP]Tadashi[SP]stole[SP]another[SP]poster.[1205][000F]\nI[SP]bet[SP]Tamaki[SP]would[SP]get[SP]mad[SP]if[SP]she[SP]knew.",
     "nom_fr": "Yukino",
-    "texte_fr": "Tadashi a encore volé une affiche.\n[1205][000F]Tamaki serait folle de rage."
+    "texte_fr": "Tadashi a encore volé une affiche.\n[000F][1205]Tamaki serait folle de rage."
   },
   {
     "id": 43,
@@ -657,7 +657,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "We[SP]can[SP]find[SP]those[SP]girls[SP]if[SP]we[SP]go[SP]to[SP]Mu,[SP]right?\nThen[SP]let's[SP]go[SP]and[SP]ask[SP]'em[SP]in[SP]person[SP]what's\ngoing[SP]on[SP]here.[1205][000F][SP]Mu's[SP]in[SP]Yumezaki.",
     "nom_fr": "Yukino",
-    "texte_fr": "On trouvera ces filles\nà Mu, non? Allons leur\ndemander ce qu'il se\npasse. [1205][000F]Mu est à Yumezaki."
+    "texte_fr": "On trouvera ces filles\nà Mu, non? Allons leur\ndemander ce qu'il se passe. [000F][1205]Mu est à Yumezaki."
   },
   {
     "id": 44,
@@ -672,7 +672,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "She's[SP]all[SP]giggly[SP]around[SP]you,[SP]but[SP]ask[SP]her[SP]about\nher[SP]other[SP]friends[SP]and[SP]she's[SP]a[SP]different[SP]person.[1205][000F]\nWhich[SP]side[SP]of[SP]her[SP]is[SP]the[SP]real[SP]Lisa...?",
     "nom_fr": "Yukino",
-    "texte_fr": "Elle rigole, mais change dès qu'on parle\nde ses amies. [1205][000F]Quelle est la vraie Lisa?"
+    "texte_fr": "Elle rigole, mais change dès qu'on parle\nde ses amies. [000F][1205]Quelle est la vraie Lisa?"
   },
   {
     "id": 45,
@@ -702,7 +702,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Why[SP]do[SP]you[SP]think[SP]rumors[SP]are[SP]coming[SP]true?\nI[SP]thought[SP]Joker[SP]was[SP]doing[SP]it[SP]at[SP]first...[1205][000F]\nBut[SP]that[SP]doesn't[SP]make[SP]much[SP]sense.",
     "nom_fr": "Yukino",
-    "texte_fr": "Pourquoi les rumeurs deviennent vraies? Je\npensais au Joker.[1205][000F].. Mais c'est illogique."
+    "texte_fr": "Pourquoi les rumeurs deviennent vraies? Je\npensais au Joker.[000F][1205].. Mais c'est illogique."
   },
   {
     "id": 47,
@@ -717,7 +717,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]mean,[SP]if[SP]Joker's[SP]making[SP]rumors[SP]come[SP]true,\nhe[SP]wouldn't[SP]let[SP]his[SP]Masked[SP]Circle[SP]get[SP]warped\nby[SP]the[SP]power[SP]of[SP]rumors,[SP]would[SP]he?",
     "nom_fr": "Yukino",
-    "texte_fr": "Si le Joker réalisait les rumeurs, il ne\nlaisserait pas son Cercle\nêtre altéré par ça,\nsi?"
+    "texte_fr": "Si le Joker réalisait les rumeurs, il ne\nlaisserait pas son Cercle\nêtre altéré par ça, si?"
   },
   {
     "id": 48,
@@ -777,7 +777,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I'm[SP]not[SP]saying[SP]you[SP]should[SP]be[SP]like[SP]him.[1205][000F][SP]I[SP]just\nthink[SP]if[SP]he[SP]was[SP]able[SP]to[SP]do[SP]it,[SP]I[SP]get[SP]the\nfeeling[SP]you[SP]can[SP]pull[SP]it[SP]off[SP]too.",
     "nom_fr": "Yukino",
-    "texte_fr": "Ne sois pas comme lui. [1205][000F]Mais s'il a pu\nle faire, je sens que tu le peux aussi."
+    "texte_fr": "Ne sois pas comme lui. [000F][1205]Mais s'il a pu\nle faire, je sens que tu le peux aussi."
   },
   {
     "id": 52,
@@ -822,7 +822,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Shunsuke-san[SP]told[SP]me[SP]to[SP]reach[SP]for[SP]my[SP]own[SP]star...[1205][000F]\nNot[SP]anyone[SP]else's,[SP]but[SP]mine...[1205][000F][SP]That's[SP]what[SP]he\nalways[SP]wanted[SP]for[SP]me.",
     "nom_fr": "Yukino",
-    "texte_fr": "Shunsuke m'a dit d'atteindre ma propre\n[1205][000F][1205][000F]étoile... La mienne...\nC'est ce qu'il voulait."
+    "texte_fr": "Shunsuke m'a dit d'atteindre ma propre\n[000F][1205][000F][1205]étoile... La mienne...\nC'est ce qu'il voulait."
   },
   {
     "id": 55,
@@ -947,7 +947,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Okay![1205][001E][SP]Wait...[SP]you[SP]don't[SP]have[SP]any[SP]magazines.\nThey[SP]sell[SP]them[SP]at[SP]Satomi[SP]Tadashi,[SP]so[SP]come\nback[SP]when[SP]you've[SP]bought[SP]some.",
     "nom_fr": "Tamaki",
-    "texte_fr": "D'accord![1205][001E] Attendez... pas de\nmagazines. Ils en vendent chez\nSatomi Tadashi, revenez plus tard."
+    "texte_fr": "D'accord![001E][1205] Attendez... pas de\nmagazines. Ils en vendent chez\nSatomi Tadashi, revenez plus tard."
   },
   {
     "id": 61,
@@ -1122,7 +1122,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Looks[SP]like[SP]Tadashi[SP]ordered[SP]off[SP]that[SP]secret\nmenu[SP]too...[1205][000F][SP]Sheesh,[SP]he's[SP]such[SP]a[SP]schemer[SP]when\nit[SP]comes[SP]to[SP]this[SP]stuff.",
     "nom_fr": "Tamaki",
-    "texte_fr": "Tadashi a aussi commandé sur ce menu.[1205][000F]..\nQuel magouilleur pour ce genre de trucs."
+    "texte_fr": "Tadashi a aussi commandé sur ce menu.[000F][1205]..\nQuel magouilleur pour ce genre de trucs."
   },
   {
     "id": 72,
@@ -1137,7 +1137,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Well,[SP]at[SP]least[SP]he[SP]didn't[SP]get[SP]such[SP]a[SP]great\nweapon.[1205][000F][SP]I'll[SP]let[SP]it[SP]slide[SP]this[SP]time.[SP]*sigh*\nWhat[SP]in[SP]the[SP]world[SP]do[SP]I[SP]see[SP]in[SP]that[SP]guy...?",
     "nom_fr": "Tamaki",
-    "texte_fr": "Au moins, son arme n'est pas si\n[1205][000F]bonne. Je laisse couler. *soupir*\nQu'est-ce que je lui trouve...?"
+    "texte_fr": "Au moins, son arme n'est pas si\n[000F][1205]bonne. Je laisse couler. *soupir*\nQu'est-ce que je lui trouve...?"
   },
   {
     "id": 73,
@@ -1167,7 +1167,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Have[SP]you[SP]found[SP]out[SP]anything[SP]about[SP]the[SP]Masked\nCircle?[SP]We're[SP]coming[SP]up[SP]empty.[1205][000F][SP]This[SP]is[SP]gonna\ntake[SP]a[SP]lot[SP]more[SP]footwork...",
     "nom_fr": "Tamaki",
-    "texte_fr": "Trouvé un truc sur le Cercle masqué? Nous\nn'avons rien. [1205][000F]Il va falloir creuser\ndavantage..."
+    "texte_fr": "Trouvé un truc sur le Cercle masqué? Nous\nn'avons rien. [000F][1205]Il va falloir creuser\ndavantage..."
   },
   {
     "id": 75,
@@ -1182,7 +1182,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Huh?[SP]That[SP]producer's[SP]a[SP]Persona-user?[1205][000F][SP]Th-Then\nshould[SP]we[SP]have[SP]let[SP]Lisa-chan[SP]go[SP]off[SP]alone\nwith[SP]him?",
     "nom_fr": "Tamaki",
-    "texte_fr": "Hein? Ce producteur a\nune Persona? [1205][000F]A-t-on bien\nfait de laisser Lisa partir seule avec lui?"
+    "texte_fr": "Hein? Ce producteur a\nune Persona? [000F][1205]A-t-on bien\nfait de laisser Lisa partir seule avec lui?"
   },
   {
     "id": 76,
@@ -1212,7 +1212,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Everyone[SP]thinks[SP]they're[SP]some[SP]kind[SP]of[SP]sinister\norganization[SP]now.[1205][000F][SP]At[SP]this[SP]point,[SP]I[SP]don't[SP]think\neven[SP]spreading[SP]a[SP]counter-rumor[SP]would[SP]help...",
     "nom_fr": "Tamaki",
-    "texte_fr": "Tous les voient comme une organisation\n[1205][000F]sinistre. Même une contre-rumeur n'aiderait\npas..."
+    "texte_fr": "Tous les voient comme une organisation\n[000F][1205]sinistre. Même une contre-rumeur n'aiderait\npas..."
   },
   {
     "id": 78,
@@ -1227,7 +1227,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Looks[SP]like[SP]Smile[SP]Hirasaka[SP]was[SP]targeted[SP]too.\nGood[SP]thing[SP]they[SP]found[SP]the[SP]bombs[SP]in[SP]time.[1205][000F]\n...I[SP]wouldn't[SP]be[SP]surprised[SP]if[SP]that[SP]was[SP]you.",
     "nom_fr": "Tamaki",
-    "texte_fr": "Smile Hirasaka était visé. Heureusement,\nbombes trouvées à temps. [1205][000F]... C'était vous,\nnon?"
+    "texte_fr": "Smile Hirasaka était visé. Heureusement,\nbombes trouvées à temps. [000F][1205]... C'était vous,\nnon?"
   },
   {
     "id": 79,
@@ -1287,7 +1287,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "The[SP]Masked[SP]Circle[SP]and[SP]Last[SP]Battalion[SP]are\nfighting[SP]all[SP]over[SP]the[SP]city.[1205][000F][SP]But[SP]the[SP]Last\nBattalion[SP]has[SP]the[SP]clear[SP]upper[SP]hand...",
     "nom_fr": "Tamaki",
-    "texte_fr": "Le Cercle masqué et le Bataillon\nse battent en ville. [1205][000F]Le Bataillon\na clairement l'avantage..."
+    "texte_fr": "Le Cercle masqué et le Bataillon\nse battent en ville. [000F][1205]Le Bataillon\na clairement l'avantage..."
   },
   {
     "id": 83,
@@ -1317,7 +1317,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "Just[SP]like[SP]I[SP]predicted,[SP]the[SP]secret[SP]dish[SP]was\nbanana[SP]char[SP]siu[SP]ramen...[1205][000F][SP]But[SP]I[SP]finally[SP]have\nmy[SP]weapon!",
     "nom_fr": "Tadashi",
-    "texte_fr": "Comme prédit, le plat\nsecret était des ramens\nau porc et banane.[1205][000F]..\nMais j'ai enfin mon arme!"
+    "texte_fr": "Comme prédit, le plat\nsecret était des ramens\nau porc et banane.[000F][1205].. Mais j'ai enfin mon arme!"
   },
   {
     "id": 85,
@@ -1332,7 +1332,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "The[SP]dreadful[SP]sword[SP]Addlepate...[SP]Hehehe,[SP]you\nmust[SP]have[SP]been[SP]waiting[SP]for[SP]me[SP]to[SP]come[SP]along...[1205][000F]\nHehehe...[1205][000A][SP]Damn,[SP]I'm[SP]good![1205][000A][SP]I[SP]kick[SP]ass!",
     "nom_fr": "Tadashi",
-    "texte_fr": "La redoutable épée Addlepate...\nTu m'attendais... Héhéhé...[1205][000A] Bon\n[1205][000F]sang, je déchire![1205][000A] Je suis doué!"
+    "texte_fr": "La redoutable épée Addlepate...\nTu m'attendais... Héhéhé...[000A][1205] Bon\n[000F][1205]sang, je déchire![000A][1205] Je suis doué!"
   },
   {
     "id": 86,
@@ -1347,7 +1347,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "N-Now[SP]that's[SP]the[SP]Yukino[SP]I[SP]remember...[1205][000F][SP]So[SP]cold,\neven[SP]during[SP]our[SP]heartwarming[SP]reunion...[1205][000F]\nWell,[SP]fine[SP]with[SP]me.[SP]Detectives[SP]work[SP]alone!",
     "nom_fr": "Tadashi",
-    "texte_fr": "C-C'est bien la Yukino\n[1205][000F][1205][000F]de mes souvenirs... Si\nfroide... Tant pis.\nUn détective bosse seul!"
+    "texte_fr": "C-C'est bien la Yukino\n[000F][1205][000F][1205]de mes souvenirs... Si\nfroide... Tant pis. Un détective bosse seul!"
   },
   {
     "id": 87,
@@ -1362,7 +1362,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "Muses...[1205][000F][SP]They're[SP]so[SP]cute...![1205][000F][SP]But[SP]I[SP]wonder[SP]who\nthat[SP]third[SP]girl[SP]in[SP]the[SP]center[SP]is.[1205][000F][SP]Wait[SP]a[SP]sec,\nif[SP]I[SP]extrapolate[SP]from[SP]this[SP]silhouette...",
     "nom_fr": "Tadashi",
-    "texte_fr": "Muses.[1205][000F][1205][000F][1205][000F].. Si mignonnes...! Mais\nqui est la 3e\nau centre? Si\nj'extrapole cette silhouette..."
+    "texte_fr": "Muses.[000F][1205][000F][1205][000F][1205].. Si mignonnes...! Mais\nqui est la 3e\nau centre? Si j'extrapole cette silhouette..."
   },
   {
     "id": 88,
@@ -1377,7 +1377,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "The[SP]Masked[SP]Circle...[1205][000F][SP]Yeah,[SP]that's[SP]gotta[SP]be\nsome[SP]evil[SP]cult.[SP]Now's[SP]my[SP]time[SP]to[SP]shine![SP]I'll\npunish[SP]them[SP]with[SP]the[SP]dreadful[SP]sword[SP]Addlepate!",
     "nom_fr": "Tadashi",
-    "texte_fr": "Le Cercle masqué.[1205][000F].. Ça doit être une secte.\nJe vais les punir avec l'épée Addlepate!"
+    "texte_fr": "Le Cercle masqué.[000F][1205].. Ça doit être une secte.\nJe vais les punir avec l'épée Addlepate!"
   },
   {
     "id": 89,
@@ -1392,7 +1392,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "Tch,[SP]where's[SP]that[SP]Masked[SP]Circle?[1205][000F][SP]Why[SP]won't[SP]they\nshow[SP]themselves!?[SP]I[SP]bet[SP]they're[SP]scared[SP]of[SP]me...!",
     "nom_fr": "Tadashi",
-    "texte_fr": "Tss, où est ce Cercle masqué? [1205][000F]Pourquoi\nse cachent-ils!? Ils ont peur de moi...!"
+    "texte_fr": "Tss, où est ce Cercle masqué? [000F][1205]Pourquoi\nse cachent-ils!? Ils ont peur de moi...!"
   },
   {
     "id": 90,
@@ -1407,7 +1407,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "Hehehe...[SP]Just[SP]like[SP]I[SP]figured,[SP]Lisa-chan[SP]was\nthe[SP]third[SP]member[SP]of[SP]Muses...[1205][000F][SP]Aw,[SP]crap,[SP]I\nshould've[SP]gotten[SP]her[SP]autograph!",
     "nom_fr": "Tadashi",
-    "texte_fr": "Héhéhé... Lisa était le\n3e membre de Muses...\n[1205]Zut, j'aurais dû\n[000F]lui demander un autographe!"
+    "texte_fr": "Héhéhé... Lisa était le\n3e membre de Muses...\n[1205]Zut, j'aurais dû [000F]lui demander un autographe!"
   },
   {
     "id": 91,
@@ -1452,7 +1452,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "Get[SP]a[SP]grip,[SP]Tadashi![1205][000F][SP]You[SP]can't[SP]let[SP]one[SP]bombing\nfreak[SP]you[SP]out!",
     "nom_fr": "Tadashi",
-    "texte_fr": "Reprends-toi, Tadashi! [1205][000F]Ne\nte laisse pas terrifier!"
+    "texte_fr": "Reprends-toi, Tadashi! [000F][1205]Ne\nte laisse pas terrifier!"
   },
   {
     "id": 94,
@@ -1497,7 +1497,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "Oh[SP]crap,[SP]we're[SP]in[SP]for[SP]it[SP]now![1205][000F][SP]Those[SP]soldiers\nare[SP]landing[SP]from[SP]Ebisu[SP]Beach[SP]too!",
     "nom_fr": "Tadashi",
-    "texte_fr": "Zut, on est dans le pétrin! [1205][000F]Des soldats\ndébarquent de la plage d'Ebisu!"
+    "texte_fr": "Zut, on est dans le pétrin! [000F][1205]Des soldats\ndébarquent de la plage d'Ebisu!"
   },
   {
     "id": 97,
@@ -1620,7 +1620,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "For[SP]a[SP]rumor[SP]to[SP]spread,[SP]it[SP]must[SP]stimulate[SP]certain\nemotions.[SP]Fear,[SP]curiosity,[SP]desire...[1205][001E][SP]These\ncannot[SP]be[SP]artificially[SP]created.",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Une rumeur doit stimuler peur, curiosité,\ndésir...[1205][001E] Impossible\nà créer artificiellement."
+    "texte_fr": "Une rumeur doit stimuler peur, curiosité,\ndésir...[001E][1205] Impossible\nà créer artificiellement."
   },
   {
     "id": 102,
@@ -1650,7 +1650,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "I[SP]know[SP]a[SP]number[SP]of[SP]rumormongers[SP]who[SP]collect\nsuch[SP]stories.[SP]It[SP]may[SP]be[SP]possible[SP]to[SP]spread[SP]the\nrumors[SP]they[SP]know[SP]and[SP]make[SP]them[SP]come[SP]true.",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Des semeurs de\nrumeurs en collectionnent. On\npeut répandre ce qu'ils savent et les\nréaliser."
+    "texte_fr": "Des semeurs de\nrumeurs en collectionnent. On\npeut répandre ce qu'ils savent et les réaliser."
   },
   {
     "id": 104,
@@ -1695,7 +1695,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "Perspective[SP]and[SP]judgement[SP]are[SP]necessary[SP]in\nbattle.[SP]It's[SP]a[SP]fool[SP]who[SP]behaves[SP]rashly[SP]and[SP]lets\nhis[SP]youth[SP]get[SP]the[SP]best[SP]of[SP]him.[1205][000F][SP]Be[SP]careful.",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Recul et jugement sont\nvitaux au combat. Seul\nun fou agit\navec impétuosité. [1205][000F]Soyez prudents."
+    "texte_fr": "Recul et jugement sont\nvitaux au combat. Seul\nun fou agit avec impétuosité. [000F][1205]Soyez prudents."
   },
   {
     "id": 107,
@@ -1770,7 +1770,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "A[SP]few[SP]bad[SP]apples[SP]have[SP]spoiled[SP]public[SP]opinion\nof[SP]the[SP]whole[SP]bunch...[1205][000F][SP]That[SP]sort[SP]of[SP]thing\nhappens[SP]all[SP]the[SP]time.",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Quelques pommes pourries gâchent\n[1205][000F]l'image du groupe... Très fréquent."
+    "texte_fr": "Quelques pommes pourries gâchent\n[000F][1205]l'image du groupe... Très fréquent."
   },
   {
     "id": 112,
@@ -1785,7 +1785,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "Well,[SP]thanks[SP]to[SP]that[SP]rumor,[SP]you[SP]won't[SP]have[SP]any\ntrouble[SP]finding[SP]Masked[SP]Circle[SP]members.[1205][000F][SP]Now,[SP]one\nglance[SP]at[SP]someone[SP]should[SP]be[SP]enough[SP]to[SP]tell.",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Avec cette rumeur, vous trouverez\nle Cercle facilement. [1205][000F]Un coup\nd'œil suffira à les reconnaître."
+    "texte_fr": "Avec cette rumeur, vous trouverez\nle Cercle facilement. [000F][1205]Un coup\nd'œil suffira à les reconnaître."
   },
   {
     "id": 113,
@@ -1800,7 +1800,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "The[SP]police[SP]and[SP]fire[SP]departments[SP]bombings[SP]prove\nthis[SP]was[SP]a[SP]well-orchestrated[SP]campaign.[1205][000F][SP]They\nmust[SP]have[SP]hit[SP]Smile[SP]Hirasaka[SP]for[SP]a[SP]reason[SP]too.",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Ces attentats prouvent que c'était\ntrès orchestré. [1205][000F]Ils ont frappé Smile\nHirasaka pour une bonne raison."
+    "texte_fr": "Ces attentats prouvent que c'était\ntrès orchestré. [000F][1205]Ils ont frappé Smile\nHirasaka pour une bonne raison."
   },
   {
     "id": 114,
@@ -1815,7 +1815,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "You[SP]must[SP]know[SP]of[SP]the[SP]multiple[SP]theories[SP]going\naround[SP]the[SP]city[SP]now.[1205][000F][SP]The[SP]Masked[SP]Circle,[SP]the\nfive[SP]terrorists,[SP]the[SP]Last[SP]Battalion...",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Vous connaissez les multiples\nthéories en ville. [1205][000F]Le Cercle masqué,\nles cinq terroristes, le Bataillon..."
+    "texte_fr": "Vous connaissez les multiples\nthéories en ville. [000F][1205]Le Cercle masqué,\nles cinq terroristes, le Bataillon..."
   },
   {
     "id": 115,
@@ -1975,7 +1975,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "Oh,[SP]you're[SP]broke,[SP]meow[1432][NULL][NULL][0007]\nShow[SP]me[SP]a[SP]liar[SP]and[SP]I'll[SP]show[SP]you[SP]a[SP]thief,[SP]meow[1432][NULL][NULL][0007]\nGet[SP]out[SP]of[SP]here,[SP]hiss[1432][NULL][NULL][0007]",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Oh, you're broke, meow[1432][NULL][NULL][0007] Show\nme a liar and I'll\nshow you a thief, meow[1432][NULL][NULL][0007]\nGet out of here, hiss[1432][NULL][NULL][0007]"
+    "texte_fr": "Oh, you're broke, meow[1432][NULL][NULL][0007] Show\nme a liar and I'll\nshow you a thief, meow[1432][NULL][NULL][0007] Get out of here, hiss[1432][NULL][NULL][0007]"
   },
   {
     "id": 125,
@@ -2005,7 +2005,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "Meowvelous![1432][NULL][NULL][0007][1205][000F]\nI[SP]can't[SP]believe[SP]you[SP]fed[SP]me[SP]50[SP]times,[SP]purrrr[1432][NULL][NULL][0007][1205][000F]\nYou're[SP]so[SP]generous,[SP]Misterrr[1432][NULL][NULL][0007]",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Miaourveilleux![1205][000F][1205][000F][1432][NULL][NULL][0007] Nourri 50 fois,\nronron[1432][NULL][NULL][0007] Très généreux, mooonsieur[1432][NULL][NULL][0007]"
+    "texte_fr": "Miaourveilleux![000F][1205][000F][1205][1432][NULL][NULL][0007] Nourri 50 fois,\nronron[1432][NULL][NULL][0007] Très généreux, mooonsieur[1432][NULL][NULL][0007]"
   },
   {
     "id": 127,
@@ -2020,7 +2020,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "Amazing,[SP]meow![1205][000F]\nYou've[SP]fed[SP]me[SP]80[SP]times[SP]now,[SP]meow[1432][NULL][NULL][0007][1205][000F]\nDo[SP]you[SP]have[SP]a[SP]kitten[SP]agenda,[SP]meow?",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Superbe, miaou! [1205][000F][1205][000F]Nourri 80 fois,\nmiaou[1432][NULL][NULL][0007] As-tu un plan caché, miaou?"
+    "texte_fr": "Superbe, miaou! [000F][1205][000F][1205]Nourri 80 fois,\nmiaou[1432][NULL][NULL][0007] As-tu un plan caché, miaou?"
   },
   {
     "id": 128,
@@ -2035,7 +2035,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "The[SP]time[SP]has[SP]finally[SP]come,[SP]meow...[1205][000F]\nAn[SP]even[SP]100[SP]feedings...[1205][000F]\nI've[SP]collected[SP]10,000[SP]yen,[SP]meow!",
     "nom_fr": "Statue de chat",
-    "texte_fr": "L'heure est arrivée... [1205][000F][1205][000F]Exactement 100\nrepas... J'ai récolté 10 000 yens, miaou!"
+    "texte_fr": "L'heure est arrivée... [000F][1205][000F][1205]Exactement 100\nrepas... J'ai récolté 10 000 yens, miaou!"
   },
   {
     "id": 129,
@@ -2050,7 +2050,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "I[SP]feel[SP]bad[SP]at[SP]being[SP]given[SP]so[SP]much,[SP]meow![1205][000F]\nSo[SP]I[SP]have[SP]a[SP]purresent[SP]for[SP]you!",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Je m'en veux d'avoir tant\n[1205][000F]reçu! Voici un cadeaou!"
+    "texte_fr": "Je m'en veux d'avoir tant\n[000F][1205]reçu! Voici un cadeaou!"
   },
   {
     "id": 130,
@@ -2209,7 +2209,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "He[SP]was[SP]a[SP]world[SP]history[SP]teacher[SP]at[SP]Sevens[SP]with\nme.[SP]He[SP]was[SP]always[SP]tormented[SP]that[SP]the[SP]history\nhe[SP]taught[SP]his[SP]students[SP]might[SP]be[SP]untrue...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "He was a world\nhistory teacher at Seven with\nme. He was always\ntormented that the history\nhe taught his students might be untrue..."
+    "texte_fr": "He was a world\nhistory teacher at Seven with\nme. He was always tormented that the history he taught his students might be untrue..."
   },
   {
     "id": 139,
@@ -2224,7 +2224,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "He[SP]was[SP]a[SP]dreamer,[SP]who[SP]loved[SP]his[SP]students[SP]very\nmuch.[1205][001E][SP]Yet[SP]he[SP]died[SP]in[SP]such[SP]a[SP]dreadful[SP]way...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Un rêveur aimant ses élèves.[1205][001E] Pourtant,\nil est mort si atrocement..."
+    "texte_fr": "Un rêveur aimant ses élèves.[001E][1205] Pourtant,\nil est mort si atrocement..."
   },
   {
     "id": 140,
@@ -2269,7 +2269,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Sudou-kun[SP]was[SP]at[SP]Sevens[SP]too,[SP]as[SP]a[SP]student...[1205][001E]\nHe[SP]was[SP]a[SP]timid[SP]boy,[SP]afraid[SP]of[SP]his[SP]extremely\nstrict[SP]father.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Sudou était élève à Seven...[1205][001E] Un garçon\ntimide, effrayé par son père strict."
+    "texte_fr": "Sudou était élève à Seven...[001E][1205] Un garçon\ntimide, effrayé par son père strict."
   },
   {
     "id": 143,
@@ -2344,7 +2344,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "[1432][NULL][NULL][0014]In[SP]Lak'ech[1432][NULL][NULL][0014][SP]means[SP][1432][NULL][NULL][0014]you[SP]are[SP]another[SP]me[1432][NULL][NULL][0014][SP]in\nMayan.[1205][001E][SP]It's[SP]what[SP]we[SP]called[SP]the[SP]oracle[SP]that\nSudou-kun[SP]channeled.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "[1432][NULL][NULL][0014]In Lak'ech[1432][NULL][NULL][0014] signifie [1432][NULL][NULL][0014]tu es un autre moi[1432][NULL][NULL][0014] en\nmaya.[1205][001E] C'est le nom de l'oracle de Sudou."
+    "texte_fr": "[1432][NULL][NULL][0014]In Lak'ech[1432][NULL][NULL][0014] signifie [1432][NULL][NULL][0014]tu es un autre moi[1432][NULL][NULL][0014] en\nmaya.[001E][1205] C'est le nom de l'oracle de Sudou."
   },
   {
     "id": 148,
@@ -2359,7 +2359,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]Maians[SP]guided[SP]our[SP]evolution[SP]once,[SP]though\nthat[SP]stage[SP]is[SP]now[SP]lost.[1205][001E][SP]Our[SP]civilization[SP]as\nit[SP]stands[SP]is[SP]a[SP]remnant[SP]from[SP]then...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Les Mayas ont guidé notre évolution.[1205][001E]\nNotre civilisation n'est qu'un vestige..."
+    "texte_fr": "Les Mayas ont guidé notre évolution.[001E][1205]\nNotre civilisation n'est qu'un vestige..."
   },
   {
     "id": 149,
@@ -2389,7 +2389,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Xibalba[SP]is[SP]the[SP]key[SP]to[SP]our[SP]evolution.[SP]We[SP]can't\nevolve[SP]without[SP]it...[1205][001E][SP]But[SP]it[SP]will[SP]come[SP]at[SP]the\ncost[SP]of[SP]this[SP]world's[SP]extinction!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Xibalba est la clé de notre évolution.[1205][001E]\nMais le prix est l'extinction du monde!"
+    "texte_fr": "Xibalba est la clé de notre évolution.[001E][1205]\nMais le prix est l'extinction du monde!"
   },
   {
     "id": 151,
@@ -2434,7 +2434,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]Mayans[SP]worshipped[SP]the[SP]Oxlahuntiku[SP]as[SP]gods\nof[SP]light...[1205][001E][SP]While[SP]they[SP]feared[SP]the[SP]Bolontiku\nas[SP]gods[SP]of[SP]the[SP]netherworld...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Ils vénéraient les Oxlahuntiku,\ndieux de lumière...[1205][001E] Et craignaient\nles Bolontiku, dieux des enfers..."
+    "texte_fr": "Ils vénéraient les Oxlahuntiku,\ndieux de lumière...[001E][1205] Et craignaient\nles Bolontiku, dieux des enfers..."
   },
   {
     "id": 154,
@@ -2449,7 +2449,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Their[SP]war[SP]consumed[SP]this[SP]solar[SP]system,[SP]and[SP]the\nOxlahuntiku[SP]perished...[1205][001E][SP]Those[SP]events[SP]are[SP]the\nsource[SP]of[SP]common[SP]legends[SP]of[SP]the[SP]flood.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "La guerre a ravagé ce système,\nles Oxlahuntiku ont péri...[1205][001E] C'est\nl'origine du mythe du déluge."
+    "texte_fr": "La guerre a ravagé ce système,\nles Oxlahuntiku ont péri...[001E][1205] C'est\nl'origine du mythe du déluge."
   },
   {
     "id": 155,
@@ -2494,7 +2494,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Ideal[SP]Energy[SP]is[SP]the[SP]power[SP]of[SP]thought[SP]held[SP]by\nus[SP]living[SP]beings...[1205][001E][SP]It's[SP]a[SP]psychological\nenergy[SP]based[SP]on[SP]one's[SP]ideals.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "L'Énergie Idéale est la force de nos\npensées...[1205][001E] Une énergie psychique de nos\nidéaux."
+    "texte_fr": "L'Énergie Idéale est la force de nos\npensées...[001E][1205] Une énergie psychique de nos\nidéaux."
   },
   {
     "id": 158,
@@ -2509,7 +2509,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]energy[SP]is[SP]heightened[SP]most[SP]when[SP]one[SP]is\npassionate[SP]about[SP]one's[SP]ideals,[SP]or[SP]when[SP]one's\ndream[SP]comes[SP]true.[1205][001E][SP]It's[SP]fed[SP]by[SP]joie[SP]de[SP]vivre.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Elle croît quand on est passionné\nou qu'un rêve se réalise.[1205][001E] Elle se\nnourrit de joie de vivre."
+    "texte_fr": "Elle croît quand on est passionné\nou qu'un rêve se réalise.[001E][1205] Elle se\nnourrit de joie de vivre."
   },
   {
     "id": 159,
@@ -2524,7 +2524,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Ideal[SP]Energy[SP]is[SP]the[SP]Maian[SP]source[SP]of[SP]power...[1205][001E]\nAnd[SP]the[SP]crystal[SP]skulls[SP]are[SP]OOPArts[SP]planted\nin[SP]mankind's[SP]history[SP]to[SP]collect[SP]it!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "C'est la source d'énergie maya...[1205][001E] Et les\ncrânes sont des OOPArts plantés pour la\nrécolter!"
+    "texte_fr": "C'est la source d'énergie maya...[001E][1205] Et les\ncrânes sont des OOPArts plantés pour la\nrécolter!"
   },
   {
     "id": 160,
@@ -2594,7 +2594,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]greatest[SP]and[SP]worst[SP]dictator[SP]of[SP]the\ncentury![1205][001E][SP]You[SP]know[SP]that[SP]much,[SP]I[SP]hope.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Le plus grand et pire dictateur du\nsiècle![1205][001E] Vous savez bien ça, j'espère."
+    "texte_fr": "Le plus grand et pire dictateur du\nsiècle![001E][1205] Vous savez bien ça, j'espère."
   },
   {
     "id": 164,
@@ -2624,7 +2624,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "He[SP]said[SP]so[SP]himself![1205][001E][SP]He's[SP]an[SP]immortal[SP]sorcerer\nwho[SP]learned[SP]magic[SP]from[SP]Mayan[SP]mystics.[SP]He\ncraved[SP]the[SP]secrets[SP]of[SP]ruins[SP]around[SP]the[SP]world!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Il l'a dit![1205][001E] Sorcier immortel formé\npar les Mayas. Il convoitait les\nsecrets des ruines du monde!"
+    "texte_fr": "Il l'a dit![001E][1205] Sorcier immortel formé\npar les Mayas. Il convoitait les\nsecrets des ruines du monde!"
   },
   {
     "id": 166,

--- a/traduction/event_scripts/script_320.json
+++ b/traduction/event_scripts/script_320.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Honestly,[SP]a[SP]grown[SP]man[SP]going[SP]around[SP]stealing\nposters?[1205][000F][SP]He[SP]must[SP]have[SP]no[SP]self-control[SP]at[SP]all.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Sérieux, un adulte qui vole des\n[1205][000F]affiches? Il n'a aucune retenue."
+    "texte_fr": "Sérieux, un adulte qui vole des\n[000F][1205]affiches? Il n'a aucune retenue."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh...?[1205][000F][SP]Those[SP]girls[SP]here...[1205][000F][SP]Oh,[SP]come[SP]on...",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein.[1205][000F][1205][000F]..? Ces filles ici... Sérieux..."
+    "texte_fr": "Hein.[000F][1205][000F][1205]..? Ces filles ici... Sérieux..."
   },
   {
     "id": 4,
@@ -102,7 +102,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Sheesh...[1205][000F][SP]Those[SP]two[SP]are[SP]at[SP]it[SP]as[SP]usual...[1205][000F]\nThey[SP]haven't[SP]changed[SP]one[SP]bit.",
     "nom_fr": "Yukino",
-    "texte_fr": "Pff.[1205][000F][1205].[000F]. Ces deux-là font comme\nd'habitude... Elles n'ont pas changé."
+    "texte_fr": "Pff.[000F][1205][1205].[000F]. Ces deux-là font comme\nd'habitude... Elles n'ont pas changé."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]think[SP]we[SP]should[SP]visit[SP]those[SP]friends[SP]of[SP]Lisa's\nfrom[SP]the[SP]poster[SP]first.[SP]Let's[SP]ask[SP]them[SP]what's\ngoing[SP]on.",
     "nom_fr": "Yukino",
-    "texte_fr": "On devrait d'abord voir\nces amies de Lisa sur\nl'affiche. Demandons-leur ce\nqu'il se passe."
+    "texte_fr": "On devrait d'abord voir\nces amies de Lisa sur\nl'affiche. Demandons-leur ce qu'il se passe."
   },
   {
     "id": 8,
@@ -240,7 +240,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "The[SP]Masked[SP]Circle...[1205][000F][SP]Could[SP]this[SP]be[SP]the\nPhantom...?[1205][000F][SP]No...[SP]It[SP]can't[SP]be...",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Le Cercle masqué.[1205][000F][1205][000F].. Serait-ce le\nFantôme...? Non... Impossible..."
+    "texte_fr": "Le Cercle masqué.[000F][1205][000F][1205].. Serait-ce le\nFantôme...? Non... Impossible..."
   },
   {
     "id": 13,
@@ -355,7 +355,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "Meowvelous![1432][NULL][NULL][0007][1205][000F]\nI[SP]can't[SP]believe[SP]you[SP]fed[SP]me[SP]50[SP]times,[SP]purrrr[1432][NULL][NULL][0007][1205][000F]\nYou're[SP]so[SP]generous,[SP]Misterrr[1432][NULL][NULL][0007]",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Miaourveilleux![1205][000F][1205][000F][1432][NULL][NULL][0007] Tu m'as nourri 50 fois,\nronron[1432][NULL][NULL][0007] Tu es si généreux, Monsieur[1432][NULL][NULL][0007]"
+    "texte_fr": "Miaourveilleux![000F][1205][000F][1205][1432][NULL][NULL][0007] Tu m'as nourri 50 fois,\nronron[1432][NULL][NULL][0007] Tu es si généreux, Monsieur[1432][NULL][NULL][0007]"
   },
   {
     "id": 20,
@@ -370,7 +370,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "Amazing,[SP]meow![1205][000F]\nYou've[SP]fed[SP]me[SP]80[SP]times[SP]now,[SP]meow[1432][NULL][NULL][0007][1205][000F]\nDo[SP]you[SP]have[SP]a[SP]kitten[SP]agenda,[SP]meow?",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Superbe, miaou! [1205][000F][1205][000F]Tu m'as nourri 80 fois,\nmiaou[1432][NULL][NULL][0007] T'as une idée en tête, miaou?"
+    "texte_fr": "Superbe, miaou! [000F][1205][000F][1205]Tu m'as nourri 80 fois,\nmiaou[1432][NULL][NULL][0007] T'as une idée en tête, miaou?"
   },
   {
     "id": 21,
@@ -400,7 +400,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "I[SP]feel[SP]bad[SP]at[SP]being[SP]given[SP]so[SP]much,[SP]meow![1205][000F]\nSo[SP]I[SP]have[SP]a[SP]purresent[SP]for[SP]you!",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Désolé de tant recevoir, miaou!\n[1205][000F]Alors voici un chadeau pour toi!"
+    "texte_fr": "Désolé de tant recevoir, miaou!\n[000F][1205]Alors voici un chadeau pour toi!"
   },
   {
     "id": 23,
@@ -460,7 +460,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "What's[SP]this[SP]poster!?[1205][000F][SP]Ugh,[SP]you[SP]stole[SP]it[SP]from\nanother[SP]station,[SP]didn't[SP]you!?[1205][000F][SP]Go[SP]put[SP]this\nback[SP]right[SP]now!",
     "nom_fr": "Tamaki",
-    "texte_fr": "C'est quoi cette affiche![1205][000F][1205][000F]? Volée dans\nune gare, avoue!? Va vite la remettre!"
+    "texte_fr": "C'est quoi cette affiche![000F][1205][000F][1205]? Volée dans\nune gare, avoue!? Va vite la remettre!"
   },
   {
     "id": 27,
@@ -475,7 +475,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "Whaaaat!?[1205][000F][SP]Noooo...[SP]I[SP]just[SP]found[SP]it![1205][000F][SP]If[SP]you\nleave[SP]them[SP]there,[SP]they'll[SP]get[SP]snatched[SP]up\nby[SP]someone[SP]else[SP]just[SP]like[SP]that!",
     "nom_fr": "Tadashi",
-    "texte_fr": "Quoooi![1205][000F][1205][000F]? Nannn... Je l'ai trouvée! Si\non les laisse là, elles seront\npiquées par quelqu'un d'autre direct!"
+    "texte_fr": "Quoooi![000F][1205][000F][1205]? Nannn... Je l'ai trouvée! Si\non les laisse là, elles seront\npiquées par quelqu'un d'autre direct!"
   },
   {
     "id": 28,
@@ -573,7 +573,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Okay![1205][001E][SP]Wait...[SP]you[SP]don't[SP]have[SP]any[SP]magazines.\nThey[SP]sell[SP]them[SP]at[SP]Satomi[SP]Tadashi,[SP]so[SP]come\nback[SP]when[SP]you've[SP]bought[SP]some.",
     "nom_fr": "Tamaki",
-    "texte_fr": "D'accord![1205][001E] Attends... tu n'as aucun\nmagazine. Ils en vendent chez Satomi\nTadashi, reviens après en avoir acheté."
+    "texte_fr": "D'accord![001E][1205] Attends... tu n'as aucun\nmagazine. Ils en vendent chez Satomi\nTadashi, reviens après en avoir acheté."
   },
   {
     "id": 33,
@@ -878,7 +878,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "Hmm,[SP]I'm[SP]curious[SP]about[SP]Muses,[SP]but[SP]also[SP]about\nthe[SP]Masked[SP]Circle...[1205][000F][SP]I[SP]get[SP]the[SP]feeling[SP]they're\na[SP]dangerous[SP]bunch.",
     "nom_fr": "Tadashi",
-    "texte_fr": "Hmm, je suis curieux sur Muses et sur le\n[1205][000F]Cercle masqué... Ils ont l'air dangereux."
+    "texte_fr": "Hmm, je suis curieux sur Muses et sur le\n[000F][1205]Cercle masqué... Ils ont l'air dangereux."
   },
   {
     "id": 52,
@@ -893,7 +893,7 @@
     "nom_orig": "Maya",
     "texte_orig": "W-Wait[SP]a[SP]sec,[SP][1113]-kun![1205][000F][SP]We[SP]need[SP]to[SP]ask\nthe[SP]Chief[SP]about[SP]the[SP]Masked[SP]Circle.[SP]Come[SP]over\nhere![SP]And[SP]make[SP]it[SP]quick!",
     "nom_fr": "Maya",
-    "texte_fr": "A-Attends, [1113]-kun! [1205][000F]On doit\nquestionner le Chef sur le Cercle\nmasqué. Viens ici! Et vite!"
+    "texte_fr": "A-Attends, [1113]-kun! [000F][1205]On doit\nquestionner le Chef sur le Cercle\nmasqué. Viens ici! Et vite!"
   },
   {
     "id": 53,
@@ -908,7 +908,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "I[SP]get[SP]the[SP]gist[SP]of[SP]your[SP]story.[1205][000F][SP]But[SP]I'm[SP]sorry,\nI've[SP]never[SP]heard[SP]of[SP]this[SP]Masked[SP]Circle.",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Je vois le topo. [1205][000F]Mais je n'ai jamais\nentendu parler de ce Cercle masqué."
+    "texte_fr": "Je vois le topo. [000F][1205]Mais je n'ai jamais\nentendu parler de ce Cercle masqué."
   },
   {
     "id": 54,
@@ -938,7 +938,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "Huh!?[1205][000F][SP]These[SP]two[SP]in[SP]the[SP]photo[SP]here[SP]are[SP]your\nclassmates!?",
     "nom_fr": "Tadashi",
-    "texte_fr": "Hein![1205][000F]? Ces filles en photo\nsont vos camarades!?"
+    "texte_fr": "Hein![000F][1205]? Ces filles en photo\nsont vos camarades!?"
   },
   {
     "id": 56,
@@ -1118,7 +1118,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Now[SP]I[SP]see...[1205][000F][SP]Those[SP]Sevens[SP]kids[SP]saw[SP]this[SP]poster\nand[SP]thought[SP]Lisa[SP]was[SP]making[SP]her[SP]debut...",
     "nom_fr": "Yukino",
-    "texte_fr": "Je vois..[1205][000F]. Ces gamins de Seven ont vu\nl'affiche et cru que Lisa débutait..."
+    "texte_fr": "Je vois..[000F][1205]. Ces gamins de Seven ont vu\nl'affiche et cru que Lisa débutait..."
   },
   {
     "id": 68,
@@ -1163,7 +1163,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Something's[SP]odd[SP]about[SP]this[SP]poster.[1205][000F][SP]It's[SP]like\nthey[SP]put[SP]these[SP]up[SP]specifically[SP]to[SP]make[SP]people\nspeculate[SP]that[SP]Lisa's[SP]the[SP]third[SP]member...",
     "nom_fr": "Maya",
-    "texte_fr": "Cette affiche est bizarre. [1205][000F]C'est comme\nsi on l'avait mise là pour que les gens\npensent que Lisa est le 3ème membre..."
+    "texte_fr": "Cette affiche est bizarre. [000F][1205]C'est comme\nsi on l'avait mise là pour que les gens\npensent que Lisa est le 3ème membre..."
   },
   {
     "id": 71,

--- a/traduction/event_scripts/script_321.json
+++ b/traduction/event_scripts/script_321.json
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Sheesh,[SP]what[SP]a[SP]complete[SP]and[SP]utter[SP]coward...[1205][000A]\nC'mon,[SP]aren't[SP]you[SP]some[SP]ace[SP]detective[SP]who\nthrives[SP]in[SP]the[SP]shadow[SP]of[SP]the[SP]city?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pfff, quel lâche absolu...[1205][000A] T'es\npas censé être un as détective qui\nprospère dans l'ombre de la ville?"
+    "texte_fr": "Pfff, quel lâche absolu...[000A][1205] T'es\npas censé être un as détective qui\nprospère dans l'ombre de la ville?"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Could[SP]the[SP]part[SP]about[SP]the[SP]Earth[SP]being[SP]annihilated\ncome[SP]true,[SP]too?[1205][000F][SP]Yeah,[SP]I'm[SP]sure[SP]it[SP]will...",
     "nom_fr": "Ginko",
-    "texte_fr": "La destruction de la Terre va-t-elle aussi\nse réaliser? [1205][000F]Ouais, j'en suis sûre..."
+    "texte_fr": "La destruction de la Terre va-t-elle aussi\nse réaliser? [000F][1205]Ouais, j'en suis sûre..."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What're[SP]we[SP]gonna[SP]do?[1205][000F][SP]Everyone's[SP]gossiping[SP]about\nhow[SP]the[SP]world's[SP]gonna[SP]end[SP]down[SP]there,[SP]just\nbecause[SP]they[SP]think[SP]they're[SP]safe.",
     "nom_fr": "Ginko",
-    "texte_fr": "Que va-t-on faire? [1205][000F]Tous parlent de\nla fin du monde en bas, juste parce\nqu'ils se croient en sécurité."
+    "texte_fr": "Que va-t-on faire? [000F][1205]Tous parlent de\nla fin du monde en bas, juste parce\nqu'ils se croient en sécurité."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yeah...[1205][000A][SP]At[SP]this[SP]rate,[SP]the[SP]people[SP]of[SP]Sumaru[SP]will\ndestroy[SP]the[SP]world...[1205][000F][SP]We[SP]have[SP]to[SP]do[SP]something\nbefore[SP]it[SP]gets[SP]to[SP]that[SP]stage.",
     "nom_fr": "Maya",
-    "texte_fr": "Ouais.[1205]..[1205][000A] À ce rythme, les gens de\n[000F]Sumaru détruiront le monde... Il\nfaut agir avant d'en arriver là."
+    "texte_fr": "Ouais.[1205]..[000A][1205] À ce rythme, les gens de\n[000F]Sumaru détruiront le monde... Il\nfaut agir avant d'en arriver là."
   },
   {
     "id": 7,
@@ -147,7 +147,7 @@
     "nom_orig": "Jun",
     "texte_orig": "The[SP]Maia[SP]Maiden...[1205][000F][SP]It[SP]seems[SP]my[SP]father[SP]still\nhopes[SP]to[SP]fulfill[SP]the[SP]Oracle...",
     "nom_fr": "Jun",
-    "texte_fr": "La Vierge Maia.[1205][000F].. Mon père espère\ntoujours accomplir l'Oracle..."
+    "texte_fr": "La Vierge Maia.[000F][1205].. Mon père espère\ntoujours accomplir l'Oracle..."
   },
   {
     "id": 10,
@@ -272,7 +272,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Okay![1205][001E][SP]Wait...[SP]you[SP]don't[SP]have[SP]any[SP]magazines.\nThey[SP]sell[SP]them[SP]at[SP]Satomi[SP]Tadashi,[SP]so[SP]come\nback[SP]when[SP]you've[SP]bought[SP]some.",
     "nom_fr": "Tamaki",
-    "texte_fr": "OK![1205][001E] Attendez... pas de magazines.\nIls en vendent chez Satomi Tadashi.\nRevenez après en avoir acheté."
+    "texte_fr": "OK![001E][1205] Attendez... pas de magazines.\nIls en vendent chez Satomi Tadashi.\nRevenez après en avoir acheté."
   },
   {
     "id": 16,
@@ -402,7 +402,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Also,[SP]you[SP]can[SP]only[SP]send[SP]in[SP]99[SP]magazines[SP]per\nentry.[SP]The[SP]more[SP]you[SP]send,[SP]the[SP]better[SP]your\nchances[SP]of[SP]winning.",
     "nom_fr": "Tamaki",
-    "texte_fr": "Limite de 99 magazines\npar envoi. Plus vous en\nenvoyez, plus vous avez\nde chances de gagner."
+    "texte_fr": "Limite de 99 magazines\npar envoi. Plus vous en\nenvoyez, plus vous avez de chances de gagner."
   },
   {
     "id": 24,
@@ -462,7 +462,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "I'm[SP]so[SP]sorry.[SP]We[SP]got[SP]careless.[1205][000F][SP]I[SP]hope[SP]you\ncan[SP]do[SP]something[SP]for[SP]that[SP]teacher.",
     "nom_fr": "Tamaki",
-    "texte_fr": "Désolée. On a été négligents. [1205][000F]J'espère\nque vous pourrez aider ce prof."
+    "texte_fr": "Désolée. On a été négligents. [000F][1205]J'espère\nque vous pourrez aider ce prof."
   },
   {
     "id": 28,
@@ -522,7 +522,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "Hehehe![SP]I[SP]finally[SP]heard[SP]a[SP]convincing[SP]theory![1205][000F]\nAfter[SP]the[SP]Grand[SP]Cross,[SP]the[SP]balance[SP]of[SP]gravity\nwill[SP]be[SP]thrown[SP]off,[SP]stopping[SP]Earth's[SP]rotation.",
     "nom_fr": "Tadashi",
-    "texte_fr": "Héhé! Une théorie convaincante! [1205][000F]Après la\nCroix, la gravité sera déséquilibrée,\narrêtant la rotation de la Terre."
+    "texte_fr": "Héhé! Une théorie convaincante! [000F][1205]Après la\nCroix, la gravité sera déséquilibrée,\narrêtant la rotation de la Terre."
   },
   {
     "id": 32,
@@ -537,7 +537,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "There's[SP]a[SP]part[SP]in[SP]the[SP]In[SP]Lak'ech[SP]that[SP]hints[SP]at\nsomething[SP]like[SP]that,[SP]too.[1205][000F][SP]Looks[SP]like[SP]I've[SP]got\nit[SP]right[SP]this[SP]time.",
     "nom_fr": "Tadashi",
-    "texte_fr": "In Lak'ech laisse aussi entendre un truc du\ngenre. [1205][000F]On dirait que\nj'ai vu juste cette fois."
+    "texte_fr": "In Lak'ech laisse aussi entendre un truc du\ngenre. [000F][1205]On dirait que\nj'ai vu juste cette fois."
   },
   {
     "id": 33,
@@ -552,7 +552,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "I[SP]was[SP]here[SP]and[SP]I[SP]couldn't[SP]stop[SP]them[SP]from\nkidnapping[SP]the[SP]teacher...[1205][000F][SP]I'm[SP]so[SP]ashamed...",
     "nom_fr": "Tadashi",
-    "texte_fr": "J'étais là et je n'ai pas pu empêcher\nl'enlèvement de la prof.[1205][000F].. J'ai si honte..."
+    "texte_fr": "J'étais là et je n'ai pas pu empêcher\nl'enlèvement de la prof.[000F][1205].. J'ai si honte..."
   },
   {
     "id": 34,
@@ -567,7 +567,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "I[SP]guess[SP]I'm[SP]not[SP]cut[SP]out[SP]for[SP]this[SP]job...[1205][000F][SP]Should\nI[SP]apply[SP]to[SP]be[SP]a[SP]game[SP]designer[SP]instead?[1205][000F][SP]That\nsounds[SP]like[SP]it[SP]might[SP]be[SP]fun...",
     "nom_fr": "Tadashi",
-    "texte_fr": "Je ne suis pas fait pour ce\n[1205][000F][1205][000F]métier... Devrais-je devenir game\ndesigner? Ça a l'air amusant..."
+    "texte_fr": "Je ne suis pas fait pour ce\n[000F][1205][000F][1205]métier... Devrais-je devenir game\ndesigner? Ça a l'air amusant..."
   },
   {
     "id": 35,
@@ -582,7 +582,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Pull[SP]yourself[SP]together,[SP]Tadashi![1205][000F][SP]You're[SP]lucky\nyou[SP]got[SP]a[SP]taste[SP]of[SP]the[SP]violence[SP]you[SP]admired.",
     "nom_fr": "Tamaki",
-    "texte_fr": "Reprends-toi, Tadashi! [1205][000F]Tu as de la chance\nd'avoir goûté à la\nviolence que tu admirais."
+    "texte_fr": "Reprends-toi, Tadashi! [000F][1205]Tu as de la chance\nd'avoir goûté à la\nviolence que tu admirais."
   },
   {
     "id": 36,
@@ -666,7 +666,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "I'm[SP]sorry[SP]for[SP]what[SP]happened[SP]to[SP]that[SP]teacher.\nLooks[SP]like[SP]Tadashi[SP]took[SP]quite[SP]a[SP]beating...[1205][000F]\nSo,[SP]do[SP]you[SP]need[SP]me[SP]to[SP]spread[SP]any[SP]rumors?\n[1208][0005]Spread[SP]rumors\nCheck[SP]rumors\nTalk[SP]with[SP]the[SP]Chief\nCancel\nLeave[SP]the[SP]detective[SP]agency",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Désolé pour ce qui est arrivé à ce\nprof. On dirait que Tadashi a pris une\nraclée.[1205][000F].. Une rumeur à répandre?\n[1208][0005]Spread rumors\nCheck rumors\nTalk with the Chief\nCancel\nLeave the detective agency",
+    "texte_fr": "Désolé pour ce qui est arrivé à ce\nprof. On dirait que Tadashi a pris une\nraclée.[000F][1205].. Une rumeur à répandre?\n[1208][0005]Spread rumors\nCheck rumors\nTalk with the Chief\nCancel\nLeave the detective agency",
     "question_orig": "I'm[SP]sorry[SP]for[SP]what[SP]happened[SP]to[SP]that[SP]teacher.\nLooks[SP]like[SP]Tadashi[SP]took[SP]quite[SP]a[SP]beating...[1205][000F]\nSo,[SP]do[SP]you[SP]need[SP]me[SP]to[SP]spread[SP]any[SP]rumors?",
     "choix_orig": [
       "Spread[SP]rumors",
@@ -804,7 +804,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "In[SP]the[SP]end,[SP]maybe[SP]humanity[SP]deserves[SP]to[SP]be\nannihilated.[1205][000F][SP]Rumors[SP]are[SP]the[SP]hidden[SP]desires\nof[SP]mankind,[SP]after[SP]all.",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Peut-être que l'humanité mérite\nd'être anéantie. [1205][000F]Les rumeurs sont\nles désirs cachés de l'homme."
+    "texte_fr": "Peut-être que l'humanité mérite\nd'être anéantie. [000F][1205]Les rumeurs sont\nles désirs cachés de l'homme."
   },
   {
     "id": 46,
@@ -849,7 +849,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "To[SP]think[SP]they'd[SP]strike[SP]when[SP]Tamaki[SP]and[SP]I[SP]were\nout...[1205][001E][SP]This[SP]was[SP]my[SP]mistake.[SP]I'm[SP]very[SP]sorry\nit[SP]happened.",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Ils ont frappé pendant notre absence...[1205][001E]\nC'est mon erreur. Je suis vraiment désolé."
+    "texte_fr": "Ils ont frappé pendant notre absence...[001E][1205]\nC'est mon erreur. Je suis vraiment désolé."
   },
   {
     "id": 49,
@@ -864,7 +864,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "But...[1205][000A][SP]I[SP]hope[SP]Tadashi[SP]understands[SP]now.[1205][000F][SP]This\nlife[SP]isn't[SP]as[SP]cool[SP]or[SP]clear-cut[SP]as[SP]they[SP]make\nit[SP]seem[SP]in[SP]TV[SP]shows[SP]and[SP]comic[SP]books.",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Mais.[1205]..[1205][000A] J'espère que Tadashi a compris.\n[000F]La vie n'est pas aussi simple et cool\nqu'à la télé ou dans les mangas."
+    "texte_fr": "Mais.[1205]..[000A][1205] J'espère que Tadashi a compris.\n[000F]La vie n'est pas aussi simple et cool\nqu'à la télé ou dans les mangas."
   },
   {
     "id": 50,
@@ -979,7 +979,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "Meowvelous![1432][NULL][NULL][0007][1205][000F]\nI[SP]can't[SP]believe[SP]you[SP]fed[SP]me[SP]50[SP]times,[SP]purrrr[1432][NULL][NULL][0007][1205][000F]\nYou're[SP]so[SP]generous,[SP]Misterrr[1432][NULL][NULL][0007]",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Miaourveilleux![1205][000F][1205][000F][1432][NULL][NULL][0007] Nourri 50 fois,\nronron[1432][NULL][NULL][0007] Très généreux, mooonsieur[1432][NULL][NULL][0007]"
+    "texte_fr": "Miaourveilleux![000F][1205][000F][1205][1432][NULL][NULL][0007] Nourri 50 fois,\nronron[1432][NULL][NULL][0007] Très généreux, mooonsieur[1432][NULL][NULL][0007]"
   },
   {
     "id": 57,
@@ -994,7 +994,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "Amazing,[SP]meow![1205][000F]\nYou've[SP]fed[SP]me[SP]80[SP]times[SP]now,[SP]meow[1432][NULL][NULL][0007][1205][000F]\nDo[SP]you[SP]have[SP]a[SP]kitten[SP]agenda,[SP]meow?",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Superbe, miaou! [1205][000F][1205][000F]Nourri 80 fois,\nmiaou[1432][NULL][NULL][0007] As-tu un plan caché, miaou?"
+    "texte_fr": "Superbe, miaou! [000F][1205][000F][1205]Nourri 80 fois,\nmiaou[1432][NULL][NULL][0007] As-tu un plan caché, miaou?"
   },
   {
     "id": 58,
@@ -1009,7 +1009,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "The[SP]time[SP]has[SP]finally[SP]come,[SP]meow...[1205][000F]\nAn[SP]even[SP]100[SP]feedings...[1205][000F]\nI've[SP]collected[SP]10,000[SP]yen,[SP]meow!",
     "nom_fr": "Statue de chat",
-    "texte_fr": "L'heure est arrivée... [1205][000F][1205][000F]Exactement 100\nrepas... J'ai récolté 10 000 yens, miaou!"
+    "texte_fr": "L'heure est arrivée... [000F][1205][000F][1205]Exactement 100\nrepas... J'ai récolté 10 000 yens, miaou!"
   },
   {
     "id": 59,
@@ -1198,7 +1198,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "He[SP]was[SP]a[SP]dreamer,[SP]who[SP]loved[SP]his[SP]students[SP]very\nmuch.[1205][001E][SP]Yet[SP]he[SP]died[SP]in[SP]such[SP]a[SP]dreadful[SP]way...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Un rêveur aimant ses élèves.[1205][001E] Pourtant,\nil est mort si atrocement..."
+    "texte_fr": "Un rêveur aimant ses élèves.[001E][1205] Pourtant,\nil est mort si atrocement..."
   },
   {
     "id": 70,
@@ -1243,7 +1243,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Sudou-kun[SP]was[SP]at[SP]Sevens[SP]too,[SP]as[SP]a[SP]student...[1205][001E]\nHe[SP]was[SP]a[SP]timid[SP]boy,[SP]afraid[SP]of[SP]his[SP]extremely\nstrict[SP]father.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Sudou était élève à Seven...[1205][001E] Un garçon\ntimide, effrayé par son père strict."
+    "texte_fr": "Sudou était élève à Seven...[001E][1205] Un garçon\ntimide, effrayé par son père strict."
   },
   {
     "id": 73,
@@ -1318,7 +1318,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "[1432][NULL][NULL][0014]In[SP]Lak'ech[1432][NULL][NULL][0014][SP]means[SP][1432][NULL][NULL][0014]you[SP]are[SP]another[SP]me[1432][NULL][NULL][0014][SP]in\nMayan.[1205][001E][SP]It's[SP]what[SP]we[SP]called[SP]the[SP]oracle[SP]that\nSudou-kun[SP]channeled.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "[1432][NULL][NULL][0014]In Lak'ech[1432][NULL][NULL][0014] signifie [1432][NULL][NULL][0014]tu es un autre moi[1432][NULL][NULL][0014] en\nmaya.[1205][001E] C'est le nom de l'oracle de Sudou."
+    "texte_fr": "[1432][NULL][NULL][0014]In Lak'ech[1432][NULL][NULL][0014] signifie [1432][NULL][NULL][0014]tu es un autre moi[1432][NULL][NULL][0014] en\nmaya.[001E][1205] C'est le nom de l'oracle de Sudou."
   },
   {
     "id": 78,
@@ -1333,7 +1333,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]Maians[SP]guided[SP]our[SP]evolution[SP]once,[SP]though\nthat[SP]stage[SP]is[SP]now[SP]lost.[1205][001E][SP]Our[SP]civilization[SP]as\nit[SP]stands[SP]is[SP]a[SP]remnant[SP]from[SP]then...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Les Mayas ont guidé notre évolution.[1205][001E]\nNotre civilisation n'est qu'un vestige..."
+    "texte_fr": "Les Mayas ont guidé notre évolution.[001E][1205]\nNotre civilisation n'est qu'un vestige..."
   },
   {
     "id": 79,
@@ -1363,7 +1363,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Xibalba[SP]is[SP]the[SP]key[SP]to[SP]our[SP]evolution.[SP]We[SP]can't\nevolve[SP]without[SP]it...[1205][001E][SP]But[SP]it[SP]will[SP]come[SP]at[SP]the\ncost[SP]of[SP]this[SP]world's[SP]extinction!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Xibalba est la clé de notre évolution.[1205][001E]\nMais le prix est l'extinction du monde!"
+    "texte_fr": "Xibalba est la clé de notre évolution.[001E][1205]\nMais le prix est l'extinction du monde!"
   },
   {
     "id": 81,
@@ -1408,7 +1408,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]Mayans[SP]worshipped[SP]the[SP]Oxlahuntiku[SP]as[SP]gods\nof[SP]light...[1205][001E][SP]While[SP]they[SP]feared[SP]the[SP]Bolontiku\nas[SP]gods[SP]of[SP]the[SP]netherworld...",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Ils vénéraient les Oxlahuntiku,\ndieux de lumière...[1205][001E] Et craignaient\nles Bolontiku, dieux des enfers..."
+    "texte_fr": "Ils vénéraient les Oxlahuntiku,\ndieux de lumière...[001E][1205] Et craignaient\nles Bolontiku, dieux des enfers..."
   },
   {
     "id": 84,
@@ -1423,7 +1423,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Their[SP]war[SP]consumed[SP]this[SP]solar[SP]system,[SP]and[SP]the\nOxlahuntiku[SP]perished...[1205][001E][SP]Those[SP]events[SP]are[SP]the\nsource[SP]of[SP]common[SP]legends[SP]of[SP]the[SP]flood.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "La guerre a ravagé ce système,\nles Oxlahuntiku ont péri...[1205][001E] C'est\nl'origine du mythe du déluge."
+    "texte_fr": "La guerre a ravagé ce système,\nles Oxlahuntiku ont péri...[001E][1205] C'est\nl'origine du mythe du déluge."
   },
   {
     "id": 85,
@@ -1468,7 +1468,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Ideal[SP]Energy[SP]is[SP]the[SP]power[SP]of[SP]thought[SP]held[SP]by\nus[SP]living[SP]beings...[1205][001E][SP]It's[SP]a[SP]psychological\nenergy[SP]based[SP]on[SP]one's[SP]ideals.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "L'Énergie Idéale est la force de nos\npensées...[1205][001E] Une énergie psychique de nos\nidéaux."
+    "texte_fr": "L'Énergie Idéale est la force de nos\npensées...[001E][1205] Une énergie psychique de nos\nidéaux."
   },
   {
     "id": 88,
@@ -1483,7 +1483,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]energy[SP]is[SP]heightened[SP]most[SP]when[SP]one[SP]is\npassionate[SP]about[SP]one's[SP]ideals,[SP]or[SP]when[SP]one's\ndream[SP]comes[SP]true.[1205][001E][SP]It's[SP]fed[SP]by[SP]joie[SP]de[SP]vivre.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Elle croît quand on est passionné\nou qu'un rêve se réalise.[1205][001E] Elle se\nnourrit de joie de vivre."
+    "texte_fr": "Elle croît quand on est passionné\nou qu'un rêve se réalise.[001E][1205] Elle se\nnourrit de joie de vivre."
   },
   {
     "id": 89,
@@ -1498,7 +1498,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "Ideal[SP]Energy[SP]is[SP]the[SP]Maian[SP]source[SP]of[SP]power...[1205][001E]\nAnd[SP]the[SP]crystal[SP]skulls[SP]are[SP]OOPArts[SP]planted\nin[SP]mankind's[SP]history[SP]to[SP]collect[SP]it!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "C'est la source d'énergie maya...[1205][001E] Et les\ncrânes sont des OOPArts plantés pour la\nrécolter!"
+    "texte_fr": "C'est la source d'énergie maya...[001E][1205] Et les\ncrânes sont des OOPArts plantés pour la\nrécolter!"
   },
   {
     "id": 90,
@@ -1568,7 +1568,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "The[SP]greatest[SP]and[SP]worst[SP]dictator[SP]of[SP]the\ncentury![1205][001E][SP]You[SP]know[SP]that[SP]much,[SP]I[SP]hope.",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Le plus grand et pire dictateur du\nsiècle![1205][001E] J'espère que vous le savez."
+    "texte_fr": "Le plus grand et pire dictateur du\nsiècle![001E][1205] J'espère que vous le savez."
   },
   {
     "id": 94,
@@ -1598,7 +1598,7 @@
     "nom_orig": "Ms.[SP]Ideal",
     "texte_orig": "He[SP]said[SP]so[SP]himself![1205][001E][SP]He's[SP]an[SP]immortal[SP]sorcerer\nwho[SP]learned[SP]magic[SP]from[SP]Mayan[SP]mystics.[SP]He\ncraved[SP]the[SP]secrets[SP]of[SP]ruins[SP]around[SP]the[SP]world!",
     "nom_fr": "Mme Idéale",
-    "texte_fr": "Il l'a dit![1205][001E] Sorcier immortel formé\npar les Mayas. Il convoitait les\nsecrets des ruines du monde!"
+    "texte_fr": "Il l'a dit![001E][1205] Sorcier immortel formé\npar les Mayas. Il convoitait les\nsecrets des ruines du monde!"
   },
   {
     "id": 96,

--- a/traduction/event_scripts/script_324.json
+++ b/traduction/event_scripts/script_324.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "M-My[SP]pops[SP]is[SP]the[SP]only[SP]man[SP]I[SP]have[SP]trouble[SP]dealing\nwith...[1205][001E][SP]Ever[SP]since[SP]I[SP]was[SP]a[SP]kid,[SP]when[SP]he[SP]yells[SP]at\nme[SP]in[SP]that[SP]scratchy[SP]voice,[SP]I[SP]freeze[SP]up.",
     "nom_fr": "Eikichi",
-    "texte_fr": "M-Mon vieux est le seul homme avec qui j'ai\ndu mal...[1205][001E] Depuis mon enfance, quand il me\ncrie dessus avec sa voix éraillée, je gèle."
+    "texte_fr": "M-Mon vieux est le seul homme avec qui j'ai\ndu mal...[001E][1205] Depuis mon enfance, quand il me\ncrie dessus avec sa voix éraillée, je gèle."
   },
   {
     "id": 1,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]hope[SP]Hanakouji-san's[SP]okay...[1205][000F][SP]I[SP]wonder[SP]if[SP]she\nwent[SP]back[SP]to[SP]talk[SP]to[SP]her[SP]friend...[SP]Mind[SP]if[SP]we\nhit[SP]Peace[SP]Diner,[SP][1113]?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pourvu qu'Hanakouji aille bien.[1205][000F]..\nEst-elle retournée parler à son amie...\nOn peut passer au Peace Diner, [1113]?"
+    "texte_fr": "Pourvu qu'Hanakouji aille bien.[000F][1205]..\nEst-elle retournée parler à son amie...\nOn peut passer au Peace Diner, [1113]?"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]can't[SP]say[SP]I[SP]ever[SP]got[SP]along[SP]with[SP]Yasuo.[1205][000F]\nBut[SP]that[SP]doesn't[SP]make[SP]what[SP]King[SP]Leo[SP]did[SP]to[SP]him\nokay![1205][000F][SP]I'll[SP]avenge[SP]him[SP]too!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je'me suis jamais bien entendu avec\n[1205][000F][1205][000F]Yasuo. Mais ça n'excuse pas ce qu'a\nfait le Roi Lion! Je le vengerai aussi!"
+    "texte_fr": "Je'me suis jamais bien entendu avec\n[000F][1205][000F][1205]Yasuo. Mais ça n'excuse pas ce qu'a\nfait le Roi Lion! Je le vengerai aussi!"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "H-Hey,[SP]Maya-san's[SP]right.[SP]Let's[SP]go[SP]over[SP]to[SP]the\ndetective[SP]agency.[1205][000F][SP]I-If[SP]I[SP]stay[SP]here[SP]any[SP]longer,\nI'm...[SP]Uuurp...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, Maya a raison. Allons à l'agence\nde détectives. [1205][000F]S-Si je reste ici plus\nlongtemps, je vais... Bweuark..."
+    "texte_fr": "Hé, Maya a raison. Allons à l'agence\nde détectives. [000F][1205]S-Si je reste ici plus\nlongtemps, je vais... Bweuark..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I-I[SP]always[SP]wonder...[1205][000A][SP]Why[SP]do[SP]we[SP]have[SP]to[SP]come\nhere[SP]to[SP]chat...?[SP]Nngh...[1205][000F][SP]Let's[SP]just[SP]get[SP]to[SP]Mu\nand[SP]see[SP]for[SP]ourselves.[1205][000F][SP]Whaddaya[SP]say?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je me demande toujours.[1205][1205]..[1205][000A] Pourquoi venir\nici discuter.[000F][000F]..? Nngh... Allons plutôt\nvoir à Mu par nous-mêmes. T'en dis quoi?"
+    "texte_fr": "Je me demande toujours.[1205][1205]..[000A][1205] Pourquoi venir\nici discuter.[000F][000F]..? Nngh... Allons plutôt\nvoir à Mu par nous-mêmes. T'en dis quoi?"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Golly,[SP]she's[SP]going[SP]purple[SP]with[SP]rage.[1205][000F][SP]Hey,[SP]let's\nget[SP]to[SP]Giga[SP]Macho[SP]before[SP]this[SP]idol[SP]wannabe[SP]goes\non[SP]a[SP]rampage.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ouah, elle est verte de rage. [1205][000F]Allons\nvite au Giga Macho avant que cette\nfuture idole ne pète un câble."
+    "texte_fr": "Ouah, elle est verte de rage. [000F][1205]Allons\nvite au Giga Macho avant que cette\nfuture idole ne pète un câble."
   },
   {
     "id": 10,
@@ -192,7 +192,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Psh...[SP]This[SP]is[SP]why[SP]kung[SP]fu[SP]chick[SP]here[SP]is\ntrouble.[1205][000F][SP]Even[SP]a[SP]child[SP]could[SP]sit[SP]down[SP]and[SP]figure\nout[SP]the[SP]next[SP]target[SP]is[SP]the[SP]Sakanoue[SP]Building.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pff... Voilà pourquoi\nla fille kung-fu attire\n[1205][000F]les ennuis. Même un gosse devinerait que la\nprochaine cible est le bâtiment Sakanoue."
+    "texte_fr": "Pff... Voilà pourquoi\nla fille kung-fu attire\n[000F][1205]les ennuis. Même un gosse devinerait que la prochaine cible est le bâtiment Sakanoue."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]bet[SP]if[SP]I[SP]told[SP]Daddy-o[SP]I[SP]stopped[SP]the[SP]bombing,\nhe[SP]wouldn't[SP]believe[SP]me.[SP]He'd[SP]probably[SP]just\nsmack[SP]me[SP]again.[SP]Well,[SP]he[SP]can[SP]say[SP]what[SP]he[SP]wants.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Si je dis à mon père que j'ai arrêté\nl'attentat, il ne me\ncroira pas. Il va juste\nme frapper encore. Bref,\nqu'il dise ce qu'ilveut."
+    "texte_fr": "Si je dis à mon père que j'ai arrêté\nl'attentat, il ne me\ncroira pas. Il va juste me frapper encore. Bref, qu'il dise ce qu'ilveut."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "First[SP]the[SP]Masked[SP]Circle,[SP]now[SP]a[SP]group[SP]of[SP]five\nterrorists...[1205][000F][SP]What's[SP]all[SP]this[SP]BS[SP]everyone's\ntalking[SP]about[SP]all[SP]of[SP]a[SP]sudden?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le Cercle masqué, puis cinq terroristes...\n[1205][000F]C'est quoi toutes ces conneries dont tout\nle monde parle d'un coup?"
+    "texte_fr": "Le Cercle masqué, puis cinq terroristes...\n[000F][1205]C'est quoi toutes ces conneries dont tout\nle monde parle d'un coup?"
   },
   {
     "id": 15,
@@ -252,7 +252,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ten[SP]years[SP]ago...[SP]Would[SP]my[SP]pops[SP]know[SP]something?[1205][000F]\nN-No...[SP]There's[SP]no[SP]way[SP]he'd[SP]know[SP]about[SP]my\ndreams...[1205][001E][SP]H-Hey,[SP]let's[SP]get[SP]going.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Il y a 10 ans... Mon vieux sait quelque\n[1205][000F]chose? N-Non... Impossible qu'il\nconnaisse mes rêves...[1205][001E] H-Hé, on y va."
+    "texte_fr": "Il y a 10 ans... Mon vieux sait quelque\n[000F][1205]chose? N-Non... Impossible qu'il\nconnaisse mes rêves...[001E][1205] H-Hé, on y va."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ow...[1205][000F][SP]I[SP]asked[SP]Daddy-o[SP]if[SP]he[SP]could[SP]kick[SP]those\nsoldiers'[SP]asses,[SP]and[SP]he[SP]just[SP]belted[SP]me[SP]one.\nWhat's[SP]he[SP]so[SP]mad[SP]about?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Aïe.[1205][000F].. J'ai demandé au vieux de botter\nle cul de ces soldats et il m'a\nfrappé. Pourquoi est-il si en colère?"
+    "texte_fr": "Aïe.[000F][1205].. J'ai demandé au vieux de botter\nle cul de ces soldats et il m'a\nfrappé. Pourquoi est-il si en colère?"
   },
   {
     "id": 18,
@@ -297,7 +297,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Snrk...[SP]Ahahahahah![1205][001E][SP]You[SP]Yisi![SP]That's[SP]hilarious![1205][001E]\nCostume[SP]practice?[SP]You[SP]always[SP]dress[SP]like[SP]that![E1][E2]\n[E3][E4][NULL][NULL]\"Ginko\nHaime!?[SP]Seriously!?[SP]The[SP]Undie[SP]Boss[SP]lives[SP]in\nfear[SP]of[SP]his[SP]dad!?",
     "nom_fr": "Lisa",
-    "texte_fr": "Pfft... Ahahaha![1205][001E] You Yisi! C'est tordant![1205][001E]\nQuel costume? Tu t'habilles toujours\ncomme ça![E1][E2]\n[E3][E4][NULL][NULL]\"Ginko\nHaime!? Sérieux!? Le\nBoss en Caleçon a peur de son père!?"
+    "texte_fr": "Pfft... Ahahaha![001E][1205] You Yisi! C'est tordant![001E][1205]\nQuel costume? Tu t'habilles toujours\ncomme ça![E1][E2]\n[E3][E4][NULL][NULL]\"Ginko\nHaime!? Sérieux!? Le\nBoss en Caleçon a peur de son père!?"
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Snrk...[SP]Ahahahahah![1205][001E][SP]You[SP]Yisi![SP]That's[SP]hilarious![1205][001E]\nCostume[SP]practice?[SP]You[SP]always[SP]dress[SP]like[SP]that!",
     "nom_fr": "Ginko",
-    "texte_fr": "Pfft... Ahahaha![1205][001E] You\nYisi! C'est tordant![1205][001E] Quel\ncostume? Tu t'habilles toujours comme ça!"
+    "texte_fr": "Pfft... Ahahaha![001E][1205] You\nYisi! C'est tordant![001E][1205] Quel\ncostume? Tu t'habilles toujours comme ça!"
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]guess[SP]Maya-san[SP]really[SP]likes[SP]crab.[SP]But[SP]what's\nthis[SP][1432][NULL][NULL][0014]silent[SP]crab[1432][NULL][NULL][0014][SP]thing?[SP]Is[SP]it[SP]because[SP]people\nget[SP]all[SP]quiet[SP]when[SP]they[SP]eat[SP]crab?[E1][E2]\n[E3][E4][NULL][NULL]\"Ginko\nKehhei![1205][000F][SP]That[SP]Undie[SP]Boss[SP]up[SP]and[SP]went[SP]off[SP]on\nhis[SP]own.[SP]How[SP]reckless[SP]can[SP]he[SP]be?",
     "nom_fr": "Ginko",
-    "texte_fr": "Maya adore vraiment le\ncrabe. Mais c'est quoi\nce [1432][NULL][NULL][0014]crabe silencieux[1432][NULL][NULL][0014]? C'est\ncar on se tait en\nen mangeant?[E1][E2]\n[E3][E4][NULL][NULL]\"Ginko\n[1205][000F]Kehhei! Ce Boss en Caleçon\nest parti seul. À\nquel point est-il imprudent?"
+    "texte_fr": "Maya adore vraiment le\ncrabe. Mais c'est quoi\nce [1432][NULL][NULL][0014]crabe silencieux[1432][NULL][NULL][0014]? C'est\ncar on se tait en\nen mangeant?[E1][E2]\n[E3][E4][NULL][NULL]\"Ginko\n[000F][1205]Kehhei! Ce Boss en Caleçon\nest parti seul. À\nquel point est-il imprudent?"
   },
   {
     "id": 22,
@@ -447,7 +447,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![1205][000F][SP]That[SP]dummy[SP]has[SP]no[SP]proof![1205][000F][SP]The[SP]next\ntarget[SP]HAS[SP]to[SP]be[SP]Smile[SP]Hirasaka!",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei! [1205][000F][1205][000F]Cet idiot n'a aucune preuve!\nLa cible DOIT être Smile Hirasaka!"
+    "texte_fr": "Kehhei! [000F][1205][000F][1205]Cet idiot n'a aucune preuve!\nLa cible DOIT être Smile Hirasaka!"
   },
   {
     "id": 30,
@@ -492,7 +492,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Why[SP]is[SP]everyone[SP]in[SP]town[SP]so[SP]eager[SP]to[SP]blame\nsomeone?[1205][000F][SP]All[SP]it's[SP]doing[SP]is[SP]making[SP]them[SP]even\nmore[SP]paranoid.[SP]I'm[SP]kind[SP]of[SP]disgusted.",
     "nom_fr": "Ginko",
-    "texte_fr": "Pourquoi la ville est si impatiente de\n[1205][000F]blâmer quelqu'un? Ça ne fait que les\nrendre plus paranoïaques. Ça me dégoûte."
+    "texte_fr": "Pourquoi la ville est si impatiente de\n[000F][1205]blâmer quelqu'un? Ça ne fait que les\nrendre plus paranoïaques. Ça me dégoûte."
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]wonder[SP]if[SP]that[SP]bastard[SP]King[SP]Leo's[SP]somewhere\nlaughing[SP]at[SP]us...[1205][000F][SP]We[SP]really[SP]blew[SP]it,[SP][1113]!",
     "nom_fr": "Ginko",
-    "texte_fr": "Si ça se trouve ce Roi Lion se rit de\nnous... [1205][000F]On a vraiment tout gâché, [1113]!"
+    "texte_fr": "Si ça se trouve ce Roi Lion se rit de\nnous... [000F][1205]On a vraiment tout gâché, [1113]!"
   },
   {
     "id": 34,
@@ -537,7 +537,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Playing[SP]Masked[SP]Circle...[1205][000F][SP]Don't[SP]you[SP]remember,\n[1113]?",
     "nom_fr": "Ginko",
-    "texte_fr": "Jouer au Cercle masqué.[1205][000F]..\nTu as oublié, [1113]?"
+    "texte_fr": "Jouer au Cercle masqué.[000F][1205]..\nTu as oublié, [1113]?"
   },
   {
     "id": 36,
@@ -582,7 +582,7 @@
     "nom_orig": "Maya",
     "texte_orig": "...[1205][001E]Hm?[SP]Oh,[SP]it's[SP]nothing...[1205][001E][SP]I'm[SP]okay...",
     "nom_fr": "Maya",
-    "texte_fr": "...[1205][001E] Hm? Oh, rien...[1205][001E] Tout va bien..."
+    "texte_fr": "...[001E][1205] Hm? Oh, rien...[001E][1205] Tout va bien..."
   },
   {
     "id": 39,
@@ -642,7 +642,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Masquerade...[1205][000F][SP]A[SP]masked[SP]dance[SP]party...[1205][000F][SP]Could\nthis[SP]masquerade[SP]be[SP]that[SP][1432][NULL][NULL][0014]initiation[1432][NULL][NULL][0014]...?",
     "nom_fr": "Maya",
-    "texte_fr": "Mascarade.[1205][000F][1205][000F].. Un bal masqué... Cette\nmascarade serait-elle cette [1432][NULL][NULL][0014]initiation[1432][NULL][NULL][0014]...?"
+    "texte_fr": "Mascarade.[000F][1205][000F][1205].. Un bal masqué... Cette\nmascarade serait-elle cette [1432][NULL][NULL][0014]initiation[1432][NULL][NULL][0014]...?"
   },
   {
     "id": 43,
@@ -657,7 +657,7 @@
     "nom_orig": "Maya",
     "texte_orig": "So[SP]that[SP]arsonist[SP]was[SP]one[SP]of[SP]the[SP]Masked[SP]Circle's\nexecutives...[1205][000F][SP]Is[SP]this[SP]fate?[1205][000F][SP]But[SP]why's[SP]he[SP]after\nme[SP]and[SP][1113]-kun?",
     "nom_fr": "Maya",
-    "texte_fr": "Ce pyromane était un cadre du Cercle\nmasqué... [1205][000F][1205][000F]Le destin? Mais pourquoi\nnous en vouloir à [1113]-kun et moi?"
+    "texte_fr": "Ce pyromane était un cadre du Cercle\nmasqué... [000F][1205][000F][1205]Le destin? Mais pourquoi\nnous en vouloir à [1113]-kun et moi?"
   },
   {
     "id": 44,
@@ -702,7 +702,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]wonder[SP]what's[SP]upsetting[SP]Lisa.[1205][000F][SP]She's[SP]been\nacting[SP]like[SP]that[SP]ever[SP]since[SP]we[SP]ran[SP]into[SP]those\ntwo[SP]at[SP]Mu.",
     "nom_fr": "Maya",
-    "texte_fr": "Je me demande ce qui perturbe Lisa.\n[1205][000F]Elle se comporte ainsi depuis qu'on\na croisé ces deux-là à Mu."
+    "texte_fr": "Je me demande ce qui perturbe Lisa.\n[000F][1205]Elle se comporte ainsi depuis qu'on\na croisé ces deux-là à Mu."
   },
   {
     "id": 47,
@@ -717,7 +717,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmmm,[SP]Eikichi-kun's[SP]right.[1205][000F][SP]Why[SP]would[SP]they\norganize[SP]this[SP]whole[SP]song[SP]and[SP]dance?[1205][000F][SP]If[SP]we\ncan[SP]figure[SP]that[SP]out,[SP]then...",
     "nom_fr": "Maya",
-    "texte_fr": "Hmmm, Eikichi-kun a raison. [1205][000F][1205][000F]Pourquoi\norganiseraient-ils tout ce cinéma? Si\non arrive à le comprendre, alors..."
+    "texte_fr": "Hmmm, Eikichi-kun a raison. [000F][1205][000F][1205]Pourquoi\norganiseraient-ils tout ce cinéma? Si\non arrive à le comprendre, alors..."
   },
   {
     "id": 48,
@@ -732,7 +732,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]flames...[SP]are[SP]here[SP]again...[1205][000F][SP]The[SP]fires\nthat[SP]kill...[1205][000F][SP]We[SP]have[SP]to[SP]do[SP]something...",
     "nom_fr": "Maya",
-    "texte_fr": "Les flammes... encore là.[1205][000F][1205][000F].. Le feu qui\ntue... Il faut faire quelque chose..."
+    "texte_fr": "Les flammes... encore là.[000F][1205][000F][1205].. Le feu qui\ntue... Il faut faire quelque chose..."
   },
   {
     "id": 49,
@@ -747,7 +747,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Sakanoue[SP]Building[SP]or[SP]Smile[SP]Hirasaka,[SP]huh...?[1205][000F]\nThey're[SP]both[SP]in[SP]the[SP]direction[SP]Elly-san[SP]gave\nus.[SP]Guess[SP]we'll[SP]have[SP]to[SP]go[SP]check[SP]them[SP]out...",
     "nom_fr": "Maya",
-    "texte_fr": "Bâtiment Sakanoue ou Smile Hirasaka,\n[1205][000F]hein...? Ils sont dans la direction donnée\npar Elly. On va devoir aller vérifier..."
+    "texte_fr": "Bâtiment Sakanoue ou Smile Hirasaka,\n[000F][1205]hein...? Ils sont dans la direction donnée\npar Elly. On va devoir aller vérifier..."
   },
   {
     "id": 50,
@@ -762,7 +762,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Thanks[SP]to[SP]Elly-san,[SP]we[SP]know[SP]the[SP]next[SP]target\nis[SP]in[SP]Yumezaki.[1205][000F][SP]Question[SP]is,[SP]which[SP]building...",
     "nom_fr": "Maya",
-    "texte_fr": "Grâce à Elly, on sait\nque la future cible est\nà Yumezaki. [1205][000F]Reste à savoir quel bâtiment..."
+    "texte_fr": "Grâce à Elly, on sait\nque la future cible est\nà Yumezaki. [000F][1205]Reste à savoir quel bâtiment..."
   },
   {
     "id": 51,
@@ -777,7 +777,7 @@
     "nom_orig": "Maya",
     "texte_orig": "People[SP]can[SP]guess[SP]what[SP]they[SP]want,[SP]but[SP]King[SP]Leo\nis[SP]still[SP]the[SP]real[SP]culprit.[1205][000F][SP]If[SP]we[SP]defeat[SP]him,\nthe[SP]rumors[SP]should[SP]go[SP]away.",
     "nom_fr": "Maya",
-    "texte_fr": "Les gens croiront ce qu'ils veulent, le\nRoi Lion reste le vrai coupable.\n[1205][000F]Battons-le, et les rumeurs disparaîtront."
+    "texte_fr": "Les gens croiront ce qu'ils veulent, le\nRoi Lion reste le vrai coupable.\n[000F][1205]Battons-le, et les rumeurs disparaîtront."
   },
   {
     "id": 52,
@@ -792,7 +792,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yeah...[SP]Yukki's[SP]right.[SP]We[SP]have[SP]something[SP]to\ntake[SP]care[SP]of[SP]before[SP]we[SP]can[SP]drown[SP]ourselves[SP]in\nregret.[1205][000F][SP]We[SP]need[SP]to[SP]stop[SP]the[SP]next[SP]bombing.",
     "nom_fr": "Maya",
-    "texte_fr": "Oui... Yukki a raison.\nNous avons des choses\nà régler avant de nous noyer dans les\n[1205][000F]regrets. Nous devons arrêter l'attentat."
+    "texte_fr": "Oui... Yukki a raison.\nNous avons des choses\nà régler avant de nous noyer dans les [000F][1205]regrets. Nous devons arrêter l'attentat."
   },
   {
     "id": 53,
@@ -807,7 +807,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Poor[SP]thing.[1205][000F][SP]I[SP]know.[SP]You're[SP]desperate[SP]to[SP]again\nbury[SP]the[SP]memories[SP]of[SP]the[SP]past[SP]that[SP]threaten\nto[SP]claw[SP]to[SP]the[SP]surface...[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nThat's[SP]why[SP]you're[SP]anxious.[1205][000F][SP]But[SP]once[SP]those\nmemories[SP]are[SP]freed,[SP]you'll[SP]be[SP]released[SP]from\nyour[SP]suffering.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nNow,[SP]let's[SP]go[SP]remember[SP]everything.[1205][000F][SP]Heh...[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nWhere[SP]in[SP]Mt.[SP]Katatsumuri[SP]would[SP]Fujii-san[SP]be...?\nI[SP]wonder[SP]if[SP]Yukki[SP]has[SP]any[SP]suggestions.",
     "nom_fr": "Maya",
-    "texte_fr": "Ma pauvre. [1205][000F][1205][000F][1205][000F]Je sais. Tu veux désespérément\nenfouir tes souvenirs du passé qui veulent\nrefaire surface...[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nC'est pour ça que tu\nangoisses. Mais une fois ces souvenirslibérés,\ntu seras libre de tes souffrances.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nMaintenant, allons tout nous rappeler.\nHéhé...[E1][E2] [E3][E4][NULL][NULL]\"Maya\nOù Fujii-san pourrait-il être au\nMont Katatsumuri...? Je me\ndemande si Yukki aune idée."
+    "texte_fr": "Ma pauvre. [000F][1205][000F][1205][000F][1205]Je sais. Tu veux désespérément\nenfouir tes souvenirs du passé qui veulent\nrefaire surface...[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nC'est pour ça que tu\nangoisses. Mais une fois ces souvenirslibérés,\ntu seras libre de tes souffrances.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nMaintenant, allons tout nous rappeler.\nHéhé...[E1][E2] [E3][E4][NULL][NULL]\"Maya\nOù Fujii-san pourrait-il être au\nMont Katatsumuri...? Je me\ndemande si Yukki aune idée."
   },
   {
     "id": 54,
@@ -822,7 +822,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yukki...[1205][000F][SP]You're[SP]right...[SP]Fujii-san[SP]lives[SP]on\nwithin[SP]us.[SP]We[SP]can't[SP]waste[SP]his[SP]sacrifice...",
     "nom_fr": "Maya",
-    "texte_fr": "Yukki.[1205][000F].. Tu as raison... Fujii-san vit\nen nous. Ne gâchons pas son sacrifice..."
+    "texte_fr": "Yukki.[000F][1205].. Tu as raison... Fujii-san vit\nen nous. Ne gâchons pas son sacrifice..."
   },
   {
     "id": 55,
@@ -837,7 +837,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I...[1205][000F][SP]What[SP]should[SP]I[SP]say[SP]to[SP]Yukki...?[1205][000F][SP]There's\nnothing[SP]I[SP]can[SP]say...",
     "nom_fr": "Maya",
-    "texte_fr": "Je.[1205][000F][1205][000F].. Que devrais-je dire à\nYukki...? Il n'y a rien à dire..."
+    "texte_fr": "Je.[000F][1205][000F][1205].. Que devrais-je dire à\nYukki...? Il n'y a rien à dire..."
   },
   {
     "id": 56,
@@ -867,7 +867,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "So[SP]where[SP]does[SP]he[SP]change[SP]and[SP]put[SP]on[SP]his[SP]makeup?[1205][001E]\n...He[SP]doesn't[SP]use[SP]the[SP]bathroom[SP]at[SP]the[SP]station,\ndoes[SP]he?",
     "nom_fr": "Yukino",
-    "texte_fr": "Où se change-t-il et se maquille-t-il\nalors?[1205][001E].. Il ne le fait pas dans les\ntoilettes de la gare, si?"
+    "texte_fr": "Où se change-t-il et se maquille-t-il\nalors?[001E][1205].. Il ne le fait pas dans les\ntoilettes de la gare, si?"
   },
   {
     "id": 58,
@@ -882,7 +882,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Toro[SP]recommended[SP]me[SP]some[SP]shoes[SP]that[SP]help[SP]you\nget[SP]slim[SP]just[SP]by[SP]wearing[SP]them.[1205][000F][SP]But[SP]I[SP]don't\nknow[SP]if[SP]I[SP]trust[SP]him[SP]for[SP]weight[SP]loss[SP]tips...",
     "nom_fr": "Yukino",
-    "texte_fr": "Toro m'a conseillé des chaussures qui font\nmaigrir rien qu'en les portant. [1205][000F]Mais je ne\nsais pas si je peux lui faire confiance..."
+    "texte_fr": "Toro m'a conseillé des chaussures qui font\nmaigrir rien qu'en les portant. [000F][1205]Mais je ne\nsais pas si je peux lui faire confiance..."
   },
   {
     "id": 59,
@@ -897,7 +897,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Eikichi's[SP]dad[SP]asked[SP]me[SP]where[SP]he[SP]went[SP]just[SP]now.\nI[SP]had[SP]to[SP]scramble[SP]to[SP]make[SP]up[SP]a[SP]story...[1205][000F][SP]Wait,\nwhy[SP]did[SP]I[SP]go[SP]through[SP]the[SP]trouble?",
     "nom_fr": "Yukino",
-    "texte_fr": "Le père d'Eikichi m'a demandé où il était.\nJ'ai dû inventer une\nhistoire à la va-vite.[1205][000F]..\nMais.. pourquoi je m'embête autant?"
+    "texte_fr": "Le père d'Eikichi m'a demandé où il était.\nJ'ai dû inventer une\nhistoire à la va-vite.[000F][1205].. Mais.. pourquoi je m'embête autant?"
   },
   {
     "id": 60,
@@ -912,7 +912,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Masks,[SP]masks,[SP]masks...[1205][000F][SP]They[SP]keep[SP]showing[SP]up\neverywhere[SP]we[SP]go.[SP]It's[SP]hard[SP]to[SP]believe[SP]this\nis[SP]all[SP]a[SP]coincidence.",
     "nom_fr": "Yukino",
-    "texte_fr": "Masques, masques, masques.[1205][000F].. Il y en\na partout où l'on va. J'ai du mal à\ncroire que ce soit une coïncidence."
+    "texte_fr": "Masques, masques, masques.[000F][1205].. Il y en\na partout où l'on va. J'ai du mal à\ncroire que ce soit une coïncidence."
   },
   {
     "id": 61,
@@ -927,7 +927,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "It[SP]seemed[SP]like[SP]that[SP]bastard[SP]not[SP]only[SP]knew[SP]about\nMaya-san,[SP]but[SP]you[SP]too,[SP][1113].[1205][000F][SP]Any[SP]idea[SP]why?",
     "nom_fr": "Yukino",
-    "texte_fr": "Cet enfoiré connaissait non seulement Maya,\nmais toi aussi, [1113]. [1205][000F]Tu sais pourquoi?"
+    "texte_fr": "Cet enfoiré connaissait non seulement Maya,\nmais toi aussi, [1113]. [000F][1205]Tu sais pourquoi?"
   },
   {
     "id": 62,
@@ -942,7 +942,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "It's[SP]bizarre[SP]that[SP]we've[SP]asked[SP]around[SP]this[SP]much\nwith[SP]nothing[SP]to[SP]show[SP]for[SP]it.[1205][000F][SP]Do[SP]you[SP]think\npeople[SP]really[SP]know[SP]and[SP]are[SP]hiding[SP]it?",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est bizarre d'avoir posé tant de\nquestions sans résultat. [1205][000F]Penses-tu\nque les gens savent et le cachent?"
+    "texte_fr": "C'est bizarre d'avoir posé tant de\nquestions sans résultat. [000F][1205]Penses-tu\nque les gens savent et le cachent?"
   },
   {
     "id": 63,
@@ -972,7 +972,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Now[SP]those[SP]two[SP]are[SP]making[SP]their[SP]idol[SP]debut?[1205][000F]\nThis[SP]is[SP]sounding[SP]more[SP]and[SP]more[SP]like[SP]the\nMasked[SP]Circle's[SP]involved.",
     "nom_fr": "Yukino",
-    "texte_fr": "Ces deux-là font leurs débuts\nd'idole? [1205][000F]Ça ressemble de plus en\nplus à un coup du Cercle masqué."
+    "texte_fr": "Ces deux-là font leurs débuts\nd'idole? [000F][1205]Ça ressemble de plus en\nplus à un coup du Cercle masqué."
   },
   {
     "id": 65,
@@ -987,7 +987,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Is[SP]it[SP]just[SP]me,[SP]or[SP]is[SP]Eikichi[SP]quieter[SP]than\nusual?[1205][000F][SP]I[SP]wonder[SP]if[SP]he's[SP]worried[SP]about[SP]Lisa.",
     "nom_fr": "Yukino",
-    "texte_fr": "Eikichi est plus calme que d'habitude\n[1205][000F]non? Il doit s'inquiéter pour Lisa."
+    "texte_fr": "Eikichi est plus calme que d'habitude\n[000F][1205]non? Il doit s'inquiéter pour Lisa."
   },
   {
     "id": 66,
@@ -1107,7 +1107,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]think[SP]Fujii-san[SP]will[SP]be[SP]at[SP]Goketsuji[SP]in[SP]the\nheart[SP]of[SP]the[SP]mountain.[1205][000F][SP]He's[SP]good[SP]friends[SP]with\nthe[SP]head[SP]monk[SP]there.",
     "nom_fr": "Yukino",
-    "texte_fr": "Je pense que Fujii-san sera à Goketsuji,\nau cœur de la montagne. [1205][000F]Il est très ami\navec le moine en chef là-bas."
+    "texte_fr": "Je pense que Fujii-san sera à Goketsuji,\nau cœur de la montagne. [000F][1205]Il est très ami\navec le moine en chef là-bas."
   },
   {
     "id": 74,
@@ -1122,7 +1122,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Shunsuke-san[SP]was[SP]proud[SP]of[SP]his[SP]job...[1205][000F][SP]It[SP]was[SP]his\nreason[SP]for[SP]living.[1205][000F][SP]You[SP]can't[SP]get[SP]that[SP]kind[SP]of\npride[SP]through[SP]something[SP]like[SP]evolution.",
     "nom_fr": "Yukino",
-    "texte_fr": "Shunsuke-san était fier de son travail.[1205][000F][1205][000F]..\nC'était sa raison de vivre. On n'obtient\npas ce genre de fierté par l'évolution."
+    "texte_fr": "Shunsuke-san était fier de son travail.[000F][1205][000F][1205]..\nC'était sa raison de vivre. On n'obtient\npas ce genre de fierté par l'évolution."
   },
   {
     "id": 75,
@@ -1258,7 +1258,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "WELCOME![1205][000F][SP]How[SP]about[SP]that?[SP]Sounded[SP]great,\ndidn't[SP]it?[SP]You[SP]gotta[SP]greet[SP]your[SP]customers\nwith[SP]your[SP]whole[SP]heart[SP]and[SP]soul[SP]like[SP]that.\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "BIENVENUE! [1205][000F]Alors, pas mal, hein?\nFaut accueillir les clients avec tout\nson cœur, comme ça.\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "BIENVENUE! [000F][1205]Alors, pas mal, hein?\nFaut accueillir les clients avec tout\nson cœur, comme ça.\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "WELCOME![1205][000F][SP]How[SP]about[SP]that?[SP]Sounded[SP]great,\ndidn't[SP]it?[SP]You[SP]gotta[SP]greet[SP]your[SP]customers\nwith[SP]your[SP]whole[SP]heart[SP]and[SP]soul[SP]like[SP]that.",
     "choix_orig": [
       "Dine[SP]in",
@@ -1311,7 +1311,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Ah![SP]Welcome,[SP]welcome![1205][000F][SP]What's[SP]this?[SP]You're\nlooking[SP]more[SP]gallant[SP]by[SP]the[SP]day![1205][000F][SP]My[SP]fool\nof[SP]a[SP]son[SP]still[SP]looks[SP]the[SP]same,[SP]though.\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Ah! [1205][000F][1205][000F]Bienvenue, bienvenue! Eh bien?\nT'es plus fringant de jour en jour!\nMon idiot de fils, lui, change pas.\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Ah! [000F][1205][000F][1205]Bienvenue, bienvenue! Eh bien?\nT'es plus fringant de jour en jour!\nMon idiot de fils, lui, change pas.\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Ah![SP]Welcome,[SP]welcome![1205][000F][SP]What's[SP]this?[SP]You're\nlooking[SP]more[SP]gallant[SP]by[SP]the[SP]day![1205][000F][SP]My[SP]fool\nof[SP]a[SP]son[SP]still[SP]looks[SP]the[SP]same,[SP]though.",
     "choix_orig": [
       "Dine[SP]in",
@@ -1364,7 +1364,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Welcome,[SP]welcome![1205][000F][SP]You[SP]kids[SP]came[SP]at[SP]a[SP]great\ntime.[SP]I[SP]just[SP]prepared[SP]a[SP]fresh[SP]catch.\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Bienvenue, bienvenue! [1205][000F]Vous tombez\nbien, les jeunes. La pêche est toute\nfraîche.\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Bienvenue, bienvenue! [000F][1205]Vous tombez\nbien, les jeunes. La pêche est toute\nfraîche.\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Welcome,[SP]welcome![1205][000F][SP]You[SP]kids[SP]came[SP]at[SP]a[SP]great\ntime.[SP]I[SP]just[SP]prepared[SP]a[SP]fresh[SP]catch.",
     "choix_orig": [
       "Dine[SP]in",
@@ -1470,7 +1470,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Welcome,[SP]welcome![1205][000F][SP]We'll[SP]be[SP]open[SP]come[SP]what\nmay![SP]If[SP]we[SP]wasted[SP]time[SP]worrying[SP]about[SP]the\nworld[SP]outside,[SP]our[SP]fish[SP]would[SP]rot!\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Bienvenue, bienvenue! [1205][000F]On reste ouverts\nquoi qu'il arrive! À s'inquiéter du monde\nextérieur, le poisson pourrirait!\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Bienvenue, bienvenue! [000F][1205]On reste ouverts\nquoi qu'il arrive! À s'inquiéter du monde\nextérieur, le poisson pourrirait!\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Welcome,[SP]welcome![1205][000F][SP]We'll[SP]be[SP]open[SP]come[SP]what\nmay![SP]If[SP]we[SP]wasted[SP]time[SP]worrying[SP]about[SP]the\nworld[SP]outside,[SP]our[SP]fish[SP]would[SP]rot!",
     "choix_orig": [
       "Dine[SP]in",
@@ -1523,7 +1523,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Yo![SP]Welcome![1205][000F][SP]You're[SP]pretty[SP]brave,[SP]going[SP]out\nat[SP]a[SP]time[SP]like[SP]this.[SP]Well,[SP]youth[SP]should[SP]be\na[SP]little[SP]reckless,[SP]I[SP]say!\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Yo! [1205][000F]Bienvenue! T'es courageux de\nsortir en ce moment. La jeunesse\ndoit être insouciante, je dis!\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Yo! [000F][1205]Bienvenue! T'es courageux de\nsortir en ce moment. La jeunesse\ndoit être insouciante, je dis!\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Yo![SP]Welcome![1205][000F][SP]You're[SP]pretty[SP]brave,[SP]going[SP]out\nat[SP]a[SP]time[SP]like[SP]this.[SP]Well,[SP]youth[SP]should[SP]be\na[SP]little[SP]reckless,[SP]I[SP]say!",
     "choix_orig": [
       "Dine[SP]in",
@@ -1629,7 +1629,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Welcome,[SP]welcome?[SP]Oh,[SP]just[SP]you[SP]two[SP]today?[1205][000F]\nLooks[SP]like[SP]someone's[SP]making[SP]his[SP]move!\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Bienvenue? Oh, juste vous\ndeux aujourd'hui? [1205][000F]On dirait que\nquelqu'un fait le premier pas!\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Bienvenue? Oh, juste vous\ndeux aujourd'hui? [000F][1205]On dirait que\nquelqu'un fait le premier pas!\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Welcome,[SP]welcome?[SP]Oh,[SP]just[SP]you[SP]two[SP]today?[1205][000F]\nLooks[SP]like[SP]someone's[SP]making[SP]his[SP]move!",
     "choix_orig": [
       "Dine[SP]in",
@@ -1788,7 +1788,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Today[SP]I[SP]recommend...[1205][000F][SP]Well,[SP]everything![1205][000A]\nIt's[SP]all[SP]fresh![SP]Now,[SP]what'll[SP]you[SP]have?\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Aujourd'hui je recommande.[1205][000F].. Eh bien,\ntout![1205][000A] C'est tout frais! Que\nvoulez-vous?\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Aujourd'hui je recommande.[000F][1205].. Eh bien,\ntout![000A][1205] C'est tout frais! Que\nvoulez-vous?\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Today[SP]I[SP]recommend...[1205][000F][SP]Well,[SP]everything![1205][000A]\nIt's[SP]all[SP]fresh![SP]Now,[SP]what'll[SP]you[SP]have?",
     "choix_orig": [
       "Dine[SP]in",
@@ -1856,7 +1856,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Seriously,[SP]that[SP]fool's[SP]always[SP]loafing[SP]around\nhere.[1205][001E][SP]I'm[SP]worried[SP]he[SP]might[SP]not[SP]be[SP]able[SP]to\ntake[SP]over[SP]for[SP]me[SP]someday.",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Sérieux, cet idiot traîne toujours\nici.[1205][001E] J'ai peur qu'il ne soit pas\ncapable de prendre la relève un jour."
+    "texte_fr": "Sérieux, cet idiot traîne toujours\nici.[001E][1205] J'ai peur qu'il ne soit pas\ncapable de prendre la relève un jour."
   },
   {
     "id": 104,
@@ -1871,7 +1871,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Huh?[SP]What[SP]about[SP]what[SP]Eikichi[SP]wants?[SP]Don't[SP]be\nridiculous,[SP]kid![SP]A[SP]son[SP]follows[SP]in[SP]his[SP]father's\nfootsteps![SP]That's[SP]how[SP]it's[SP]always[SP]been.",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Hein? Et ce que veut Eikichi? Sois pas\nridicule, mon grand! Un\nfils suit les traces\nde son père! Ça a toujours été comme ça."
+    "texte_fr": "Hein? Et ce que veut Eikichi? Sois pas\nridicule, mon grand! Un\nfils suit les traces de son père! Ça a toujours été comme ça."
   },
   {
     "id": 105,
@@ -1901,7 +1901,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Hm?[SP]Where's[SP]my[SP]good-for-nothing[SP]boy?[1205][000F][SP]He's[SP]not\nwith[SP]you[SP]today?",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Où est mon vaurien de fils?\n[1205][000F]Pas avec vous aujourd'hui?"
+    "texte_fr": "Où est mon vaurien de fils?\n[000F][1205]Pas avec vous aujourd'hui?"
   },
   {
     "id": 107,
@@ -1916,7 +1916,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Kasugayama's[SP]school[SP]festival[SP]looks[SP]like[SP]a[SP]real\nblast[SP]this[SP]year.[SP]That[SP]student[SP]council[SP]president\nof[SP]theirs[SP]is[SP]something[SP]else,[SP]right,[SP]Eikichi!?",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Le festival de\nLycée Kakasu s'annonce génial\ncette année. Leur président du conseil des\nélèves est incroyable,\nn'est-ce pas Eikichi!?"
+    "texte_fr": "Le festival de\nLycée Kakasu s'annonce génial\ncette année. Leur président du conseil des élèves est incroyable, n'est-ce pas Eikichi!?"
   },
   {
     "id": 108,
@@ -1946,7 +1946,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "What[SP]was[SP]it...[SP]Muses,[SP]right?[1205][000F][SP]I[SP]dunno,[SP]sounds\nlike[SP]some[SP]detergent[SP]to[SP]me.",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "C'était quoi... Muses? [1205][000F]Ch'ais pas,\nça me rappelle de la lessive."
+    "texte_fr": "C'était quoi... Muses? [000F][1205]Ch'ais pas,\nça me rappelle de la lessive."
   },
   {
     "id": 110,
@@ -1961,7 +1961,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Seems[SP]the[SP]detergent[SP]trio's[SP]gonna[SP]be[SP]playing\na[SP]concert[SP]already.[1205][000F][SP]Pretty[SP]impressive[SP]for\ngirls[SP]so[SP]young,[SP]wouldn't[SP]you[SP]say,[SP]Eikichi!?",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Le trio de lessive va déjà faire un\nconcert. [1205][000F]Impressionnant pour de si jeunes\nfilles, tu ne trouves pas, Eikichi!?"
+    "texte_fr": "Le trio de lessive va déjà faire un\nconcert. [000F][1205]Impressionnant pour de si jeunes\nfilles, tu ne trouves pas, Eikichi!?"
   },
   {
     "id": 111,
@@ -1976,7 +1976,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Sheesh,[SP]what's[SP]gotten[SP]into[SP]that[SP]CEO[SP]over[SP]there?[1205][000F]\nHe's[SP]been[SP]acting[SP]that[SP]way[SP]since[SP]the[SP]terror[SP]wave\nstarted[SP]up.[SP]Has[SP]he[SP]gone[SP]crazy[SP]with[SP]fear?",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Punaise, qu'est-ce qui prend\nà ce PDG là-bas?\n[1205][000F]Il agit comme ça depuis\nle début de la vague\nde terrorisme. La peur l'a rendu fou?"
+    "texte_fr": "Punaise, qu'est-ce qui prend\nà ce PDG là-bas?\n[000F][1205]Il agit comme ça depuis le début de la vague de terrorisme. La peur l'a rendu fou?"
   },
   {
     "id": 112,
@@ -2036,7 +2036,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Why's[SP]Eikichi[SP]look[SP]like[SP]he's[SP]gonna[SP]cry?[1205][000F]\nIs[SP]this[SP]about[SP]what[SP]happened[SP]about[SP]Smile\nHirasaka?[1205][000F][SP]Yeah...[SP]that[SP]was[SP]bad,[SP]all[SP]right...",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Pourquoi Eikichi a l'air de pleurer? [1205][000F][1205][000F]C'est\nà cause de ce qui s'est passé à Smile\nHirasaka? Ouais... C'était terrible..."
+    "texte_fr": "Pourquoi Eikichi a l'air de pleurer? [000F][1205][000F][1205]C'est\nà cause de ce qui s'est passé à Smile\nHirasaka? Ouais... C'était terrible..."
   },
   {
     "id": 116,
@@ -2111,7 +2111,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "What's[SP]wrong[SP]with[SP]Eikichi[SP]and[SP]that[SP]girl?[1205][000F]\nThey[SP]look[SP]half[SP]dead.[1205][000F][SP]Did[SP]something[SP]happen?",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Qu'ont Eikichi et cette fille? [1205][000F][1205][000F]Ils ont\nl'air morts. Quelque chose s'est passé?"
+    "texte_fr": "Qu'ont Eikichi et cette fille? [000F][1205][000F][1205]Ils ont\nl'air morts. Quelque chose s'est passé?"
   },
   {
     "id": 121,
@@ -2171,7 +2171,7 @@
     "nom_orig": "???",
     "texte_orig": "I'll[SP]have[SP]you[SP]know[SP]I'm[SP]an[SP]extremely[SP]skilled\nsalesman.[SP]A[SP]man[SP]in[SP]my[SP]line[SP]of[SP]work[SP]hears[SP]a[SP]lot\nof[SP]rumors.[SP]Some[SP]people[SP]call[SP]me[SP]a[SP]rumormonger.",
     "nom_fr": "???",
-    "texte_fr": "Sachez que je suis\nun vendeur très compétent.\nUn homme de mon métier entend beaucoup de\nrumeurs. Certains\nm'appellent un informateur."
+    "texte_fr": "Sachez que je suis\nun vendeur très compétent.\nUn homme de mon métier entend beaucoup de rumeurs. Certains m'appellent un informateur."
   },
   {
     "id": 125,
@@ -2352,7 +2352,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Whoa...[1205][001E][SP]The[SP]principal[SP]at[SP]Sevens[SP]suddenly[SP]grew\nsome[SP]hair?[SP]I[SP]wonder[SP]if[SP]that[SP]was[SP]his[SP]request\nfor[SP]Joker.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Ouah...[1205][001E] Le proviseur de\nSeven a des cheveux?\nJe me demande si c'était sa requête pour\nJoker."
+    "texte_fr": "Ouah...[001E][1205] Le proviseur de\nSeven a des cheveux?\nJe me demande si c'était sa requête pour Joker."
   },
   {
     "id": 133,
@@ -2382,7 +2382,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh...[SP]You[SP]were[SP]at[SP]Sevens'[SP]clock[SP]tower...[1205][000F][SP]and\nyou[SP]saw[SP]a[SP]real[SP]ghost?[SP]Yikes,[SP]I'm[SP]not[SP]much[SP]for\nspooky[SP]stuff.[1205][000F][SP]I'll[SP]tell[SP]you[SP]a[SP]story[SP]instead.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hm... À la tour de Seven, un vrai fantôme?\n[1205][000F][1205][000F]Oh là là, les trucs effrayants, c'est pas\nmon truc. Voici une histoire à la place."
+    "texte_fr": "Hm... À la tour de Seven, un vrai fantôme?\n[000F][1205][000F][1205]Oh là là, les trucs effrayants, c'est pas\nmon truc. Voici une histoire à la place."
   },
   {
     "id": 135,
@@ -2442,7 +2442,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "What!?[SP]Ginji[SP]Sasaki[SP]is[SP]in[SP]the[SP]Masked[SP]Circle?\nFor[SP]reals?[SP]That's[SP]a[SP]great[SP]scoop![SP]Thanks![1205][000F]\nHere's[SP]what[SP]I've[SP]got[SP]for[SP]you[SP]in[SP]return...",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Quoi!? Ginji Sasaki est dans le Cercle\nmasqué? Vraiment? Super scoop! [1205][000F]Merci!\nVoilà ce que j'ai en échange..."
+    "texte_fr": "Quoi!? Ginji Sasaki est dans le Cercle\nmasqué? Vraiment? Super scoop! [000F][1205]Merci!\nVoilà ce que j'ai en échange..."
   },
   {
     "id": 139,
@@ -2457,7 +2457,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "You[SP]know[SP]the[SP][E4][NULL][NULL][0006]Jolly[SP]Roger[E4][NULL][NULL][0002][SP]cafe[SP]in[SP]Kounan?[1205][000F]\nThey[SP]supposedly[SP]sell[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002].[1205][000F][SP]Their\nselection[SP]is[SP][E4][NULL][NULL][0006]cheap[SP]and[SP]low[SP]quality[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Le café [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à Kounan? Il\n[1205][000F][1205][000F]vendrait de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. Leur choix\nest [E4][NULL][NULL][0006]bon marché et de basse qualité[E4][NULL][NULL][0002]."
+    "texte_fr": "Le café [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à Kounan? Il\n[000F][1205][000F][1205]vendrait de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. Leur choix\nest [E4][NULL][NULL][0006]bon marché et de basse qualité[E4][NULL][NULL][0002]."
   },
   {
     "id": 140,
@@ -2472,7 +2472,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh...[1205][001E][SP]Something[SP]terrible[SP]will[SP]happen[SP]if[SP]the\nclock[SP]at[SP]Sevens[SP]starts[SP]again?[SP]That's[SP]pretty\nout-there.[SP]Well,[SP]here's[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hein...[1205][001E] Quelque chose de terrible arrivera\nsi l'horloge de Seven redémarre? C'est\nn'importe quoi. Voici ce que je sais."
+    "texte_fr": "Hein...[001E][1205] Quelque chose de terrible arrivera\nsi l'horloge de Seven redémarre? C'est\nn'importe quoi. Voici ce que je sais."
   },
   {
     "id": 141,
@@ -2487,7 +2487,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "The[SP]rumor[SP]is[SP]that[SP][E4][NULL][NULL][0006]Rosa[SP]Candida[E4][NULL][NULL][0002][SP]sells\n[E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]They[SP]have[SP][E4][NULL][NULL][0006]reasonable[SP]prices,\nbut[SP]low-quality[SP]stuff[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "On dit que[E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002]\nvend de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002].\n[1205][000F]Leurs [E4][NULL][NULL][0006]prix sont bon, mais de basse qualité[E4][NULL][NULL][0002]."
+    "texte_fr": "On dit que[E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002]\nvend de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002].\n[000F][1205]Leurs [E4][NULL][NULL][0006]prix sont bon, mais de basse qualité[E4][NULL][NULL][0002]."
   },
   {
     "id": 142,
@@ -2517,7 +2517,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "There's[SP]a[SP]rumor[SP]you[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002][SP]at\n[E4][NULL][NULL][0006]Anima[SP]Mundi[E4][NULL][NULL][0002][SP]in[SP]Yumezaki.[1205][000F][SP]Their[SP]stuff[SP]is\n[E4][NULL][NULL][0006]cheap[SP]and[SP]subpar[SP]quality[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "On vendrait de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002] chez\n[E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002] à Yumezaki. [1205][000F]C'est [E4][NULL][NULL][0006]bon\nmarché, mais de qualité médiocre[E4][NULL][NULL][0002]."
+    "texte_fr": "On vendrait de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002] chez\n[E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002] à Yumezaki. [000F][1205]C'est [E4][NULL][NULL][0006]bon\nmarché, mais de qualité médiocre[E4][NULL][NULL][0002]."
   },
   {
     "id": 144,
@@ -2577,7 +2577,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "There's[SP]a[SP]shop[SP]called[SP][E4][NULL][NULL][0006]London[SP]Clothier[E4][NULL][NULL][0002][SP]in[SP]Kounan\nthat[SP]even[SP]tailors[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]The[SP][E4][NULL][NULL][0006]quality[SP]is\nsubpar,[SP]but[SP]they're[SP]cheap[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Le [E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] de Kounan fait des\n[E4][NULL][NULL][0006]vraies armures sur mesure[E4][NULL][NULL][0002]. [1205][000F]De [E4][NULL][NULL][0006]mauvaise\nqualité, mais c'est pas cher[E4][NULL][NULL][0002]."
+    "texte_fr": "Le [E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] de Kounan fait des\n[E4][NULL][NULL][0006]vraies armures sur mesure[E4][NULL][NULL][0002]. [000F][1205]De [E4][NULL][NULL][0006]mauvaise\nqualité, mais c'est pas cher[E4][NULL][NULL][0002]."
   },
   {
     "id": 148,
@@ -2607,7 +2607,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "What[SP]is[SP]that[SP]exactly?[1205][000F][SP]Some[SP]kind[SP]of[SP]special\njob...?[1205][000F][SP]Well,[SP]anyways.[SP]Here's[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "C'est quoi au juste? [1205][000F][1205][000F]Un métier spécial...?\nEnfin bref. Voici ce que je sais."
+    "texte_fr": "C'est quoi au juste? [000F][1205][000F][1205]Un métier spécial...?\nEnfin bref. Voici ce que je sais."
   },
   {
     "id": 150,
@@ -2667,7 +2667,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Do[SP]you[SP]know[SP]the[SP]arcade[SP][E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]?[1205][000F][SP]I[SP]hear[SP]that[SP]place\nis[SP]really[SP]a[SP][E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002],[SP]and[SP]people[SP]can[SP]make[SP]a[SP][E4][NULL][NULL][0006]ton\nof[SP]money[SP]on[SP]the[SP]slots[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "L'arcade [E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]? [1205][000F]On dit que c'est un\n[E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002], et qu'on peut se faire un\n[E4][NULL][NULL][0006]max de fric aux machines à sous[E4][NULL][NULL][0002]."
+    "texte_fr": "L'arcade [E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]? [000F][1205]On dit que c'est un\n[E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002], et qu'on peut se faire un\n[E4][NULL][NULL][0006]max de fric aux machines à sous[E4][NULL][NULL][0002]."
   },
   {
     "id": 154,
@@ -2682,7 +2682,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "This[SP]place[SP]is[SP]as[SP]good[SP]as[SP]I'd[SP]hoped[SP]for[SP]gathering\ninformation.[SP]I[SP]can[SP]listen[SP]to[SP]people[SP]talk[SP]and[SP]eat\ngreat[SP]sushi.[1205][000F][SP]Ahh...[SP]This[SP]is[SP]the[SP]life.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Cet endroit est parfait\npour y rassembler des\ninfos. Je peux écouter\nles gens et manger de\nbons sushis. [1205][000F]Ahh... C'est la belle vie."
+    "texte_fr": "Cet endroit est parfait\npour y rassembler des\ninfos. Je peux écouter les gens et manger de bons sushis. [000F][1205]Ahh... C'est la belle vie."
   },
   {
     "id": 155,
@@ -2697,7 +2697,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh?[SP]Masked[SP]Circle?[SP]I've[SP]never[SP]heard[SP]of[SP]it.[1205][000F]\nIs[SP]that[SP]some[SP]kind[SP]of[SP]organization?[SP]And[SP]these\npeople[SP]are[SP]here,[SP]in[SP]this[SP]city?",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hein? Le Cercle masqué? Jamais entendu\n[1205][000F]parler. C'est une organisation? Et ces\ngens sont ici, dans cette ville?"
+    "texte_fr": "Hein? Le Cercle masqué? Jamais entendu\n[000F][1205]parler. C'est une organisation? Et ces\ngens sont ici, dans cette ville?"
   },
   {
     "id": 156,
@@ -2712,7 +2712,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "That's[SP]big.[SP]I[SP]should[SP]look[SP]into[SP]it[SP]immediately.[1205][000F]\nHmm,[SP]maybe[SP]the[SP]girl[SP]at[SP]Peace[SP]Diner[SP]might[SP]know\nmore.[SP]Have[SP]you[SP]tried[SP]asking[SP]her[SP]about[SP]them?",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "C'est grave. Je dois enquêter tout de\n[1205][000F]suite. Hmm, peut-être que la fille au Peace\nDiner en sait plus. Lui as-tu demandé?"
+    "texte_fr": "C'est grave. Je dois enquêter tout de\n[000F][1205]suite. Hmm, peut-être que la fille au Peace\nDiner en sait plus. Lui as-tu demandé?"
   },
   {
     "id": 157,
@@ -2727,7 +2727,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Looks[SP]like[SP]you've[SP]got[SP]a[SP]lot[SP]of[SP]rumors[SP]ready\nto[SP]unload.[1205][000F][SP]I'll[SP]gather[SP]some[SP]new[SP]ones[SP]too,\nso[SP]let's[SP]swap[SP]stories[SP]then.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "On dirait que tu as plein de rumeurs à\nraconter. [1205][000F]J'en rassemblerai de\nnouvelles aussi, pour se les échanger."
+    "texte_fr": "On dirait que tu as plein de rumeurs à\nraconter. [000F][1205]J'en rassemblerai de\nnouvelles aussi, pour se les échanger."
   },
   {
     "id": 158,
@@ -2742,7 +2742,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Heehee,[SP]I'm[SP]on[SP]fire.[SP]I've[SP]got[SP]a[SP]whole[SP]stack[SP]of\nrumors.[1205][000F][SP]How[SP]about[SP]you?[SP]Want[SP]me[SP]to[SP]tell[SP]you[SP]the\nlatest[SP]rumor[SP]in[SP]exchange[SP]for[SP]what[SP]you[SP]know?",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Héhé, je suis en forme. J'ai une tonne de\n[1205][000F]rumeurs. Et toi? Veux-tu que je te raconte\nla dernière contre tes propres infos?"
+    "texte_fr": "Héhé, je suis en forme. J'ai une tonne de\n[000F][1205]rumeurs. Et toi? Veux-tu que je te raconte\nla dernière contre tes propres infos?"
   },
   {
     "id": 159,
@@ -2862,7 +2862,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "The[SP]girls[SP]in[SP]Muses[SP]are[SP]high[SP]school[SP]students?\nShouldn't[SP]they[SP]be[SP]studying...?[1205][000F][SP]Listen[SP]to[SP]me.\nI'm[SP]starting[SP]to[SP]sound[SP]like[SP]an[SP]old[SP]man.",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "Les filles des Muses sont lycéennes? Elles\nne devraient pas étudier.[1205][000F]..? Écoutez-moi.\nJe commence à parler comme un vieux."
+    "texte_fr": "Les filles des Muses sont lycéennes? Elles\nne devraient pas étudier.[000F][1205]..? Écoutez-moi.\nJe commence à parler comme un vieux."
   },
   {
     "id": 167,
@@ -2877,7 +2877,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "What[SP]the[SP]hell[SP]is[SP]this[SP]old[SP]man[SP]saying!?[SP]It[SP]was\nplaying[SP]with[SP]fire[SP]that[SP]killed[SP]tons[SP]of[SP]people!\nI'll[SP]sew[SP]up[SP]that[SP]mouth[SP]and[SP]see[SP]how[SP]you[SP]like[SP]it!",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "Qu'est-ce qu'il raconte\nce vieux!? Jouer avec\nle feu a tué des\ntonnes de gens! Je vais lui\ncoudre la bouche pour voir s'il aime ça!"
+    "texte_fr": "Qu'est-ce qu'il raconte\nce vieux!? Jouer avec\nle feu a tué des tonnes de gens! Je vais lui coudre la bouche pour voir s'il aime ça!"
   },
   {
     "id": 168,
@@ -2922,7 +2922,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "Did[SP]you[SP]read[SP]that[SP]In[SP]Lak'ech[SP]book,[SP]too?[1205][000F]\nWhenever[SP]society's[SP]in[SP]turmoil,[SP]you[SP]see\nscrewed-up[SP]books[SP]like[SP]that[SP]pop[SP]up.",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "As-tu lu le livre In Lak'ech? Dès que\n[1205][000F]la société est en crise, on voit de\ndrôles de livres comme ça apparaître."
+    "texte_fr": "As-tu lu le livre In Lak'ech? Dès que\n[000F][1205]la société est en crise, on voit de\ndrôles de livres comme ça apparaître."
   },
   {
     "id": 171,
@@ -2937,7 +2937,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "Th-That[SP]president[SP]guy[SP]just[SP]up[SP]and[SP]rushed[SP]out\nall[SP]of[SP]a[SP]sudden.[1205][000F][SP]He's[SP]not[SP]gonna[SP]go[SP]pick[SP]a[SP]fight\nwith[SP]those[SP]guys,[SP]is[SP]he?",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "Ce président est parti d'un coup. Il ne va\n[1205][000F]pas chercher des noises à ces gars, si?"
+    "texte_fr": "Ce président est parti d'un coup. Il ne va\n[000F][1205]pas chercher des noises à ces gars, si?"
   },
   {
     "id": 172,
@@ -2952,7 +2952,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "Hwaha![SP]I've[SP]finally[SP]been[SP]promoted[SP]to[SP]president.\nEating[SP]sushi[SP]at[SP]lunch[SP]while[SP]my[SP]underlings[SP]do\nall[SP]the[SP]work[SP]proves[SP]I've[SP]gone[SP]up[SP]the[SP]ladder!",
     "nom_fr": "PDG",
-    "texte_fr": "Hwaha! Je suis\nenfin devenu président. Manger\ndes sushis pendant\nque mes employés bossent,\nça prouve que j'ai grimpé les échelons!"
+    "texte_fr": "Hwaha! Je suis\nenfin devenu président. Manger\ndes sushis pendant que mes employés bossent, ça prouve que j'ai grimpé les échelons!"
   },
   {
     "id": 173,
@@ -2967,7 +2967,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "Now[SP]that[SP]I'm[SP]president,[SP]I[SP]shouldn't[SP]be[SP]so\nstingy[SP]anymore.[1205][000F][SP]Hey,[SP]chef![SP]Go[SP]easy[SP]on[SP]the\nrice,[SP]okay?[SP]Hahaha!",
     "nom_fr": "PDG",
-    "texte_fr": "Puisque je suis président, je ne\ndevrais plus être radin. [1205][000F]Hé, chef!\nAllez-y mollo sur le riz, okay? Hahaha!"
+    "texte_fr": "Puisque je suis président, je ne\ndevrais plus être radin. [000F][1205]Hé, chef!\nAllez-y mollo sur le riz, okay? Hahaha!"
   },
   {
     "id": 174,
@@ -2982,7 +2982,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "I'm[SP]finally[SP]company[SP]president,[SP]so[SP]I[SP]want[SP]to\nsplurge[SP]a[SP]little[SP]and[SP]get[SP]an[SP]entire[SP]fish,[SP]but\nmy[SP]tastes[SP]haven't[SP]changed.[1205][000F][SP]One[SP]albacore,[SP]chef!",
     "nom_fr": "PDG",
-    "texte_fr": "Je suis enfin président de l'entreprise, je\nveux dépenser un peu et m'offrir un poisson\nentier, mais mes goûts\n[1205][000F]restent. Un thon, chef!"
+    "texte_fr": "Je suis enfin président de l'entreprise, je\nveux dépenser un peu et m'offrir un poisson\nentier, mais mes goûts [000F][1205]restent. Un thon, chef!"
   },
   {
     "id": 175,
@@ -2997,7 +2997,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "Hahaha.[1205][000F][SP]I[SP]hear[SP]there's[SP]going[SP]to[SP]be[SP]a[SP]masquerade\nas[SP]part[SP]of[SP]Cuss[SP]High's[SP]school[SP]festival.[1205][000F][SP]Kids\nsure[SP]come[SP]up[SP]with[SP]some[SP]interesting[SP]ideas.",
     "nom_fr": "PDG",
-    "texte_fr": "Hahaha. [1205][000F][1205][000F]J'ai entendu dire qu'il y aura une\nmascarade pour le festival de Lycée Kakasu.\nCes enfants ont\ndes idées vraimentintéressantes."
+    "texte_fr": "Hahaha. [000F][1205][000F][1205]J'ai entendu dire qu'il y aura une\nmascarade pour le festival de Lycée Kakasu.\nCes enfants ont des idées vraimentintéressantes."
   },
   {
     "id": 176,
@@ -3012,7 +3012,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "M-M-Masked[SP]Circle?[1205][000F][SP]Where[SP]did[SP]you[SP]hear--[1205][000F]\nUh,[SP]I[SP]mean...[SP]Sorry,[SP]I[SP]don't[SP]know[SP]what[SP]you're\ntalking[SP]about.",
     "nom_fr": "PDG",
-    "texte_fr": "L-Le Cercle masqué? [1205][000F][1205][000F]Où avez- vous\nentendu-- Euh, je veux dire... Désolé,\nje ne vois pas de quoi vous parlez."
+    "texte_fr": "L-Le Cercle masqué? [000F][1205][000F][1205]Où avez- vous\nentendu-- Euh, je veux dire... Désolé,\nje ne vois pas de quoi vous parlez."
   },
   {
     "id": 177,
@@ -3027,7 +3027,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Hahaha![1205][000F][SP]That's[SP]right,[SP]burn![1205][000F][SP]Burn![SP]Joker[SP]gave\nme[SP]my[SP]position[SP]as[SP]company[SP]president,[SP]but[SP]I\nwasn't[SP]satisfied.",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Haha! [1205][000F][1205][000F]C'est ça, brûlez! Brûlez!\nJoker m'a donné mon poste de\nprésident, mais ça ne suffisait pas."
+    "texte_fr": "Haha! [000F][1205][000F][1205]C'est ça, brûlez! Brûlez!\nJoker m'a donné mon poste de\nprésident, mais ça ne suffisait pas."
   },
   {
     "id": 178,
@@ -3042,7 +3042,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "If[SP]anything,[SP]it[SP]made[SP]me[SP]feel[SP]even[SP]emptier![1205][000F]\nThat's[SP]because[SP]this[SP]society[SP]is[SP]boring!\nThis[SP]world[SP]should[SP]go[SP]up[SP]in[SP]flames!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Faux, je me sentais encore plus vide!\n[1205][000F]Cette société est ennuyeuse! Ce monde\ndevrait périr dans les flammes!"
+    "texte_fr": "Faux, je me sentais encore plus vide!\n[000F][1205]Cette société est ennuyeuse! Ce monde\ndevrait périr dans les flammes!"
   },
   {
     "id": 179,
@@ -3117,7 +3117,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Th-Those[SP]five[SP]are[SP]heroes[SP]fighting[SP]against[SP]the\nMasked[SP]Circle!?[1205][000F][SP]Then[SP]that[SP]makes[SP]them[SP]the[SP]enemy!\nWhy[SP]didn't[SP]anyone[SP]tell[SP]me!?",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "C-Ces cinq sont des héros luttant contre\nle Cercle masqué![1205][000F]? Ce sont des ennemis!\nPourquoi personne m'a rien dit!?"
+    "texte_fr": "C-Ces cinq sont des héros luttant contre\nle Cercle masqué![000F][1205]? Ce sont des ennemis!\nPourquoi personne m'a rien dit!?"
   },
   {
     "id": 184,
@@ -3222,7 +3222,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "The[SP]third[SP]member[SP]of[SP]Muses[SP]is[SP]still[SP]a[SP]mystery.\nIt's[SP]human[SP]nature[SP]to[SP]be[SP]intrigued[SP]by[SP]such\nthings.[1205][000F][SP]It's[SP]a[SP]very[SP]clever[SP]promotional[SP]trick.",
     "nom_fr": "Royauté du Sushi",
-    "texte_fr": "Le 3e membre des\nMuses est un mystère. C'est\ndans la nature humaine d'être intrigué.\n[1205][000F]C'est une tactique très ingénieuse."
+    "texte_fr": "Le 3e membre des\nMuses est un mystère. C'est\ndans la nature humaine d'être intrigué. [000F][1205]C'est une tactique très ingénieuse."
   },
   {
     "id": 191,
@@ -3237,7 +3237,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "The[SP]third[SP]member[SP]of[SP]Muses[SP]has[SP]finally[SP]been\nannounced![1205][000F][SP]Sadly,[SP]I[SP]only[SP]heard[SP]her[SP]voice[SP]over\nthe[SP]radio...[SP]I[SP]can't[SP]wait[SP]to[SP]see[SP]her[SP]face!",
     "nom_fr": "Royauté du Sushi",
-    "texte_fr": "Le 3e membre des Muses a été annoncé!\n[1205][000F]Je n'ai entendu sa voix qu'à la\nradio... J'ai hâte de voir son visage!"
+    "texte_fr": "Le 3e membre des Muses a été annoncé!\n[000F][1205]Je n'ai entendu sa voix qu'à la\nradio... J'ai hâte de voir son visage!"
   },
   {
     "id": 192,
@@ -3342,7 +3342,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Rumor[SP]has[SP]it[SP]that[SP]the[SP]ghost[SP]Hanako-san[SP]is\nhaunting[SP]Sevens.[1205][000F][SP]Does[SP]she[SP]actually[SP]exist?",
     "nom_fr": "Royauté du Sushi",
-    "texte_fr": "La rumeur veut que le fantôme Hanako-san\nhante Seven. [1205][000F]Existe-t-elle vraiment?"
+    "texte_fr": "La rumeur veut que le fantôme Hanako-san\nhante Seven. [000F][1205]Existe-t-elle vraiment?"
   },
   {
     "id": 199,
@@ -3372,7 +3372,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "I[SP]heard[SP]the[SP]ghost[SP]of[SP]an[SP]idol[SP]who[SP]starved[SP]to\ndeath[SP]at[SP]Aoba[SP]Park[SP]is[SP]appearing[SP]there.[SP]That's\none[SP]of[SP]the[SP]saddest[SP]things[SP]I've[SP]ever[SP]heard...",
     "nom_fr": "Royauté du Sushi",
-    "texte_fr": "Le fantôme d'une idole\nmorte de faim au Parc\nAoba y apparaîtrait. C'est l'une des choses\nles plus tristes que j'aie entendues."
+    "texte_fr": "Le fantôme d'une idole\nmorte de faim au Parc\nAoba y apparaîtrait. C'est l'une des choses les plus tristes que j'aie entendues."
   },
   {
     "id": 201,
@@ -3462,7 +3462,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Gah...[1205][000F][SP]I[SP]heard[SP]something[SP]awful...[1205][000F][SP]K-Kudan's...\nKudan's[SP]at[SP]the[SP]abandoned[SP]factory...[1205][000F][SP]No,[SP]I[SP]don't\nwant[SP]to[SP]think[SP]about[SP]it!",
     "nom_fr": "Royauté du Sushi",
-    "texte_fr": "Gah.[1205][000F][1205][000F][1205][000F].. J'ai entendu une chose\nhorrible... K-Kudan... Kudan est à\nl'usine... Non, je ne veux pas y penser!"
+    "texte_fr": "Gah.[000F][1205][000F][1205][000F][1205].. J'ai entendu une chose\nhorrible... K-Kudan... Kudan est à\nl'usine... Non, je ne veux pas y penser!"
   },
   {
     "id": 207,
@@ -3477,7 +3477,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "You[SP]know[SP]about[SP]Giga[SP]Macho's[SP]secret[SP]CD?[1205][000F]\nI[SP]hear[SP]there[SP]is[SP]one.[SP]I'd[SP]love[SP]to[SP]know[SP]what\nkind[SP]of[SP]tracks[SP]are[SP]on[SP]it.",
     "nom_fr": "Royauté du Sushi",
-    "texte_fr": "Connais-tu le CD secret de Giga\n[1205][000F]Macho? Il y en aurait un. Je\nveux savoir quelles pistes il a."
+    "texte_fr": "Connais-tu le CD secret de Giga\n[000F][1205]Macho? Il y en aurait un. Je\nveux savoir quelles pistes il a."
   },
   {
     "id": 208,
@@ -3492,7 +3492,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "The[SP]dreaded[SP]Dresser[SP]Hag[SP]is[SP]apparently[SP]showing\nup[SP]at[SP]the[SP]abandoned[SP]factory[SP]in[SP]Kounan.[1205][000F][SP]What\nkind[SP]of[SP]monster[SP]is[SP]that,[SP]I[SP]ask[SP]you?",
     "nom_fr": "Royauté du Sushi",
-    "texte_fr": "La terrible Sorcière de commode\napparaîtrait à l'usine de Kounan.\n[1205][000F]Quel genre de monstre est-ce donc?"
+    "texte_fr": "La terrible Sorcière de commode\napparaîtrait à l'usine de Kounan.\n[000F][1205]Quel genre de monstre est-ce donc?"
   },
   {
     "id": 209,
@@ -3957,7 +3957,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Does[SP]that[SP]London[SP]Clothier[SP]tailor[SP]armor[SP]too?\nLooks[SP]can[SP]be[SP]deceiving,[SP]I[SP]guess.[SP]Their[SP]prices\nare[SP]low,[SP]but[SP]so[SP]is[SP]the[SP]quality[SP]of[SP]their[SP]stuff.",
     "nom_fr": "Royauté du Sushi",
-    "texte_fr": "London Clothier fait\ndes armures sur mesure?\nLes apparences sont trompeuses, on dirait.\nLes prix sont bas, la qualité aussi."
+    "texte_fr": "London Clothier fait\ndes armures sur mesure?\nLes apparences sont trompeuses, on dirait. Les prix sont bas, la qualité aussi."
   },
   {
     "id": 240,
@@ -4002,7 +4002,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Does[SP]that[SP]London[SP]Clothier[SP]tailor[SP]armor[SP]too?\nLooks[SP]can[SP]be[SP]deceiving,[SP]I[SP]guess.[SP]Their[SP]selection\nisn't[SP]good,[SP]but[SP]their[SP]resale[SP]price[SP]is[SP]high.",
     "nom_fr": "Royauté du Sushi",
-    "texte_fr": "London Clothier fait\ndes armures sur mesure?\nLes apparences sont trompeuses. Leurs choix\nsont nuls, mais ils reprennent cher."
+    "texte_fr": "London Clothier fait\ndes armures sur mesure?\nLes apparences sont trompeuses. Leurs choix sont nuls, mais ils reprennent cher."
   },
   {
     "id": 243,
@@ -4167,7 +4167,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Seems[SP]Time[SP]Castle[SP]doesn't[SP]have[SP]their[SP]legendary\nweapon[SP]yet.[SP]The[SP]owner's[SP]scared[SP]of[SP]monsters[SP]and\ncan't[SP]go[SP]get[SP]it[SP]from[SP]the[SP]abandoned[SP]factory.",
     "nom_fr": "Royauté du Sushi",
-    "texte_fr": "On dirait que le Time Castle n'a pas encore\nl'arme légendaire. Le proprio a peur des\nmonstres et ne\npeut aller à l'usineabandonnée."
+    "texte_fr": "On dirait que le Time Castle n'a pas encore\nl'arme légendaire. Le proprio a peur des\nmonstres et ne peut aller à l'usineabandonnée."
   },
   {
     "id": 254,

--- a/traduction/event_scripts/script_325.json
+++ b/traduction/event_scripts/script_325.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey,[SP]don't[SP]forget.[1205][000A][SP]We[SP]haven't[SP]been[SP]to[SP]the\ntemple[SP]in[SP]Yumezaki[SP]yet.[SP]Let's[SP]hurry[SP]and[SP]go\nget[SP]that[SP]crystal[SP]skull.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, n'oublie pas.[1205][000A] On n'est pas\nencore au temple de Yumezaki. Vite,\nallons chercher ce crâne de cristal."
+    "texte_fr": "Hé, n'oublie pas.[000A][1205] On n'est pas\nencore au temple de Yumezaki. Vite,\nallons chercher ce crâne de cristal."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Heheh...[1205][000A][SP]Miyabi[SP]sure[SP]kicks[SP]ass.[1205][000F][SP]She[SP]hasn't\nchanged[SP]a[SP]bit[SP]since[SP]back[SP]then.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Héhé.[1205]..[1205][000A] Miyabi assure. [000F]Elle n'a\npas changé d'un poil depuis."
+    "texte_fr": "Héhé.[1205]..[000A][1205] Miyabi assure. [000F]Elle n'a\npas changé d'un poil depuis."
   },
   {
     "id": 2,
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We[SP]gotta[SP]hurry[SP]and[SP]get[SP]the[SP]crystal[SP]skull[SP]from\nthe[SP]temple[SP]at[SP]Kounan,[SP]too.[1205][000F][SP]Let's[SP]go!",
     "nom_fr": "Ginko",
-    "texte_fr": "Vite, il nous faut le crâne de cristal\ndu temple de Kounan. [1205][000F]Allons-y!"
+    "texte_fr": "Vite, il nous faut le crâne de cristal\ndu temple de Kounan. [000F][1205]Allons-y!"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah![1205][000F][SP]Then[SP]it[SP]was[SP]you[SP]who[SP]took[SP]the[SP]In[SP]Lak'ech\nto[SP]Kismet[SP]Publishing,[SP]Jun!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Aïe! [1205][000F]C'est toi qui as emmené\nIn Lak'ech chez Kismet, Jun!?"
+    "texte_fr": "Aïe! [000F][1205]C'est toi qui as emmené\nIn Lak'ech chez Kismet, Jun!?"
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Wow,[SP]your[SP]double[SP]really[SP]looked[SP]evil.[1205][000F][SP]Can[SP]you\nmake[SP]a[SP]face[SP]like[SP]that,[SP][1113]-kun?[1205][000A][SP]Probably\nnot,[SP]huh.",
     "nom_fr": "Maya",
-    "texte_fr": "Wow, ton double avait l'air\n[1205]mauvais. [000F]Tu peux faire cette tête,\n[1113]-kun?[1205][000A] Sûrement pas, hein."
+    "texte_fr": "Wow, ton double avait l'air\n[1205]mauvais. [000F]Tu peux faire cette tête,\n[1113]-kun?[000A][1205] Sûrement pas, hein."
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Jun",
     "texte_orig": "The[SP]Aquarius[SP]Temple[SP]has[SP]appeared[SP]in[SP]Hirasaka.\nWe[SP]still[SP]need[SP]the[SP]crystal[SP]skull[SP]from[SP]there.[1205][000F]\nIt[SP]can't[SP]fall[SP]into[SP]their[SP]hands...",
     "nom_fr": "Jun",
-    "texte_fr": "Le Temple du Verseau est à Hirasaka.\nIl nous faut son crâne de cristal.\n[1205][000F]Ils ne doivent pas l'avoir..."
+    "texte_fr": "Le Temple du Verseau est à Hirasaka.\nIl nous faut son crâne de cristal.\n[000F][1205]Ils ne doivent pas l'avoir..."
   },
   {
     "id": 11,
@@ -192,7 +192,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Ngh...[1205][000A][SP]My[SP]head...[1205][000A][SP]hurts...[1205][000F][SP]It's[SP]no[SP]good.\nI[SP]can't[SP]remember.[1205][000F][SP]Who[SP]was[SP]supposed[SP]to[SP]have\nbeen[SP]waiting[SP]for[SP]us[SP]there?",
     "nom_fr": "Jun",
-    "texte_fr": "Ngh.[1205][1205]..[1205][000A] Ma tête.[000F][000F]..[1205][000A] fait mal... Impossible.\nJ'ai oublié. Qui\ndevait nous attendre là-bas?"
+    "texte_fr": "Ngh.[1205][1205]..[000A][1205] Ma tête.[000F][000F]..[000A][1205] fait mal... Impossible.\nJ'ai oublié. Qui\ndevait nous attendre là-bas?"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]wanted[SP]to[SP]prove[SP]my[SP]father's[SP]theory.[SP]That's\nall[SP]I[SP]had[SP]in[SP]mind[SP]at[SP]the[SP]start...[1205][000F][SP]To[SP]think[SP]it\nwould[SP]lead[SP]to[SP]such[SP]a[SP]catastrophe...",
     "nom_fr": "Jun",
-    "texte_fr": "Je voulais prouver la\nthéorie de mon père...\n[1205]Dire que ça a\n[000F]mené à une telle catastrophe..."
+    "texte_fr": "Je voulais prouver la\nthéorie de mon père...\n[1205]Dire que ça a [000F]mené à une telle catastrophe..."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Ah,[SP]so[SP]you[SP]guys[SP]are[SP]safe[SP]too![1205][000F][SP]Sheesh,[SP]first\nthat[SP]huge[SP]quake,[SP]and[SP]now[SP]the[SP]city's[SP]flying...\nWhat[SP]in[SP]the[SP]world's[SP]going[SP]on?\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Ah, vous êtes sains et saufs! [1205][000F]D'abord le\nséisme, puis la ville vole...\nQue se passe-t-il?\n[1208][0004]Manger sur place\nParler au père\nPeu importe\nQuitter",
+    "texte_fr": "Ah, vous êtes sains et saufs! [000F][1205]D'abord le\nséisme, puis la ville vole...\nQue se passe-t-il?\n[1208][0004]Manger sur place\nParler au père\nPeu importe\nQuitter",
     "question_orig": "Ah,[SP]so[SP]you[SP]guys[SP]are[SP]safe[SP]too![1205][000F][SP]Sheesh,[SP]first\nthat[SP]huge[SP]quake,[SP]and[SP]now[SP]the[SP]city's[SP]flying...\nWhat[SP]in[SP]the[SP]world's[SP]going[SP]on?",
     "choix_orig": [
       "Dine[SP]in",
@@ -275,7 +275,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Today[SP]I[SP]recommend...[1205][000F][SP]Well,[SP]everything![1205][000A]\nIt's[SP]all[SP]fresh![SP]Now,[SP]what'll[SP]you[SP]have?\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Je recommande..[1205]. [000F]Eh bien, tout![1205][000A]\nTout est frais! Que prendrez-vous?\n[1208][0004]Manger sur place\nParler au père\nPeu importe\nQuitter",
+    "texte_fr": "Je recommande..[1205]. [000F]Eh bien, tout![000A][1205]\nTout est frais! Que prendrez-vous?\n[1208][0004]Manger sur place\nParler au père\nPeu importe\nQuitter",
     "question_orig": "Today[SP]I[SP]recommend...[1205][000F][SP]Well,[SP]everything![1205][000A]\nIt's[SP]all[SP]fresh![SP]Now,[SP]what'll[SP]you[SP]have?",
     "choix_orig": [
       "Dine[SP]in",
@@ -328,7 +328,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Hey,[SP]kid.[1205][000A][SP]This[SP]is[SP]just[SP]between[SP]us,[SP]okay?[1205][000F][SP]You\nknow[SP]how[SP]Eikichi's[SP]freaked[SP]out[SP]by[SP]my[SP]having\nranks[SP]in[SP]all[SP]sorts[SP]of[SP]martial[SP]arts?",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Hé, les jeunes.[1205][1205][000A] Ça reste entre\n[000F]nous. Vous savez qu'Eikichi a peur\nde mes grades en arts martiaux?"
+    "texte_fr": "Hé, les jeunes.[1205][000A][1205] Ça reste entre\n[000F]nous. Vous savez qu'Eikichi a peur\nde mes grades en arts martiaux?"
   },
   {
     "id": 19,
@@ -343,7 +343,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "That's[SP]all[SP]actually[SP]a[SP]little[SP]white[SP]lie[SP]I[SP]told\nhim.[1205][000F][SP]I[SP]don't[SP]have[SP]any[SP]training[SP]in[SP]that[SP]stuff.\nI'm[SP]certified[SP]at[SP]the[SP]abacus,[SP]but...",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "C'est un petit mensonge. Je n'ai aucune\n[1205][000F]formation là-dedans. Je\nmaîtrise le boulier,\nmais..."
+    "texte_fr": "C'est un petit mensonge. Je n'ai aucune\n[000F][1205]formation là-dedans. Je\nmaîtrise le boulier, mais..."
   },
   {
     "id": 20,
@@ -373,7 +373,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "But[SP]it[SP]seems[SP]he's[SP]past[SP]his[SP]rebellious[SP]phase,\nso[SP]I'm[SP]thinking[SP]it[SP]might[SP]be[SP]time[SP]to[SP]come[SP]clean.[1205][000F]\nThe[SP]right[SP]opportunity[SP]just[SP]hasn't[SP]come[SP]up[SP]yet.",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Sa crise d'ado est passée, il est temps\nd'avouer. [1205][000F]L'occasion ne\ns'est pas présentée."
+    "texte_fr": "Sa crise d'ado est passée, il est temps\nd'avouer. [000F][1205]L'occasion ne\ns'est pas présentée."
   },
   {
     "id": 22,
@@ -388,7 +388,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Man,[SP]that[SP]boy[SP]of[SP]mine![1205][000F][SP]Where'd[SP]he[SP]find[SP]a[SP]beauty\nlike[SP]her!?[SP]Looks[SP]like[SP]he's[SP]finally[SP]playing[SP]the\nfield.",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Mon fils! Où a-t-il\n[1205][000F]trouvé une telle beauté!?\nOn dirait qu'il profite enfin de la vie."
+    "texte_fr": "Mon fils! Où a-t-il\n[000F][1205]trouvé une telle beauté!?\nOn dirait qu'il profite enfin de la vie."
   },
   {
     "id": 23,
@@ -403,7 +403,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "This[SP]is[SP]wonderful![1205][000A][SP]No,[SP]really![1205][000F][SP]Hey,[SP]honey!\nCook[SP]up[SP]some[SP]red[SP]beans[SP]and[SP]rice.[SP]I'm[SP]gonna\nmake[SP]my[SP]special[SP]sushi[SP]today!",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "C'est génial![1205][1205][000A] Vraiment! [000F]Chérie!\nFais du riz aux haricots rouges.\nJe fais mes sushis spéciaux!"
+    "texte_fr": "C'est génial![1205][000A][1205] Vraiment! [000F]Chérie!\nFais du riz aux haricots rouges.\nJe fais mes sushis spéciaux!"
   },
   {
     "id": 24,
@@ -599,7 +599,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Whoa...[1205][001E][SP]The[SP]principal[SP]at[SP]Sevens[SP]suddenly[SP]grew\nsome[SP]hair?[SP]I[SP]wonder[SP]if[SP]that[SP]was[SP]his[SP]request\nfor[SP]Joker.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Waouh...[1205][001E] Le dirlo de Seven a des\ncheveux? C'était son vœu au Joker?"
+    "texte_fr": "Waouh...[001E][1205] Le dirlo de Seven a des\ncheveux? C'était son vœu au Joker?"
   },
   {
     "id": 33,
@@ -629,7 +629,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh...[SP]You[SP]were[SP]at[SP]Sevens'[SP]clock[SP]tower...[1205][000F][SP]and\nyou[SP]saw[SP]a[SP]real[SP]ghost?[SP]Yikes,[SP]I'm[SP]not[SP]much[SP]for\nspooky[SP]stuff.[1205][000F][SP]I'll[SP]tell[SP]you[SP]a[SP]story[SP]instead.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hein... Tu as vu un fantôme à la\n[1205][000F][1205][000F]tour de l'horloge? J'aime pas\nça. Je vais te raconter un truc."
+    "texte_fr": "Hein... Tu as vu un fantôme à la\n[000F][1205][000F][1205]tour de l'horloge? J'aime pas\nça. Je vais te raconter un truc."
   },
   {
     "id": 35,
@@ -644,7 +644,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Rumor[SP]is[SP]you[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002][SP]at[SP][E4][NULL][NULL][0006]Tony's\nShop[E4][NULL][NULL][0002][SP]in[SP]Yumezaki.[SP]They're[SP][E4][NULL][NULL][0006]cheap,[SP]but[SP]low\nquality[E4][NULL][NULL][0002].[1205][000F][SP]Well?[SP]Worth[SP]your[SP]while,[SP]huh?",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "On dit qu'on peut acheter de [E4][NULL][NULL][0006]vraies\narmes[E4][NULL][NULL][0002] chez [E4][NULL][NULL][0006]Tony's Shop[E4][NULL][NULL][0002]. Elles sont\n[E4][NULL][NULL][0006]bon marché, mais mauvaises[E4][NULL][NULL][0002]. [1205][000F]Pas mal?"
+    "texte_fr": "On dit qu'on peut acheter de [E4][NULL][NULL][0006]vraies\narmes[E4][NULL][NULL][0002] chez [E4][NULL][NULL][0006]Tony's Shop[E4][NULL][NULL][0002]. Elles sont\n[E4][NULL][NULL][0006]bon marché, mais mauvaises[E4][NULL][NULL][0002]. [000F][1205]Pas mal?"
   },
   {
     "id": 36,
@@ -689,7 +689,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "What!?[SP]Ginji[SP]Sasaki[SP]is[SP]in[SP]the[SP]Masked[SP]Circle?\nFor[SP]reals?[SP]That's[SP]a[SP]great[SP]scoop![SP]Thanks![1205][000F]\nHere's[SP]what[SP]I've[SP]got[SP]for[SP]you[SP]in[SP]return...",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Quoi!? Ginji est dans le Cercle masqué?\nSuper scoop! [1205][000F]Merci! Voici en retour..."
+    "texte_fr": "Quoi!? Ginji est dans le Cercle masqué?\nSuper scoop! [000F][1205]Merci! Voici en retour..."
   },
   {
     "id": 39,
@@ -704,7 +704,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "You[SP]know[SP]the[SP][E4][NULL][NULL][0006]Jolly[SP]Roger[E4][NULL][NULL][0002][SP]cafe[SP]in[SP]Kounan?[1205][000F]\nThey[SP]supposedly[SP]sell[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002].[1205][000F][SP]Their\nselection[SP]is[SP][E4][NULL][NULL][0006]cheap[SP]and[SP]low-quality[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Le café [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002]? [1205][000F][1205][000F]Ils vendraient de\n[E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. C'est [E4][NULL][NULL][0006]peu cher et médiocre[E4][NULL][NULL][0002]."
+    "texte_fr": "Le café [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002]? [000F][1205][000F][1205]Ils vendraient de\n[E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. C'est [E4][NULL][NULL][0006]peu cher et médiocre[E4][NULL][NULL][0002]."
   },
   {
     "id": 40,
@@ -719,7 +719,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh...[1205][001E][SP]Something[SP]terrible[SP]will[SP]happen[SP]if[SP]the\nclock[SP]at[SP]Sevens[SP]starts[SP]again?[SP]That's[SP]pretty\nout-there.[SP]Well,[SP]here's[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hein...[1205][001E] Un drame si l'horloge de Seven\nredémarre? C'est fou. Bref, voici."
+    "texte_fr": "Hein...[001E][1205] Un drame si l'horloge de Seven\nredémarre? C'est fou. Bref, voici."
   },
   {
     "id": 41,
@@ -734,7 +734,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "The[SP]rumor[SP]is[SP]that[SP][E4][NULL][NULL][0006]Rosa[SP]Candida[E4][NULL][NULL][0002][SP]sells\n[E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]They[SP]have[SP][E4][NULL][NULL][0006]reasonable[SP]prices,\nbut[SP]low-quality[SP]stuff[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "[E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002] vendrait de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002].\n[1205][000F]Leurs prix sont\n[E4][NULL][NULL][0006]raisonnables, qualité basse[E4][NULL][NULL][0002]."
+    "texte_fr": "[E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002] vendrait de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002].\n[000F][1205]Leurs prix sont\n[E4][NULL][NULL][0006]raisonnables, qualité basse[E4][NULL][NULL][0002]."
   },
   {
     "id": 42,
@@ -764,7 +764,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "There's[SP]a[SP]rumor[SP]you[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002][SP]at\n[E4][NULL][NULL][0006]Anima[SP]Mundi[E4][NULL][NULL][0002][SP]in[SP]Yumezaki.[1205][000F][SP]Their[SP]stuff[SP]is\n[E4][NULL][NULL][0006]cheap[SP]and[SP]subpar[SP]quality[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "On peut acheter de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002] à\n[E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002]. [1205][000F]C'est [E4][NULL][NULL][0006]peu cher et médiocre[E4][NULL][NULL][0002]."
+    "texte_fr": "On peut acheter de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002] à\n[E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002]. [000F][1205]C'est [E4][NULL][NULL][0006]peu cher et médiocre[E4][NULL][NULL][0002]."
   },
   {
     "id": 44,
@@ -779,7 +779,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh,[SP]so[SP]the[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High[SP]used[SP]to\nbe[SP]the[SP]Undie[SP]Boss'[SP]flunky.[SP]The[SP]world[SP]of[SP]high\nschool[SP]sounds[SP]rough...[SP]Here's[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Le nouveau chef du\nLycée Kasu était le larbin\nd'Boss des calbutes. Dur\ndur... Voici pour toi."
+    "texte_fr": "Le nouveau chef du\nLycée Kasu était le larbin\nd'Boss des calbutes. Dur dur... Voici pour toi."
   },
   {
     "id": 45,
@@ -824,7 +824,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "There's[SP]a[SP]shop[SP]called[SP][E4][NULL][NULL][0006]London[SP]Clothier[E4][NULL][NULL][0002][SP]in[SP]Kounan\nthat[SP]even[SP]tailors[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]The[SP][E4][NULL][NULL][0006]quality[SP]is\nsubpar,[SP]but[SP]they're[SP]cheap[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "[E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] taille de [E4][NULL][NULL][0006]vraies\narmures[E4][NULL][NULL][0002]. [1205][000F][E4][NULL][NULL][0006]Qualité faible, mais pas cher[E4][NULL][NULL][0002]."
+    "texte_fr": "[E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] taille de [E4][NULL][NULL][0006]vraies\narmures[E4][NULL][NULL][0002]. [000F][1205][E4][NULL][NULL][0006]Qualité faible, mais pas cher[E4][NULL][NULL][0002]."
   },
   {
     "id": 48,
@@ -854,7 +854,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "What[SP]is[SP]that[SP]exactly?[1205][000F][SP]Some[SP]kind[SP]of[SP]special\njob...?[1205][000F][SP]Well,[SP]anyways.[SP]Here's[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "C'est quoi? [1205][000F][1205][000F]Un travail\nspécial...? Bref. Voici."
+    "texte_fr": "C'est quoi? [000F][1205][000F][1205]Un travail\nspécial...? Bref. Voici."
   },
   {
     "id": 50,
@@ -914,7 +914,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Do[SP]you[SP]know[SP]the[SP]arcade[SP][E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]?[1205][000F][SP]I[SP]hear[SP]that[SP]place\nis[SP]really[SP]a[SP][E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002],[SP]and[SP]people[SP]can[SP]make[SP]a[SP][E4][NULL][NULL][0006]ton\nof[SP]money[SP]on[SP]the[SP]slots[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "L'arcade [E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]? [1205][000F]C'est un [E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002] où\non peut [E4][NULL][NULL][0006]gagner gros aux machines[E4][NULL][NULL][0002]."
+    "texte_fr": "L'arcade [E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]? [000F][1205]C'est un [E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002] où\non peut [E4][NULL][NULL][0006]gagner gros aux machines[E4][NULL][NULL][0002]."
   },
   {
     "id": 54,
@@ -944,7 +944,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Was[SP]that[SP]what[SP]the[SP][1432][NULL][NULL][0014]flames[SP]of[SP]expiation[1432][NULL][NULL][0014][SP]part[SP]of\nthe[SP]Oracle[SP]was[SP]about...?[1205][000F][SP]Well,[SP]anyway,[SP]let[SP]me\ntell[SP]you[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Les [1432][NULL][NULL][0014]flammes de l'expiation[1432][NULL][NULL][0014].[1205][000F]..? Bref, voilà."
+    "texte_fr": "Les [1432][NULL][NULL][0014]flammes de l'expiation[1432][NULL][NULL][0014].[000F][1205]..? Bref, voilà."
   },
   {
     "id": 56,
@@ -959,7 +959,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "You[SP]know[SP]the[SP][E4][NULL][NULL][0006]legendary[SP]weapon[SP]at[SP]Time[SP]Castle[E4][NULL][NULL][0002]?\nYeah,[SP][E4][NULL][NULL][0006]a[SP]demon[SP]stole[SP]it[E4][NULL][NULL][0002].[1205][000F][SP]No[SP]wonder[SP]he[SP]won't\nsell[SP]it[SP]to[SP]you[SP]if[SP]you[SP]go[SP]there.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "L'[E4][NULL][NULL][0006]arme de Time Castle[E4][NULL][NULL][0002]? [E4][NULL][NULL][0006]Un démon l'a\n[1205][000F]volée[E4][NULL][NULL][0002]. Normal qu'il ne te la vende pas."
+    "texte_fr": "L'[E4][NULL][NULL][0006]arme de Time Castle[E4][NULL][NULL][0002]? [E4][NULL][NULL][0006]Un démon l'a\n[000F][1205]volée[E4][NULL][NULL][0002]. Normal qu'il ne te la vende pas."
   },
   {
     "id": 57,
@@ -974,7 +974,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "People[SP]are[SP]buzzing[SP]about[SP]the[SP]temples[SP]appearing\nat[SP]the[SP]sites[SP]of[SP]the[SP]bombings,[SP]but[SP]it[SP]doesn't\nsurprise[SP]me.[1205][000F][SP]I[SP]saw[SP]much[SP]worse[SP]in[SP]school.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Les temples sur les lieux des bombes\nne m'étonnent pas. [1205][000F]J'ai vu pire."
+    "texte_fr": "Les temples sur les lieux des bombes\nne m'étonnent pas. [000F][1205]J'ai vu pire."
   },
   {
     "id": 58,
@@ -1019,7 +1019,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "This[SP]has[SP]to[SP]be[SP]just[SP]a[SP]bad[SP]dream...[1205][000F][SP]How[SP]else[SP]do\nyou[SP]explain[SP]it?[1205][000A][SP]Soldiers[SP]falling[SP]from[SP]the[SP]sky,\nthe[SP]city[SP]taking[SP]to[SP]the[SP]air,[SP]those[SP]temples...",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "C'est un cauchemar... [1205][000F]Sinon comment\nexpliquer?[1205][000A] Soldats du ciel, ville\nqui vole, ces temples..."
+    "texte_fr": "C'est un cauchemar... [000F][1205]Sinon comment\nexpliquer?[000A][1205] Soldats du ciel, ville\nqui vole, ces temples..."
   },
   {
     "id": 61,
@@ -1034,7 +1034,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "But,[SP]ah...[1205][000A][SP]This[SP]sinus-clearing[SP]blast[SP]of[SP]wasabi\nis[SP]real[SP]enough...[1205][000F][SP]This[SP]is[SP]no[SP]dream...[1205][000F][SP]Then[SP]why\nis[SP]it[SP]happening?",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "Mais..[1205][1205].[1205][000A] Ce wasabi qui dégage les sinus est\n[000F][000F]réel... Pas un rêve... Alors pourquoi?"
+    "texte_fr": "Mais..[1205][1205].[000A][1205] Ce wasabi qui dégage les sinus est\n[000F][000F]réel... Pas un rêve... Alors pourquoi?"
   },
   {
     "id": 62,
@@ -1079,7 +1079,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "The[SP]Earth's[SP]destruction's[SP]gonna[SP]happen[SP]just[SP]like\nthe[SP]Oracle[SP]says,[SP]huh...[1205][000F][SP]There's[SP]talk[SP]it'll[SP]be\ncaused[SP]by[SP]a[SP]quake[SP]or[SP]tsunami[SP]or[SP]something.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "La Terre sera détruite comme le dit\n[1205][000F]l'Oracle... On parle de\nséisme ou de tsunami."
+    "texte_fr": "La Terre sera détruite comme le dit\n[000F][1205]l'Oracle... On parle de\nséisme ou de tsunami."
   },
   {
     "id": 65,
@@ -1094,7 +1094,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Heh,[SP]there's[SP]even[SP]a[SP]rumor[SP]that[SP]Xibalba's[SP]going\nto[SP]directly[SP]attack[SP]the[SP]Earth[SP]below[SP]and[SP]destroy\nit[SP]that[SP]way.[1205][000F][SP]That[SP]might[SP]be[SP]interesting[SP]to[SP]see.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Xibalba attaquerait la Terre pour la\ndétruire. [1205][000F]Ce serait intéressant à voir."
+    "texte_fr": "Xibalba attaquerait la Terre pour la\ndétruire. [000F][1205]Ce serait intéressant à voir."
   },
   {
     "id": 66,
@@ -1109,7 +1109,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "The[SP]word[SP]around[SP]the[SP]city[SP]is[SP]that[SP]the[SP]Earth[SP]will\nstop[SP]spinning[SP]after[SP]the[SP]Grand[SP]Cross.[1205][000F][SP]Something\nabout[SP]gravitational[SP]forces[SP]being[SP]thrown[SP]off.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "La Terre s'arrêtera de tourner après la\nCroix. [1205][000F]Une histoire de gravité perturbée."
+    "texte_fr": "La Terre s'arrêtera de tourner après la\nCroix. [000F][1205]Une histoire de gravité perturbée."
   },
   {
     "id": 67,
@@ -1124,7 +1124,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "If[SP]that[SP]happened,[SP]the[SP]Earth[SP]would[SP]be[SP]like[SP]a[SP]car\nthat[SP]slams[SP]on[SP]the[SP]brakes.[1205][000F][SP]It'd[SP]be[SP]the[SP]end[SP]of\neverything.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "La Terre serait comme une voiture qui\nfreine sec. [1205][000F]Ce serait la fin de tout."
+    "texte_fr": "La Terre serait comme une voiture qui\nfreine sec. [000F][1205]Ce serait la fin de tout."
   },
   {
     "id": 68,
@@ -1139,7 +1139,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Rumor[SP]has[SP]it[SP]that[SP]the[SP]ghost[SP]Hanako-san[SP]is\nhaunting[SP]Sevens.[1205][000F][SP]Does[SP]she[SP]actually[SP]exist?",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Le fantôme d'Hanako hante\nSeven. [1205][000F]Existe-t-elle vraiment?"
+    "texte_fr": "Le fantôme d'Hanako hante\nSeven. [000F][1205]Existe-t-elle vraiment?"
   },
   {
     "id": 69,
@@ -1229,7 +1229,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Apparently,[SP]Kuchisake-onna[SP]is[SP]at[SP]Mt.[SP]Iwato.\nMy[SP]teachers[SP]used[SP]to[SP]say[SP]that[SP]if[SP]I[SP]didn't[SP]head\nstraight[SP]home[SP]after[SP]school,[SP]she'd[SP]get[SP]me.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Kuchisake-onna est au Mt.\nIwato. On disait que\nsi je ne rentrais\npas direct, elle m'aurait."
+    "texte_fr": "Kuchisake-onna est au Mt.\nIwato. On disait que\nsi je ne rentrais pas direct, elle m'aurait."
   },
   {
     "id": 75,
@@ -1259,7 +1259,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Gah...[1205][000F][SP]I[SP]heard[SP]something[SP]awful...[1205][000F][SP]K-Kudan's...\nKudan's[SP]at[SP]the[SP]abandoned[SP]factory...[1205][000F][SP]No,[SP]I[SP]don't\nwant[SP]to[SP]think[SP]about[SP]it!",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Gah.[1205][000F][1205][000F][1205][000F].. K-Kudan est à l'usine\nabandonnée... Je ne veux pas y penser!"
+    "texte_fr": "Gah.[000F][1205][000F][1205][000F][1205].. K-Kudan est à l'usine\nabandonnée... Je ne veux pas y penser!"
   },
   {
     "id": 77,
@@ -1274,7 +1274,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "You[SP]know[SP]about[SP]Giga[SP]Macho's[SP]secret[SP]CD?[1205][000F]\nI[SP]hear[SP]there[SP]is[SP]one.[SP]I'd[SP]love[SP]to[SP]know[SP]what\nkind[SP]of[SP]tracks[SP]are[SP]on[SP]it.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Le CD secret de Giga Macho? [1205][000F]Je\nveux savoir ce qu'il y a dessus."
+    "texte_fr": "Le CD secret de Giga Macho? [000F][1205]Je\nveux savoir ce qu'il y a dessus."
   },
   {
     "id": 78,
@@ -1289,7 +1289,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "The[SP]dreaded[SP]Dresser[SP]Hag[SP]is[SP]apparently[SP]showing\nup[SP]at[SP]the[SP]abandoned[SP]factory[SP]in[SP]Kounan.[1205][000F][SP]What\nkind[SP]of[SP]monster[SP]is[SP]that,[SP]I[SP]ask[SP]you?",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "La Sorcière de la commode est à\n[1205][000F]l'usine de Kounan. C'est quoi?"
+    "texte_fr": "La Sorcière de la commode est à\n[000F][1205]l'usine de Kounan. C'est quoi?"
   },
   {
     "id": 79,
@@ -2054,7 +2054,7 @@
     "nom_orig": "Miyabi",
     "texte_orig": "I'm[SP]all[SP]right[SP]now,[SP]thank[SP]you.[1205][000F][SP]Please[SP]look[SP]after\nEikichi-kun[SP]instead.[1205][000F][SP]You[SP]know[SP]how[SP]reckless[SP]he\ncan[SP]be[SP]at[SP]times.",
     "nom_fr": "Miyabi",
-    "texte_fr": "Je vais bien, merci. [1205][000F][1205][000F]Veillez sur\nEikichi. Il peut être très imprudent."
+    "texte_fr": "Je vais bien, merci. [000F][1205][000F][1205]Veillez sur\nEikichi. Il peut être très imprudent."
   },
   {
     "id": 130,

--- a/traduction/event_scripts/script_326.json
+++ b/traduction/event_scripts/script_326.json
@@ -252,7 +252,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Shouldn't[SP]we[SP]hurry[SP]to[SP]Mt.[SP]Katatsumuri?[1205][000F][SP]She's\ngonna[SP]get[SP]upset...[1205][000F][SP]And[SP]an[SP]angry[SP]Yukino-san[SP]is\nscarier[SP]than[SP]the[SP]Last[SP]Battalion!",
     "nom_fr": "Ginko",
-    "texte_fr": "Ne devrions-nous pas filer au Mont\n[1205][000F][1205][000F]Katatsumuri? Elle va\ns'énerver... Une Yukino\nen colère, c'est pire que le Bataillon!"
+    "texte_fr": "Ne devrions-nous pas filer au Mont\n[000F][1205][000F][1205]Katatsumuri? Elle va\ns'énerver... Une Yukino en colère, c'est pire que le Bataillon!"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We...[SP]We[SP]did[SP]what[SP]we[SP]could,[SP]right?[1205][000F][SP]I[SP]just\ndon't[SP]know...[1205][000F][SP]What's[SP]there[SP]to[SP]say...?",
     "nom_fr": "Ginko",
-    "texte_fr": "On... On a fait ce qu'on pouvait, non?\n[1205][000F][1205][000F]Je sais pas trop... Quoi dire...?"
+    "texte_fr": "On... On a fait ce qu'on pouvait, non?\n[000F][1205][000F][1205]Je sais pas trop... Quoi dire...?"
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Could[SP]there[SP]be[SP]an[SP]underground[SP]casino[SP]here?[1205][000F]\nI've[SP]never[SP]heard[SP]about[SP]anything[SP]like[SP]that\nat[SP]work...[SP]Weird.",
     "nom_fr": "Maya",
-    "texte_fr": "Il y aurait un\ncasino clandestin ici? [1205][000F]J'en ai\njamais entendu parler au boulot... Étrange."
+    "texte_fr": "Il y aurait un\ncasino clandestin ici? [000F][1205]J'en ai\njamais entendu parler au boulot... Étrange."
   },
   {
     "id": 19,
@@ -327,7 +327,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Did[SP]that[SP]guy[SP]at[SP]the[SP]counter[SP]appear[SP]through[SP]the\npower[SP]of[SP]rumors...?[1205][000F][SP]He[SP]looks[SP]normal...",
     "nom_fr": "Maya",
-    "texte_fr": "Le type au comptoir est apparu grâce\naux rumeurs...? [1205][000F]Il a l'air si normal..."
+    "texte_fr": "Le type au comptoir est apparu grâce\naux rumeurs...? [000F][1205]Il a l'air si normal..."
   },
   {
     "id": 22,
@@ -372,7 +372,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Heh.[SP]What[SP]have[SP]you[SP]come[SP]here[SP]for?[1205][000F][SP]To[SP]try[SP]and\nescape[SP]the[SP]resurfacing[SP]memories?[1205][000F][SP]Sorry[SP]to[SP]say,\nbut[SP]that[SP]won't[SP]be[SP]possible.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nDon't[SP]worry,[SP]Yukki.[SP]I'm[SP]sure[SP]Fujii-san[SP]will[SP]be\njust[SP]fine.[SP]C'mon,[SP]you[SP]need[SP]to[SP]calm[SP]down.",
     "nom_fr": "Maya",
-    "texte_fr": "Hé. Que viens-tu faire ici? [1205][000F][1205][000F]Tenter d'fuir\nles souvenirs qui refont surface? Désolée,\nmais c'est impossible.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nT'en fais pas, Yukki. Je suis sûre\nque Fujii-san ira bien. Allez, calme-toi."
+    "texte_fr": "Hé. Que viens-tu faire ici? [000F][1205][000F][1205]Tenter d'fuir\nles souvenirs qui refont surface? Désolée,\nmais c'est impossible.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nT'en fais pas, Yukki. Je suis sûre\nque Fujii-san ira bien. Allez, calme-toi."
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Men[SP]pursue[SP]their[SP]own[SP]dreams...[1205][000F][SP]and[SP]then\njust[SP]disappear...",
     "nom_fr": "Maya",
-    "texte_fr": "Les hommes suivent leurs\n[1205][000F]rêves... et disparaissent..."
+    "texte_fr": "Les hommes suivent leurs\n[000F][1205]rêves... et disparaissent..."
   },
   {
     "id": 26,
@@ -432,7 +432,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]can't[SP]believe[SP]you[SP]took[SP]the[SP]time[SP]to[SP]spread[SP]the\nrumor[SP]to[SP]turn[SP]this[SP]place[SP]into[SP]a[SP]casino.[1205][000F][SP]*sigh*\nOh[SP]well...[1205][000F][SP]Try[SP]not[SP]to[SP]waste[SP]too[SP]much[SP]money.",
     "nom_fr": "Yukino",
-    "texte_fr": "J'y crois pas que tu aies pris le temps de\nlancer la rumeur pour\nfaire d'ici un casino.\n[1205][000F][1205][000F]*soupir* Bref... Essaie\nde ne pas tropgaspiller."
+    "texte_fr": "J'y crois pas que tu aies pris le temps de\nlancer la rumeur pour\nfaire d'ici un casino. [000F][1205][000F][1205]*soupir* Bref... Essaie de ne pas tropgaspiller."
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Just[SP]between[SP]you[SP]and[SP]me,[SP]Maya-san's[SP]really[SP]bad\nat[SP]Rock,[SP]Paper,[SP]Scissors.[SP]She[SP]has[SP]a[SP]bad[SP]habit\nof[SP]always[SP]playing[SP]scissors.[SP]Play[SP]her[SP]and[SP]see.",
     "nom_fr": "Yukino",
-    "texte_fr": "Entre nous, Maya-san est vraiment nulle à\nPierre-Feuille-Ciseaux. Elle a la fâcheuse\nhabitude de jouer ciseaux.\nJoue avec elle pourvoir."
+    "texte_fr": "Entre nous, Maya-san est vraiment nulle à\nPierre-Feuille-Ciseaux. Elle a la fâcheuse\nhabitude de jouer ciseaux. Joue avec elle pourvoir."
   },
   {
     "id": 30,
@@ -522,7 +522,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Anna's[SP]probably[SP]at[SP]the[SP]Caracol,[SP]too.[1205][000F][SP]No[SP]more\ntragedies...[1205][000F][SP]I[SP]have[SP]to[SP]save[SP]her[SP]at[SP]all[SP]costs.",
     "nom_fr": "Yukino",
-    "texte_fr": "Anna est sûrement au\n[1205]Caracol aussi. [1205][000F][000F]Fini les\ntragédies... Je dois la sauver à tout prix."
+    "texte_fr": "Anna est sûrement au\n[1205]Caracol aussi. [000F][1205][000F]Fini les\ntragédies... Je dois la sauver à tout prix."
   },
   {
     "id": 35,
@@ -552,7 +552,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "A[SP]coin[SP]exchange[SP]clerk[SP]suddenly[SP]showed[SP]up[SP]and\nthis[SP]place[SP]became[SP]a[SP]casino![1205][000F][SP]Guess[SP]it[SP]was[SP]worth\nthe[SP]trip[SP]after[SP]all.",
     "nom_fr": "Jeune Homme",
-    "texte_fr": "Un caissier est soudain apparu et\nc'est devenu un casino! [1205][000F]Ça valait\nle coup de venir, finalement."
+    "texte_fr": "Un caissier est soudain apparu et\nc'est devenu un casino! [000F][1205]Ça valait\nle coup de venir, finalement."
   },
   {
     "id": 37,
@@ -597,7 +597,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "*sigh*[SP]I[SP]lose[SP]again...[1205][000F][SP]Well,[SP]maybe[SP]I'll[SP]get\nlucky[SP]next[SP]time.[1205][000F][SP]Alright,[SP]one[SP]more[SP]try!",
     "nom_fr": "Jeune Homme",
-    "texte_fr": "Pff, encore perdu.[1205][000F][1205][000F].. La prochaines c'est\nla bonne. Allez, un dernier essai!"
+    "texte_fr": "Pff, encore perdu.[000F][1205][000F][1205].. La prochaines c'est\nla bonne. Allez, un dernier essai!"
   },
   {
     "id": 40,
@@ -687,7 +687,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "See,[SP]I[SP]told[SP]you[SP]the[SP]rumor[SP]was[SP]true![1205][000F][SP]Hmm,[SP]so[SP]I\nhear[SP]it's[SP]easy[SP]to[SP]win[SP]at[SP]the[SP]#5[SP]poker[SP]machine.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "La rumeur était vraie!\n[1205][000F]Hmm, on dit qu'il est\nfacile de gagner à la machine de poker N°5."
+    "texte_fr": "La rumeur était vraie!\n[000F][1205]Hmm, on dit qu'il est\nfacile de gagner à la machine de poker N°5."
   },
   {
     "id": 46,
@@ -702,7 +702,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "See,[SP]I[SP]told[SP]you[SP]it[SP]really[SP]was[SP]a[SP]casino![1205][000F][SP]Hmm,[SP]so\nI[SP]hear[SP]it's[SP]easy[SP]to[SP]win[SP]at[SP]the[SP]#1[SP]slot[SP]machine.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "C'est vraiment un casino! [1205][000F]Hmm, on dit qu'on\ngagne facilement à la machine à sous N°1."
+    "texte_fr": "C'est vraiment un casino! [000F][1205]Hmm, on dit qu'on\ngagne facilement à la machine à sous N°1."
   },
   {
     "id": 47,
@@ -717,7 +717,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "You[SP]see?[SP]I[SP]told[SP]you[SP]the[SP]rumor[SP]was[SP]true![1205][000F][SP]Hmm,[SP]so\nthe[SP]rumor[SP]was[SP]that[SP]blackjack's[SP]great[SP]because[SP]it\nhas[SP]a[SP]high[SP]payout.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Tu vois? La rumeur était vraie!\n[1205][000F]Hmm, on dit que le blackjack est\ngénial car il rapporte beaucoup."
+    "texte_fr": "Tu vois? La rumeur était vraie!\n[000F][1205]Hmm, on dit que le blackjack est\ngénial car il rapporte beaucoup."
   },
   {
     "id": 48,
@@ -777,7 +777,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "The[SP]rumor[SP]said[SP]blackjack[SP]gives[SP]the[SP]highest\npayout...[1205][000F][SP]C'mon,[SP]let's[SP]play[SP]that[SP]and[SP]get[SP]back\non[SP]our[SP]feet!",
     "nom_fr": "Jeune femme",
-    "texte_fr": "La rumeur dit que le blackjack\nrapporte le plus.[1205][000F].. Allez, jouons\nà ça pour nous refaire une santé!"
+    "texte_fr": "La rumeur dit que le blackjack\nrapporte le plus.[000F][1205].. Allez, jouons\nà ça pour nous refaire une santé!"
   },
   {
     "id": 52,
@@ -807,7 +807,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Geez,[SP]he's[SP]completely[SP]blown[SP]his[SP]stack...[1205][000F][SP]And\npoker's[SP]supposed[SP]to[SP]have[SP]the[SP]best[SP]odds.[1205][000F][SP]If[SP]he\ncan't[SP]win[SP]after[SP]this[SP]many[SP]tries,[SP]he[SP]just[SP]sucks.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Pff, il a tout cramé... [1205][000F][1205][000F]Et le poker offre\nles meilleures chances. S'il gagne pas\naprès tous ces essais, c'est qu'il est nul."
+    "texte_fr": "Pff, il a tout cramé... [000F][1205][000F][1205]Et le poker offre\nles meilleures chances. S'il gagne pas\naprès tous ces essais, c'est qu'il est nul."
   },
   {
     "id": 54,
@@ -822,7 +822,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Geez,[SP]he's[SP]completely[SP]blown[SP]his[SP]stack...[1205][000F][SP]The\nslots're[SP]supposed[SP]to[SP]have[SP]the[SP]best[SP]odds.[1205][000F][SP]If[SP]he\ncan't[SP]win[SP]after[SP]this[SP]many[SP]tries,[SP]he[SP]just[SP]sucks.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Pff, il a tout cramé... [1205][000F][1205][000F]Les machines à sous\noffrent de meilleures chances. S'il gagne\npas après tous ces\nessais, il est juste nul."
+    "texte_fr": "Pff, il a tout cramé... [000F][1205][000F][1205]Les machines à sous\noffrent de meilleures chances. S'il gagne\npas après tous ces essais, il est juste nul."
   },
   {
     "id": 55,
@@ -837,7 +837,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Geez,[SP]he's[SP]completely[SP]blown[SP]his[SP]top...[1205][000F][SP]And[SP]the\nblackjacks[SP]odds[SP]are[SP]supposed[SP]to[SP]be[SP]great.[1205][000F][SP]If[SP]he\ncan't[SP]win[SP]after[SP]this[SP]many[SP]tries,[SP]he[SP]just[SP]sucks.",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Pff, il a tout cramé... [1205][000F][1205][000F]Et les cotes du\nblackjack sont superbes. S'il gagne pas\naprès tous ces essais, c'est qu'il est nul."
+    "texte_fr": "Pff, il a tout cramé... [000F][1205][000F][1205]Et les cotes du\nblackjack sont superbes. S'il gagne pas\naprès tous ces essais, c'est qu'il est nul."
   },
   {
     "id": 56,
@@ -867,7 +867,7 @@
     "nom_orig": "Inveterate[SP]gambler",
     "texte_orig": "I[SP]heard[SP]you[SP]could[SP]gamble[SP]here,[SP]so[SP]I[SP]came[SP]all\nthis[SP]way...[1205][000F][SP]But[SP]apparently[SP]it[SP]was[SP]just[SP]a\nbaseless[SP]rumor.",
     "nom_fr": "Joueur invétéré",
-    "texte_fr": "J'ai entendu dire qu'on pouvait\nparier ici, alors je suis venu.[1205][000F]..\nMais ce n'était qu'une fausse rumeur."
+    "texte_fr": "J'ai entendu dire qu'on pouvait\nparier ici, alors je suis venu.[000F][1205]..\nMais ce n'était qu'une fausse rumeur."
   },
   {
     "id": 58,
@@ -987,7 +987,7 @@
     "nom_orig": "Inveterate[SP]gambler",
     "texte_orig": "Ever[SP]hear[SP]of[SP]Russian[SP]roulette?[SP]It's[SP]the[SP]ultimate\nform[SP]of[SP]gambling,[SP]where[SP]your[SP]own[SP]life[SP]is[SP]on[SP]the\nline.[SP]I'll[SP]bet[SP]on[SP]whether[SP]Mu[SP]gets[SP]bombed...",
     "nom_fr": "Joueur invétéré",
-    "texte_fr": "T'as entendu parler de la roulette russe?\nC'est la forme ultime du\npari, où ta vie est\nen jeu. Je parie\nsur si Mu se ferabombarder..."
+    "texte_fr": "T'as entendu parler de la roulette russe?\nC'est la forme ultime du\npari, où ta vie est en jeu. Je parie sur si Mu se ferabombarder..."
   },
   {
     "id": 66,
@@ -1017,7 +1017,7 @@
     "nom_orig": "Inveterate[SP]gambler",
     "texte_orig": "The[SP]Last[SP]Battalion...[SP]They're[SP]a[SP]real[SP]wild[SP]card.[1205][000F]\nThe[SP]stakes[SP]are[SP]this[SP]entire[SP]city...[SP]What's[SP]going\nto[SP]decide[SP]Sumaru's[SP]fate...[SP]is[SP]cards...",
     "nom_fr": "Joueur invétéré",
-    "texte_fr": "Le Bataillon... Ce sont de sacrés jokers.\n[1205][000F]L'enjeu, c'est cette\nville... Ce qui décidera\ndu sort de Sumaru... ce sont les cartes..."
+    "texte_fr": "Le Bataillon... Ce sont de sacrés jokers.\n[000F][1205]L'enjeu, c'est cette\nville... Ce qui décidera du sort de Sumaru... ce sont les cartes..."
   },
   {
     "id": 68,
@@ -1109,7 +1109,7 @@
     "nom_orig": "Manager",
     "texte_orig": "What?[SP]You[SP]still[SP]want[SP]something?[1205][000F]\n...Nah,[SP]just[SP]kidding.[SP]What'll[SP]it[SP]be?\n[1208][0005]Buy[SP]coins\nRedeem[SP]for[SP]prizes\nTalk[SP]to[SP]the[SP]manager\nNever[SP]mind\nLeave",
     "nom_fr": "Gérant",
-    "texte_fr": "Quoi? Encore un truc?\n...[1205][000F]Non, je rigole. Vous voulez?\n[1208][0005]Acheter des jetons\nÉchanger des prix\nParler au gérant\nPeu importe\nQuitter",
+    "texte_fr": "Quoi? Encore un truc?\n...[000F][1205]Non, je rigole. Vous voulez?\n[1208][0005]Acheter des jetons\nÉchanger des prix\nParler au gérant\nPeu importe\nQuitter",
     "question_orig": "What?[SP]You[SP]still[SP]want[SP]something?[1205][000F]\n...Nah,[SP]just[SP]kidding.[SP]What'll[SP]it[SP]be?",
     "choix_orig": [
       "Buy[SP]coins",
@@ -1191,7 +1191,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Why[SP]am[SP]I[SP]standing[SP]here?[1205][000F][SP]I[SP]feel[SP]like[SP]I've[SP]been\nhere[SP]the[SP]whole[SP]time,[SP]too...[1205][000F][SP]Was[SP]I[SP]exchanging\ncoins[SP]or[SP]something?",
     "nom_fr": "Gérant",
-    "texte_fr": "Pourquoi suis-je ici? [1205][000F][1205][000F]J'ai l'impression\nd'être là depuis toujours...\nJ'échangeais des jetons ou quoi?"
+    "texte_fr": "Pourquoi suis-je ici? [000F][1205][000F][1205]J'ai l'impression\nd'être là depuis toujours...\nJ'échangeais des jetons ou quoi?"
   },
   {
     "id": 75,
@@ -1206,7 +1206,7 @@
     "nom_orig": "Manager",
     "texte_orig": "A[SP]secret[SP]lounge?[1205][000F][SP]Well,[SP]I've[SP]heard[SP]the[SP]rumors,\nbut[SP]I've[SP]never[SP]been[SP]myself...",
     "nom_fr": "Gérant",
-    "texte_fr": "Un salon secret? [1205][000F]J'ai entendu les\nrumeurs, mais je n'y suis jamais allé..."
+    "texte_fr": "Un salon secret? [000F][1205]J'ai entendu les\nrumeurs, mais je n'y suis jamais allé..."
   },
   {
     "id": 76,
@@ -1221,7 +1221,7 @@
     "nom_orig": "Manager",
     "texte_orig": "C'mon,[SP]you[SP]gotta[SP]go[SP]to[SP]the[SP]Kasuga[SP]Festival![1205][000F]\nHuh?[SP]Me?[SP]How[SP]can[SP]I[SP]leave[SP]when[SP]it's[SP]so[SP]busy\nhere?[1205][000F][SP]Meh,[SP]go[SP]have[SP]fun[SP]for[SP]me[SP]too...",
     "nom_fr": "Gérant",
-    "texte_fr": "Vas au festival Kasuga! Moi? [1205][000F][1205][000F]Comment\npartir avec tout ce monde ici? Bref,\namuse-toi bien pour moi..."
+    "texte_fr": "Vas au festival Kasuga! Moi? [000F][1205][000F][1205]Comment\npartir avec tout ce monde ici? Bref,\namuse-toi bien pour moi..."
   },
   {
     "id": 77,
@@ -1251,7 +1251,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Everything's[SP]Muses[SP]this[SP]and[SP]Muses[SP]that[SP]these\ndays.[SP]They're[SP]not[SP]really[SP]my[SP]thing...[1205][000F][SP]Too[SP]young.[1205][000F]\nI[SP]can't[SP]relate[SP]to[SP]their[SP]songs...[SP]Hmm.",
     "nom_fr": "Gérant",
-    "texte_fr": "On n'entend plus que Muses par-ci, Muses\npar-là. C'est pas trop mon truc.[1205][000F][1205][000F].. Trop\njeune. Leurs chansons\nme parlent pas... Hmm."
+    "texte_fr": "On n'entend plus que Muses par-ci, Muses\npar-là. C'est pas trop mon truc.[000F][1205][000F][1205].. Trop\njeune. Leurs chansons me parlent pas... Hmm."
   },
   {
     "id": 79,
@@ -1266,7 +1266,7 @@
     "nom_orig": "Manager",
     "texte_orig": "The[SP]whole[SP]city's[SP]excited[SP]over[SP]Muses.[1205][000F][SP]I[SP]wish\nwe[SP]could[SP]capture[SP]a[SP]little[SP]of[SP]that[SP]enthusiasm\nsometime...[SP]Pardon[SP]me[SP]while[SP]I[SP]go[SP]sulk.",
     "nom_fr": "Gérant",
-    "texte_fr": "Toute la ville est à fond sur Muses.\n[1205][000F]J'aimerais bien qu'on suscite un peu de cet\nengouement... Pardonnez-moi,\nje vais bouder."
+    "texte_fr": "Toute la ville est à fond sur Muses.\n[000F][1205]J'aimerais bien qu'on suscite un peu de cet\nengouement... Pardonnez-moi, je vais bouder."
   },
   {
     "id": 80,
@@ -1296,7 +1296,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Noooo![SP]It's[SP]burning![1205][000F][SP]GOLD[SP]is[SP]burning![1205][000F]\n...Can't[SP]you[SP]act[SP]at[SP]least[SP]a[SP]little[SP]panicked,\nman?",
     "nom_fr": "Gérant",
-    "texte_fr": "Noooon! [1205][000F][1205][000F]Ça brûle! GOLD brûle! ... Tu\npourrais pas paniquer un peu, mec?"
+    "texte_fr": "Noooon! [000F][1205][000F][1205]Ça brûle! GOLD brûle! ... Tu\npourrais pas paniquer un peu, mec?"
   },
   {
     "id": 82,
@@ -1311,7 +1311,7 @@
     "nom_orig": "Manager",
     "texte_orig": "It's[SP]a[SP]little[SP]late[SP]to[SP]be[SP]sniffing[SP]out[SP]the\nculprit,[SP]you[SP]know?[1205][000F][SP]They've[SP]hit[SP]six[SP]places\nalready.",
     "nom_fr": "Gérant",
-    "texte_fr": "Un peu tard pour chercher le coupable, non?\nIls ont déjà frappé\n[1205][000F]à six endroits différents."
+    "texte_fr": "Un peu tard pour chercher le coupable, non?\nIls ont déjà frappé\n[000F][1205]à six endroits différents."
   },
   {
     "id": 83,
@@ -1341,7 +1341,7 @@
     "nom_orig": "Manager",
     "texte_orig": "Yep,[SP]might[SP]as[SP]well[SP]enjoy[SP]gambling[SP]at[SP]a[SP]time\nlike[SP]this.[SP]It's[SP]not[SP]like[SP]panicking[SP]will[SP]help.\n...Though[SP]to[SP]be[SP]honest,[SP]I'm[SP]freaking[SP]out!",
     "nom_fr": "Gérant",
-    "texte_fr": "Ouais, autant profiter des jeux d'argent\ndans un moment pareil.\nPaniquer ne servira à\nrien... Même si, en vrai,\nje flippe à fond!"
+    "texte_fr": "Ouais, autant profiter des jeux d'argent\ndans un moment pareil.\nPaniquer ne servira à rien... Même si, en vrai, je flippe à fond!"
   },
   {
     "id": 85,

--- a/traduction/event_scripts/script_327.json
+++ b/traduction/event_scripts/script_327.json
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Why[SP]aren't[SP]the[SP]people[SP]here[SP]running?[SP]Eh,[SP]I[SP]guess\nthere's[SP]nowhere[SP]to[SP]run[SP]with[SP]the[SP]city[SP]in[SP]the\nsky...[1205][000F][SP]They[SP]seem[SP]pretty[SP]casual[SP]about[SP]all[SP]this.",
     "nom_fr": "Ginko",
-    "texte_fr": "Pourquoi les gens ne\nfuient pas? Bah, il n'y\na nulle part où aller\navec la ville dans les\n[1205][000F]airs... Ils ont l'air bien détendus."
+    "texte_fr": "Pourquoi les gens ne\nfuient pas? Bah, il n'y\na nulle part où aller avec la ville dans les [000F][1205]airs... Ils ont l'air bien détendus."
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Y-Yeah...[1205][000F][SP]I'm[SP]not[SP]Joker[SP]anymore,[SP]but[SP]I[SP]think\nit'll[SP]still[SP]come[SP]true[SP]if[SP]the[SP]rumor's[SP]spread...",
     "nom_fr": "Jun",
-    "texte_fr": "O-Oui.[1205][000F].. Je ne suis plus le Joker, mais\nça marchera si la rumeur se répand..."
+    "texte_fr": "O-Oui.[000F][1205].. Je ne suis plus le Joker, mais\nça marchera si la rumeur se répand..."
   },
   {
     "id": 6,
@@ -132,7 +132,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Um...[1205][000A][SP]What's[SP]going[SP]on[SP]out[SP]there?[1205][000F][SP]We've[SP]both\nbeen[SP]hiding[SP]here[SP]ever[SP]since[SP]we[SP]saw[SP]those\nsoldiers...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Euh.[1205]..[1205][000A] Que se passe dehors? [000F]On se cache ici\ndepuis qu'on a vu\nces soldats tous les deux..."
+    "texte_fr": "Euh.[1205]..[000A][1205] Que se passe dehors? [000F]On se cache ici\ndepuis qu'on a vu\nces soldats tous les deux..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Inveterate[SP]gambler",
     "texte_orig": "The[SP]Last[SP]Battalion...[SP]They're[SP]a[SP]real[SP]wild[SP]card.[1205][000F]\nThe[SP]stakes[SP]are[SP]this[SP]entire[SP]city...[SP]What's[SP]going\nto[SP]decide[SP]Sumaru's[SP]fate...[SP]is[SP]cards...",
     "nom_fr": "Joueur invétéré",
-    "texte_fr": "Le Bataillon... Un vrai\njoker dans la partie.\n[1205][000F]L'enjeu, c'est toute la ville... Ce qui\ndécidera du sort de\nSumaru... les cartes..."
+    "texte_fr": "Le Bataillon... Un vrai\njoker dans la partie.\n[000F][1205]L'enjeu, c'est toute la ville... Ce qui décidera du sort de Sumaru... les cartes..."
   },
   {
     "id": 10,
@@ -259,7 +259,7 @@
     "nom_orig": "Manager",
     "texte_orig": "What?[SP]You[SP]still[SP]want[SP]something?[1205][000F]\n...Nah,[SP]just[SP]kidding.[SP]What'll[SP]it[SP]be?\n[1208][0005]Buy[SP]coins\nRedeem[SP]for[SP]prizes\nTalk[SP]to[SP]the[SP]manager\nNever[SP]mind\nLeave",
     "nom_fr": "Gérant",
-    "texte_fr": "Quoi? Encore un truc?\n...[1205][000F]Non, je rigole. Que désirez-vous?\n[1208][0005]Acheter des jetons\nÉchanger des prix\nParler au gérant\nAnnuler\nSortir",
+    "texte_fr": "Quoi? Encore un truc?\n...[000F][1205]Non, je rigole. Que désirez-vous?\n[1208][0005]Acheter des jetons\nÉchanger des prix\nParler au gérant\nAnnuler\nSortir",
     "question_orig": "What?[SP]You[SP]still[SP]want[SP]something?[1205][000F]\n...Nah,[SP]just[SP]kidding.[SP]What'll[SP]it[SP]be?",
     "choix_orig": [
       "Buy[SP]coins",

--- a/traduction/event_scripts/script_332.json
+++ b/traduction/event_scripts/script_332.json
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Do[SP]only[SP]the[SP]Masked[SP]Circle[SP]rank[SP]and[SP]file[SP]have\norders[SP]to[SP]fight?[1205][000F][SP]What[SP]happened[SP]to[SP]the\nexecutives?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Seuls les sous-fifres du Cercle masqué ont\nordre de se battre? [1205][000F]Que sont devenus les\ncadres?"
+    "texte_fr": "Seuls les sous-fifres du Cercle masqué ont\nordre de se battre? [000F][1205]Que sont devenus les\ncadres?"
   },
   {
     "id": 11,
@@ -237,7 +237,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "A[SP]goal,[SP]huh...?[1205][000F][SP]Do[SP]you[SP]have[SP]anything[SP]like[SP]that,\n[1113]?[1205][000F][SP]I...[1205][000F][SP]Nah,[SP]forget[SP]it.",
     "nom_fr": "Ginko",
-    "texte_fr": "Un but.[1205][000F][1205][000F][1205][000F]..? Tu en as un,\n[1113]? Moi... Laisse tomber."
+    "texte_fr": "Un but.[000F][1205][000F][1205][000F][1205]..? Tu en as un,\n[1113]? Moi... Laisse tomber."
   },
   {
     "id": 16,
@@ -267,7 +267,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Sheba[SP]and[SP]Mee-ho[SP]aren't[SP]my[SP]friends.[SP]They[SP]think\nthey[SP]are,[SP]but[SP]they[SP]have[SP]nothing[SP]to[SP]do[SP]with[SP]me.",
     "nom_fr": "Ginko",
-    "texte_fr": "Sheba et Mee-ho ne\nsont pas mes amies. Elles\nle pensent, mais n'ont\nrien à voir avec moi."
+    "texte_fr": "Sheba et Mee-ho ne\nsont pas mes amies. Elles\nle pensent, mais n'ont rien à voir avec moi."
   },
   {
     "id": 18,
@@ -342,7 +342,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Smile[SP]Hirasaka,[SP]GOLD...[SP]even[SP]the[SP]Aerospace\nMuseum[SP]went[SP]up[SP]in[SP]flames...[1205][000F][SP]Did[SP]Joker[SP]want\nthis[SP]to[SP]happen?[1205][000F][SP]Was[SP]this...[SP]their[SP]wish...?",
     "nom_fr": "Ginko",
-    "texte_fr": "Smile Hirasaka, GOLD... même le musée\naérospatial a brûlé.[1205].[1205][000F][000F]. Le Joker voulait\nque ça arrive? C'était... leur souhait...?"
+    "texte_fr": "Smile Hirasaka, GOLD... même le musée\naérospatial a brûlé.[1205].[000F][1205][000F]. Le Joker voulait\nque ça arrive? C'était... leur souhait...?"
   },
   {
     "id": 23,
@@ -387,7 +387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Ooh,[SP]this[SP]dolphin[SP]brooch[SP]is[SP]so[SP]cute![1205][000F][SP]Ever[SP]seen\na[SP]real[SP]dolphin,[SP][1113]-kun?[SP]I[SP]saw[SP]them[SP]a[SP]lot\nwhen[SP]I[SP]used[SP]to[SP]go[SP]scuba[SP]diving.",
     "nom_fr": "Maya",
-    "texte_fr": "Ooh, mignonne cette broche! [1205][000F]Déjà\nvu un vrai dauphin, [1113]-kun?\nJ'en voyais plein en plongeant."
+    "texte_fr": "Ooh, mignonne cette broche! [000F][1205]Déjà\nvu un vrai dauphin, [1113]-kun?\nJ'en voyais plein en plongeant."
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]think[SP]Eikichi-kun[SP]is[SP]just[SP]anxious...[1205][000F][SP]He[SP]wants\nto[SP]believe[SP]in[SP]his[SP]classmates.[SP]He's[SP]their[SP]Boss,\nafter[SP]all.",
     "nom_fr": "Maya",
-    "texte_fr": "Je pense qu'Eikichi-kun est anxieux.[1205][000F]..\nIl veut croire en ses camarades. Il\nest leur Boss, après tout."
+    "texte_fr": "Je pense qu'Eikichi-kun est anxieux.[000F][1205]..\nIl veut croire en ses camarades. Il\nest leur Boss, après tout."
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]is[SP]Eikichi-kun[SP]we're[SP]talking[SP]about.\nHe[SP]may[SP]have[SP]quit[SP]being[SP]Boss,[SP]but[SP]he'll[SP]find[SP]a\nnew[SP]goal[SP]in[SP]no[SP]time.[SP]I[SP]bet[SP]he[SP]already[SP]has[SP]one!",
     "nom_fr": "Maya",
-    "texte_fr": "C'est d'Eikichi-kun qu'on parle. Il n'est\nplus le Boss, mais il trouvera un autre but\nen un rien de temps.\nIl l'a déjà, je parie !"
+    "texte_fr": "C'est d'Eikichi-kun qu'on parle. Il n'est\nplus le Boss, mais il trouvera un autre but\nen un rien de temps. Il l'a déjà, je parie !"
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]Masked[SP]Circle[SP]is[SP]made[SP]up[SP]of[SP]people[SP]who[SP]had\ntheir[SP]ideals[SP]granted[SP]by[SP]Joker...[1205][000F][SP]But[SP]there's\nno[SP]way[SP]we[SP]could[SP]figure[SP]that[SP]out.",
     "nom_fr": "Maya",
-    "texte_fr": "Le Cercle masqué regroupe ceux dont les\nidéaux ont été exaucés par le Joker.[1205][000F]..\nMais on ne pouvait pas le deviner."
+    "texte_fr": "Le Cercle masqué regroupe ceux dont les\nidéaux ont été exaucés par le Joker.[000F][1205]..\nMais on ne pouvait pas le deviner."
   },
   {
     "id": 30,
@@ -477,7 +477,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Aren't[SP]Sheba[SP]and[SP]Mee-ho[SP]Lisa's[SP]good[SP]friends?[1205][000F]\nI[SP]wonder[SP]why[SP]she[SP]keeps[SP]badmouthing[SP]them...",
     "nom_fr": "Maya",
-    "texte_fr": "Sheba et Mee-ho ne sont-elles pas les amies\n[1205][000F]de Lisa? Pourquoi les insulte-t-elle?"
+    "texte_fr": "Sheba et Mee-ho ne sont-elles pas les amies\n[000F][1205]de Lisa? Pourquoi les insulte-t-elle?"
   },
   {
     "id": 32,
@@ -492,7 +492,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Maybe[SP]the[SP]Masked[SP]Circle[SP]planted[SP]the[SP]rumor[SP]about\nPrint[SP]Club[SP]photos[SP]leading[SP]to[SP]a[SP]debut.[1205][000F][SP]If[SP]that's\nthe[SP]case,[SP]there[SP]must[SP]be[SP]more[SP]to[SP]this.",
     "nom_fr": "Maya",
-    "texte_fr": "Peut-être que le Cercle masqué a lancé\nla rumeur sur les photos Purikura. [1205][000F]Si\nc'est ça, ça cache autre chose."
+    "texte_fr": "Peut-être que le Cercle masqué a lancé\nla rumeur sur les photos Purikura. [000F][1205]Si\nc'est ça, ça cache autre chose."
   },
   {
     "id": 33,
@@ -567,7 +567,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]bet[SP]King[SP]Leo's[SP]desperate[SP]now.[SP]But[SP]then,[SP]so\nare[SP]we...[SP]We'll[SP]extinguish[SP]those[SP]awful\nflames[SP]of[SP]his[SP]this[SP]time!",
     "nom_fr": "Maya",
-    "texte_fr": "Le Roi Lion est\ndésespéré. Mais nous aussi...\nOn éteindra ses\nhorribles flammes cette fois!"
+    "texte_fr": "Le Roi Lion est\ndésespéré. Mais nous aussi...\nOn éteindra ses horribles flammes cette fois!"
   },
   {
     "id": 38,
@@ -762,7 +762,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "The[SP]Masked[SP]Circle[SP]are[SP]just[SP]ordinary[SP]people!\nThere's[SP]no[SP]way[SP]they[SP]can[SP]fight[SP]those[SP]soldiers!\nIs[SP]he[SP]planning[SP]to[SP]use[SP]them[SP]as[SP]cannon[SP]fodder?",
     "nom_fr": "Yukino",
-    "texte_fr": "Ce Cercle masqué n'est fait que de civils !\nIls ne font pas le\npoids face à ces soldats!\nIl veut les utiliser comme chair à canon?"
+    "texte_fr": "Ce Cercle masqué n'est fait que de civils !\nIls ne font pas le\npoids face à ces soldats! Il veut les utiliser comme chair à canon?"
   },
   {
     "id": 51,
@@ -1047,7 +1047,7 @@
     "nom_orig": "Tony",
     "texte_orig": "I[SP]make[SP]each[SP]one[SP]a'[SP]these[SP]by[SP]hand.[SP]Buy[SP]'em[SP]all,\nwhat[SP]you[SP]think?[SP]I[SP]give[SP]a[SP]good[SP]discount[SP]for\nthe[SP]girls.",
     "nom_fr": "Tony",
-    "texte_fr": "Je les fais tous à\nla main. Achète tout, t'en\ndis quoi? Je fais un\nbon prix pour les filles."
+    "texte_fr": "Je les fais tous à\nla main. Achète tout, t'en\ndis quoi? Je fais un bon prix pour les filles."
   },
   {
     "id": 62,
@@ -1062,7 +1062,7 @@
     "nom_orig": "Tony",
     "texte_orig": "I'm[SP]a[SP]smuggler[SP]for[SP]the[SP]Silician[SP]Mafia,[SP]you[SP]know.\nYou[SP]give[SP]me[SP]the[SP]money,[SP]I[SP]get[SP]you[SP]the[SP]thing[SP]what\nyou[SP]want.[SP]Weapons,[SP]girls,[SP]anything.",
     "nom_fr": "Tony",
-    "texte_fr": "Je suis passeur pour\nla Mafia Silicienne, tu\nsais. Tu donnes l'argent, je te trouve ce\nque tu veux. Armes, filles, n'importe quoi."
+    "texte_fr": "Je suis passeur pour\nla Mafia Silicienne, tu\nsais. Tu donnes l'argent, je te trouve ce que tu veux. Armes, filles, n'importe quoi."
   },
   {
     "id": 63,
@@ -1317,7 +1317,7 @@
     "nom_orig": "Tony",
     "texte_orig": "Already[SP]there's[SP]a[SP]crowd[SP]at[SP]Giga[SP]Macho,[SP]alla\nthem[SP]drooling[SP]to[SP]see[SP]Ginji[SP]Sasaki[SP]and[SP]his[SP]third\nmember.[SP]Those[SP]other[SP]two[SP]Muses[SP]there[SP]too.",
     "nom_fr": "Tony",
-    "texte_fr": "Y'a déjà foule au\nGiga Macho, ils bavent tous\nd'envie de voir Ginji Sasaki et le 3ème\nmembre. Les deux autres\nMuses y seront aussi."
+    "texte_fr": "Y'a déjà foule au\nGiga Macho, ils bavent tous\nd'envie de voir Ginji Sasaki et le 3ème membre. Les deux autres Muses y seront aussi."
   },
   {
     "id": 80,
@@ -1377,7 +1377,7 @@
     "nom_orig": "Tony",
     "texte_orig": "Those[SP]terrorists[SP]are[SP]with[SP]the[SP]Masked[SP]Circle?\nPfagh![SP]But[SP]I[SP]have[SP]my[SP]weapons.[SP]They[SP]come[SP]here,\nI[SP]teach[SP]'em[SP]a[SP]thing[SP]or[SP]two.[SP]I'll[SP]be[SP]fine.",
     "nom_fr": "Tony",
-    "texte_fr": "Ces terroristes sont avec\nle Cercle masqué ?\nPff! Mais j'ai mes armes. Qu'ils viennent,\nje leur apprendrai. Je m'en sortirai."
+    "texte_fr": "Ces terroristes sont avec\nle Cercle masqué ?\nPff! Mais j'ai mes armes. Qu'ils viennent, je leur apprendrai. Je m'en sortirai."
   },
   {
     "id": 84,
@@ -1407,7 +1407,7 @@
     "nom_orig": "Tony",
     "texte_orig": "You[SP]heard,[SP]my[SP]friend?[SP]The[SP]Last[SP]Battalion[SP]was\nthe[SP]terrorists.[SP]But[SP]I[SP]don'a[SP]know[SP]if[SP]they[SP]even\nexist.[SP]Sure[SP]would[SP]be[SP]bad[SP]if[SP]they[SP]did,[SP]huh?",
     "nom_fr": "Tony",
-    "texte_fr": "T'as entendu? Le Bataillon était les\nterroristes. J'sais même\npas s'ils existent.\nCe serait moche si c'était vrai, hein?"
+    "texte_fr": "T'as entendu? Le Bataillon était les\nterroristes. J'sais même\npas s'ils existent. Ce serait moche si c'était vrai, hein?"
   },
   {
     "id": 86,
@@ -1452,7 +1452,7 @@
     "nom_orig": "Tony",
     "texte_orig": "I[SP]don'a[SP]know[SP]if[SP]even[SP]my[SP]weapons[SP]could...[SP]Nah!\nWhat'm[SP]I[SP]saying?[SP]These[SP]weapons[SP]you[SP]see,[SP]they're\nthe[SP]greatest[SP]around.[SP]Buy[SP]'em![SP]My[SP]whole[SP]stock!",
     "nom_fr": "Tony",
-    "texte_fr": "Même mes armes ne pourraient pas... Nan!\nQu'est-ce que je dis?\nCes armes que tu vois,\nc'est les meilleures.\nAchète! Tout mon stock!"
+    "texte_fr": "Même mes armes ne pourraient pas... Nan!\nQu'est-ce que je dis?\nCes armes que tu vois, c'est les meilleures. Achète! Tout mon stock!"
   },
   {
     "id": 89,
@@ -1542,7 +1542,7 @@
     "nom_orig": "Tony",
     "texte_orig": "I[SP]hear[SP]those[SP]thugs,[SP]they[SP]no'a[SP]show[SP]mercy[SP]to\nwomen[SP]and[SP]kids[SP]if[SP]they[SP]resist.[SP]It[SP]won'a[SP]be[SP]a\ngood[SP]day[SP]if[SP]they[SP]know[SP]I[SP]sell[SP]weapons...",
     "nom_fr": "Tony",
-    "texte_fr": "Ces voyous n'ont aucune\npitié pour les femmes\net enfants s'ils résistent. Ça va chauffer\ns'ils savent que je vends des armes..."
+    "texte_fr": "Ces voyous n'ont aucune\npitié pour les femmes\net enfants s'ils résistent. Ça va chauffer s'ils savent que je vends des armes..."
   },
   {
     "id": 95,
@@ -1827,7 +1827,7 @@
     "nom_orig": "Mummy",
     "texte_orig": "We[SP]already[SP]have[SP]pet[SP]names[SP]for[SP]each[SP]other.\nHe's[SP]Pappy[SP]and[SP]I'm[SP]Mummy.[SP]Don't[SP]we[SP]sound[SP]like\na[SP]married[SP]couple[SP]already?",
     "nom_fr": "Mamy",
-    "texte_fr": "On a déjà des surnoms.\nIl est Papy et je suis\nMamy. On ne dirait\npas déjà un couple marié?"
+    "texte_fr": "On a déjà des surnoms.\nIl est Papy et je suis\nMamy. On ne dirait pas déjà un couple marié?"
   },
   {
     "id": 114,
@@ -1887,7 +1887,7 @@
     "nom_orig": "Mummy",
     "texte_orig": "Hey,[SP]Pappy,[SP]let's[SP]check[SP]out[SP]Cuss[SP]High's[SP]school\nfestival.[SP]I[SP]hear[SP]it's[SP]amazing[SP]this[SP]year.\nCome[SP]on!",
     "nom_fr": "Mamy",
-    "texte_fr": "Hé, Papy, allons au festival de\nCuss High. Il paraît qu'il est\nincroyable cette année. Viens!"
+    "texte_fr": "Hé, Papy, allons au festival de\nLycée Kasu. Il paraît qu'il est\nincroyable cette année. Viens!"
   },
   {
     "id": 118,
@@ -1902,7 +1902,7 @@
     "nom_orig": "Mummy",
     "texte_orig": "Huh?[SP]Masked[SP]Circle...?[1205][000F][SP]N-No,[SP]I[SP]don't[SP]know[SP]the\nfirst[SP]thing[SP]about[SP]them.[SP]It.[SP]I[SP]have[SP]no[SP]idea!",
     "nom_fr": "Mamy",
-    "texte_fr": "Le Cercle masqué.[1205][000F]..? N-Non, je ne\nsais rien sur eux. Aucune idée!"
+    "texte_fr": "Le Cercle masqué.[000F][1205]..? N-Non, je ne\nsais rien sur eux. Aucune idée!"
   },
   {
     "id": 119,
@@ -1947,7 +1947,7 @@
     "nom_orig": "Mummy",
     "texte_orig": "But[SP]it[SP]was[SP]all[SP]a[SP]misunderstanding.[SP]He'd[SP]always\nbeen[SP]interested[SP]in[SP]me.[1205][000F][SP]And[SP]I[SP]went[SP]and[SP]asked\nfor[SP]that[SP]stupid[SP]wish[SP]anyway...",
     "nom_fr": "Mamy",
-    "texte_fr": "Mais c'était un malentendu. Il s'est\ntoujours intéressé à moi. [1205][000F]Et j'ai\nquand même fait ce vœu stupide..."
+    "texte_fr": "Mais c'était un malentendu. Il s'est\ntoujours intéressé à moi. [000F][1205]Et j'ai\nquand même fait ce vœu stupide..."
   },
   {
     "id": 122,
@@ -2022,7 +2022,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "B-But[SP]Pappy...[1205][000F][SP]It's[SP]the[SP]responsibility[SP]of[SP]we\nin[SP]the[SP]Masked[SP]Circle[SP]to[SP]protect[SP]this[SP]city[SP]from\nthem![SP]Let[SP]me[SP]go!",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "M-Mais Papy.[1205][000F].. C'est la responsabilité\ndu Cercle masqué de protéger cette\nville d'eux! Lâche-moi!"
+    "texte_fr": "M-Mais Papy.[000F][1205].. C'est la responsabilité\ndu Cercle masqué de protéger cette\nville d'eux! Lâche-moi!"
   },
   {
     "id": 127,
@@ -2137,7 +2137,7 @@
     "nom_orig": "Tony",
     "texte_orig": "The[SP]buyback[SP]price,[SP]it's[SP]about[SP]half[SP]of[SP]what[SP]you\npay[SP]inna[SP]first[SP]place.[SP]And[SP]you[SP]can't[SP]sell[SP]what\nyou're[SP]wearing,[SP]or[SP]something[SP]too[SP]special.",
     "nom_fr": "Tony",
-    "texte_fr": "Le rachat, c'est environ\nla moitié de ce que\nt'as payé. Et tu peux pas vendre ce que tu\nportes, ni quelque chose de trop spécial."
+    "texte_fr": "Le rachat, c'est environ\nla moitié de ce que\nt'as payé. Et tu peux pas vendre ce que tu portes, ni quelque chose de trop spécial."
   },
   {
     "id": 134,
@@ -2257,7 +2257,7 @@
     "nom_orig": "Tony",
     "texte_orig": "The[SP]buyback[SP]price,[SP]it's[SP]about[SP]half[SP]of[SP]what[SP]you\npay[SP]inna[SP]first[SP]place.[SP]And[SP]you[SP]can't[SP]sell[SP]what\nyou're[SP]wearing,[SP]or[SP]something[SP]too[SP]special.",
     "nom_fr": "Tony",
-    "texte_fr": "Le rachat, c'est environ\nla moitié de ce que\nt'as payé. Et tu peux pas vendre ce que tu\nportes, ni quelque chose de trop spécial."
+    "texte_fr": "Le rachat, c'est environ\nla moitié de ce que\nt'as payé. Et tu peux pas vendre ce que tu portes, ni quelque chose de trop spécial."
   },
   {
     "id": 142,

--- a/traduction/event_scripts/script_333.json
+++ b/traduction/event_scripts/script_333.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Heheh,[SP]I'm[SP]half[SP]glad[SP]and[SP]half[SP]annoyed.[1205][000F][SP]If[SP]we\ndon't[SP]get[SP]moving,[SP]they'll[SP]hog[SP]all[SP]the[SP]glory!\nWe[SP]can't[SP]fall[SP]behind!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Heheh, mi-content, mi-énervé. Faut\n[1205][000F]avancer sinon ils prennent toute la\ngloire! On peut pas se distancer !"
+    "texte_fr": "Heheh, mi-content, mi-énervé. Faut\n[000F][1205]avancer sinon ils prennent toute la\ngloire! On peut pas se distancer !"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey,[SP]those[SP]guys[SP]don't[SP]know[SP]about[SP]Yukino-san,\ndo[SP]they?[1205][000F][SP]We[SP]should...[1205][000A][SP]tell[SP]them,[SP]huh...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, ces types ne\nsavent pas pour Yukino-san,\nnon? [1205][000F]On devrait...[1205][000A] leur dire, hein..."
+    "texte_fr": "Hé, ces types ne\nsavent pas pour Yukino-san,\nnon? [000F][1205]On devrait...[000A][1205] leur dire, hein..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Telling[SP]them[SP]now[SP]will[SP]just[SP]confuse[SP]them.[1205][000F]",
     "nom_fr": "Eikichi",
-    "texte_fr": "Leur dire maintenant les troublerait.[1205][000F]"
+    "texte_fr": "Leur dire maintenant les troublerait.[000F][1205]"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It[SP]won't[SP]matter[SP]anyway[SP]if[SP]we[SP]stop[SP]Jun's[SP]dad.[1205][000F]\nLet's[SP]just[SP]keep[SP]quiet[SP]about[SP]it.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Si on arrête le père de Jun, peu\n[1205][000F]importe. Gardons ça pour nous."
+    "texte_fr": "Si on arrête le père de Jun, peu\n[000F][1205]importe. Gardons ça pour nous."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Wow![SP]Hoisamuro![1205][000F][SP]They're[SP]gonna[SP]help[SP]us[SP]out![1205][000A]\nThings[SP]are[SP]looking[SP]up!",
     "nom_fr": "Ginko",
-    "texte_fr": "Waouh! [1205][000F]Hoisamuro! Ils vont\nnous aider![1205][000A] Ça s'arrange!"
+    "texte_fr": "Waouh! [000F][1205]Hoisamuro! Ils vont\nnous aider![000A][1205] Ça s'arrange!"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "You[SP]know,[SP]I[SP]don't[SP]think[SP]these[SP]guys[SP]know[SP]about\nrumors[SP]coming[SP]true.[1205][000F][SP]Shouldn't[SP]we[SP]tell[SP]them?",
     "nom_fr": "Ginko",
-    "texte_fr": "Ces types ne savent pas que les rumeurs\nse réalisent. [1205][000F]On devrait les prévenir?"
+    "texte_fr": "Ces types ne savent pas que les rumeurs\nse réalisent. [000F][1205]On devrait les prévenir?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "And[SP]that's[SP]why[SP]Yukki[SP]handed[SP]off[SP]her[SP]Persona[SP]to\nJun-kun...[1205][000F][SP]She[SP]said[SP]she[SP]didn't[SP]need[SP]it[SP]anymore.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est pour ça que Yukki a transmis\nsa Persona à Jun-kun.[1205][000F].. Elle a dit\nn'en avoir plus besoin."
+    "texte_fr": "C'est pour ça que Yukki a transmis\nsa Persona à Jun-kun.[000F][1205].. Elle a dit\nn'en avoir plus besoin."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Elly",
     "texte_orig": "I[SP]see...[1205][000F][SP]Well,[SP]I'm[SP]certain[SP]it[SP]was[SP]all[SP]for[SP]the\nbest.[SP]To[SP]be[SP]honest,[SP]that[SP]sounds[SP]like[SP]something\nYukino[SP]would[SP]do.",
     "nom_fr": "Elly",
-    "texte_fr": "Je vois.[1205][000F].. Je suis sûre que c'était pour le\nmieux. C'est tout à\nfait ce que Yukino ferait."
+    "texte_fr": "Je vois.[000F][1205].. Je suis sûre que c'était pour le\nmieux. C'est tout à\nfait ce que Yukino ferait."
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Elly",
     "texte_orig": "No...[SP]I[SP]can't[SP]believe[SP]this![1205][000A][SP]Yukino[SP]wouldn't...[1205][000F]\nShe[SP]isn't...[1205][000F][SP]L-Let's[SP]not[SP]discuss[SP]this[SP]now.",
     "nom_fr": "Elly",
-    "texte_fr": "Non... Impossible![1205][1205][1205][000A] Yukino n'aurait pas.[000F][000F]..\nElle n'est pas... N-Parlons-en plus tard."
+    "texte_fr": "Non... Impossible![1205][1205][000A][1205] Yukino n'aurait pas.[000F][000F]..\nElle n'est pas... N-Parlons-en plus tard."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Elly",
     "texte_orig": "I'm[SP]sure[SP]that[SP]Yukino[SP]is[SP]safe.[1205][000F][SP]Right[SP]now,[SP]we\nshould[SP]turn[SP]our[SP]attention[SP]to[SP]the[SP]situation\nin[SP]Sumaru.",
     "nom_fr": "Elly",
-    "texte_fr": "Je suis certaine que Yukino va bien.\n[1205][000F]Pour l'instant, concentrons-nous sur\nla situation à Sumaru."
+    "texte_fr": "Je suis certaine que Yukino va bien.\n[000F][1205]Pour l'instant, concentrons-nous sur\nla situation à Sumaru."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]wonder[SP]what[SP]Brown-san[SP]meant[SP]by[SP][1432][NULL][NULL][0014]tin[SP]men[1432][NULL][NULL][0014]...[1205][000F]\nDoes[SP]he[SP]know[SP]something...?",
     "nom_fr": "Maya",
-    "texte_fr": "Que veut dire Brown par [1432][NULL][NULL][0014]hommes de\nfer[1432][NULL][NULL][0014].[1205][000F].. Il saurait quelque chose?"
+    "texte_fr": "Que veut dire Brown par [1432][NULL][NULL][0014]hommes de\nfer[1432][NULL][NULL][0014].[000F][1205].. Il saurait quelque chose?"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Tony-san[SP]just[SP]told[SP]me[SP]that[SP]Maki-san[SP]and[SP]the\nothers[SP]went[SP]to[SP]Sevens.[1205][000F][SP]Could[SP]they[SP]have[SP]gone\nto[SP]rescue[SP]the[SP]students...?",
     "nom_fr": "Maya",
-    "texte_fr": "Tony-san dit que Maki-san et les\nautres sont allés à Seven. [1205][000F]Ils\nseraient allés secourir les élèves...?"
+    "texte_fr": "Tony-san dit que Maki-san et les\nautres sont allés à Seven. [000F][1205]Ils\nseraient allés secourir les élèves...?"
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Are[SP]those[SP]people[SP]Persona-users[SP]too?[1205][000F]",
     "nom_fr": "Jun",
-    "texte_fr": "Eux aussi ont des Personae?[1205][000F]"
+    "texte_fr": "Eux aussi ont des Personae?[000F][1205]"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Jun",
     "texte_orig": "What's[SP]this[SP]feeling...?[1205][000F][SP]The[SP]Persona[SP]Yukino-san\ngave[SP]me[SP]is[SP]resonating...[1205][000F][SP]It's[SP]as[SP]if[SP]they're\ncalling[SP]to[SP]each[SP]other...",
     "nom_fr": "Jun",
-    "texte_fr": "Qu'est-ce que c'est.[1205][000F][1205][000F]..? La Persona de\nYukino-san résonne... Comme si elles se\nrépondaient..."
+    "texte_fr": "Qu'est-ce que c'est.[000F][1205][000F][1205]..? La Persona de\nYukino-san résonne... Comme si elles se\nrépondaient..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Yukino-san's[SP]friends...[1205][001E][SP]I...[SP]How[SP]do[SP]I[SP]explain\nthis[SP]to[SP]them...?",
     "nom_fr": "Jun",
-    "texte_fr": "Les amis de Yukino-san...[1205][001E] Je...\nComment leur expliquer ça...?"
+    "texte_fr": "Les amis de Yukino-san...[001E][1205] Je...\nComment leur expliquer ça...?"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Yukino-san's[SP]friends...[1205][001E][SP]I...[SP]How[SP]do[SP]I[SP]explain\nthis[SP]to[SP]them...?",
     "nom_fr": "Jun",
-    "texte_fr": "Les amis de Yukino-san...[1205][001E] Je...\nComment leur expliquer ça...?"
+    "texte_fr": "Les amis de Yukino-san...[001E][1205] Je...\nComment leur expliquer ça...?"
   },
   {
     "id": 18,
@@ -538,7 +538,7 @@
     "nom_orig": "Tony",
     "texte_orig": "The[SP]city,[SP]how's[SP]it[SP]fly?[1205][000F][SP]I[SP]don'a[SP]think[SP]that[SP]kinda\nthing[SP]is[SP]possible![1205][000F][SP]I[SP]think[SP]I'ma[SP]gonna[SP]faint.",
     "nom_fr": "Tony",
-    "texte_fr": "La ville vole? [1205][000F][1205][000F]Pas possible! Je\ncrois que je vais m'évanouir."
+    "texte_fr": "La ville vole? [000F][1205][000F][1205]Pas possible! Je\ncrois que je vais m'évanouir."
   },
   {
     "id": 28,
@@ -553,7 +553,7 @@
     "nom_orig": "Tony",
     "texte_orig": "But[SP]the[SP]In[SP]Lak'ech,[SP]it[SP]come[SP]true![SP]Am[SP]I[SP]gonna\nbe[SP]an[SP]Idealian?[1205][000F][SP]Oh,[SP]so[SP]much[SP]fun[SP]that[SP]would[SP]be!",
     "nom_fr": "Tony",
-    "texte_fr": "Mais l'In Lak'ech, ça\ns'est réalisé! Je vais\n[1205][000F]devenir un Idéalien? Oh, ce serait super!"
+    "texte_fr": "Mais l'In Lak'ech, ça\ns'est réalisé! Je vais\n[000F][1205]devenir un Idéalien? Oh, ce serait super!"
   },
   {
     "id": 29,
@@ -568,7 +568,7 @@
     "nom_orig": "Tony",
     "texte_orig": "The[SP]Masked[SP]Circle[SP]and[SP]Last[SP]Battalion,[SP]they\nstill[SP]fighting[SP]in[SP]that[SP]strange[SP]building.[1205][000F]\nVery[SP]scary...[SP]This[SP]city,[SP]it's[SP]so[SP]dangerous!",
     "nom_fr": "Tony",
-    "texte_fr": "Le Cercle masqué et le Bataillon se battent\nencore dans ce bâtiment bizarre. [1205][000F]Très\neffrayant... Cette ville est dangereuse!"
+    "texte_fr": "Le Cercle masqué et le Bataillon se battent\nencore dans ce bâtiment bizarre. [000F][1205]Très\neffrayant... Cette ville est dangereuse!"
   },
   {
     "id": 30,
@@ -583,7 +583,7 @@
     "nom_orig": "Tony",
     "texte_orig": "But[SP]don'a[SP]you[SP]worry.[1205][000A][SP]I[SP]get[SP]me[SP]a[SP]new[SP]batch[SP]of\nthe[SP]weapons.[1205][000F][SP]Hm?[SP]You[SP]no'a[SP]got[SP]money?[SP]Don'a\nworry,[SP]I[SP]got[SP]none[SP]neither.",
     "nom_fr": "Tony",
-    "texte_fr": "Mais t'inquiète pas.[1205][1205][000A] J'ai un\nnouveau stock d'armes. [000F]Hm? T'as pas\nd'argent? T'inquiète, moi non plus."
+    "texte_fr": "Mais t'inquiète pas.[1205][000A][1205] J'ai un\nnouveau stock d'armes. [000F]Hm? T'as pas\nd'argent? T'inquiète, moi non plus."
   },
   {
     "id": 31,
@@ -598,7 +598,7 @@
     "nom_orig": "Tony",
     "texte_orig": "They[SP]still[SP]fighting[SP]in[SP]those[SP]temples?[1205][000F][SP]Xibalba,\nit's[SP]already[SP]flying.[SP]Nothing[SP]to[SP]do[SP]but[SP]evolve,\nno?[SP]What[SP]else[SP]canna[SP]happen?",
     "nom_fr": "Tony",
-    "texte_fr": "Ils se battent encore dans ces temples?\n[1205][000F]Xibalba vole déjà. Faut évoluer, non?\nQu'est-ce qui peut encore arriver?"
+    "texte_fr": "Ils se battent encore dans ces temples?\n[000F][1205]Xibalba vole déjà. Faut évoluer, non?\nQu'est-ce qui peut encore arriver?"
   },
   {
     "id": 32,
@@ -613,7 +613,7 @@
     "nom_orig": "Tony",
     "texte_orig": "That[SP]man[SP]on[SP]TV,[SP]Brown,[SP]he[SP]just[SP]here.[1205][000F][SP]He[SP]had\ntwo[SP]bellas[SP]with[SP]him,[SP]too.[SP]They[SP]seemed[SP]like\nthey[SP]were[SP]going[SP]to[SP]Sevens.",
     "nom_fr": "Tony",
-    "texte_fr": "Ce type à la télé, Brown, il était là.\n[1205][000F]Il avait deux belles avec lui. Ils\navaient l'air de partir vers Seven."
+    "texte_fr": "Ce type à la télé, Brown, il était là.\n[000F][1205]Il avait deux belles avec lui. Ils\navaient l'air de partir vers Seven."
   },
   {
     "id": 33,
@@ -658,7 +658,7 @@
     "nom_orig": "Tony",
     "texte_orig": "That[SP]man[SP]on[SP]TV,[SP]Brown,[SP]he[SP]just[SP]here.[1205][000F][SP]He[SP]had\ntwo[SP]bellas[SP]with[SP]him,[SP]too.[SP]They[SP]seemed[SP]like\nthey[SP]were[SP]going[SP]to[SP]Sevens.",
     "nom_fr": "Tony",
-    "texte_fr": "Ce type à la télé, Brown, il était là.\n[1205][000F]Il avait deux belles avec lui. Ils\navaient l'air de partir vers Seven."
+    "texte_fr": "Ce type à la télé, Brown, il était là.\n[000F][1205]Il avait deux belles avec lui. Ils\navaient l'air de partir vers Seven."
   },
   {
     "id": 36,
@@ -688,7 +688,7 @@
     "nom_orig": "Elly",
     "texte_orig": "Ahaha...[SP]If[SP]we[SP]dawdle[SP]too[SP]long,[SP]Yukino[SP]will\nget[SP]upset.[1205][000F][SP]I[SP]don't[SP]mean[SP]to[SP]be[SP]presumptuous,\nbut[SP]please[SP]allow[SP]us[SP]to[SP]help.",
     "nom_fr": "Elly",
-    "texte_fr": "Ahaha... Si on traîne, Yukino va se fâcher.\n[1205][000F]Je ne veux pas paraître présomptueuse, mais\npermettez-nous d'aider."
+    "texte_fr": "Ahaha... Si on traîne, Yukino va se fâcher.\n[000F][1205]Je ne veux pas paraître présomptueuse, mais\npermettez-nous d'aider."
   },
   {
     "id": 38,
@@ -703,7 +703,7 @@
     "nom_orig": "Elly",
     "texte_orig": "Oh![SP]Speaking[SP]of[SP]which,[SP]I[SP]contacted[SP]Kei[SP]too...[1205][000F]\nHas[SP]he[SP]not[SP]arrived[SP]yet?",
     "nom_fr": "Elly",
-    "texte_fr": "Oh! J'ai aussi contacté Kei...\n[1205][000F]Il n'est pas encore arrivé?"
+    "texte_fr": "Oh! J'ai aussi contacté Kei...\n[000F][1205]Il n'est pas encore arrivé?"
   },
   {
     "id": 39,
@@ -718,7 +718,7 @@
     "nom_orig": "Elly",
     "texte_orig": "Something[SP]tells[SP]me[SP]we[SP]can't[SP]count[SP]Yukino[SP]out\njust[SP]yet.[SP]I'm[SP]sure[SP]she's[SP]still[SP]here...[1205][000F][SP]We[SP]must\nput[SP]an[SP]end[SP]to[SP]this[SP]to[SP]clear[SP]the[SP]way[SP]for[SP]her!",
     "nom_fr": "Elly",
-    "texte_fr": "Quelque chose me dit\nqu'on ne peut pas encore\nconsidérer Yukino hors jeu. [1205][000F]Je suis sûre\nqu'elle est encore là... Il faut en finir!"
+    "texte_fr": "Quelque chose me dit\nqu'on ne peut pas encore\nconsidérer Yukino hors jeu. [000F][1205]Je suis sûre qu'elle est encore là... Il faut en finir!"
   },
   {
     "id": 40,
@@ -733,7 +733,7 @@
     "nom_orig": "Elly",
     "texte_orig": "The[SP]Last[SP]Battalion[SP]has[SP]evidently[SP]invaded\nSevens.[1205][000F][SP]We'll[SP]secure[SP]the[SP]city.[SP]You[SP]ought[SP]to\ngo[SP]help[SP]your[SP]classmates.",
     "nom_fr": "Elly",
-    "texte_fr": "Le Bataillon a envahi Seven. [1205][000F]Nous allons\nsécuriser la ville. Va aider tes camarades."
+    "texte_fr": "Le Bataillon a envahi Seven. [000F][1205]Nous allons\nsécuriser la ville. Va aider tes camarades."
   },
   {
     "id": 41,
@@ -748,7 +748,7 @@
     "nom_orig": "???",
     "texte_orig": "Yo![SP]Long[SP]time[SP]no[SP]see![1205][000F][SP]Wait,[SP]I[SP]don't[SP]know[SP]you.[1205][000F]\nYo![SP]Long[SP]time[SP]no[SP]meet![1205][000F][SP]Heeheehee![1205][000F][SP]Alright,\nallow[SP]me[SP]to[SP]introduce[SP]myself...",
     "nom_fr": "???",
-    "texte_fr": "Yo, longtemps! [1205][000F][1205][000F][1205][000F][1205][000F]Attends, je te connais\npas. Yo! Longtemps qu'on s'est pas\nvus! Hiihi! laisse-moi me présenter..."
+    "texte_fr": "Yo, longtemps! [000F][1205][000F][1205][000F][1205][000F][1205]Attends, je te connais\npas. Yo! Longtemps qu'on s'est pas\nvus! Hiihi! laisse-moi me présenter..."
   },
   {
     "id": 42,
@@ -833,7 +833,7 @@
     "nom_orig": "Brown",
     "texte_orig": "I[SP]know[SP]what[SP]they[SP]say[SP]about[SP]me,[SP]but[SP]I[SP]hate[SP]to\nsee[SP]a[SP]job[SP]half[SP]done.[SP]I'll[SP]take[SP]care[SP]of[SP]things\nhere,[SP]so[SP]don't[SP]you[SP]worry[SP]about[SP]that.",
     "nom_fr": "Brown",
-    "texte_fr": "Je sais ce qu'on dit\nde moi, mais je déteste\nvoir un travail inachevé. Je m'occupe des \nchoses ici, alors ne t'en fais pas."
+    "texte_fr": "Je sais ce qu'on dit\nde moi, mais je déteste\nvoir un travail inachevé. Je m'occupe des choses ici, alors ne t'en fais pas."
   },
   {
     "id": 47,
@@ -848,7 +848,7 @@
     "nom_orig": "???",
     "texte_orig": "Seriously!?[SP]I'm...[SP]I'm[SP]Brown.[SP]Can't[SP]you[SP]tell?[1205][000F]\nYou[SP]mean[SP]to[SP]say[SP]you[SP]don't[SP]watch[SP]my[SP]show?[1205][000F][SP]Yikes,\nI[SP]think[SP]it[SP]just[SP]got[SP]a[SP]couple[SP]degrees[SP]colder.",
     "nom_fr": "???",
-    "texte_fr": "Sérieusement!? Je... Je suis Brown. [1205][000F][1205][000F]Tu\nvois pas? Tu regardes pas mon émission?\nAïe, il fait quelques degrés de moins."
+    "texte_fr": "Sérieusement!? Je... Je suis Brown. [000F][1205][000F][1205]Tu\nvois pas? Tu regardes pas mon émission?\nAïe, il fait quelques degrés de moins."
   },
   {
     "id": 48,
@@ -878,7 +878,7 @@
     "nom_orig": "Brown",
     "texte_orig": "I[SP]know[SP]what[SP]they[SP]say[SP]about[SP]me,[SP]but[SP]I[SP]hate[SP]to\nsee[SP]a[SP]job[SP]half[SP]done.[SP]I'll[SP]take[SP]care[SP]of[SP]things\nhere,[SP]so[SP]don't[SP]you[SP]worry[SP]about[SP]that.",
     "nom_fr": "Brown",
-    "texte_fr": "Je sais ce qu'on dit\nde moi, mais je déteste\nvoir un travail inachevé. Je m'occupe des \nchoses ici, alors ne t'en fais pas."
+    "texte_fr": "Je sais ce qu'on dit\nde moi, mais je déteste\nvoir un travail inachevé. Je m'occupe des choses ici, alors ne t'en fais pas."
   },
   {
     "id": 50,
@@ -893,7 +893,7 @@
     "nom_orig": "Brown",
     "texte_orig": "Heeheehee,[SP]what's[SP]the[SP]matter?[SP]You[SP]look[SP]like\na[SP]deer[SP]in[SP]headlights.[1205][000F][SP]They[SP]always[SP]save[SP]the\nbest[SP]for[SP]last,[SP]right?",
     "nom_fr": "Brown",
-    "texte_fr": "Hiihiihii, qu'est-ce qui t'arrive?\nT'as l'air d'un lapin dans les\n[1205][000F]phares. Le meilleur pour la fin, non?"
+    "texte_fr": "Hiihiihii, qu'est-ce qui t'arrive?\nT'as l'air d'un lapin dans les\n[000F][1205]phares. Le meilleur pour la fin, non?"
   },
   {
     "id": 51,
@@ -938,7 +938,7 @@
     "nom_orig": "Brown",
     "texte_orig": "Then[SP]again...[SP]Where[SP]are[SP]we[SP]supposed[SP]to[SP]evacuate\nthese[SP]people[SP]to?[1205][000F][SP]I[SP]guess[SP]we[SP]should[SP]deal[SP]with\nthe[SP]bad[SP]guys[SP]first,[SP]huh?",
     "nom_fr": "Brown",
-    "texte_fr": "Cela dit... Où on est censés évacuer\nces gens? [1205][000F]Je suppose qu'on devrait\nrégler les méchants d'abord, hein?"
+    "texte_fr": "Cela dit... Où on est censés évacuer\nces gens? [000F][1205]Je suppose qu'on devrait\nrégler les méchants d'abord, hein?"
   },
   {
     "id": 54,
@@ -953,7 +953,7 @@
     "nom_orig": "Brown",
     "texte_orig": "Looks[SP]like[SP]they're[SP]still[SP]having[SP]it[SP]out[SP]inside\nthat[SP]temple.[1205][000F]",
     "nom_fr": "Brown",
-    "texte_fr": "On dirait qu'ils se battent\nencore dans ce temple.[1205][000F]"
+    "texte_fr": "On dirait qu'ils se battent\nencore dans ce temple.[000F][1205]"
   },
   {
     "id": 55,
@@ -968,7 +968,7 @@
     "nom_orig": "Brown",
     "texte_orig": "If[SP]we[SP]don't[SP]hurry[SP]and[SP]do[SP]something,[SP]those\ntin[SP]men[SP]are[SP]gonna[SP]kill[SP]somebody.[1205][000F][SP]Now,[SP]what\nto[SP]do...",
     "nom_fr": "Brown",
-    "texte_fr": "Si on n'agit pas vite, ces hommes de fer\nvont tuer quelqu'un. [1205][000F]Alors, que faire..."
+    "texte_fr": "Si on n'agit pas vite, ces hommes de fer\nvont tuer quelqu'un. [000F][1205]Alors, que faire..."
   },
   {
     "id": 56,
@@ -998,7 +998,7 @@
     "nom_orig": "Maki",
     "texte_orig": "Elly[SP]filled[SP]me[SP]in.[1205][000F][SP]I[SP]don't[SP]know[SP]how[SP]much[SP]we\ncan[SP]help,[SP]but[SP]we'll[SP]fight[SP]with[SP]you.[SP]Let's[SP]all\nwork[SP]together[SP]on[SP]this.",
     "nom_fr": "Maki",
-    "texte_fr": "Elly m'a mise au courant. [1205][000F]Je sais pas\ncombien on peut aider, mais on se\nbattra avec vous. Travaillons ensemble."
+    "texte_fr": "Elly m'a mise au courant. [000F][1205]Je sais pas\ncombien on peut aider, mais on se\nbattra avec vous. Travaillons ensemble."
   },
   {
     "id": 58,
@@ -1013,7 +1013,7 @@
     "nom_orig": "Maki",
     "texte_orig": "We'll[SP]protect[SP]the[SP]people[SP]of[SP]Sumaru.[1205][000F][SP]Including\nthe[SP]Masked[SP]Circle[SP]members.",
     "nom_fr": "Maki",
-    "texte_fr": "On protégera les habitants de\n[1205][000F]Sumaru, y compris le Cercle masqué."
+    "texte_fr": "On protégera les habitants de\n[000F][1205]Sumaru, y compris le Cercle masqué."
   },
   {
     "id": 59,
@@ -1043,7 +1043,7 @@
     "nom_orig": "Maki",
     "texte_orig": "Hm?[SP]This[SP]flower?[1205][000F][SP]The[SP]Count[SP]at[SP]Time[SP]Castle\ngave[SP]it[SP]to[SP]me.[1205][000F][SP]He[SP]said[SP]it[SP]was[SP]a[SP]symbol[SP]of\ndestiny[SP]to[SP]be[SP]passed[SP]on...",
     "nom_fr": "Maki",
-    "texte_fr": "Hm? [1205][000F][1205]Cette fleur? [000F]Le Comte du\nChâteau du Temps me l'a donnée. Un\nsymbole de destin à transmettre..."
+    "texte_fr": "Hm? [000F][1205][1205]Cette fleur? [000F]Le Comte du\nChâteau du Temps me l'a donnée. Un\nsymbole de destin à transmettre..."
   },
   {
     "id": 61,
@@ -1083,7 +1083,7 @@
     "nom_orig": "Maki",
     "texte_orig": "A[SP]legendary[SP]flower?[1205][000F][SP]This?[1205][000F][SP]Huh...[SP]It[SP]doesn't\nlook[SP]like[SP]it...[1205][000F][SP]But[SP]stranger[SP]things[SP]have\nhappened.",
     "nom_fr": "Maki",
-    "texte_fr": "Une fleur légendaire? [1205][000F][1205][000F][1205][000F]Celle-là? Hmm...\nElle n'en a pas l'air... Mais bon."
+    "texte_fr": "Une fleur légendaire? [000F][1205][000F][1205][000F][1205]Celle-là? Hmm...\nElle n'en a pas l'air... Mais bon."
   },
   {
     "id": 63,
@@ -1113,7 +1113,7 @@
     "nom_orig": "Maki",
     "texte_orig": "But...[SP]I[SP]wonder[SP]what[SP]he[SP]meant[SP]about[SP]it[SP]being\na[SP]symbol[SP]of[SP]destiny[SP]to[SP]be[SP]passed[SP]on...[1205][000F][SP]Well,\nlet's[SP]just[SP]give[SP]thanks[SP]and[SP]put[SP]it[SP]to[SP]good[SP]use.",
     "nom_fr": "Maki",
-    "texte_fr": "Mais... je me demande ce qu'il voulait dire\npar symbole de\ndestin à transmettre.[1205][000F].. Enfin,\nremercions-le et faisons-en bon usage."
+    "texte_fr": "Mais... je me demande ce qu'il voulait dire\npar symbole de\ndestin à transmettre.[000F][1205].. Enfin, remercions-le et faisons-en bon usage."
   },
   {
     "id": 65,
@@ -1128,7 +1128,7 @@
     "nom_orig": "Maki",
     "texte_orig": "Hmmm.[SP]What[SP]should[SP]we[SP]do...[1205][000F][SP]I[SP]want[SP]to[SP]get[SP]the\npeople[SP]to[SP]a[SP]safe[SP]place,[SP]but[SP]where?",
     "nom_fr": "Maki",
-    "texte_fr": "Hmm. Qu'est-ce qu'on devrait faire.[1205][000F]..\nJe veux les gens en sécurité, mais où?"
+    "texte_fr": "Hmm. Qu'est-ce qu'on devrait faire.[000F][1205]..\nJe veux les gens en sécurité, mais où?"
   },
   {
     "id": 66,

--- a/traduction/event_scripts/script_334.json
+++ b/traduction/event_scripts/script_334.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]wonder[SP]sometimes...[1205][000F][SP]if[SP]Hanakouji-san[SP]would\nthink[SP]better[SP]of[SP]me[SP]now...[1205][000F][SP]I'm[SP]not[SP]the[SP]kid\nI[SP]used[SP]to[SP]be.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Parfois je me demande.[1205][000F][1205][000F].. si\nHanakouji-san penserait du bien de\nmoi... Je ne suis plus un gamin."
+    "texte_fr": "Parfois je me demande.[000F][1205][000F][1205].. si\nHanakouji-san penserait du bien de\nmoi... Je ne suis plus un gamin."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "H-Hey,[SP][1113]...[SP]I[SP]just[SP]got[SP]this[SP]chill[SP]down\nmy[SP]spine.[1205][000F][SP]Wonder[SP]what[SP]that's[SP]about...",
     "nom_fr": "Eikichi",
-    "texte_fr": "H-Hé, [1113]... J'ai eu des frissons\ndans le dos. [1205][000F]Je me demande pourquoi..."
+    "texte_fr": "H-Hé, [1113]... J'ai eu des frissons\ndans le dos. [000F][1205]Je me demande pourquoi..."
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yikes...[1205][000F][SP]Damn,[SP]but[SP]Ginko[SP]can[SP]be[SP]harsh.[SP]Is[SP]this\nwhat[SP]she's[SP]really[SP]like?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Oups.[1205][000F].. Ginko peut être dure.\nEst-ce sa vraie nature?"
+    "texte_fr": "Oups.[000F][1205].. Ginko peut être dure.\nEst-ce sa vraie nature?"
   },
   {
     "id": 6,
@@ -147,7 +147,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ginko's[SP]probably[SP]right.[1205][000F][SP]They[SP]say[SP]villains[SP]are\nalways[SP]ugly.[SP]Then[SP]again,[SP]who[SP]isn't,[SP]compared\nto[SP]me?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ginko a raison. [1205]On\n[000F]dit que les méchants sont\nmoches. Mais qui ne\nl'est pas comparé à moi?"
+    "texte_fr": "Ginko a raison. [1205]On\n[000F]dit que les méchants sont\nmoches. Mais qui ne l'est pas comparé à moi?"
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]bet[SP]everyone's[SP]nervous...[SP]Is[SP]that[SP]why[SP]they're\ntrusting[SP]in[SP]the[SP]In[SP]Lak'ech?[1205][000F][SP]I[SP]guess[SP]there's[SP]no\ngetting[SP]around[SP]it...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tous sont nerveux... C'est pour\nça qu'ils croient en In Lak'ech?\n[1205][000F]Je suppose qu'on n'y peut rien..."
+    "texte_fr": "Tous sont nerveux... C'est pour\nça qu'ils croient en In Lak'ech?\n[000F][1205]Je suppose qu'on n'y peut rien..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey,[SP][1114],[SP]did[SP]you[SP]talk[SP]to[SP]those[SP]girls?[1205][000F]\nWhat[SP]should[SP]we[SP]do?[1205][000F][SP]We[SP]can't[SP]save[SP]her[SP]if[SP]we\ndon't[SP]know[SP]where[SP]she[SP]is...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, [1114], tu as parlé à ces filles?\n[1205][000F][1205][000F]On fait quoi? On ne peut pas la\nsauver sans savoir où elle est..."
+    "texte_fr": "Hé, [1114], tu as parlé à ces filles?\n[000F][1205][000F][1205]On fait quoi? On ne peut pas la\nsauver sans savoir où elle est..."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Wha--What's[SP]with[SP]this[SP]old[SP]lady!?[1205][000F][SP]Why's[SP]she\nhitting[SP]on[SP]my[SP][1113]!?[1205][000F][SP]I[SP]kinda[SP]hate[SP]her[SP]now!",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est quoi cette vieille![1205][000F][1205][000F]? Pourquoi\ndraguer mon [1113]!? Je la hais!"
+    "texte_fr": "C'est quoi cette vieille![000F][1205][000F][1205]? Pourquoi\ndraguer mon [1113]!? Je la hais!"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Ugh,[SP]Undie[SP]Boss[SP]is[SP]such[SP]an[SP]idiot![1205][000F][SP]Look[SP]at[SP]all\nthe[SP]trouble[SP]he[SP]caused[SP]us,[SP]taking[SP]off[SP]like[SP]that!",
     "nom_fr": "Ginko",
-    "texte_fr": "Argh, Boss des calbutes\nest idiot! [1205][000F]Regarde tous les\nennuis qu'il nous cause en fuyant ainsi!"
+    "texte_fr": "Argh, Boss des calbutes\nest idiot! [000F][1205]Regarde tous les\nennuis qu'il nous cause en fuyant ainsi!"
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Are[SP]you[SP]listening[SP]to[SP]this,[SP][1113]!?[SP]That[SP]lady\nsaid[SP]she[SP]doesn't[SP]want[SP]to[SP]sell[SP]me[SP]anything![1205][000F]\nIsn't[SP]that[SP]a[SP]little[SP]rude!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Tu entends ça, [1113]!? Cette\ndame dit qu'elle ne veut rien me\nvendre! [1205][000F]C'est pas un peu malpoli!?"
+    "texte_fr": "Tu entends ça, [1113]!? Cette\ndame dit qu'elle ne veut rien me\nvendre! [000F][1205]C'est pas un peu malpoli!?"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Wait[SP]a[SP]sec![1205][000F][SP]What[SP]do[SP]you[SP]mean,[SP][1432][NULL][NULL][0014]debut[1432][NULL][NULL][0014]?[1205][000F][SP]I[SP]don't\nknow[SP]what[SP]you're[SP]talking[SP]about.",
     "nom_fr": "Ginko",
-    "texte_fr": "Attends! [1205][000F][1205][000F]Que veux-tu dire par [1432][NULL][NULL][0014]début[1432][NULL][NULL][0014]?\nJe ne sais pas de quoi tu parles."
+    "texte_fr": "Attends! [000F][1205][000F][1205]Que veux-tu dire par [1432][NULL][NULL][0014]début[1432][NULL][NULL][0014]?\nJe ne sais pas de quoi tu parles."
   },
   {
     "id": 16,
@@ -312,7 +312,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Wai,[SP][1113].[1205][000F][SP]Isn't[SP]that[SP]girl[SP]in[SP]the[SP]Masked\nCircle?[SP]Think[SP]she[SP]knows[SP]what[SP]the[SP]next[SP]target\nwill[SP]be?[E1][E2]\n\n[E3][E4][NULL][NULL]\"Ginko\nYou[SP]know[SP]how[SP]King[SP]Leo[SP]always[SP]wears[SP]a[SP]mask?\nI[SP]bet[SP]it's[SP]because[SP]he's[SP]trying[SP]to[SP]hide[SP]how\nbutt-ugly[SP]he[SP]is.",
     "nom_fr": "Ginko",
-    "texte_fr": "Attends, [1113]. [1205][000F]Elle est du Cercle masqué?\nSait-elle la prochaine cible?[E1][E2]\n[E3][E4][NULL][NULL]\"Ginko\nYou know\nhow Roi Lion always wears a mask? I\nbet it'sbecause he's trying to hide how butt-ugly he\nis."
+    "texte_fr": "Attends, [1113]. [000F][1205]Elle est du Cercle masqué?\nSait-elle la prochaine cible?[E1][E2]\n[E3][E4][NULL][NULL]\"Ginko\nYou know\nhow Roi Lion always wears a mask? I\nbet it'sbecause he's trying to hide how butt-ugly he\nis."
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "[1432][NULL][NULL][0014]Creepy[1432][NULL][NULL][0014]'s[SP]going[SP]a[SP]little[SP]far...[1205][000F][SP]Although...\nI[SP]guess[SP]they're[SP]right...[1205][000F][SP]I[SP]mean,[SP]we[SP]did...",
     "nom_fr": "Ginko",
-    "texte_fr": "[1432][NULL][NULL][0014]Glauque[1432][NULL][NULL][0014] va un peu loin.[1205][000F][1205][000F].. Bien que... Je\nsuppose qu'ils ont raison... Enfin, on a..."
+    "texte_fr": "[1432][NULL][NULL][0014]Glauque[1432][NULL][NULL][0014] va un peu loin.[000F][1205][000F][1205].. Bien que... Je\nsuppose qu'ils ont raison... Enfin, on a..."
   },
   {
     "id": 22,
@@ -372,7 +372,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Sheba...[1205][000F][SP]Mee-ho...[1205][000F][SP]I[SP]see...[SP]That[SP]girl...\nShe's[SP]just[SP]like[SP]me...[1205][000F][SP]I[SP]have[SP]to[SP]save[SP]her!",
     "nom_fr": "Ginko",
-    "texte_fr": "Sheba.[1205][000F][1205][000F][1205][000F].. Mee-ho... Je vois... Elle\nest comme moi... Je dois la sauver!"
+    "texte_fr": "Sheba.[000F][1205][000F][1205][000F][1205].. Mee-ho... Je vois... Elle\nest comme moi... Je dois la sauver!"
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Whoa...[1205][000F][SP]These[SP]clothes[SP]are[SP]see-through[SP]all[SP]over!\nHere...[1205][000A][SP]And[SP]here[SP]too![1205][000F][SP]I[SP]can't[SP]wear[SP]these...!",
     "nom_fr": "Maya",
-    "texte_fr": "Whoa.[1205][000F][1205][000F].. Ces vêtements sont transparents!\nIci...[1205][000A] Et ici aussi! Je\nne peux pas porter ça!"
+    "texte_fr": "Whoa.[000F][1205][000F][1205].. Ces vêtements sont transparents!\nIci...[000A][1205] Et ici aussi! Je\nne peux pas porter ça!"
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Lisa's[SP]being[SP]too[SP]hard[SP]on[SP]Eikichi-kun.[1205][000F][SP]Sure,\nhe's[SP]reckless[SP]sometimes,[SP]but[SP]that's[SP]what[SP]makes\nhim[SP]who[SP]he[SP]is.",
     "nom_fr": "Maya",
-    "texte_fr": "Lisa est dure avec Eikichi. [1205][000F]Il est\nimprudent, mais c'est ce qu'il est."
+    "texte_fr": "Lisa est dure avec Eikichi. [000F][1205]Il est\nimprudent, mais c'est ce qu'il est."
   },
   {
     "id": 27,
@@ -432,7 +432,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1432][NULL][NULL][0014]Debut[1432][NULL][NULL][0014]...?[1205][000F][SP]Did[SP]Lisa[SP]audition[SP]for[SP]anything?",
     "nom_fr": "Maya",
-    "texte_fr": "[1432][NULL][NULL][0014]Début[1432][NULL][NULL][0014].[1205][000F]..? Lisa a passé une audition?"
+    "texte_fr": "[1432][NULL][NULL][0014]Début[1432][NULL][NULL][0014].[000F][1205]..? Lisa a passé une audition?"
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]only[SP]natural[SP]the[SP]kids[SP]at[SP]Sevens[SP]would\nthink[SP]Lisa's[SP]the[SP]third[SP]member[SP]if[SP]they're[SP]going\nby[SP]that[SP]poster.[1205][000F][SP]This[SP]rumor[SP]might[SP]have[SP]legs...",
     "nom_fr": "Maya",
-    "texte_fr": "Il est naturel que les élèves de Seven\npensent que Lisa est le\n3e membre avec cette \naffiche. [1205][000F]Cette rumeur\npourrait être fondée..."
+    "texte_fr": "Il est naturel que les élèves de Seven\npensent que Lisa est le\n3e membre avec cette affiche. [000F][1205]Cette rumeur pourrait être fondée..."
   },
   {
     "id": 30,
@@ -477,7 +477,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]don't[SP]think[SP]it[SP]was[SP]just[SP]because[SP]of[SP]the[SP]Masked\nCircle[SP]that[SP]Lisa[SP]wasn't[SP]wild[SP]about[SP]debuting.[1205][000F]\nIt's[SP]not[SP]her[SP]friends'[SP]fault[SP]either...",
     "nom_fr": "Maya",
-    "texte_fr": "Ce n'est pas juste à cause du Cercle\nque Lisa refusait de débuter. Ce\n[1205][000F]n'est pas la faute de ses amies..."
+    "texte_fr": "Ce n'est pas juste à cause du Cercle\nque Lisa refusait de débuter. Ce\n[000F][1205]n'est pas la faute de ses amies..."
   },
   {
     "id": 32,
@@ -492,7 +492,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]feel[SP]like[SP]there[SP]was[SP]something[SP]deeper[SP]there.[1205][000F]\nI[SP]just[SP]wish[SP]I'd[SP]been[SP]able[SP]to[SP]figure[SP]it[SP]out...",
     "nom_fr": "Maya",
-    "texte_fr": "J'ai l'impression qu'il\ny avait quelque chose\n[1205][000F]de plus profond.\nJ'aurais aimé comprendre..."
+    "texte_fr": "J'ai l'impression qu'il\ny avait quelque chose\n[000F][1205]de plus profond. J'aurais aimé comprendre..."
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It[SP]means[SP]Joker's[SP]granted[SP]a[SP]lot[SP]of[SP]ideals[SP]for\nthese[SP]kids.[1205][000F][SP]The[SP]younger[SP]someone[SP]is,[SP]the[SP]more\ntempting[SP]the[SP]easy[SP]way[SP]looks[SP]to[SP]them.",
     "nom_fr": "Maya",
-    "texte_fr": "Ça veut dire que le Joker a exaucé les\n[1205][000F]idéaux de ces enfants. Plus on est\njeune, plus la facilité est tentante."
+    "texte_fr": "Ça veut dire que le Joker a exaucé les\n[000F][1205]idéaux de ces enfants. Plus on est\njeune, plus la facilité est tentante."
   },
   {
     "id": 34,
@@ -567,7 +567,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Bringing[SP]destruction[SP]on[SP]their[SP]own[SP]heads[SP]through\nthe[SP]rumors[SP]they[SP]spread...[1205][000F][SP]What[SP]humans[SP]need[SP]is\nnot[SP]salvation,[SP]but[SP]evolution.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nIsn't[SP]the[SP]Last[SP]Battalion[SP]headed[SP]to[SP]Mt.\nKatatsumuri?[SP]If[SP]we[SP]do[SP]something[SP]about[SP]that,\nthe[SP]Last[SP]Battalion[SP]might[SP]disappear[SP]too!",
     "nom_fr": "Maya",
-    "texte_fr": "S'attirer la destruction par leurs propres\nrumeurs... L'homme a\n[1205][000F]besoin d'évolution, pas\nde salut.[E1][E2] [E3][E4][NULL][NULL]\"Maya\n Isn't the Bataillon headed\nto Mt. Katatsumuri? If we do\nsomething aboutthat, the Bataillon might disappear too!"
+    "texte_fr": "S'attirer la destruction par leurs propres\nrumeurs... L'homme a\n[000F][1205]besoin d'évolution, pas\nde salut.[E1][E2] [E3][E4][NULL][NULL]\"Maya\n Isn't the Bataillon headed\nto Mt. Katatsumuri? If we do\nsomething aboutthat, the Bataillon might disappear too!"
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Maya",
     "texte_orig": "But[SP]no...[1205][000F][SP]It's[SP]more[SP]important[SP]to[SP]stop[SP]what's\ncausing[SP]rumors[SP]to[SP]become[SP]reality.[1205][000F][SP]Let's[SP]hurry\nto[SP]Mt.[SP]Katatsumuri,[SP][1113]-kun.",
     "nom_fr": "Maya",
-    "texte_fr": "Mais non.[1205][000F][1205][000F].. Il faut stopper ce qui\nrend les rumeurs réelles. Vite, allons\nau Mt. Katatsumuri, [1113]-kun."
+    "texte_fr": "Mais non.[000F][1205][000F][1205].. Il faut stopper ce qui\nrend les rumeurs réelles. Vite, allons\nau Mt. Katatsumuri, [1113]-kun."
   },
   {
     "id": 39,
@@ -612,7 +612,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Hm!?[1205][000A][SP]O-Oh,[SP]it's[SP]you,[SP][1113].[SP]Didn't[SP]see\nyou[SP]there...[1205][000F][SP]Sorry,[SP]I[SP]was[SP]just[SP]talking[SP]to\nmyself.",
     "nom_fr": "Yukino",
-    "texte_fr": "Hm![1205]?[1205][000A] O-Oh, c'est toi, [1113]. Je ne t'avais\n[000F]pas vu... Désolée, je parlais toute seule."
+    "texte_fr": "Hm![1205]?[000A][1205] O-Oh, c'est toi, [1113]. Je ne t'avais\n[000F]pas vu... Désolée, je parlais toute seule."
   },
   {
     "id": 41,
@@ -627,7 +627,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Going[SP]head-on[SP]into[SP]danger[SP]to[SP]save[SP]the[SP]girl[SP]he\nloves...[1205][000F][SP]I[SP]knew[SP]an[SP]idiot[SP]like[SP]that,[SP]too.\nI'm[SP]a[SP]little[SP]jealous[SP]of[SP]that[SP]type,[SP]frankly.",
     "nom_fr": "Yukino",
-    "texte_fr": "Foncer au danger pour\nla fille qu'il aime.[1205][000F]..\nJ'ai connu un idiot\npareil. Je l'envie un peu."
+    "texte_fr": "Foncer au danger pour\nla fille qu'il aime.[000F][1205]..\nJ'ai connu un idiot pareil. Je l'envie un peu."
   },
   {
     "id": 42,
@@ -642,7 +642,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Didn't[SP]Hamya[SP]say[SP]something[SP]like[SP][1432][NULL][NULL][0014]Glory[SP]to[SP]the\nmask[1432][NULL][NULL][0014][SP]back[SP]at[SP]Sevens?[1205][000F][SP]Is[SP]this[SP]what[SP]that[SP]was\nabout...?",
     "nom_fr": "Yukino",
-    "texte_fr": "Hamya n'a pas dit\nquelque chose comme [1432][NULL][NULL][0014] Gloire\nau masque[1432][NULL][NULL][0014] à Seven?\n[1205][000F]Est-ce que c'était ça...?"
+    "texte_fr": "Hamya n'a pas dit\nquelque chose comme [1432][NULL][NULL][0014] Gloire\nau masque[1432][NULL][NULL][0014] à Seven? [000F][1205]Est-ce que c'était ça...?"
   },
   {
     "id": 43,
@@ -657,7 +657,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Is[SP]Lisa[SP]going[SP]to[SP]debut?[1205][000F][SP]First[SP]I[SP]heard[SP]of[SP]it...[1205][000F]\nDid[SP]she[SP]mention[SP]this[SP]to[SP]you,[SP][1113]?",
     "nom_fr": "Yukino",
-    "texte_fr": "Lisa va débuter? [1205][000F][1205][000F]Première nouvelle...\nElle t'en a parlé, [1113]?"
+    "texte_fr": "Lisa va débuter? [000F][1205][000F][1205]Première nouvelle...\nElle t'en a parlé, [1113]?"
   },
   {
     "id": 44,
@@ -672,7 +672,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Looks[SP]like[SP]it'll[SP]be[SP]quicker[SP]to[SP]ask[SP]Lisa's\nfriends[SP]from[SP]the[SP]poster.[SP]Maybe[SP]they[SP]can[SP]tell\nus[SP]something[SP]about[SP]the[SP]Masked[SP]Circle,[SP]too.",
     "nom_fr": "Yukino",
-    "texte_fr": "On ira plus vite en demandant aux amies de\nLisa sur l'affiche.\nElles pourront peut-être\nnous renseigner sur le Cercle masqué."
+    "texte_fr": "On ira plus vite en demandant aux amies de\nLisa sur l'affiche.\nElles pourront peut-être nous renseigner sur le Cercle masqué."
   },
   {
     "id": 45,
@@ -992,7 +992,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "*sigh*[SP]I[SP]haven't[SP]had[SP]any[SP]time[SP]to[SP]relax[SP]lately...[1205][000F]\nMy[SP]doujinshi[SP]deadline[SP]is[SP]soon.[1205][000F][SP]But[SP]I[SP]can't[SP]take\nany[SP]days[SP]off,[SP]so[SP]I'm[SP]falling[SP]behind...",
     "nom_fr": "Vendeuse",
-    "texte_fr": "*soupir* Pas de détente... Ma deadline\n[1205][000F][1205][000F]de doujinshi approche. Je ne peux pas\nprendre de congé, je suis en retard..."
+    "texte_fr": "*soupir* Pas de détente... Ma deadline\n[000F][1205][000F][1205]de doujinshi approche. Je ne peux pas\nprendre de congé, je suis en retard..."
   },
   {
     "id": 61,
@@ -1007,7 +1007,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Why[SP]am[SP]I[SP]selling[SP]armor[SP]now,[SP]anyway?[1205][000F][SP]I[SP]mean,\nI[SP]always[SP]have,[SP]I[SP]guess,[SP]but...",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Pourquoi vendre des armures? [1205][000F]Je\nl'ai toujours fait, mais bon..."
+    "texte_fr": "Pourquoi vendre des armures? [000F][1205]Je\nl'ai toujours fait, mais bon..."
   },
   {
     "id": 62,
@@ -1082,7 +1082,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "So[SP]do[SP]you[SP]shop[SP]for[SP]all[SP]your[SP]friends?[SP]Because\nI[SP]really[SP]don't[SP]want[SP]to[SP]sell[SP]that[SP]crazy[SP]girl\nanything,[SP]but[SP]if[SP]that's[SP]the[SP]case...[SP]Oh[SP]well.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Vous faites les courses\npour tous vos amis ?\nCar je ne veux vraiment\nrien vendre à cette \nfolle, mais si c'est le cas... Tant pis."
+    "texte_fr": "Vous faites les courses\npour tous vos amis ?\nCar je ne veux vraiment rien vendre à cette folle, mais si c'est le cas... Tant pis."
   },
   {
     "id": 67,
@@ -1097,7 +1097,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "So[SP]do[SP]you[SP]shop[SP]for[SP]all[SP]your[SP]friends?[SP]Because\nI[SP]really[SP]don't[SP]want[SP]to[SP]sell[SP]that[SP]crazy[SP]girl\nanything,[SP]but[SP]if[SP]that's[SP]the[SP]case...[SP]Oh[SP]well.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Vous faites les courses\npour tous vos amis ?\nCar je ne veux vraiment\nrien vendre à cette \nfolle, mais si c'est le cas... Tant pis."
+    "texte_fr": "Vous faites les courses\npour tous vos amis ?\nCar je ne veux vraiment rien vendre à cette folle, mais si c'est le cas... Tant pis."
   },
   {
     "id": 68,
@@ -1112,7 +1112,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "By[SP]the[SP]way,[SP]I[SP]heard[SP]Cuss[SP]High[SP]is[SP]throwing[SP]a\nmasquerade[SP]as[SP]part[SP]of[SP]their[SP]school[SP]festival.\nIf[SP]you[SP]wouldn't[SP]mind...[1205][000F][SP]Would[SP]you[SP]go[SP]with[SP]me?",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Au fait, j'ai appris\nque Lycée Kakasu organise\nune mascarade pour leur festival. Si ça ne\nvous dérange pas.[1205][000F].. Vous iriez avec moi?"
+    "texte_fr": "Au fait, j'ai appris\nque Lycée Kakasu organise\nune mascarade pour leur festival. Si ça ne vous dérange pas.[000F][1205].. Vous iriez avec moi?"
   },
   {
     "id": 69,
@@ -1127,7 +1127,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "That[SP]blonde[SP]girl...[1205][000F][SP]The[SP]one[SP]in[SP]the[SP]poster...\nSh-She's[SP]not...[1205][000F][SP]Nah,[SP]couldn't[SP]be.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Cette fille blonde.[1205][000F][1205][000F]..\nCelle sur l'affiche...\nC-Ce n'est pas... Nan, impossible."
+    "texte_fr": "Cette fille blonde.[000F][1205][000F][1205]..\nCelle sur l'affiche...\nC-Ce n'est pas... Nan, impossible."
   },
   {
     "id": 70,
@@ -1142,7 +1142,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Even[SP]I[SP]wouldn't[SP]stand[SP]a[SP]chance[SP]against[SP]an[SP]idol.[1205][000F]\n*sigh*[SP]I[SP]feel[SP]like[SP]a[SP]woman[SP]fading[SP]into[SP]the\nsunset...",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Aucune chance face à une idole. [1205][000F]*soupir*\nJe m'efface dans le crépuscule..."
+    "texte_fr": "Aucune chance face à une idole. [000F][1205]*soupir*\nJe m'efface dans le crépuscule..."
   },
   {
     "id": 71,
@@ -1157,7 +1157,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "What[SP]is[SP]that[SP]student[SP]talking[SP]about?[1205][000F][SP]Something\nabout[SP]congratulations[SP]on[SP]the[SP]debut...[1205][000F][SP]So[SP]that\nwas[SP]that[SP]blonde[SP]girl[SP]on[SP]the[SP]poster[SP]after[SP]all?",
     "nom_fr": "Vendeuse",
-    "texte_fr": "De quoi parle-t-il? [1205][000F][1205][000F]Des\nfélicitations pour ses débuts...\nC'était donc la blonde de l'affiche?"
+    "texte_fr": "De quoi parle-t-il? [000F][1205][000F][1205]Des\nfélicitations pour ses débuts...\nC'était donc la blonde de l'affiche?"
   },
   {
     "id": 72,
@@ -1202,7 +1202,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "I'm[SP]the[SP]only[SP]one[SP]who[SP]can[SP]truly[SP]understand[SP]you.[1205][000F]\nHey,[SP]why[SP]don't[SP]you[SP]come[SP]over[SP]to[SP]my[SP]place\nsometime?[SP]I'll[SP]cook[SP]you[SP]dinner...",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Je suis la seule à vous comprendre. [1205][000F]Venez\nchez moi un jour, je vous ferai à dîner..."
+    "texte_fr": "Je suis la seule à vous comprendre. [000F][1205]Venez\nchez moi un jour, je vous ferai à dîner..."
   },
   {
     "id": 75,
@@ -1232,7 +1232,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "It's[SP]that[SP]kind[SP]of[SP]thinking[SP]that[SP]keeps[SP]me[SP]from\nsleeping[SP]at[SP]night.[1205][000F][SP]Although...[SP]You[SP]must[SP]have\nyour[SP]reasons.[SP]So[SP]I'll[SP]keep[SP]selling[SP]you[SP]armor.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "C'est ce genre de pensées qui m'empêche de\ndormir. Bien que.[1205].[000F]. Vous avez vos raisons.\nAlors je continuerai\nà vous vendre desarmures."
+    "texte_fr": "C'est ce genre de pensées qui m'empêche de\ndormir. Bien que.[1205].[000F]. Vous avez vos raisons.\nAlors je continuerai à vous vendre desarmures."
   },
   {
     "id": 77,
@@ -1247,7 +1247,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Hm?[SP]Where's[SP]Lisa-san?[SP]Oh,[SP]right,[SP]she's[SP]in[SP]the\nmiddle[SP]of[SP]a[SP]concert[SP]now.[SP]She[SP]must[SP]not[SP]have[SP]any\ntime[SP]for[SP]anyone[SP]else,[SP]now[SP]that[SP]she's[SP]an[SP]idol.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Hm? Où est Lisa-san?\nOh, c'est vrai, elle est\nen plein concert. Elle\nn'a plus de temps pour\nles autres, maintenant qu'elle est idole."
+    "texte_fr": "Hm? Où est Lisa-san?\nOh, c'est vrai, elle est\nen plein concert. Elle n'a plus de temps pour les autres, maintenant qu'elle est idole."
   },
   {
     "id": 78,
@@ -1292,7 +1292,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "...Oh...[1205][000F][SP]Then[SP]make[SP]sure[SP]you're[SP]prepared.\n*sigh*[SP]The[SP]setting[SP]sun[SP]hurts[SP]my[SP]eyes...",
     "nom_fr": "Vendeuse",
-    "texte_fr": "... [1205][000F]Oh... Soyez prêt. *soupir* Le\ncrépuscule me fait mal aux yeux..."
+    "texte_fr": "... [000F][1205]Oh... Soyez prêt. *soupir* Le\ncrépuscule me fait mal aux yeux..."
   },
   {
     "id": 81,
@@ -1307,7 +1307,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Lisa-san[SP]quit[SP]being[SP]an[SP]idol?[1205][000F][SP]What[SP]a[SP]waste...\nIt[SP]was[SP]such[SP]a[SP]good[SP]opportunity[SP]for[SP]her.[SP]Wait,\nweren't[SP]there[SP]other[SP]members[SP]besides[SP]her?",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Lisa a arrêté? [1205][000F]Quel gâchis...\nC'était une super chance. Attendez,\nil n'y avait pas d'autres filles?"
+    "texte_fr": "Lisa a arrêté? [000F][1205]Quel gâchis...\nC'était une super chance. Attendez,\nil n'y avait pas d'autres filles?"
   },
   {
     "id": 82,
@@ -1322,7 +1322,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Huh...[SP]I[SP]remember[SP]Lisa-san[SP]being[SP]part[SP]of[SP]Muses.[1205][000F]\nBut[SP]I[SP]don't[SP]remember[SP]who[SP]else[SP]there[SP]was.[SP]Oh\nwell,[SP]it's[SP]not[SP]as[SP]if[SP]I[SP]cared[SP]who[SP]they[SP]were.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Huh... Je me souviens que Lisa-san faisait\n[1205][000F]partie de Muses. Mais je ne sais plus qui\nd'autre y était. Tant\npis, je m'en fiche unpeu."
+    "texte_fr": "Huh... Je me souviens que Lisa-san faisait\n[000F][1205]partie de Muses. Mais je ne sais plus qui\nd'autre y était. Tant pis, je m'en fiche unpeu."
   },
   {
     "id": 83,
@@ -1352,7 +1352,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "It's[SP]still[SP]dangerous[SP]out[SP]there.[1205][000F][SP]I[SP]hope[SP]you're\nfully[SP]prepared,[SP]in[SP]case[SP]anything[SP]happens.[1205][000F]\nMaybe[SP]I[SP]should[SP]give[SP]Lisa-san[SP]a[SP]defective[SP]one.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "C'est toujours dangereux\n[1205][000F][1205][000F]dehors. J'espère que\nvous êtes prêt au\ncas où. Je devrais peut-être\ndonner une armure défectueuse à Lisa-san."
+    "texte_fr": "C'est toujours dangereux\n[000F][1205][000F][1205]dehors. J'espère que\nvous êtes prêt au cas où. Je devrais peut-être donner une armure défectueuse à Lisa-san."
   },
   {
     "id": 85,
@@ -1367,7 +1367,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "The[SP]terrorists[SP]targeted[SP]Smile[SP]Hirasaka[SP]too,\nright?[1205][000F][SP]Thank[SP]goodness[SP]someone[SP]stopped[SP]them.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Les terroristes ont\naussi visé Smile Hirasaka,\n[1205][000F]non? Dieu merci quelqu'un les a arrêtés."
+    "texte_fr": "Les terroristes ont\naussi visé Smile Hirasaka,\n[000F][1205]non? Dieu merci quelqu'un les a arrêtés."
   },
   {
     "id": 86,
@@ -1412,7 +1412,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "I've[SP]had[SP]more[SP]people[SP]wanting[SP]armor[SP]lately.[1121]Is[SP]it\nbecause[SP]of[SP]all[SP]the[SP]attacks?[SP]I[SP]don't[SP]blame[SP]them\nfor[SP]being[SP]nervous,[SP]since[SP]the[SP]police[SP]were[SP]hit.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "J'ai eu plus de gens voulant des armures.[1121]\nEst-ce à cause des\nattaques? Je ne les blâme\npas d'être nerveux, vu\nque la police a ététouchée."
+    "texte_fr": "J'ai eu plus de gens voulant des armures.[1121]\nEst-ce à cause des\nattaques? Je ne les blâme pas d'être nerveux, vu que la police a ététouchée."
   },
   {
     "id": 89,
@@ -1442,7 +1442,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "[1112]-kun,[SP]did[SP]you[SP]hear?[1205][000F][SP]They[SP]set[SP]bombs[SP]at\nGOLD,[SP]too.[SP]Thank[SP]goodness[SP]someone[SP]found[SP]them\nbefore[SP]they[SP]went[SP]off.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "[1112], entendu? [1205][000F]Bombes au GOLD. Trouvées\navant l'explosion, dieu merci."
+    "texte_fr": "[1112], entendu? [000F][1205]Bombes au GOLD. Trouvées\navant l'explosion, dieu merci."
   },
   {
     "id": 91,
@@ -1502,7 +1502,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Noooo![SP]Even[SP]GOLD[SP]went[SP]up[SP]in[SP]flames...?[1205][000F][SP]I[SP]was\na[SP]member[SP]there![SP]My[SP]membership[SP]fees...!",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Nooon! Le GOLD a brûlé? [1205][000F]J'y\nétais abonnée! Mes frais...!"
+    "texte_fr": "Nooon! Le GOLD a brûlé? [000F][1205]J'y\nétais abonnée! Mes frais...!"
   },
   {
     "id": 95,
@@ -1517,7 +1517,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Oh...[SP]I'm[SP]feeling[SP]faint...[1205][000F][SP][1112]-kun,\nwould[SP]you[SP]mind[SP]takine[SP]care[SP]of[SP]me?",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Oh... Je me sens faible.[1205][000F]..\n[1112], pouvez-vous m'aider?"
+    "texte_fr": "Oh... Je me sens faible.[000F][1205]..\n[1112], pouvez-vous m'aider?"
   },
   {
     "id": 96,
@@ -1577,7 +1577,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Some[SP]kids[SP]were[SP]just[SP]here[SP]saying[SP]you're[SP]a[SP]hero\nfighting[SP]against[SP]the[SP]Masked[SP]Circle.[1205][000F][SP]Thank\ngoodness...[SP]You're[SP]the[SP]hero[SP]I[SP]knew[SP]you[SP]were!",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Des enfants ont dit que vous êtes un\n[1205][000F]héros contre le Cercle masqué. Ouf..."
+    "texte_fr": "Des enfants ont dit que vous êtes un\n[000F][1205]héros contre le Cercle masqué. Ouf..."
   },
   {
     "id": 100,
@@ -1592,7 +1592,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "I[SP]don't[SP]know[SP]exactly[SP]what[SP]you're[SP]going[SP]through,\nso[SP]all[SP]I[SP]can[SP]do[SP]is[SP]sell[SP]you[SP]armor.[1205][000F][SP]Please...\nCome[SP]back[SP]safe...",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Je ne peux que vous vendre des\narmures. [1205][000F]Revenez sain et sauf..."
+    "texte_fr": "Je ne peux que vous vendre des\narmures. [000F][1205]Revenez sain et sauf..."
   },
   {
     "id": 101,
@@ -1622,7 +1622,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "It[SP]may[SP]not[SP]be[SP]ideal,[SP]but[SP]it's[SP]not[SP]so[SP]bad...[1205][000F]\nIt's[SP]our[SP]only[SP]way[SP]of[SP]knowing[SP]how[SP]we[SP]should\ntreat[SP]one[SP]another.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Pas idéal, mais pas si mal... [1205][000F]C'est le\nseul moyen de savoir comment se traiter."
+    "texte_fr": "Pas idéal, mais pas si mal... [000F][1205]C'est le\nseul moyen de savoir comment se traiter."
   },
   {
     "id": 103,
@@ -1637,7 +1637,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "If[SP]you[SP]put[SP]your[SP]faith[SP]in[SP]a[SP]book[SP]like[SP]that,\nyou'll[SP]lose[SP]all[SP]touch[SP]with[SP]reality.[1205][000F][SP]So[SP]I[SP]think\nI'll[SP]pass[SP]on[SP]it.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Croire à un tel livre coupe de\nla réalité. [1205][000F]Je passe mon tour."
+    "texte_fr": "Croire à un tel livre coupe de\nla réalité. [000F][1205]Je passe mon tour."
   },
   {
     "id": 104,
@@ -1667,7 +1667,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "It[SP]may[SP]not[SP]be[SP]ideal,[SP]but[SP]it's[SP]not[SP]so[SP]bad...[1205][000F]\nIt's[SP]our[SP]only[SP]way[SP]of[SP]knowing[SP]how[SP]we[SP]should\ntreat[SP]one[SP]another.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Pas idéal, mais pas si mal... [1205][000F]C'est le\nseul moyen de savoir comment se traiter."
+    "texte_fr": "Pas idéal, mais pas si mal... [000F][1205]C'est le\nseul moyen de savoir comment se traiter."
   },
   {
     "id": 106,
@@ -1682,7 +1682,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "If[SP]you[SP]put[SP]your[SP]faith[SP]in[SP]a[SP]book[SP]like[SP]that,\nyou'll[SP]lose[SP]all[SP]touch[SP]with[SP]reality.[1205][000F][SP]So[SP]I[SP]think\nI'll[SP]pass[SP]on[SP]it.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Croire à un tel livre coupe de\nla réalité. [1205][000F]Je passe mon tour."
+    "texte_fr": "Croire à un tel livre coupe de\nla réalité. [000F][1205]Je passe mon tour."
   },
   {
     "id": 107,
@@ -1727,7 +1727,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "I[SP]hate[SP]having[SP]to[SP]be[SP]the[SP]one[SP]to[SP]sell[SP]you[SP]this\narmor...[1205][000F][SP]But[SP]it's[SP]the[SP]only[SP]way[SP]I[SP]can[SP]see\nyou[SP]off...",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Je hais vous vendre ces armures...\n[1205][000F]Seule façon de vous dire au revoir..."
+    "texte_fr": "Je hais vous vendre ces armures...\n[000F][1205]Seule façon de vous dire au revoir..."
   },
   {
     "id": 110,
@@ -1802,7 +1802,7 @@
     "nom_orig": "Sachiko",
     "texte_orig": "I'm[SP]like,[SP]a[SP]Ginji[SP]Sasaki[SP]superfan.[1205][000F][SP]His[SP]songs,\nlike,[SP]really[SP]speak[SP]to[SP]me.[1205][000F][SP]I'm[SP]can't[SP]wait[SP]to\nhear[SP]what[SP]he's[SP]doing[SP]with[SP]Muses!",
     "nom_fr": "Sachiko",
-    "texte_fr": "Je suis fan de\n[1205][000F][1205][000F]Ginji Sasaki. Ses musiques me\nparlent. Hâte de voir\nson travail avec Muses!"
+    "texte_fr": "Je suis fan de\n[000F][1205][000F][1205]Ginji Sasaki. Ses musiques me\nparlent. Hâte de voir son travail avec Muses!"
   },
   {
     "id": 115,
@@ -1892,7 +1892,7 @@
     "nom_orig": "Sachiko",
     "texte_orig": "Do[SP]you[SP]know[SP]the[SP]Last[SP]Battalion?[1205][000F][SP]I[SP]heard,[SP]like,\nthey[SP]were[SP]the[SP]ones[SP]behind[SP]the[SP]attacks.",
     "nom_fr": "Sachiko",
-    "texte_fr": "Tu connais le Bataillon? [1205][000F]J'ai entendu dire\nque c'était eux derrière les attaques."
+    "texte_fr": "Tu connais le Bataillon? [000F][1205]J'ai entendu dire\nque c'était eux derrière les attaques."
   },
   {
     "id": 121,
@@ -1997,7 +1997,7 @@
     "nom_orig": "Mika",
     "texte_orig": "Ooh,[SP]you're[SP]so[SP]cool![SP]Wait,[SP]what[SP]school[SP]do[SP]you\ngo[SP]to?[1205][000F][SP]Oh...[SP]Sevens?[SP]Psh,[SP]then[SP]you[SP]suck.\nCuss[SP]High's[SP]the[SP]best[SP]now.",
     "nom_fr": "Mika",
-    "texte_fr": "T'es cool! Tu vas à quelle école? [1205][000F]Seven?\nT'es nul. Lycée Kakasu est la meilleure."
+    "texte_fr": "T'es cool! Tu vas à quelle école? [000F][1205]Seven?\nT'es nul. Lycée Kakasu est la meilleure."
   },
   {
     "id": 128,
@@ -2027,7 +2027,7 @@
     "nom_orig": "Mika",
     "texte_orig": "Hey,[SP]did[SP]you[SP]hear?[SP]A[SP]bunch[SP]of[SP]Cuss[SP]High[SP]guys\nare[SP]gonna[SP]be[SP]at[SP]Zodiac's[SP]secret[SP]lounge![1205][000F][SP]This\nis[SP]our[SP]chance![SP]C'mon,[SP]let's[SP]go!",
     "nom_fr": "Mika",
-    "texte_fr": "Hé, tu as entendu? Des gars de Lycée\nKakasu seront au salon secret du Zodiac!\n[1205][000F]C'est notre chance! Allez, on y va!"
+    "texte_fr": "Hé, tu as entendu? Des gars de Lycée\nKakasu seront au salon secret du Zodiac!\n[000F][1205]C'est notre chance! Allez, on y va!"
   },
   {
     "id": 130,
@@ -2057,7 +2057,7 @@
     "nom_orig": "Mika",
     "texte_orig": "It's[SP]like,[SP]if[SP]Ginji[SP]Sasaki's[SP]producing[SP]them,\nI[SP]don't[SP]really[SP]care[SP]who's[SP]in[SP]the[SP]group.[SP]That\nguy[SP]can[SP]make[SP]any[SP]girl[SP]into[SP]an[SP]idol.",
     "nom_fr": "Mika",
-    "texte_fr": "Si Ginji Sasaki les\nproduit, je m'en fiche du\ngroupe. Il transforme\nn'importe qui en idole."
+    "texte_fr": "Si Ginji Sasaki les\nproduit, je m'en fiche du\ngroupe. Il transforme n'importe qui en idole."
   },
   {
     "id": 132,
@@ -2087,7 +2087,7 @@
     "nom_orig": "Mika",
     "texte_orig": "You[SP]didn't[SP]get[SP]tickets[SP]AGAIN?[1205][000F][SP]Come[SP]on![SP]We[SP]miss\nout[SP]on[SP]everything...[1205][000F][SP]I'm[SP]not[SP]trusting[SP]you[SP]with\nthis[SP]stuff[SP]anymore,[SP]Sachiko!",
     "nom_fr": "Mika",
-    "texte_fr": "Tu n'as ENCORE rien eu? [1205][000F][1205][000F]Allez! On rate\ntout... Je ne te fais plus confiance\npour ce genre de choses, Sachiko!"
+    "texte_fr": "Tu n'as ENCORE rien eu? [000F][1205][000F][1205]Allez! On rate\ntout... Je ne te fais plus confiance\npour ce genre de choses, Sachiko!"
   },
   {
     "id": 134,
@@ -2147,7 +2147,7 @@
     "nom_orig": "Mika",
     "texte_orig": "Geez,[SP]you're[SP]so[SP]dumb,[SP]Sachiko.[1205][000F][SP]Guys[SP]like[SP]that\ndon't[SP]exist.[SP]The[SP]group[SP]of[SP]five[SP]terrorists[SP]was,\nlike,[SP]way[SP]more[SP]plausible.",
     "nom_fr": "Mika",
-    "texte_fr": "T'es bête, Sachiko. [1205][000F]Les 5\nterroristes sont plus plausibles."
+    "texte_fr": "T'es bête, Sachiko. [000F][1205]Les 5\nterroristes sont plus plausibles."
   },
   {
     "id": 138,
@@ -2162,7 +2162,7 @@
     "nom_orig": "Mika",
     "texte_orig": "Whoa,[SP]calm[SP]down,[SP]Sachiko![SP]There's[SP]no[SP]way[SP]the\nculprits[SP]would[SP]be[SP]the[SP]kinda[SP]guys[SP]you[SP]see[SP]in\nmanga.[SP]It's[SP]gotta[SP]be[SP]those[SP]five[SP]terrorists!",
     "nom_fr": "Mika",
-    "texte_fr": "Calme-toi, Sachiko! Les\ncoupables ne sont pas\ndes mecs de mangas.\nCe sont les 5 terroristes!"
+    "texte_fr": "Calme-toi, Sachiko! Les\ncoupables ne sont pas\ndes mecs de mangas. Ce sont les 5 terroristes!"
   },
   {
     "id": 139,
@@ -2222,7 +2222,7 @@
     "nom_orig": "Mika",
     "texte_orig": "Akemi[SP]was[SP]different,[SP]and[SP]not[SP]very[SP]good[SP]at\nsocializing...[1205][000F][SP]She[SP]was[SP]my[SP]friend.",
     "nom_fr": "Mika",
-    "texte_fr": "Akemi était asociale... [1205][000F]C'était mon amie."
+    "texte_fr": "Akemi était asociale... [000F][1205]C'était mon amie."
   },
   {
     "id": 143,
@@ -2252,7 +2252,7 @@
     "nom_orig": "Akemi",
     "texte_orig": "Oh...[SP]Are[SP]you[SP]hitting[SP]on[SP]me?[1205][000F][SP]Heheh...[1205][000F][SP]You're\nthe[SP]eighth[SP]one[SP]today.[SP]Like[SP]fish[SP]in[SP]a[SP]barrel...[1205][000F]\nHaving[SP]him[SP]make[SP]me[SP]cute[SP]was[SP]a[SP]great[SP]idea.",
     "nom_fr": "Akemi",
-    "texte_fr": "Tu me dragues? [1205][000F][1205][000F][1205]Héhé.[000F].. Le 8e\naujourd'hui. Trop facile... Me rendre\nmignonne était une bonne idée."
+    "texte_fr": "Tu me dragues? [000F][1205][000F][1205][1205]Héhé.[000F].. Le 8e\naujourd'hui. Trop facile... Me rendre\nmignonne était une bonne idée."
   },
   {
     "id": 145,
@@ -2267,7 +2267,7 @@
     "nom_orig": "Akemi",
     "texte_orig": "Being[SP]a[SP]normal[SP]high[SP]schooler[SP]wasn't[SP]making[SP]me\nenough[SP]cash[SP]lately...[1205][000F][SP]Guess[SP]it's[SP]worth\nlistening[SP]to[SP]rumors[SP]sometimes.[SP]Heheh...",
     "nom_fr": "Akemi",
-    "texte_fr": "Être lycéenne ne rapportait pas assez... Ça\n[1205][000F]vaut le coup d'écouter les rumeurs. Héhé..."
+    "texte_fr": "Être lycéenne ne rapportait pas assez... Ça\n[000F][1205]vaut le coup d'écouter les rumeurs. Héhé..."
   },
   {
     "id": 146,
@@ -2282,7 +2282,7 @@
     "nom_orig": "Akemi",
     "texte_orig": "A[SP]secret[SP]lounge...[1205][000F][SP]with[SP]lots[SP]of[SP]Cuss[SP]High\nkids...[1205][000F][SP]That[SP]means[SP]plenty[SP]of[SP]suckers...[1205][000F]\nHeheheh.",
     "nom_fr": "Akemi",
-    "texte_fr": "Un salon secret.[1205][000F][1205][000F][1205][000F].. plein de gosses de Lycée\nKakasu... Plein de pigeons... Héhéhé."
+    "texte_fr": "Un salon secret.[000F][1205][000F][1205][000F][1205].. plein de gosses de Lycée\nKakasu... Plein de pigeons... Héhéhé."
   },
   {
     "id": 147,
@@ -2297,7 +2297,7 @@
     "nom_orig": "Akemi",
     "texte_orig": "Heheh...[1205][000F][SP]I[SP]had[SP]my[SP]sights[SP]set[SP]on[SP]the[SP]new[SP]Leader\nat[SP]Cuss[SP]High,[SP]but[SP]he[SP]wasn't[SP]strong[SP]enough.[1205][000F]\nHow[SP]stupid[SP]of[SP]me...",
     "nom_fr": "Akemi",
-    "texte_fr": "Héhé.[1205][000F][1205][000F].. Je visais le\nnouveau Leader de Lycée\nKakasu, mais trop faible. Quelle idiotie..."
+    "texte_fr": "Héhé.[000F][1205][000F][1205].. Je visais le\nnouveau Leader de Lycée\nKakasu, mais trop faible. Quelle idiotie..."
   },
   {
     "id": 148,
@@ -2312,7 +2312,7 @@
     "nom_orig": "Akemi",
     "texte_orig": "But[SP]I[SP]already[SP]know[SP]who[SP]my[SP]next[SP]target[SP]is.\nEikichi-san...[1205][000F][SP]Heheheh...[1205][000F][SP]You're[SP]all[SP]mine.",
     "nom_fr": "Akemi",
-    "texte_fr": "Mais je sais déjà qui est ma prochaine\ncible. [1205][000F][1205][000F]Eikichi-san... Héhéhé...\nTu es à moi."
+    "texte_fr": "Mais je sais déjà qui est ma prochaine\ncible. [000F][1205][000F][1205]Eikichi-san... Héhéhé...\nTu es à moi."
   },
   {
     "id": 149,
@@ -2357,7 +2357,7 @@
     "nom_orig": "Akemi",
     "texte_orig": "There's[SP]going[SP]to[SP]be[SP]an[SP]English[SP]solo[SP]in[SP]their\nsong,[SP]right?[SP]I'm[SP]good[SP]at[SP]English,[SP]but[SP]I[SP]can't\nspeak[SP]it.[1205][000F][SP]That[SP]third[SP]member[SP]can...[1205][000F][SP]Heheh.",
     "nom_fr": "Akemi",
-    "texte_fr": "Un solo anglais prévu?\nJe suis douée mais je\nne le parle pas. [1205]Ce\n[1205][000F][000F]3e membre le peut... Héhé."
+    "texte_fr": "Un solo anglais prévu?\nJe suis douée mais je\nne le parle pas. [1205]Ce [000F][1205][000F]3e membre le peut... Héhé."
   },
   {
     "id": 152,
@@ -2372,7 +2372,7 @@
     "nom_orig": "Akemi",
     "texte_orig": "I'm[SP]only[SP]different[SP]on[SP]the[SP]outside...[1205][000F][SP]Inside,[SP]I\nhaven't[SP]changed[SP]at[SP]all.[1205][000F][SP]Men[SP]who[SP]approach[SP]me[SP]all\nleave...[1205][000F][SP]I'll[SP]never[SP]be[SP]good[SP]enough...",
     "nom_fr": "Akemi",
-    "texte_fr": "Différente qu'à l'extérieur.[1205][000F][1205][000F][1205][000F].. Dedans,\nje n'ai pas changé. Les hommes partent\ntous... Jamais assez bien..."
+    "texte_fr": "Différente qu'à l'extérieur.[000F][1205][000F][1205][000F][1205].. Dedans,\nje n'ai pas changé. Les hommes partent\ntous... Jamais assez bien..."
   },
   {
     "id": 153,
@@ -2387,7 +2387,7 @@
     "nom_orig": "Akemi",
     "texte_orig": "Heheh.[SP]That's[SP]right,[SP]I'm[SP]actually[SP]one[SP]of[SP]the\nMasked[SP]Circle.[SP]I[SP]asked[SP]Joker[SP]to[SP]make[SP]me[SP]cute...[1205][000F]\nWell?[SP]Are[SP]you[SP]scared[SP]of[SP]me[SP]now?[SP]Heheh.",
     "nom_fr": "Akemi",
-    "texte_fr": "Héhé. Je suis du Cercle masqué. Joker\nm'a rendue mignonne.[1205][000F].. As-tu peur? Héhé."
+    "texte_fr": "Héhé. Je suis du Cercle masqué. Joker\nm'a rendue mignonne.[000F][1205].. As-tu peur? Héhé."
   },
   {
     "id": 154,
@@ -2402,7 +2402,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "It's[SP]true...[SP]Without[SP]these[SP]attacks,[SP]this[SP]city\nwould[SP]be[SP]so[SP]boring[SP]I[SP]could[SP]die...[SP]Heheheh.[1205][000F]\nI[SP]hope[SP]we[SP]get[SP]to[SP]see[SP]more[SP]fires.",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "Vrai... Sans ces attaques, la ville serait\nmortelle d'ennui.[1205][000F].. Héhé. Plus de feux!"
+    "texte_fr": "Vrai... Sans ces attaques, la ville serait\nmortelle d'ennui.[000F][1205].. Héhé. Plus de feux!"
   },
   {
     "id": 155,
@@ -2492,7 +2492,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "If[SP]the[SP]In[SP]Lak'ech[SP]is[SP]right...[SP]Then[SP]I[SP]can[SP]start\nover[SP]again...[SP]in[SP]body[SP]and[SP]mind...[SP]I[SP]can[SP]become\nthe[SP]woman[SP]I[SP]want[SP]to[SP]be...[SP]Heheheh...",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "Si In Lak'ech a raison... Alors je peux\nrecommencer... de corps\net d'esprit... Je peux\ndevenir la femme que\nje veux être...Héhéhé..."
+    "texte_fr": "Si In Lak'ech a raison... Alors je peux\nrecommencer... de corps\net d'esprit... Je peux devenir la femme que je veux être...Héhéhé..."
   },
   {
     "id": 161,
@@ -2537,7 +2537,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "Huh?[1205][000F][SP]Isn't[SP]there[SP]a[SP]recording[SP]going[SP]on[SP]at[SP]Giga\nMacho?[SP]Shouldn't[SP]you[SP]be[SP]there,[SP]Lisa-san?",
     "nom_fr": "Lycéen",
-    "texte_fr": "Huh? [1205][000F]Ça n'enregistre pas au Giga\nMacho? Vous n'y êtes pas, Lisa?"
+    "texte_fr": "Huh? [000F][1205]Ça n'enregistre pas au Giga\nMacho? Vous n'y êtes pas, Lisa?"
   },
   {
     "id": 164,

--- a/traduction/event_scripts/script_335.json
+++ b/traduction/event_scripts/script_335.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Dude,[SP]you[SP]do[SP]the[SP]same[SP]thing,[SP]Ginko...[SP]Quit\nwasting[SP]your[SP]time[SP]picking[SP]fights[SP]with[SP]the\nsaleswoman.[1205][000F][SP]That's[SP]what[SP]Yukino-san[SP]would[SP]say.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Toi aussi tu fais pareil, Ginko... Arrête\nde te battre avec la vendeuse comme ça.\n[1205][000F]C'est ce que dirait Yukino-san."
+    "texte_fr": "Toi aussi tu fais pareil, Ginko... Arrête\nde te battre avec la vendeuse comme ça.\n[000F][1205]C'est ce que dirait Yukino-san."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![SP]The[SP]city's[SP]a[SP]mess,[SP]but[SP]that[SP]saleswoman\nis[SP]still[SP]making[SP]eyes[SP]at[SP][1113].[1205][000F][SP]What[SP]a[SP]slut,\ngiving[SP]him[SP]those[SP]disgusting[SP]looks!",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei! La ville est sens dessus dessous,\nmais cette vendeuse fait de l'œil à [1113].\n[1205][000F]Quelle traînée, ces regards écœurants!"
+    "texte_fr": "Kehhei! La ville est sens dessus dessous,\nmais cette vendeuse fait de l'œil à [1113].\n[000F][1205]Quelle traînée, ces regards écœurants!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]wonder[SP]if[SP]Jun-kun[SP]feels[SP]guilty[SP]about[SP]giving\nthe[SP]order[SP]to[SP]protect[SP]the[SP]city's[SP]people...[1205][U+0019][SP]But\nif[SP]he[SP]hadn't,[SP]even[SP]more[SP]people[SP]would[SP]have[SP]died.",
     "nom_fr": "Maya",
-    "texte_fr": "Je me demande si Jun-kun se sent coupable\nd'avoir ordonné de\nprotéger les gens...[1205] Mais\ns'il ne l'avait pas\nfait, bien plus auraientpéri.[U+0019]"
+    "texte_fr": "Je me demande si Jun-kun se sent coupable\nd'avoir ordonné de\nprotéger les gens...[1205] Mais s'il ne l'avait pas fait, bien plus auraientpéri.[U+0019]"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "He's[SP]basically[SP]just[SP]too[SP]kind.[1205][000A][SP]That's[SP]why[SP]he\ntries[SP]to[SP]carry[SP]the[SP]weight[SP]of[SP]the[SP]world[SP]himself.[1205][000F]\nWe[SP]need[SP]to[SP]hurry[SP]and[SP]end[SP]this[SP]madness.",
     "nom_fr": "Maya",
-    "texte_fr": "Il est trop gentil.[1205][1205][000A] C'est pourquoi il\nessaie de porter le poids du monde\n[000F]seul. On doit mettre fin à cette folie."
+    "texte_fr": "Il est trop gentil.[1205][000A][1205] C'est pourquoi il\nessaie de porter le poids du monde\n[000F]seul. On doit mettre fin à cette folie."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Those[SP]girls[SP]had[SP]a[SP]friend[SP]who[SP]was[SP]in[SP]the[SP]Masked\nCircle...[SP]I[SP]didn't[SP]know[SP]her...[SP]but[SP]she's[SP]out\nfighting[SP]right[SP]now.[SP]I[SP]hope[SP]she's[SP]safe...",
     "nom_fr": "Jun",
-    "texte_fr": "Ces filles avaient une amie dans le Cercle\nmasqué... Je la\nconnaissais pas... Mais elle\nse bat là-bas. J'espère qu'elle va bien."
+    "texte_fr": "Ces filles avaient une amie dans le Cercle\nmasqué... Je la\nconnaissais pas... Mais elle se bat là-bas. J'espère qu'elle va bien."
   },
   {
     "id": 5,
@@ -257,7 +257,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Ugh...[1205][000A][SP]I[SP]can[SP]barely[SP]stand...[1205][000A][SP]I[SP]feel[SP]like[SP]I'm\ngoing[SP]to[SP]faint...[1205][000F][SP]Is[SP]the[SP]city[SP]actually[SP]flying?[1205][000F]\nI[SP]can't[SP]tell[SP]what's[SP]real[SP]and[SP]what's[SP]not...",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Urgh.[1205][1205]..[1205][000A] Je tiens à peine debout...[1205][000A] J'ai\n[000F][000F]l'impression de m'évanouir... La ville vole\nvraiment? Je ne sais\nplus ce qui est réel..."
+    "texte_fr": "Urgh.[1205][1205]..[000A][1205] Je tiens à peine debout...[000A][1205] J'ai\n[000F][000F]l'impression de m'évanouir... La ville vole\nvraiment? Je ne sais plus ce qui est réel..."
   },
   {
     "id": 12,
@@ -272,7 +272,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "I[SP]would've[SP]wanted[SP]you[SP]to[SP]be[SP]the[SP]one[SP]to[SP]make[SP]me\nlightheaded[SP]like[SP]this...[1205][0014][SP]Hey,[SP]we're[SP]going[SP]to\nbecome[SP]Idealians[SP]soon,[SP]right?",
     "nom_fr": "Vendeuse",
-    "texte_fr": "J'aurais voulu que ce soit toi qui me\nfasses tourner la tête ainsi...[1205][0014] Dis-moi,\non va bientôt devenir des Idéaliens, non?"
+    "texte_fr": "J'aurais voulu que ce soit toi qui me\nfasses tourner la tête ainsi...[0014][1205] Dis-moi,\non va bientôt devenir des Idéaliens, non?"
   },
   {
     "id": 13,
@@ -287,7 +287,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Why[SP]don't[SP]we[SP]go[SP]make[SP]a[SP]few[SP]last[SP]memories[SP]of\nour[SP]lives[SP]as[SP]humans?[1205][000F][SP]Just[SP]ditch[SP]blondie[SP]there.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Et si on créait\nquelques derniers souvenirs en\ntant qu'humains? [1205][000F]Laisse tomber le blond là."
+    "texte_fr": "Et si on créait\nquelques derniers souvenirs en\ntant qu'humains? [000F][1205]Laisse tomber le blond là."
   },
   {
     "id": 14,
@@ -302,7 +302,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "I'm[SP]pretty[SP]sure[SP]I[SP]understand[SP]you[SP]as[SP]a[SP]person...[1205][000F]\nIt's[SP]useless[SP]to[SP]try[SP]and[SP]stop[SP]you.[1205][000A][SP]I[SP]know[SP]that.[1205][000F]\nI[SP]only[SP]want[SP]you[SP]to[SP]be[SP]safe...",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Je pense te connaître assez bien... Essayer\n[1205][000F][1205][000F]de t'arrêter ne sert à rien.[1205][000A] Je le sais. Je\nveux juste que tu sois en sécurité..."
+    "texte_fr": "Je pense te connaître assez bien... Essayer\n[000F][1205][000F][1205]de t'arrêter ne sert à rien.[000A][1205] Je le sais. Je\nveux juste que tu sois en sécurité..."
   },
   {
     "id": 15,
@@ -317,7 +317,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "I[SP]don't[SP]give[SP]a[SP]damn[SP]about[SP]blondie[SP]there...[1205][000F]\nBut[SP]you?[SP]I[SP]want[SP]you[SP]to[SP]come[SP]back[SP]to[SP]me[SP]safe.[1205][000F]\nThat's[SP]why[SP]I[SP]prepared[SP]my[SP]newest[SP]creations...",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Ce blond, je m'en\nfiche... Mais toi? [1205][000F][1205][000F]Je veux\nque tu reviennes sain\net sauf. C'est pourquoi\nj'ai préparé mes dernières créations..."
+    "texte_fr": "Ce blond, je m'en\nfiche... Mais toi? [000F][1205][000F][1205]Je veux\nque tu reviennes sain et sauf. C'est pourquoi j'ai préparé mes dernières créations..."
   },
   {
     "id": 16,
@@ -332,7 +332,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Go[SP]on,[SP]take[SP]a[SP]look.[SP]Every[SP]one[SP]of[SP]them[SP]is[SP]a\nsecure[SP]piece[SP]of[SP]armor[SP]to[SP]protect[SP]you![SP]All\nmade[SP]with[SP]love...",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Allez, regarde. Chacune\nest une armure solide\npour te protéger!\nToutes faites avec amour..."
+    "texte_fr": "Allez, regarde. Chacune\nest une armure solide\npour te protéger! Toutes faites avec amour..."
   },
   {
     "id": 17,

--- a/traduction/event_scripts/script_336.json
+++ b/traduction/event_scripts/script_336.json
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "But[SP]how[SP]does[SP]everyone[SP]in[SP]town[SP]know[SP]about[SP]the\nMasked[SP]Circle?[1205][000F][SP]They[SP]didn't[SP]when[SP]we[SP]were[SP]asking\naround.[1205][000F][SP]Did[SP]the[SP]news[SP]spread[SP]somehow?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Haha, tu entends, ? Il connaît le\n[1205][000F][1205][000F]Joker! Il n'a rien à craindre pour sa\nboutique!"
+    "texte_fr": "Haha, tu entends, ? Il connaît le\n[000F][1205][000F][1205]Joker! Il n'a rien à craindre pour sa\nboutique!"
   },
   {
     "id": 8,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]ask[SP]me,[SP]I[SP]think[SP]Yukino-san's[SP]overthinking\nthis.[1205][000F][SP]I[SP]doubt[SP]anyone[SP]would[SP]read[SP]that[SP]much[SP]into\na[SP]piece[SP]of[SP]crap[SP]like[SP]that[SP]book.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Yukino se prend trop la tête. [1205][000F]Personne\nne prendrait ce livre nul au sérieux."
+    "texte_fr": "Yukino se prend trop la tête. [000F][1205]Personne\nne prendrait ce livre nul au sérieux."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey...[1205][000F][SP]Should[SP]we[SP]have[SP]left[SP]Yukino-san\nlike[SP]that?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé.[1205][000F].. Devait-on laisser Yukino ainsi?"
+    "texte_fr": "Hé.[000F][1205].. Devait-on laisser Yukino ainsi?"
   },
   {
     "id": 13,
@@ -222,7 +222,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hehe,[SP]Yukino-san's[SP]been[SP]looking[SP]really[SP]seriously\nat[SP]the[SP]health[SP]food[SP]corner.[1205][000F][SP]I[SP]wonder[SP]if[SP]she\nworries[SP]about[SP]her[SP]looks[SP]too.",
     "nom_fr": "Ginko",
-    "texte_fr": "Héhé, Yukino a l'air très\nintéressée par le rayon santé. [1205][000F]Elle\nse soucie aussi de son apparence?"
+    "texte_fr": "Héhé, Yukino a l'air très\nintéressée par le rayon santé. [000F][1205]Elle\nse soucie aussi de son apparence?"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I'm[SP]surprised[SP]Eikichi[SP]let[SP]that[SP]Sugimoto[SP]guy[SP]off\nthe[SP]hook[SP]so[SP]fast.[1205][000F][SP]I[SP]really[SP]thought[SP]he[SP]was[SP]gonna\npants[SP]him[SP]for[SP]the[SP]whole[SP]world[SP]to[SP]see.",
     "nom_fr": "Ginko",
-    "texte_fr": "Je suis surprise qu'Eikichi ait laissé\nSugimoto filer si vite. [1205][000F]Je pensais qu'il\nallait le mettre en\nslip devant tout le monde."
+    "texte_fr": "Je suis surprise qu'Eikichi ait laissé\nSugimoto filer si vite. [000F][1205]Je pensais qu'il\nallait le mettre en slip devant tout le monde."
   },
   {
     "id": 16,
@@ -357,7 +357,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "If[SP]everyone[SP]believes[SP]the[SP]In[SP]Lak'ech,[SP]then[SP]the\nstuff[SP]it[SP]says[SP]will[SP]come[SP]true,[SP]right?[SP]Oh[SP]God...\nWhat[SP]should[SP]we[SP]do?",
     "nom_fr": "Ginko",
-    "texte_fr": "Si tout le monde y croit, ce que dit In\nLak'ech se réalisera, non?\nOh mon Dieu... Que\nfaire?"
+    "texte_fr": "Si tout le monde y croit, ce que dit In\nLak'ech se réalisera, non?\nOh mon Dieu... Que faire?"
   },
   {
     "id": 24,
@@ -492,7 +492,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yeah...[SP]I'm[SP]still[SP]scared.[SP]I[SP]feel[SP]like[SP]I'll\ncompletely[SP]freeze[SP]up[SP]if[SP]I[SP]see[SP]those[SP]flames\nagain...[SP]Haha,[SP]pathetic,[SP]aren't[SP]I...?",
     "nom_fr": "Maya",
-    "texte_fr": "Ouais... J'ai encore\npeur. Je paralyserais si\nje revoyais ces\nflammes... Pathétique, non...?"
+    "texte_fr": "Ouais... J'ai encore\npeur. Je paralyserais si\nje revoyais ces flammes... Pathétique, non...?"
   },
   {
     "id": 33,
@@ -522,7 +522,7 @@
     "nom_orig": "Maya",
     "texte_orig": "And[SP]yet...[SP]Man's[SP]sins[SP]are[SP]not[SP]cleansed.[SP]The\nOracle[SP]cannot[SP]be[SP]entirely[SP]fulfilled[SP]until[SP]the\nmoment[SP]that[SP]the[SP]last[SP]sacrifice[SP]is[SP]offered.",
     "nom_fr": "Maya",
-    "texte_fr": "Pourtant... les péchés\nne sont pas purifiés.\nL'Oracle ne sera pas accompli tant que le\ndernier sacrifice ne sera pas offert."
+    "texte_fr": "Pourtant... les péchés\nne sont pas purifiés.\nL'Oracle ne sera pas accompli tant que le dernier sacrifice ne sera pas offert."
   },
   {
     "id": 35,
@@ -537,7 +537,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]think[SP]Yukki's[SP]right.[1205][000F][SP]At[SP]the[SP]very[SP]least,[SP]if\nthe[SP]Oracle[SP]keeps[SP]coming[SP]true,[SP]people[SP]will[SP]start\nto[SP]be[SP]suspicious[SP]of[SP]it.",
     "nom_fr": "Maya",
-    "texte_fr": "La plupart des filles rêvent d'être\n[1205][000F]idole, je suppose. Mais pas elle."
+    "texte_fr": "La plupart des filles rêvent d'être\n[000F][1205]idole, je suppose. Mais pas elle."
   },
   {
     "id": 36,
@@ -552,7 +552,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What's[SP]this[SP]feeling...?[1205][000F][SP]I[SP]have[SP]a[SP]bad\npremonition...[1205][000F][SP]But[SP]why...?",
     "nom_fr": "Maya",
-    "texte_fr": "Lisa a dû feindre de s'entendre\n[1205][000F][1205][000F]avec elles. Les jeunes font ça?"
+    "texte_fr": "Lisa a dû feindre de s'entendre\n[000F][1205][000F][1205]avec elles. Les jeunes font ça?"
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]was[SP]just[SP]looking[SP]at[SP]the[SP]health[SP]food[SP]and\nEikichi[SP]recommended[SP]some[SP]for[SP]me.[1205][000F][SP]Why[SP]in[SP]the\nworld[SP]does[SP]he[SP]know[SP]so[SP]much[SP]about[SP]them...?",
     "nom_fr": "Yukino",
-    "texte_fr": "Je regardais le rayon santé et Eikichi m'a\n[1205][000F]conseillé. Pourquoi en sait-il autant...?"
+    "texte_fr": "Je regardais le rayon santé et Eikichi m'a\n[000F][1205]conseillé. Pourquoi en sait-il autant...?"
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]know[SP]it's[SP]good[SP]to[SP]be[SP]prepared,[SP]but[SP]shouldn't\nwe[SP]be[SP]going[SP]after[SP]Eikichi?[1205][000F][SP]Who[SP]knows[SP]what\nstunts[SP]he[SP]might[SP]pull?",
     "nom_fr": "Yukino",
-    "texte_fr": "Je sais qu'il faut se préparer,\nmais ne devrait-on pas suivre\n[1205][000F]Eikichi? Qui sait ce qu'il prépare?"
+    "texte_fr": "Je sais qu'il faut se préparer,\nmais ne devrait-on pas suivre\n[000F][1205]Eikichi? Qui sait ce qu'il prépare?"
   },
   {
     "id": 39,
@@ -627,7 +627,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "What's[SP]gotten[SP]into[SP]Lisa?[1205][000F][SP]This[SP]could[SP]be[SP]a[SP]setup\nby[SP]the[SP]Masked[SP]Circle.[SP]We[SP]can't[SP]ignore[SP]it.",
     "nom_fr": "Yukino",
-    "texte_fr": "Qu'a Lisa? [1205][000F]Peut-être un piège du\nCercle masqué. On ne peut l'ignorer."
+    "texte_fr": "Qu'a Lisa? [000F][1205]Peut-être un piège du\nCercle masqué. On ne peut l'ignorer."
   },
   {
     "id": 42,
@@ -792,7 +792,7 @@
     "nom_orig": "Crybaby",
     "texte_orig": "*sob*[1205][000A][SP]*sniff*[1205][000F][SP]I-I[SP]finally[SP]got[SP]a[SP]girlfriend...[1205][000A]\n*sniff*[1205][000F][SP]But[SP]a[SP]kid[SP]from[SP]Cuss[SP]High...[SP]s-stole\nher...[1205][000F][SP]Waaaaah!",
     "nom_fr": "Pleurnichard",
-    "texte_fr": "*snif*[1205][000A] *snif* J-J'avais enfin une copine.[000F][1205][000F][1205][000F][1205]..[1205][000A]\n*snif* Un gars de\nKasu me l'a volée... Ouin!"
+    "texte_fr": "*snif*[000A][1205] *snif* J-J'avais enfin une copine.[000F][000F][1205][000F][1205][1205]..[000A][1205]\n*snif* Un gars de\nKasu me l'a volée... Ouin!"
   },
   {
     "id": 53,
@@ -837,7 +837,7 @@
     "nom_orig": "Crybaby",
     "texte_orig": "*sniff*[SP]I[SP]wanted[SP]to[SP]see[SP]the[SP]live[SP]recording...\nSo[SP]I[SP]went[SP]to[SP]Giga[SP]Macho...[SP]*sniff*[SP]But[SP]it[SP]was\nalready[SP]too[SP]full[SP]and[SP]I[SP]couldn't[SP]get[SP]in.[SP]*sob*",
     "nom_fr": "Pleurnichard",
-    "texte_fr": "*renifle* Je voulais voir\nle live... Je suis\nallé au Giga\nMacho... *renifle* Mais c'était\nplein et je n'ai pas pu entrer. *snif*"
+    "texte_fr": "*renifle* Je voulais voir\nle live... Je suis\nallé au Giga Macho... *renifle* Mais c'était plein et je n'ai pas pu entrer. *snif*"
   },
   {
     "id": 56,
@@ -852,7 +852,7 @@
     "nom_orig": "Crybaby",
     "texte_orig": "*sniff*[SP]They[SP]finally[SP]announced[SP]the[SP]third[SP]member.[1205][000F]\nBut[SP]she...[SP]she[SP]already[SP]has[SP]a[SP]boyfriend...[1205][000A][SP]*sob*\nIt's[SP]not[SP]fair...",
     "nom_fr": "Pleurnichard",
-    "texte_fr": "*renifle* Le troisième membre est\nannoncé. [1205][000F]Mais... elle a déjà un\npetit ami...[1205][000A] *snif* C'est injuste..."
+    "texte_fr": "*renifle* Le troisième membre est\nannoncé. [000F][1205]Mais... elle a déjà un\npetit ami...[000A][1205] *snif* C'est injuste..."
   },
   {
     "id": 57,
@@ -987,7 +987,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "Eeheehee.[SP]Hello,[SP]and[SP]welcome[SP]to[SP]Satomi[SP]Tadashi.[1205][000F]\nSo,[SP]what'll[SP]it[SP]be?\n[1208][0006]Buy[SP]items\nSell[SP]items\nTalk[SP]to[SP]Sister[SP]#4\n[1210][B_00][U+5601][B_00]iew[SP]items\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Hihihi. Bonjour, bienvenue chez\nSatomi Tadashi.\n[1205][000F]Alors, que désires-tu?\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°4\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
+    "texte_fr": "Hihihi. Bonjour, bienvenue chez\nSatomi Tadashi.\n[000F][1205]Alors, que désires-tu?\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°4\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
     "question_orig": "Eeheehee.[SP]Hello,[SP]and[SP]welcome[SP]to[SP]Satomi[SP]Tadashi.[1205][000F]\nSo,[SP]what'll[SP]it[SP]be?",
     "choix_orig": [
       "Buy[SP]items",
@@ -1157,7 +1157,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "Eeheehee.[SP]People[SP]always[SP]say[SP]us[SP]managers[SP]of\nSatomi[SP]Tadashi[SP]all[SP]look[SP]the[SP]same.[1205][000F][SP]Of[SP]course\nwe[SP]do![SP]We're[SP]septuplets,[SP]after[SP]all.",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Héhéhé. On dit que les gérantes\nde Satomi Tadashi se ressemblent.\n[1205][000F]Bien sûr! Nous sommes septuplées."
+    "texte_fr": "Héhéhé. On dit que les gérantes\nde Satomi Tadashi se ressemblent.\n[000F][1205]Bien sûr! Nous sommes septuplées."
   },
   {
     "id": 72,
@@ -1172,7 +1172,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "But[SP]that[SP]alone[SP]isn't[SP]enough[SP]of[SP]a[SP]hook[SP]to[SP]make\nthe[SP]store[SP]stand[SP]out.[1205][000F][SP]That's[SP]why[SP]every[SP]branch\nplays[SP]different[SP]music.",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Quoi? T'es sûr? J'sais pas... Nos lits\n[1205][000F]font du bien au corps. À toi de voir..."
+    "texte_fr": "Quoi? T'es sûr? J'sais pas... Nos lits\n[000F][1205]font du bien au corps. À toi de voir..."
   },
   {
     "id": 73,
@@ -1202,7 +1202,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "Eeheehee...[SP]It[SP]seems[SP]Hirasaka[SP]is[SP]pretty[SP]crowded\nnow[SP]thanks[SP]to[SP]Cuss[SP]High's[SP]school[SP]festival.[1205][000F]\nMaybe[SP]I[SP]should[SP]go[SP]give[SP]their[SP]masquerade[SP]a[SP]look.",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Héhéhé... Hirasaka est bondé avec\nle festival de Cuss High. [1205][000F]Je\ndevrais aller voir leur mascarade."
+    "texte_fr": "Héhéhé... Hirasaka est bondé avec\nle festival de Lycée Kasu. [000F][1205]Je\ndevrais aller voir leur mascarade."
   },
   {
     "id": 75,
@@ -1232,7 +1232,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "What[SP]would[SP]really[SP]be[SP]nice[SP]is[SP]if[SP]they[SP]sang[SP]our\nstore[SP]theme.[1205][000F][SP]Then[SP]brainwashi--[1205][000A]I[SP]mean,[SP]spreading\nour[SP]chain[SP]across[SP]Japan[SP]would[SP]be[SP]easy.[1205][000F][SP]Eeheehee.",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Ça donne une superbe couleur dorée et\n[1205][000F][1205][1205][000F]c'est bon pour la santé. [000A]On guérit toute\nblessure ou maladie en un rien de temps!"
+    "texte_fr": "Ça donne une superbe couleur dorée et\n[000F][1205][1205][000F][1205]c'est bon pour la santé. [000A]On guérit toute\nblessure ou maladie en un rien de temps!"
   },
   {
     "id": 77,
@@ -1247,7 +1247,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "Eeheehee.[SP]I[SP]wish[SP]that[SP]Ginji[SP]Sasaki[SP]would\nproduce[SP]a[SP]remix[SP]for[SP]our[SP]stores.[1205][000F][SP]Then[SP]it'd[SP]be\neasy[SP]to[SP]spread[SP]our[SP]chain[SP]across[SP]the[SP]country.",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Héhéhé. Si seulement Ginji Sasaki\nproduisait un remix pour nous.\n[1205][000F]S'étendre à tout le pays serait facile."
+    "texte_fr": "Héhéhé. Si seulement Ginji Sasaki\nproduisait un remix pour nous.\n[000F][1205]S'étendre à tout le pays serait facile."
   },
   {
     "id": 78,
@@ -1337,7 +1337,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "Eeheehee![SP]Our[SP]medicines[SP]are[SP]selling[SP]like\ngangbusters[SP]lately![SP]Is[SP]it[SP]because[SP]everyone's\nafraid[SP]of[SP]all[SP]these[SP]attacks?",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Héhéhé! Nos médicaments\nse vendent comme des\npetits pains! Est-ce à\ncause de ces attaques?"
+    "texte_fr": "Héhéhé! Nos médicaments\nse vendent comme des\npetits pains! Est-ce à cause de ces attaques?"
   },
   {
     "id": 84,
@@ -1352,7 +1352,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "I[SP]don't[SP]know[SP]how[SP]to[SP]feel[SP]about[SP]that.[SP]It's[SP]like\nwe're[SP]profiting[SP]off[SP]fear[SP]of[SP]the[SP]Masked[SP]Circle.[1205][000F]\nThen[SP]again,[SP]money's[SP]money![SP]Eeheehee!",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Je ne sais pas quoi en penser. On\nprofite de la peur du Cercle masqué.\n[1205][000F]Mais l'argent est l'argent! Héhéhé!"
+    "texte_fr": "Je ne sais pas quoi en penser. On\nprofite de la peur du Cercle masqué.\n[000F][1205]Mais l'argent est l'argent! Héhéhé!"
   },
   {
     "id": 85,
@@ -1382,7 +1382,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "But[SP]I[SP]worry[SP]about[SP]what[SP]will[SP]happen[SP]to[SP]our[SP]sales\nafter[SP]that...[1205][000F][SP]*sniff*[SP]It[SP]could[SP]be[SP]disastrous.",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Mais je m'inquiète pour nos ventes après\nça... [1205][000F]*snif* Ce pourrait être désastreux."
+    "texte_fr": "Mais je m'inquiète pour nos ventes après\nça... [000F][1205]*snif* Ce pourrait être désastreux."
   },
   {
     "id": 87,
@@ -1397,7 +1397,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "Eeheehee...[SP]This[SP]is[SP]terrible.[1205][000F][SP]The[SP]Last[SP]Battalion\nreally[SP]exists?[1205][000F][SP]Why[SP]did[SP]they[SP]have[SP]to[SP]invade\nSumaru,[SP]then!?",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Héhéhé... C'est terrible.\n[1205][000F][1205][000F]Le Bataillon existe\nvraiment? Pourquoi avoir envahi Sumaru!?"
+    "texte_fr": "Héhéhé... C'est terrible.\n[000F][1205][000F][1205]Le Bataillon existe\nvraiment? Pourquoi avoir envahi Sumaru!?"
   },
   {
     "id": 88,
@@ -1412,7 +1412,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "Are[SP]we[SP]still[SP]going[SP]to[SP]be[SP]able[SP]to[SP]spread[SP]our\nchain[SP]across[SP]the[SP]country?[SP]I[SP]should[SP]consult\nmy[SP]sisters...[SP]*sniff*[SP]*sniff*",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Pourrons-nous encore étendre\nnotre chaîne? Je\ndevrais consulter mes\nsœurs... *snif* *snif*"
+    "texte_fr": "Pourrons-nous encore étendre\nnotre chaîne? Je\ndevrais consulter mes sœurs... *snif* *snif*"
   },
   {
     "id": 89,
@@ -1442,7 +1442,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "This[SP]guy's[SP]been[SP]crying[SP]the[SP]entire[SP]time.[SP]His\ngirlfriend[SP]left[SP]him[SP]for[SP]a[SP]Cuss[SP]High[SP]student...\nHe[SP]seems[SP]more[SP]miserable[SP]than[SP]pitiful[SP]now.",
     "nom_fr": "Employé",
-    "texte_fr": "Ce type pleure depuis tout à l'heure.\nSa copine l'a quitté pour un élève de\nCuss High... Il fait pitié."
+    "texte_fr": "Ce type pleure depuis tout à l'heure.\nSa copine l'a quitté pour un élève de\nLycée Kasu... Il fait pitié."
   },
   {
     "id": 91,
@@ -1457,7 +1457,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Is[SP]it[SP]a[SP]must[SP]for[SP]men[SP]these[SP]days[SP]to[SP]be[SP]cool?[1205][000F]\nFrom[SP]the[SP]looks[SP]of[SP]things,[SP]I[SP]guess[SP]so.",
     "nom_fr": "Employé",
-    "texte_fr": "Attends... Tu... ressembles au gars des\n[1205][000F]croquis... N-Nan, c'est pas possible..."
+    "texte_fr": "Attends... Tu... ressembles au gars des\n[000F][1205]croquis... N-Nan, c'est pas possible..."
   },
   {
     "id": 92,
@@ -1472,7 +1472,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Don't[SP]you[SP]think[SP]he[SP]should[SP]get[SP]over[SP]her[SP]by[SP]now?[1205][000F]\nThe[SP]guy's[SP]just[SP]too[SP]good-natured!",
     "nom_fr": "Employé",
-    "texte_fr": "Il ne devrait pas avoir tourné la page\n[1205][000F]depuis le temps? Il est trop gentil!"
+    "texte_fr": "Il ne devrait pas avoir tourné la page\n[000F][1205]depuis le temps? Il est trop gentil!"
   },
   {
     "id": 93,
@@ -1532,7 +1532,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Hey,[SP]do[SP]you[SP]know[SP]the[SP]Masked[SP]Circle?[SP]There's\nsome[SP]organization[SP]called[SP]that.[SP]Even[SP]their\nname[SP]is[SP]suspicious.",
     "nom_fr": "Employé",
-    "texte_fr": "Connaissez-vous le Cercle\nmasqué? C'est le nom\nd'une organisation. Même\nle nom est suspect."
+    "texte_fr": "Connaissez-vous le Cercle\nmasqué? C'est le nom\nd'une organisation. Même le nom est suspect."
   },
   {
     "id": 97,
@@ -1622,7 +1622,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Honestly,[SP]what[SP]is[SP]he[SP]thinking?[1205][000F][SP]Who[SP]else[SP]could\nit[SP]be[SP]but[SP]the[SP]Masked[SP]Circle!?[SP]But[SP]there[SP]he\ngoes,[SP]spouting[SP]nonsense[SP]about[SP]a[SP]gang[SP]of[SP]five!",
     "nom_fr": "Employé",
-    "texte_fr": "À quoi pense-t-il? [1205][000F]Qui\nd'autre que le Cercle\nmasqué!? Et lui, il\nparle d'un gang de cinq!"
+    "texte_fr": "À quoi pense-t-il? [000F][1205]Qui\nd'autre que le Cercle\nmasqué!? Et lui, il parle d'un gang de cinq!"
   },
   {
     "id": 103,
@@ -1652,7 +1652,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "There[SP]are[SP]several[SP]theories[SP]about[SP]the[SP]culprits,\nbut[SP]they're[SP]all[SP]moot[SP]now[SP]that[SP]they've[SP]released\nthose[SP]composite[SP]sketches.",
     "nom_fr": "Employé",
-    "texte_fr": "Il y a plusieurs\nthéories sur les coupables,\nmais avec les\nportraits-robots, c'est réglé."
+    "texte_fr": "Il y a plusieurs\nthéories sur les coupables,\nmais avec les portraits-robots, c'est réglé."
   },
   {
     "id": 105,
@@ -1682,7 +1682,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Wh-What[SP]should[SP]we[SP]do?[1205][000F][SP]The[SP]Last[SP]Battalion[SP]really\ndid[SP]invade![SP]Tell[SP]me[SP]this[SP]isn't[SP]happening!",
     "nom_fr": "Employé",
-    "texte_fr": "Qu-Que faire? [1205][000F]Le Bataillon a vraiment\nenvahi la ville! Dites-moi que je rêve!"
+    "texte_fr": "Qu-Que faire? [000F][1205]Le Bataillon a vraiment\nenvahi la ville! Dites-moi que je rêve!"
   },
   {
     "id": 107,
@@ -1812,7 +1812,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "Our[SP]resale[SP]prices[SP]are[SP]around[SP]half[SP]the[SP]original\nprice.[SP]You[SP]can't[SP]sell[SP]anything[SP]you[SP]have[SP]equipped,\nand[SP]some[SP]special[SP]items[SP]are[SP]off-limits[SP]too.",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Our resale prices are around half the\noriginal price. You can't sell\nanything you have equipped,\nand somespecial items are off-limits too."
+    "texte_fr": "Our resale prices are around half the\noriginal price. You can't sell\nanything you have equipped, and somespecial items are off-limits too."
   },
   {
     "id": 115,

--- a/traduction/event_scripts/script_337.json
+++ b/traduction/event_scripts/script_337.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]know,[SP]right!?[1205][000F][SP]I[SP]don't[SP]get[SP]it[SP]either...[1205][000F][SP]Though\nthere[SP]is[SP]a[SP]rumor[SP]this[SP]store[SP]brainwashes[SP]its\ncustomers[SP]with[SP]that[SP]song.[1205][000F][SP]Maybe[SP]that's[SP]it?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je sais!? [1205][000F][1205][000F][1205][000F]Moi non plus je comprends pas...\nEnfin, il paraît que ce magasin envoûte\nses clients avec cette chanson. C'est ça?"
+    "texte_fr": "Je sais!? [000F][1205][000F][1205][000F][1205]Moi non plus je comprends pas...\nEnfin, il paraît que ce magasin envoûte\nses clients avec cette chanson. C'est ça?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Oh...[1205][0008][SP]Yeah,[SP]I[SP]don't[SP]really[SP]need[SP]this[SP]stuff\nanymore.[1205][000F][SP]Trying[SP]to[SP]make[SP]myself[SP]prettier[SP]and\nacting[SP]like[SP]someone[SP]else...[1205][000F][SP]It[SP]seems[SP]so[SP]dumb.",
     "nom_fr": "Ginko",
-    "texte_fr": "Oh.[1205][1205]..[1205][0008] J'ai plus vraiment besoin de tout ça\n[000F][000F]maintenant. Vouloir me rendre plus belle et\njouer un rôle... C'est tellement stupide."
+    "texte_fr": "Oh.[1205][1205]..[0008][1205] J'ai plus vraiment besoin de tout ça\n[000F][000F]maintenant. Vouloir me rendre plus belle et\njouer un rôle... C'est tellement stupide."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hey,[SP]Lisa.[1205][000A][SP]Weren't[SP]you[SP]looking[SP]for[SP]that[SP]nonfat\ncandy?[1205][000F][SP]They[SP]have[SP]it[SP]here.[1205][000A][SP]You[SP]gonna[SP]buy[SP]some?",
     "nom_fr": "Maya",
-    "texte_fr": "Hé, Lisa.[1205][1205][000A] Tu cherchais pas ces bonbons\n[000F]allégés? Ils en ont ici.[1205][000A] Tu en prends?"
+    "texte_fr": "Hé, Lisa.[1205][000A][1205] Tu cherchais pas ces bonbons\n[000F]allégés? Ils en ont ici.[000A][1205] Tu en prends?"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Huh!?[1205][000A][SP]Big[SP]Maya[SP]LIKES[SP]these[SP]songs?[1205][000F][SP]Really?[1205][000A]\nThe[SP]ones[SP]about[SP]hit[SP]points[SP]and[SP]things...?",
     "nom_fr": "Jun",
-    "texte_fr": "Hein![1205]?[1205][000A] Maya AIME ces chansons? [000F]Vraiment?[1205][000A]\nCelles sur les PV et tout ça...?"
+    "texte_fr": "Hein![1205]?[000A][1205] Maya AIME ces chansons? [000F]Vraiment?[000A][1205]\nCelles sur les PV et tout ça...?"
   },
   {
     "id": 4,
@@ -117,7 +117,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "Eeheehee.[SP]Hello,[SP]and[SP]welcome[SP]to[SP]Satomi[SP]Tadashi.[1205][000F]\nSo,[SP]what'll[SP]it[SP]be?\n[1208][0006]Buy[SP]items\nSell[SP]items\nTalk[SP]to[SP]Sister[SP]#4\n[1210][B_00][U+5601][B_00]iew[SP]items\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Hihihi. Bonjour, bienvenue chez\nSatomi Tadashi.\n[1205][000F]Alors, que désires-tu?\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°4\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
+    "texte_fr": "Hihihi. Bonjour, bienvenue chez\nSatomi Tadashi.\n[000F][1205]Alors, que désires-tu?\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°4\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
     "question_orig": "Eeheehee.[SP]Hello,[SP]and[SP]welcome[SP]to[SP]Satomi[SP]Tadashi.[1205][000F]\nSo,[SP]what'll[SP]it[SP]be?",
     "choix_orig": [
       "Buy[SP]items",
@@ -302,7 +302,7 @@
     "nom_orig": "Sister[SP]#4",
     "texte_orig": "I[SP]wonder[SP]what[SP]my[SP]sisters[SP]will[SP]do...[1205][000F][SP]*sigh*\nThis[SP]is[SP]so[SP]depressing.",
     "nom_fr": "Sœur n°4",
-    "texte_fr": "Mes sœurs... que vont-elles faire?\n[1205][000F]*soupir* C'est si déprimant."
+    "texte_fr": "Mes sœurs... que vont-elles faire?\n[000F][1205]*soupir* C'est si déprimant."
   },
   {
     "id": 15,
@@ -332,7 +332,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "N-No[SP]way...[1205][000A][SP]The[SP]city's[SP]really[SP]flying...?[1205][000F]\nXibalba[SP]actually[SP]exists...?[1205][000F][SP]No...[SP]There's[SP]no\nway...[1205][000A][SP]This[SP]can't[SP]be...",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "C-C'est pas possible.[1205][1205]..[1205][000A] La ville\n[000F][000F]vole...? Xibalba existe...? Non...\nImpossible...[1205][000A] Ça ne peut pas..."
+    "texte_fr": "C-C'est pas possible.[1205][1205]..[000A][1205] La ville\n[000F][000F]vole...? Xibalba existe...? Non...\nImpossible...[000A][1205] Ça ne peut pas..."
   },
   {
     "id": 17,
@@ -347,7 +347,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Waaaaaaah![1205][000F][SP]We[SP]don't[SP]even[SP]have[SP]anywhere[SP]to[SP]run\nto[SP]now![SP]What's[SP]going[SP]to[SP]happen[SP]to[SP]us!?",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Waaaaah! [1205][000F]On n'a plus nulle part où\nfuir! Qu'est-ce qui va nous arriver!?"
+    "texte_fr": "Waaaaah! [000F][1205]On n'a plus nulle part où\nfuir! Qu'est-ce qui va nous arriver!?"
   },
   {
     "id": 18,

--- a/traduction/event_scripts/script_338.json
+++ b/traduction/event_scripts/script_338.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]don't[SP]get[SP]people[SP]who[SP]do[SP]this[SP]stuff.[1205][000F][SP]What're\nthey[SP]gonna[SP]do[SP]if[SP]it[SP]leaves[SP]behind[SP]liver[SP]spots?[1205][000F]\nBrrr...[SP]Unbelievable.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je ne comprends pas les gens qui\n[1205][000F][1205][000F]font ça. Et si ça laisse des\ntaches de vieillesse? Brrr... Fou."
+    "texte_fr": "Je ne comprends pas les gens qui\n[000F][1205][000F][1205]font ça. Et si ça laisse des\ntaches de vieillesse? Brrr... Fou."
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "But[SP]didn't[SP]Ginko[SP]put[SP]up[SP]those[SP]Print[SP]Club[SP]photos\nin[SP]Mu[SP]because[SP]of[SP]the[SP]recruiting[SP]rumor?[SP]How[SP]come\ndidn't[SP]she[SP]remember[SP]that[SP]until[SP]now?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mais Ginko n'a-t-elle pas mis ces photos\nPurikura à Mu à cause de cette rumeur?\nPourquoi ne s'en\nsouvient-elle que maintenant?"
+    "texte_fr": "Mais Ginko n'a-t-elle pas mis ces photos\nPurikura à Mu à cause de cette rumeur?\nPourquoi ne s'en souvient-elle que maintenant?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]hear[SP]what[SP]Yukino-san's[SP]saying,[SP]but[SP]what[SP]do\nyou[SP]think,[SP][1113]?[1205][000F][SP]Those[SP]guys[SP]must[SP]know\nGinko[SP]has[SP]a[SP]Persona[SP]and[SP]crazy[SP]kung[SP]fu[SP]skills.",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'entends ce que dit Yukino, mais t'en\npenses quoi, [1113]? [1205][000F]Ils savent que Ginko\na une Persona et maîtrise le kung-fu."
+    "texte_fr": "J'entends ce que dit Yukino, mais t'en\npenses quoi, [1113]? [000F][1205]Ils savent que Ginko\na une Persona et maîtrise le kung-fu."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Haha,[SP]hear[SP]that,[SP][1113]?[1205][000F][SP]Bro[SP]here[SP]knows\nJoker![1205][000F][SP]Guess[SP]HE[SP]doesn't[SP]have[SP]to[SP]worry[SP]about\nhis[SP]place[SP]going[SP]up[SP]in[SP]smoke!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Haha, t'entends ça, [1113]? [1205][000F][1205][000F]Il connaît le\nJoker! Lui n'a pas à s'en faire pour sa\nboutique!"
+    "texte_fr": "Haha, t'entends ça, [1113]? [000F][1205][000F][1205]Il connaît le\nJoker! Lui n'a pas à s'en faire pour sa\nboutique!"
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ugh![SP]What's[SP]with[SP]that[SP]shopkeeper!?[1205][000F][SP]Does[SP]he\nnot[SP]care[SP]about[SP]anything[SP]so[SP]long[SP]as[SP]he's[SP]safe!?[1205][000F]\nI'm[SP]gonna[SP]humiliate[SP]him,[SP]Death[SP]Boss-style!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Argh! C'est quoi ce vendeur![1205][000F][1205][000F]? Il se\nfiche de tout tant qu'il est en sécurité\n!? Je vais l'humilier, façon Death Boss!"
+    "texte_fr": "Argh! C'est quoi ce vendeur![000F][1205][000F][1205]? Il se\nfiche de tout tant qu'il est en sécurité\n!? Je vais l'humilier, façon Death Boss!"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "If[SP]you[SP]sit[SP]under[SP]the[SP]lights[SP]here,[SP]your[SP]wounds\nand[SP]even[SP]diseases[SP]get[SP]cured.[1205][000F][SP]That's[SP]what[SP]a\nclassmate[SP]of[SP]mine[SP]said,[SP]anyway.",
     "nom_fr": "Ginko",
-    "texte_fr": "S'asseoir sous ces lampes guérit\nles blessures et maladies. [1205][000F]Enfin,\nc'est ce qu'a dit un camarade."
+    "texte_fr": "S'asseoir sous ces lampes guérit\nles blessures et maladies. [000F][1205]Enfin,\nc'est ce qu'a dit un camarade."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Oh,[SP]crap![SP]That[SP]reminds[SP]me,[SP]Undie[SP]Boss[SP]took[SP]off\nwithout[SP]knowing[SP]Kozy[SP]is[SP]Miyabi...[1205][000F][SP]Should[SP]we\nhave[SP]mentioned[SP]that?",
     "nom_fr": "Ginko",
-    "texte_fr": "Oh, mince! Boss des\ncalbutes est parti sans savoir\nque Kozy est Miyabi.[1205][000F]..\nAurait-on dû lui dire?"
+    "texte_fr": "Oh, mince! Boss des\ncalbutes est parti sans savoir\nque Kozy est Miyabi.[000F][1205].. Aurait-on dû lui dire?"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hmph.[SP]What's[SP]with[SP]Eikichi?[SP]He's[SP]trying[SP]to[SP]act\nall[SP]cool[SP]when[SP]he[SP]just[SP]got[SP]his[SP]face[SP]kicked[SP]in.[1205][000F]\nWell...[1205][000F][SP]I[SP]guess[SP]it's[SP]okay.",
     "nom_fr": "Ginko",
-    "texte_fr": "Pfff. Qu'a Eikichi? Il fait son malin\nalors qu'il vient de se faire botter\n[1205][1205][000F]les fesses. [000F]Enfin... C'est pas grave."
+    "texte_fr": "Pfff. Qu'a Eikichi? Il fait son malin\nalors qu'il vient de se faire botter\n[1205][000F][1205]les fesses. [000F]Enfin... C'est pas grave."
   },
   {
     "id": 12,
@@ -267,7 +267,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Sheesh![SP]What's[SP]Eikichi[SP]doing?[1205][000F][SP]There's[SP]no[SP]point\npicking[SP]a[SP]fight[SP]with[SP]the[SP]shopkeeper[SP]at[SP]a[SP]time\nlike[SP]this...",
     "nom_fr": "Ginko",
-    "texte_fr": "Bon sang! Que fait Eikichi? [1205][000F]Inutile\nde chercher des noises à ce vendeur\ndans une telle situation..."
+    "texte_fr": "Bon sang! Que fait Eikichi? [000F][1205]Inutile\nde chercher des noises à ce vendeur\ndans une telle situation..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmmm...[1205][000F][SP]Don't[SP]you[SP]think[SP]if[SP]you[SP]want[SP]a[SP]tan,[SP]you\nshould[SP]hit[SP]the[SP]beach?[1205][000F][SP]I[SP]don't[SP]really[SP]like[SP]this\nfake[SP]tan[SP]stuff.",
     "nom_fr": "Maya",
-    "texte_fr": "Hmmm.[1205][000F][1205][000F].. Tu ne trouves pas que pour\nbronzer, il faut aller à la plage? Je\nn'aime pas le bronzage artificiel."
+    "texte_fr": "Hmmm.[000F][1205][000F][1205].. Tu ne trouves pas que pour\nbronzer, il faut aller à la plage? Je\nn'aime pas le bronzage artificiel."
   },
   {
     "id": 19,
@@ -327,7 +327,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Sure,[SP]it[SP]had[SP]been[SP]a[SP]while,[SP]but[SP]wasn't[SP]she\nhis[SP]first[SP]love?[1205][000F][SP]Is[SP]it[SP]that[SP]easy[SP]to[SP]forget\nsomeone's[SP]face?",
     "nom_fr": "Maya",
-    "texte_fr": "Certes, ça faisait\nlongtemps, mais c'était son\n[1205][000F]premier amour. Oublie-t-on\nun visage si vite?"
+    "texte_fr": "Certes, ça faisait\nlongtemps, mais c'était son\n[000F][1205]premier amour. Oublie-t-on un visage si vite?"
   },
   {
     "id": 22,
@@ -372,7 +372,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Is[SP]that[SP]really[SP]what[SP]Lisa[SP]thinks?[1205][000F][SP]I[SP]doubt[SP]it...[1205][000F]\nWhy[SP]is[SP]she[SP]rejecting[SP]her[SP]friends[SP]so[SP]fiercely?",
     "nom_fr": "Maya",
-    "texte_fr": "Lisa le pense-t-elle? [1205][000F][1205][000F]J'en doute...\nPourquoi repousse-t-elle ses amies si fort?"
+    "texte_fr": "Lisa le pense-t-elle? [000F][1205][000F][1205]J'en doute...\nPourquoi repousse-t-elle ses amies si fort?"
   },
   {
     "id": 25,
@@ -462,7 +462,7 @@
     "nom_orig": "Maya",
     "texte_orig": "...It'll[SP]be[SP]okay.[SP]I'm[SP]sure[SP]Yukki[SP]can[SP]recover\nfrom[SP]this.[1205][000F][SP]I...[SP]believe[SP]in[SP]her.",
     "nom_fr": "Maya",
-    "texte_fr": "... Ça ira. Yukki s'en remettra, j'en\nsuis sûre. [1205][000F]Je... Je crois en elle."
+    "texte_fr": "... Ça ira. Yukki s'en remettra, j'en\nsuis sûre. [000F][1205]Je... Je crois en elle."
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "A[SP]tanning[SP]salon[SP]that[SP]cures[SP]disease?[1205][000F][SP]Isn't[SP]it\nusually[SP]the[SP]other[SP]way[SP]around?[1205][000F][SP]Or[SP]have[SP]rumors\nalso[SP]done[SP]something[SP]to[SP]this[SP]place?",
     "nom_fr": "Yukino",
-    "texte_fr": "Un salon de bronzage qui guérit?\n[1205][000F][1205][000F]C'est l'inverse d'habitude. Les\nrumeurs ont aussi touché cet endroit?"
+    "texte_fr": "Un salon de bronzage qui guérit?\n[000F][1205][000F][1205]C'est l'inverse d'habitude. Les\nrumeurs ont aussi touché cet endroit?"
   },
   {
     "id": 32,
@@ -552,7 +552,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "They[SP]might[SP]have[SP]deliberately[SP]recruited[SP]those\ntwo[SP]to[SP]draw[SP]Lisa[SP]out.[1205][000F][SP]Whatever[SP]they're[SP]up[SP]to,\nit[SP]can't[SP]be[SP]good.",
     "nom_fr": "Yukino",
-    "texte_fr": "Elles ont peut-être été recrutées\npour attirer Lisa. [1205][000F]Quel que soit leur\nplan, ça ne présage rien de bon."
+    "texte_fr": "Elles ont peut-être été recrutées\npour attirer Lisa. [000F][1205]Quel que soit leur\nplan, ça ne présage rien de bon."
   },
   {
     "id": 37,
@@ -612,7 +612,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "That's[SP]right...[1205][000F][SP]There's[SP]something[SP]I[SP]still[SP]have\nto[SP]do...[1205][000F][SP]If[SP]I[SP]quit[SP]now...[SP]He'd[SP]have[SP]a[SP]few\nchoice[SP]words[SP]for[SP]me.",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est vrai.[1205][000F][1205][000F].. Je dois encore faire\nun truc... Si j'abandonnais... Il\nm'en ferait entendre de belles."
+    "texte_fr": "C'est vrai.[000F][1205][000F][1205].. Je dois encore faire\nun truc... Si j'abandonnais... Il\nm'en ferait entendre de belles."
   },
   {
     "id": 41,
@@ -657,7 +657,7 @@
     "nom_orig": "Expressionless[SP]woman",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]the[SP]Joker[SP]Game?[1205][000F][SP]If[SP]you[SP]play\nit,[SP]it'll[SP]fulfill[SP]any[SP]ideal[SP]you[SP]name...[1205][000F][SP]What\nwould[SP]you[SP]ask[SP]for?",
     "nom_fr": "Femme sans expression",
-    "texte_fr": "Connais-tu le Jeu du Joker? [1205][000F][1205][000F]Il réalise\nn'importe lequel de tes idéaux... Que\ndemanderais-tu?"
+    "texte_fr": "Connais-tu le Jeu du Joker? [000F][1205][000F][1205]Il réalise\nn'importe lequel de tes idéaux... Que\ndemanderais-tu?"
   },
   {
     "id": 44,
@@ -672,7 +672,7 @@
     "nom_orig": "Expressionless[SP]woman",
     "texte_orig": "I'm[SP]not[SP]sure[SP]what[SP]I'd[SP]want...[1205][000F][SP]I[SP]mean,[SP]what's[SP]an\nideal,[SP]really?[1205][000F][SP]I've[SP]never[SP]given[SP]it[SP]any[SP]thought\nbefore...",
     "nom_fr": "Femme sans expression",
-    "texte_fr": "Je ne sais pas ce que je\n[1205][000F][1205][000F]voudrais... C'est quoi un idéal, au\njuste? Je n'y ai jamais pensé..."
+    "texte_fr": "Je ne sais pas ce que je\n[000F][1205][000F][1205]voudrais... C'est quoi un idéal, au\njuste? Je n'y ai jamais pensé..."
   },
   {
     "id": 45,
@@ -702,7 +702,7 @@
     "nom_orig": "Expressionless[SP]woman",
     "texte_orig": "I[SP]wonder[SP]if[SP]that's[SP]why[SP]it's[SP]so[SP]painful[SP]being\nwith[SP]him...[1205][000F][SP]I[SP]feel[SP]more[SP]and[SP]more[SP]like[SP]I'm[SP]a\nterrible[SP]person...",
     "nom_fr": "Femme sans expression",
-    "texte_fr": "C'est peut-être pour ça qu'être\navec lui est douloureux.[1205][000F].. J'ai\nl'impression d'être affreuse..."
+    "texte_fr": "C'est peut-être pour ça qu'être\navec lui est douloureux.[000F][1205].. J'ai\nl'impression d'être affreuse..."
   },
   {
     "id": 47,
@@ -717,7 +717,7 @@
     "nom_orig": "Expressionless[SP]woman",
     "texte_orig": "It[SP]may[SP]be[SP]some[SP]girls'[SP]dream[SP]to[SP]debut[SP]as[SP]an\nidol...[1205][000F][SP]But[SP]I...[1205][000F][SP]I[SP]know[SP]it's[SP]impossible...",
     "nom_fr": "Femme sans expression",
-    "texte_fr": "Certaines rêvent d'être idoles... Mais\n[1205][1205][000F]moi.[000F].. je sais que c'est impossible..."
+    "texte_fr": "Certaines rêvent d'être idoles... Mais\n[1205][000F][1205]moi.[000F].. je sais que c'est impossible..."
   },
   {
     "id": 48,
@@ -732,7 +732,7 @@
     "nom_orig": "Expressionless[SP]woman",
     "texte_orig": "Did[SP]those[SP]three[SP]have[SP]their[SP]ideals[SP]granted[SP]by\nbecoming[SP]Muses?[SP]Do[SP]they[SP]actually[SP]feel[SP]like\ntheir[SP]dream's[SP]come[SP]true?",
     "nom_fr": "Femme sans expression",
-    "texte_fr": "Ont-elles réalisé leur\nidéal en devenant des\nMuses? Ont-elles l'impression de vivre un\nrêve?"
+    "texte_fr": "Ont-elles réalisé leur\nidéal en devenant des\nMuses? Ont-elles l'impression de vivre un rêve?"
   },
   {
     "id": 49,
@@ -762,7 +762,7 @@
     "nom_orig": "Expressionless[SP]woman",
     "texte_orig": "That[SP]song,[SP][1432][NULL][NULL][0014]Joker[1432][NULL][NULL][0014]...[1205][000F][SP]I[SP]bet[SP]it's[SP]just[SP]about\ngranting[SP]your[SP]ideals[SP]and[SP]such.[SP]Will[SP]it[SP]help\nme[SP]to[SP]find[SP]my[SP]own[SP]ideals...?",
     "nom_fr": "Femme sans expression",
-    "texte_fr": "Cette chanson, [1432][NULL][NULL][0014]Joker[1432][NULL][NULL][0014].[1205][000F].. Je parie\nqu'elle parle d'idéaux exaucés.\nM'aidera-t-elle à trouver les miens?"
+    "texte_fr": "Cette chanson, [1432][NULL][NULL][0014]Joker[1432][NULL][NULL][0014].[000F][1205].. Je parie\nqu'elle parle d'idéaux exaucés.\nM'aidera-t-elle à trouver les miens?"
   },
   {
     "id": 51,
@@ -882,7 +882,7 @@
     "nom_orig": "Tanned[SP]woman",
     "texte_orig": "I[SP]wanted[SP]to[SP]get[SP]a[SP]nice,[SP]deep[SP]tan[SP]like[SP]everyone\nelse.[SP]That's[SP]why[SP]I[SP]talked[SP]to[SP]that[SP]guy[SP]from[SP]the\nrumor.[1205][000F][SP]No[SP]problem,[SP]he[SP]told[SP]me...",
     "nom_fr": "Femme bronzée",
-    "texte_fr": "Je voulais un beau bronzage profond comme\ntout le monde. J'ai parlé au mec de la\nrumeur. [1205][000F]Pas de problème, a-t-il dit..."
+    "texte_fr": "Je voulais un beau bronzage profond comme\ntout le monde. J'ai parlé au mec de la\nrumeur. [000F][1205]Pas de problème, a-t-il dit..."
   },
   {
     "id": 59,
@@ -897,7 +897,7 @@
     "nom_orig": "Tanned[SP]woman",
     "texte_orig": "Hey,[SP]have[SP]I[SP]gotten[SP]darker?[SP]I[SP]don't[SP]really[SP]feel\nlike[SP]it.[1205][000F][SP]Actually,[SP]I[SP]don't[SP]feel[SP]like[SP]doing\nanything...",
     "nom_fr": "Femme bronzée",
-    "texte_fr": "Hé, j'ai foncé? Je ne le remarque pas.\n[1205][000F]En fait, je n'ai envie de rien faire..."
+    "texte_fr": "Hé, j'ai foncé? Je ne le remarque pas.\n[000F][1205]En fait, je n'ai envie de rien faire..."
   },
   {
     "id": 60,
@@ -912,7 +912,7 @@
     "nom_orig": "Tanned[SP]woman",
     "texte_orig": "The[SP]secret[SP]lounge...[1205][000F][SP]That's[SP]right...[SP]I've\nbeen[SP]there[SP]too...[1205][000F][SP]Whew...[SP]It's[SP]too[SP]much\neffort[SP]to[SP]talk[SP]anymore...[E1][E2]\n[E3][E4][NULL][NULL]\"Tanned[SP]woman\nHe[SP]said...[SP]he'd[SP]grant[SP]my[SP]ideals...[1205][000F][SP]Did[SP]my\ndreams[SP]come[SP]true?[1205][000F][SP]It[SP]doesn't[SP]feel[SP]like[SP]it...[1205][000F]\nNot[SP]that[SP]it[SP]even[SP]matters...[E1][E2]\n[E3][E4][NULL][NULL]\"Tanned[SP]woman\nIt's[SP]so[SP]strange...[1205][000F][SP]I[SP]feel[SP]less[SP]and[SP]less\nmotivated...[1205][000F][SP]Even[SP]breathing[SP]is[SP]too[SP]much\ntrouble[SP]now...[E1][E2]\n[E3][E4][NULL][NULL]\"Tanned[SP]woman\nNngh...[SP]Uungh...[SP]Nnngh...[E1][E2]\n[E3][E4][NULL][NULL]\"Tanned[SP]woman\nNngh...[SP]Uungh...[SP]Nnngh...[E1][E2]\n[E3][E4][NULL][NULL]\"Tanned[SP]woman\n......[E1][E2]\n[E3][E4][NULL][NULL]\"Bro\nHey,[SP]how's[SP]it[SP]going?[SP]Check[SP]me[SP]out![SP]Am[SP]I[SP]cool\nor[SP]what?[1205][000F][SP]Anyway,[SP]welcome[SP]to[SP]Bikini[SP]Line!\nWhich[SP]course[SP]did[SP]you[SP]have[SP]in[SP]mind[SP]today?",
     "nom_fr": "Femme bronzée",
-    "texte_fr": "Le salon secret..[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]. C'est\nça... J'y suis allée\naussi... Pfiou... C'est trop d'efforts de\nparler...[E1][E2] [E3][E4][NULL][NULL]\"Tanned woman\n Il a dit... qu'il\nexaucerait mes idéaux... Mes rêves se sontréalisés?\nOn ne dirait pas... Pas que ça\nimporte...[E1][E2] [E3][E4][NULL][NULL]\"Tanned woman\n C'est si bizarre...\nJe suis de moins en moins\nmotivée... Mêmerespirer est une corvée maintenant...[E1][E2] [E3][E4][NULL][NULL]\"Tanned\nwoman Nngh... Uungh...\nNnngh...[E1][E2] [E3][E4][NULL][NULL]\"Tanned woman\nNngh... Uungh... Nnngh...[E1][E2]\n[E3][E4][NULL][NULL]\"Tanned woman ......\n[E1][E2]\n[E3][E4][NULL][NULL]\"Bro\n Salut! Regarde-moi ça! Je suis cool ou\nquoi? Bienvenue chez\nBikini Line! Quelleséance voulais-tu?"
+    "texte_fr": "Le salon secret..[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]. C'est\nça... J'y suis allée\naussi... Pfiou... C'est trop d'efforts de\nparler...[E1][E2] [E3][E4][NULL][NULL]\"Tanned woman\n Il a dit... qu'il\nexaucerait mes idéaux... Mes rêves se sontréalisés?\nOn ne dirait pas... Pas que ça\nimporte...[E1][E2] [E3][E4][NULL][NULL]\"Tanned woman\n C'est si bizarre...\nJe suis de moins en moins\nmotivée... Mêmerespirer est une corvée maintenant...[E1][E2] [E3][E4][NULL][NULL]\"Tanned\nwoman Nngh... Uungh...\nNnngh...[E1][E2] [E3][E4][NULL][NULL]\"Tanned woman\nNngh... Uungh... Nnngh...[E1][E2]\n[E3][E4][NULL][NULL]\"Tanned woman ......\n[E1][E2]\n[E3][E4][NULL][NULL]\"Bro\n Salut! Regarde-moi ça! Je suis cool ou\nquoi? Bienvenue chez\nBikini Line! Quelleséance voulais-tu?"
   },
   {
     "id": 61,
@@ -1039,7 +1039,7 @@
     "nom_orig": "Bro",
     "texte_orig": "Huh?[SP]But[SP]you[SP]guys[SP]are[SP]fine![1205][000F][SP]You[SP]don't[SP]wanna\nbake[SP]too[SP]long[SP]under[SP]the[SP]lights,[SP]or[SP]it'll[SP]cause\nproblems[SP]down[SP]the[SP]line.[SP]Maybe[SP]some[SP]other[SP]time.",
     "nom_fr": "Mec",
-    "texte_fr": "Hein? Mais vous allez\n[1205]bien! [000F]Ne restez pas trop\nsous les lampes, ou ça posera des problèmes\nplus tard. Peut-être une autre fois."
+    "texte_fr": "Hein? Mais vous allez\n[1205]bien! [000F]Ne restez pas trop\nsous les lampes, ou ça posera des problèmes plus tard. Peut-être une autre fois."
   },
   {
     "id": 68,
@@ -1094,7 +1094,7 @@
     "nom_orig": "Bro",
     "texte_orig": "Whaaat?[1205][000F][SP]You're[SP]sure?[1205][000F][SP]I[SP]dunno...[SP]Our[SP]tanning\nbeds[SP]really[SP]do[SP]a[SP]body[SP]good.[1205][000F][SP]Suit[SP]yourself...",
     "nom_fr": "Mec",
-    "texte_fr": "Quoiii? [1205][000F][1205][000F][1205][000F]T'es sûr? Nos lits font\ndu bien. Fais comme tu veux..."
+    "texte_fr": "Quoiii? [000F][1205][000F][1205][000F][1205]T'es sûr? Nos lits font\ndu bien. Fais comme tu veux..."
   },
   {
     "id": 71,
@@ -1154,7 +1154,7 @@
     "nom_orig": "Bro",
     "texte_orig": "Not[SP]only[SP]does[SP]it[SP]give[SP]you[SP]an[SP]amazing[SP]golden\ncoating,[SP]it's[SP]good[SP]for[SP]your[SP]health.[1205][000F][SP]We[SP]can\nheal[SP]any[SP]wound[SP]or[SP]disease[SP]in[SP]an[SP]instant!",
     "nom_fr": "Mec",
-    "texte_fr": "Ça te donne une couleur dorée et\nc'est bon pour la santé. [1205][000F]On guérit\ntoute blessure en un rien de temps!"
+    "texte_fr": "Ça te donne une couleur dorée et\nc'est bon pour la santé. [000F][1205]On guérit\ntoute blessure en un rien de temps!"
   },
   {
     "id": 75,
@@ -1169,7 +1169,7 @@
     "nom_orig": "Bro",
     "texte_orig": "Secret[SP]lounge?[1205][000F][SP]Oh,[SP]like[SP]the[SP]one[SP]that's[SP]supposed\nto[SP]be[SP]deep[SP]inside[SP]Zodiac?[SP]You[SP]still[SP]believe\neverything[SP]you[SP]hear?",
     "nom_fr": "Mec",
-    "texte_fr": "Salon secret? [1205][000F]Comme celui qui est\ncensé être au fond du Zodiac? Tu\ncrois encore tout ce qu'on te dit?"
+    "texte_fr": "Salon secret? [000F][1205]Comme celui qui est\ncensé être au fond du Zodiac? Tu\ncrois encore tout ce qu'on te dit?"
   },
   {
     "id": 76,
@@ -1199,7 +1199,7 @@
     "nom_orig": "Bro",
     "texte_orig": "Hey,[SP]is[SP]that[SP]blonde[SP]cutie[SP]a[SP]friend[SP]of[SP]yours?[1205][000F]\nI[SP]actually[SP]have[SP]a[SP]friend[SP]who[SP]works[SP]at[SP]Sumaru\nTV...[SP]I[SP]wouldn't[SP]mind[SP]introducing[SP]her[SP]to[SP]him...",
     "nom_fr": "Mec",
-    "texte_fr": "Hé, cette mignonne blonde est ton\n[1205][000F]amie? J'ai un pote qui bosse à Sumaru\nTV... Je pourrais la lui présenter..."
+    "texte_fr": "Hé, cette mignonne blonde est ton\n[000F][1205]amie? J'ai un pote qui bosse à Sumaru\nTV... Je pourrais la lui présenter..."
   },
   {
     "id": 78,
@@ -1214,7 +1214,7 @@
     "nom_orig": "Bro",
     "texte_orig": "You[SP]mind[SP]passing[SP]along[SP]the[SP]message?[1205][000F][SP]And[SP]hey,\nall[SP]I[SP]ask[SP]in[SP]return[SP]is[SP]that[SP]she[SP]goes[SP]out[SP]to\ndinner[SP]with[SP]me[SP]once[SP]or[SP]twice.",
     "nom_fr": "Mec",
-    "texte_fr": "Tu pourrais lui dire? [1205][000F]Et tout ce que\nje demande, c'est qu'elle vienne\ndîner avec moi une ou deux fois."
+    "texte_fr": "Tu pourrais lui dire? [000F][1205]Et tout ce que\nje demande, c'est qu'elle vienne\ndîner avec moi une ou deux fois."
   },
   {
     "id": 79,
@@ -1229,7 +1229,7 @@
     "nom_orig": "Bro",
     "texte_orig": "Ginji[SP]Sasaki[SP]was[SP]actually[SP]an[SP]underclassman[SP]of\nmine[SP]in[SP]high[SP]school.[1205][000F][SP]I'm[SP]the[SP]one[SP]who[SP]taught\nhim[SP]to[SP]play[SP]guitar![SP]Hahah!",
     "nom_fr": "Mec",
-    "texte_fr": "Ginji Sasaki était un de mes camarades\nau lycée. [1205][000F]C'est moi qui lui ai appris\nà jouer de la guitare! Hahah!"
+    "texte_fr": "Ginji Sasaki était un de mes camarades\nau lycée. [000F][1205]C'est moi qui lui ai appris\nà jouer de la guitare! Hahah!"
   },
   {
     "id": 80,
@@ -1334,7 +1334,7 @@
     "nom_orig": "Bro",
     "texte_orig": "Huh?[SP]The[SP]attacks?[1205][000F][SP]Well,[SP]it's[SP]the[SP]Masked[SP]Circle\ndoing[SP]it,[SP]right?[1205][000F][SP]Then[SP]my[SP]place[SP]should[SP]be[SP]fine!",
     "nom_fr": "Mec",
-    "texte_fr": "Hein? [1205][000F][1205][000F]Les attaques? C'est le Cercle masqué,\nnon? Ma boutique devrait être épargnée!"
+    "texte_fr": "Hein? [000F][1205][000F][1205]Les attaques? C'est le Cercle masqué,\nnon? Ma boutique devrait être épargnée!"
   },
   {
     "id": 87,
@@ -1349,7 +1349,7 @@
     "nom_orig": "Bro",
     "texte_orig": "I'm[SP]Joker's[SP]best[SP]friend.[1205][000F][SP]He[SP]wouldn't[SP]go[SP]after\na[SP]pal[SP]like[SP]me.[1205][000F][SP]Unless[SP]he[SP]decides[SP]to[SP]pull[SP]a\nprank[SP]and[SP]crank[SP]the[SP]heat[SP]way[SP]up!",
     "nom_fr": "Mec",
-    "texte_fr": "Je suis le meilleur pote du Joker. [1205][000F][1205][000F]Il ne\ns'en prendrait pas à un ami. Sauf s'il\nblague et monte le chauffage à fond!"
+    "texte_fr": "Je suis le meilleur pote du Joker. [000F][1205][000F][1205]Il ne\ns'en prendrait pas à un ami. Sauf s'il\nblague et monte le chauffage à fond!"
   },
   {
     "id": 88,
@@ -1379,7 +1379,7 @@
     "nom_orig": "Bro",
     "texte_orig": "Waaaait[SP]a[SP]second...[1205][000F][SP]You...[SP]kinda[SP]look[SP]like[SP]the\nguy[SP]in[SP]those[SP]sketches...[1205][000F][SP]N-Nah,[SP]can't[SP]be...",
     "nom_fr": "Mec",
-    "texte_fr": "Attends une seconde.[1205][000F][1205][000F].. Tu... ressembles\nau gars de ces croquis... N-Nan..."
+    "texte_fr": "Attends une seconde.[000F][1205][000F][1205].. Tu... ressembles\nau gars de ces croquis... N-Nan..."
   },
   {
     "id": 90,
@@ -1491,7 +1491,7 @@
     "nom_orig": "Bro",
     "texte_orig": "Yikes![SP]C'mon,[SP]dude.[SP]You[SP]don't[SP]have[SP]enough[SP]money.[1205][000F]\nI[SP]can't[SP]let[SP]you[SP]use[SP]the[SP]tanning[SP]beds[SP]like[SP]this.",
     "nom_fr": "Mec",
-    "texte_fr": "Ouille! Mec, t'as pas\nassez d'argent. [1205]Je peux\n[000F]pas te laisser les\nlits de bronzage comme ça."
+    "texte_fr": "Ouille! Mec, t'as pas\nassez d'argent. [1205]Je peux\n[000F]pas te laisser les lits de bronzage comme ça."
   },
   {
     "id": 96,

--- a/traduction/event_scripts/script_339.json
+++ b/traduction/event_scripts/script_339.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Okay,[SP]that's[SP]it![1205][000A][SP]I've[SP]had[SP]it![1205][000F][SP]That[SP]tanned\nbastard[SP]doesn't[SP]give[SP]a[SP]rat's[SP]ass[SP]about[SP]the\npeople[SP]down[SP]there[SP]as[SP]long[SP]as[SP]he[SP]gets[SP]his!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ça suffit![1205][1205][000A] J'en ai marre! [000F]Ce basané\nn'a rien à faire des gens en bas du\nmoment qu'il a ce qu'il veut!"
+    "texte_fr": "Ça suffit![1205][000A][1205] J'en ai marre! [000F]Ce basané\nn'a rien à faire des gens en bas du\nmoment qu'il a ce qu'il veut!"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Nothing's[SP]worse[SP]than[SP]guys[SP]like[SP]him![1205][000F][SP]After[SP]this\nis[SP]over,[SP]I'm[SP]gonna[SP]give[SP]him[SP]a[SP]little[SP]Death[SP]Boss-\nstyle[SP]embarrassment![1205][000F][SP]He[SP]better[SP]be[SP]ready!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Y'a pas pire que des gars comme lui! [1205][000F][1205][000F]Quand\ntout sera fini, je lui ferai honte à la\nDeath Boss-style! Il a intérêt à se tenir!"
+    "texte_fr": "Y'a pas pire que des gars comme lui! [000F][1205][000F][1205]Quand\ntout sera fini, je lui ferai honte à la\nDeath Boss-style! Il a intérêt à se tenir!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP][1113]...[1205][0008][SP]Do[SP]you[SP]know[SP]your[SP]own[SP]reason\nfor[SP]living?[1205][000F][SP]When[SP]I[SP]think[SP]of[SP]it[SP]like[SP]that,[SP]it's\nhard[SP]to[SP]explain...",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, [1113].[1205]..[1205][0008] Tu connais ta raison\nde vivre? [000F]Quand j'y pense comme ça,\nc'est difficile à expliquer..."
+    "texte_fr": "Hé, [1113].[1205]..[0008][1205] Tu connais ta raison\nde vivre? [000F]Quand j'y pense comme ça,\nc'est difficile à expliquer..."
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]actually[SP]something[SP]very[SP]simple...[1205][000A]\nIt[SP]comes[SP]naturally[SP]to[SP]you.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est en fait très simple...[1205][000A]\nÇa vient naturellement."
+    "texte_fr": "C'est en fait très simple...[000A][1205]\nÇa vient naturellement."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "And[SP]everyone[SP]already[SP]has[SP]one.[1205][000F][SP]They[SP]just[SP]don't\nrealize[SP]it.[1205][000F][SP]What's[SP]most[SP]important[SP]can't[SP]be\nseen[SP]with[SP]one's[SP]eyes,[SP]after[SP]all...",
     "nom_fr": "Maya",
-    "texte_fr": "Et tout le monde en a déjà une. [1205][000F][1205][000F]Ils\nne s'en rendent juste pas compte. Ce\nqui compte le plus ne se voit pas."
+    "texte_fr": "Et tout le monde en a déjà une. [000F][1205][000F][1205]Ils\nne s'en rendent juste pas compte. Ce\nqui compte le plus ne se voit pas."
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]thought[SP]it[SP]couldn't[SP]be[SP]filled[SP]unless[SP]I[SP]found\nmy[SP]purpose[SP]in[SP]life...[1205][000F][SP]But[SP]that[SP]wasn't[SP]it.",
     "nom_fr": "Jun",
-    "texte_fr": "Je pensais qu'il ne pouvait être comblé\nque si je trouvais mon but.[1205][000F].. Mais non."
+    "texte_fr": "Je pensais qu'il ne pouvait être comblé\nque si je trouvais mon but.[000F][1205].. Mais non."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]still[SP]haven't[SP]really[SP]found[SP]that.[1205][000F][SP]But[SP]when[SP]I\ncame[SP]to,[SP]I[SP]noticed[SP]that[SP]emptiness[SP]had[SP]been\nfilled.[1205][000F][SP]Maybe[SP]that's[SP]my[SP]answer...",
     "nom_fr": "Jun",
-    "texte_fr": "Je ne l'ai pas encore trouvé. [1205][000F][1205][000F]Mais en\nrevenant à moi, j'ai vu que ce vide s'était\ncomblé. C'est peut-être ma réponse."
+    "texte_fr": "Je ne l'ai pas encore trouvé. [000F][1205][000F][1205]Mais en\nrevenant à moi, j'ai vu que ce vide s'était\ncomblé. C'est peut-être ma réponse."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Expressionless[SP]woman",
     "texte_orig": "If[SP]mankind[SP]becomes[SP]Idealians,[SP]we'll[SP]all[SP]learn\nour[SP]purpose[SP]in[SP]life...[1205][000F][SP]I'll[SP]finally[SP]know[SP]mine\nbeyond[SP]the[SP]shadow[SP]of[SP]a[SP]doubt...",
     "nom_fr": "Femme sans expression",
-    "texte_fr": "Si l'humanité devient Idéaliens,\nnous saurons tous notre but dans la\n[1205][000F]vie... Je connaîtrai enfin le mien."
+    "texte_fr": "Si l'humanité devient Idéaliens,\nnous saurons tous notre but dans la\n[000F][1205]vie... Je connaîtrai enfin le mien."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Expressionless[SP]woman",
     "texte_orig": "But[SP]is[SP]that[SP]right?[1205][000F][SP]How[SP]can[SP]any[SP]purpose[SP]found\nin[SP]such[SP]a[SP]way[SP]be[SP]truly[SP]yours...?",
     "nom_fr": "Femme sans expression",
-    "texte_fr": "Mais est-ce juste? [1205][000F]Un but trouvé\nainsi peut-il vraiment être le tien?"
+    "texte_fr": "Mais est-ce juste? [000F][1205]Un but trouvé\nainsi peut-il vraiment être le tien?"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Expressionless[SP]woman",
     "texte_orig": "I[SP]want[SP]to[SP]find[SP]my[SP]own[SP]purpose...[1205][000F][SP]I[SP]want[SP]to\nknow[SP]the[SP]reason[SP]I'm[SP]here[SP]before[SP]I[SP]evolve...",
     "nom_fr": "Femme sans expression",
-    "texte_fr": "Je veux trouver mon propre but.[1205][000F]..\nJe veux connaître ma raison d'être."
+    "texte_fr": "Je veux trouver mon propre but.[000F][1205]..\nJe veux connaître ma raison d'être."
   },
   {
     "id": 12,
@@ -319,7 +319,7 @@
     "nom_orig": "Bro",
     "texte_orig": "Huh?[SP]But[SP]you[SP]guys[SP]are[SP]fine![1205][000F][SP]You[SP]don't[SP]wanna\nbake[SP]too[SP]long[SP]under[SP]the[SP]lights,[SP]or[SP]it'll[SP]cause\nproblems[SP]down[SP]the[SP]line.[SP]Maybe[SP]some[SP]other[SP]time.",
     "nom_fr": "Mec",
-    "texte_fr": "Hein? Mais vous allez bien! [1205][000F]Trop longtemps\nsous les lampes, ça pourrait causer des\nproblèmes. Peut-être une prochaine fois."
+    "texte_fr": "Hein? Mais vous allez bien! [000F][1205]Trop longtemps\nsous les lampes, ça pourrait causer des\nproblèmes. Peut-être une prochaine fois."
   },
   {
     "id": 20,
@@ -374,7 +374,7 @@
     "nom_orig": "Bro",
     "texte_orig": "Whaaat?[1205][000F][SP]You're[SP]sure?[1205][000F][SP]I[SP]dunno...[SP]Our[SP]tanning\nbeds[SP]really[SP]do[SP]a[SP]body[SP]good.[1205][000F][SP]Suit[SP]yourself...",
     "nom_fr": "Mec",
-    "texte_fr": "Quoooi? [1205][000F][1205][000F][1205][000F]Vous êtes sûr? J'sais pas... Nos\ncabines font du bien. Comme vous voulez..."
+    "texte_fr": "Quoooi? [000F][1205][000F][1205][000F][1205]Vous êtes sûr? J'sais pas... Nos\ncabines font du bien. Comme vous voulez..."
   },
   {
     "id": 23,
@@ -419,7 +419,7 @@
     "nom_orig": "Bro",
     "texte_orig": "I[SP]was[SP]seriously[SP]worried[SP]for[SP]a[SP]while[SP]about[SP]how\nthis[SP]would[SP]end...[1205][000A][SP]But[SP]c'mon![SP]We're[SP]on[SP]Xibalba\nnow![SP]What's[SP]the[SP]worst[SP]that[SP]could[SP]happen?",
     "nom_fr": "Mec",
-    "texte_fr": "J'ai eu peur un moment de comment tout\nça allait finir...[1205][000A] Mais allez ! On est\nsur Xibalba! Qu'est-ce qui peut arriver?"
+    "texte_fr": "J'ai eu peur un moment de comment tout\nça allait finir...[000A][1205] Mais allez ! On est\nsur Xibalba! Qu'est-ce qui peut arriver?"
   },
   {
     "id": 26,
@@ -434,7 +434,7 @@
     "nom_orig": "Bro",
     "texte_orig": "Not[SP]only[SP]that,[SP]but[SP]I'll[SP]be[SP]even[SP]cooler[SP]after\nI[SP]evolve![1205][000A][SP]Yessss![1205][000F][SP]Huh?[1205][000F][SP]The[SP]Earth?[1205][000F][SP]Psh,[SP]who\ngives[SP]a[SP]damn[SP]about[SP]those[SP]guys?",
     "nom_fr": "Mec",
-    "texte_fr": "Et en plus, je serai encore plus\n[1205][1205][1205]stylé après avoir évolué![000F][000F][1205][000F][000A] Ouiiiii!\nHein? La Terre? Bah, qui s'en soucie?"
+    "texte_fr": "Et en plus, je serai encore plus\n[1205][1205][1205]stylé après avoir évolué![000F][000F][000F][1205][000A] Ouiiiii!\nHein? La Terre? Bah, qui s'en soucie?"
   },
   {
     "id": 27,
@@ -501,7 +501,7 @@
     "nom_orig": "Bro",
     "texte_orig": "Yikes![SP]C'mon,[SP]dude.[SP]You[SP]don't[SP]have[SP]enough[SP]money.[1205][000F]\nI[SP]can't[SP]let[SP]you[SP]use[SP]the[SP]tanning[SP]beds[SP]like[SP]this.",
     "nom_fr": "Mec",
-    "texte_fr": "Aïe, mec. Vous n'avez\npas assez d'argent. [1205][000F]Je\nne peux pas vous\nlaisser utiliser les cabines."
+    "texte_fr": "Aïe, mec. Vous n'avez\npas assez d'argent. [000F][1205]Je\nne peux pas vous laisser utiliser les cabines."
   },
   {
     "id": 30,

--- a/traduction/event_scripts/script_342.json
+++ b/traduction/event_scripts/script_342.json
@@ -12,7 +12,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "That's[SP]weird...[1205][000F][SP]Kozy's[SP]not[SP]here.[1205][000F][SP]I[SP]thought\nshe'd[SP]be[SP]munching[SP]on[SP]a[SP]Big[SP]Peace[SP]Burger...",
     "nom_fr": "Ginko",
-    "texte_fr": "Bizarre..[1205][000F][1205]. [000F]Kozy n'est pas là. Je pensais\nqu'elle irait manger au Big Peace Burger..."
+    "texte_fr": "Bizarre..[000F][1205][1205]. [000F]Kozy n'est pas là. Je pensais\nqu'elle irait manger au Big Peace Burger..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "???",
     "texte_orig": "Huh?[1205][000F][SP]Hey,[SP]is[SP]that[SP]you,[SP]Lisa-san?[1205][000F][SP]Fancy[SP]meeting\nyou[SP]here!",
     "nom_fr": "???",
-    "texte_fr": "Hein? [1205][000F][1205][000F]Hé, c'est toi Lisa?\nSympa de te croiser ici!"
+    "texte_fr": "Hein? [000F][1205][000F][1205]Hé, c'est toi Lisa?\nSympa de te croiser ici!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh...?[SP]Oh[SP]yeah,[SP]you're[SP]on[SP]Kozy's[SP]newspaper\nstaff...[SP]Umm...[1205][000F][SP]Chikarin?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein...? Ah, tu bosses dans le\njournal de Kozy... [1205][000F]Chikarin je crois?"
+    "texte_fr": "Hein...? Ah, tu bosses dans le\njournal de Kozy... [000F][1205]Chikarin je crois?"
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Perfect[SP]timing![1205][000F][SP]Have[SP]you[SP]seen[SP]Kozy?",
     "nom_fr": "Ginko",
-    "texte_fr": "Timing parfait! [1205][000F]Tu as vu Kozy?"
+    "texte_fr": "Timing parfait! [000F][1205]Tu as vu Kozy?"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "She[SP]found[SP]out[SP]the[SP]Cuss[SP]High[SP]guys[SP]who[SP]spread[SP]the\nrumor[SP]about[SP]the[SP]disease[SP]were[SP]at[SP]Zodiac,[SP]so[SP]she\nwent[SP]to[SP]infiltrate[SP]the[SP]club[SP]and[SP]talk[SP]to[SP]them.",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Elle a découvert que les gars de Kakasu\nrépandant la rumeur de la maladie\nétaient au Zodiac, et est\npartieinfiltrer le club pour leur parler."
+    "texte_fr": "Elle a découvert que les gars de Kakasu\nrépandant la rumeur de la maladie\nétaient au Zodiac, et est partieinfiltrer le club pour leur parler."
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey![SP]Pay[SP]attention,[SP]Undie[SP]Boss![1205][000F][SP]Sounds[SP]like\nit[SP]was[SP]Cuss[SP]High[SP]students[SP]who[SP]spread[SP]the[SP]rumor\nabout[SP]that[SP]disease!",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé! Écoute, Boss des Calbutes! [1205][000F]On\ndirait que c'est ceux de Kakasu qui\nont répandu la rumeur sur la maladie!"
+    "texte_fr": "Hé! Écoute, Boss des Calbutes! [000F][1205]On\ndirait que c'est ceux de Kakasu qui\nont répandu la rumeur sur la maladie!"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "There's[SP]no[SP]way[SP]my[SP]guys[SP]would[SP]stoop[SP]to[SP]that!\nI[SP]didn't[SP]teach[SP]'em[SP]to[SP]be[SP]cowards![1205][000F][SP]Fatty[SP]must\nhave[SP]gotten[SP]some[SP]bad[SP]info.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Jamais mes gars auraient fait ça! Je\nleur ai pas appris à être des lâches!\n[1205][000F]Grossy a sûrement pas eu la bonne info."
+    "texte_fr": "Jamais mes gars auraient fait ça! Je\nleur ai pas appris à être des lâches!\n[000F][1205]Grossy a sûrement pas eu la bonne info."
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "That's[SP]two[SP]witnesses[SP]now![1205][000F][SP]Are[SP]you[SP]still[SP]gonna\ntry[SP]and[SP]play[SP]dumb!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Ça fait deux témoins! [1205][000F]Tu vas\ncontinuer de faire l'autruche!?"
+    "texte_fr": "Ça fait deux témoins! [000F][1205]Tu vas\ncontinuer de faire l'autruche!?"
   },
   {
     "id": 12,
@@ -252,7 +252,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I'm[SP]the[SP]one[SP]who[SP]should[SP]be[SP]saying[SP][1432][NULL][NULL][0014]kehhei[1432][NULL][NULL][0014][SP]here![1205][000F]\nMy[SP]guys[SP]would[SP]never[SP]do[SP]that![1205][000F][SP]And[SP]I'm[SP]not[SP]taking\nthis[SP]airhead's[SP]word[SP]that[SP]they[SP]did!",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est moi qui devrait dire [1432][NULL][NULL][0014]kehhei[1432][NULL][NULL][0014] là!\n[1205][000F][1205][000F]Mes gars feraient jamais ça! Et je crois\npas un mot de ce qu'a dit cette idiote!"
+    "texte_fr": "C'est moi qui devrait dire [1432][NULL][NULL][0014]kehhei[1432][NULL][NULL][0014] là!\n[000F][1205][000F][1205]Mes gars feraient jamais ça! Et je crois\npas un mot de ce qu'a dit cette idiote!"
   },
   {
     "id": 17,
@@ -297,7 +297,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]want[SP]one,[SP][1113]?[1205][000F][SP]I'll[SP]give[SP]you[SP]the\nfriend[SP]discount.",
     "nom_fr": "Eikichi",
-    "texte_fr": "T'en veux un, [1113]? [1205][000F]Je\nte ferais un prix d'ami."
+    "texte_fr": "T'en veux un, [1113]? [000F][1205]Je\nte ferais un prix d'ami."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Someone[SP]must[SP]know...[1205][000F][SP]But[SP]we've[SP]been[SP]all[SP]over.[1205][000F]\nIs[SP]there[SP]any[SP]rumormonger[SP]we[SP]haven't[SP]checked\nin[SP]with[SP]yet?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Quelqu'un doit savoir.[1205][000F][1205][000F].. Mais on a été\npartout. Ou bien il y a des rumeur qu'on a\nratées?"
+    "texte_fr": "Quelqu'un doit savoir.[000F][1205][000F][1205].. Mais on a été\npartout. Ou bien il y a des rumeur qu'on a\nratées?"
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]kind[SP]of[SP]impressive[SP]they[SP]rigged[SP]a[SP]debut\nwithout[SP]the[SP]debuting[SP]singer's[SP]knowledge.[1205][000F]\nBut[SP]it[SP]could[SP]happen[SP]to[SP]me[SP]too,[SP]I'm[SP]sure.",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est assez fou en soi d'avoir organisé un\nconcert sans prévenir la chanteuse\n[1205][000F]concernée. Mais ça\npourrait m'arriver aussi."
+    "texte_fr": "C'est assez fou en soi d'avoir organisé un\nconcert sans prévenir la chanteuse\n[000F][1205]concernée. Mais ça pourrait m'arriver aussi."
   },
   {
     "id": 22,
@@ -372,7 +372,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Looks[SP]like[SP]tickets[SP]are[SP]sold[SP]out.[SP]I[SP]doubt[SP]we'll\nbe[SP]getting[SP]in[SP]through[SP]the[SP]front.[1205][000F][SP]Any[SP]ideas?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Y'a plus de tickets,\non dirait. Je pense pas\nqu'on pourra passer\n[1205]par l'entrée. [000F]Des idées?"
+    "texte_fr": "Y'a plus de tickets,\non dirait. Je pense pas\nqu'on pourra passer [1205]par l'entrée. [000F]Des idées?"
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Dammit![SP]We[SP]should've[SP]nabbed[SP]that[SP]King[SP]Leo\nbastard[SP]at[SP]the[SP]concert[SP]hall![1205][000F][SP]Then[SP]we'd[SP]know\nwhere[SP]they'll[SP]strike[SP]next!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Merde! On aurait du choper cet enfoiré\nRoi Lion au concert! [1205][000F]On aurait pu\nconnaître leur prochaine cible!"
+    "texte_fr": "Merde! On aurait du choper cet enfoiré\nRoi Lion au concert! [000F][1205]On aurait pu\nconnaître leur prochaine cible!"
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Tch...[SP]So[SP]Smile[SP]Hirasaka[SP]was[SP]the[SP]real[SP]target...\nI[SP]wonder[SP]if[SP]my[SP]instincts[SP]are[SP]getting[SP]rusty.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tss... Donc la cible était le Smile\nHirasaka... Peut-être que\nmon instinct rouille\nun peu."
+    "texte_fr": "Tss... Donc la cible était le Smile\nHirasaka... Peut-être que\nmon instinct rouille un peu."
   },
   {
     "id": 28,
@@ -447,7 +447,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Why[SP]did[SP]that[SP]ghost[SP]seem[SP]so[SP]familiar...?[1205][000F]\nThe[SP]guy[SP]died[SP]more[SP]than[SP]ten[SP]years[SP]ago...[1205][000F]\nI-Is[SP]this[SP]another...[1205][000F][SP]No,[SP]couldn't[SP]be.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pourquoi ce fantôme m'est si familier.[1205][000F][1205][000F][1205][000F]..?\nCe gars est mort y'a plus de dix ans...\nO-Où c'est un autre... Pas moyen."
+    "texte_fr": "Pourquoi ce fantôme m'est si familier.[000F][1205][000F][1205][000F][1205]..?\nCe gars est mort y'a plus de dix ans...\nO-Où c'est un autre... Pas moyen."
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Geez,[SP]the[SP]world's[SP]ending?[1205][000F][SP]What[SP]exactly's[SP]gonna\nhappen?[1205][000F][SP]Hey,[SP]what[SP]do[SP]you[SP]think,[SP][1114]?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pff, c'est la fin du monde? [1205][000F][1205][000F]Il va se\npasser quoi exactement? T'en penses quoi [1114]?"
+    "texte_fr": "Pff, c'est la fin du monde? [000F][1205][000F][1205]Il va se\npasser quoi exactement? T'en penses quoi [1114]?"
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![1205][000F][SP]Those[SP]Cuss[SP]High[SP]students[SP]were[SP]the[SP]ones\nwho[SP]really[SP]spread[SP]that[SP]rumor.[SP]I[SP]bet[SP]Undie[SP]Boss\nwas[SP]part[SP]of[SP]it[SP]too!",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei! [1205][000F]C'est les élèves de Kakasu qui\nont répandu la rumeur. Je parie que le\nBoss des Calbutes était avec eux!"
+    "texte_fr": "Kehhei! [000F][1205]C'est les élèves de Kakasu qui\nont répandu la rumeur. Je parie que le\nBoss des Calbutes était avec eux!"
   },
   {
     "id": 32,
@@ -537,7 +537,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Poster?[1205][000F][SP]Debut?[SP]What[SP]the[SP]hell?",
     "nom_fr": "Ginko",
-    "texte_fr": "Poster? [1205][000F]Groupe? De quoi?"
+    "texte_fr": "Poster? [000F][1205]Groupe? De quoi?"
   },
   {
     "id": 36,
@@ -552,7 +552,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I'm[SP]exhausted.[1205][000F][SP]Hey[SP][1113],[SP]can[SP]we[SP]take\na[SP]break[SP]here?",
     "nom_fr": "Ginko",
-    "texte_fr": "Je suis épuisée. [1205][000F]Dis [1113],\non peut se poser ici?"
+    "texte_fr": "Je suis épuisée. [000F][1205]Dis [1113],\non peut se poser ici?"
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "This[SP]better[SP]not[SP]be[SP]those[SP]two[SP]again.[1205][000F][SP]Are[SP]they\ntrying[SP]to[SP]rope[SP]me[SP]into[SP]this!?[SP]This[SP]isn't[SP]funny!",
     "nom_fr": "Ginko",
-    "texte_fr": "J'espère que c'est pas encore ces deux-là.\n[1205][000F]Dans quoi on veut m'embarquer? C'est pas\ndrôle!"
+    "texte_fr": "J'espère que c'est pas encore ces deux-là.\n[000F][1205]Dans quoi on veut m'embarquer? C'est pas\ndrôle!"
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![SP]Kehhei![1205][000F][SP]A[SP]solo[SP]part!?[SP]To[SP]show[SP]me[SP]off!?\nBullshit![SP]They're[SP]the[SP]ones[SP]showing[SP]off!",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei! [1205][000F]Un solo!? Me mettre en avant!? Des\nconneries! Ils font ça pour leurs pommes!"
+    "texte_fr": "Kehhei! [000F][1205]Un solo!? Me mettre en avant!? Des\nconneries! Ils font ça pour leurs pommes!"
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Forget[SP]them,[SP][1113]![1205][000F][SP]I'm[SP]not[SP]going!",
     "nom_fr": "Ginko",
-    "texte_fr": "Oublie-les, [1113]! [1205][000F]J'irais pas!"
+    "texte_fr": "Oublie-les, [1113]! [000F][1205]J'irais pas!"
   },
   {
     "id": 40,
@@ -687,7 +687,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Is[SP]that[SP]why[SP]that[SP]teacher[SP]was[SP]trying[SP]to[SP]stop\nthe[SP]clock[SP]at[SP]Sevens[SP]from[SP]starting,[SP]even[SP]after\ndeath...?[1205][000F][SP]Holeen,[SP]I[SP]feel[SP]kinda[SP]sorry[SP]for[SP]him.",
     "nom_fr": "Ginko",
-    "texte_fr": "C'est pour ça que\nce prof essayait d'empêcher\nl'horloge de Seven de\nredémarrer, même après\n[1205]sa mort.[000F]..? Holeen, je\nme sens mal pour lui."
+    "texte_fr": "C'est pour ça que\nce prof essayait d'empêcher\nl'horloge de Seven de redémarrer, même après [1205]sa mort.[000F]..? Holeen, je me sens mal pour lui."
   },
   {
     "id": 46,
@@ -702,7 +702,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hmm,[SP]will[SP]a[SP]volcano[SP]erupt?[1205][000F][SP]A[SP]huge[SP]earthquake?[1205][000A]\nA[SP]tsunami?[1205][000A][SP]Meteors?[1205][000A][SP]Nuclear[SP]missiles?[1205][000A][SP]How's\nthe[SP]Earth[SP]gonna[SP]be[SP]destroyed?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hmm, une éruption volcanique? [1205][1205][1205][1205][1205][000F]Un séisme?\n[000A][000A][000A][000A]Tsunami? Météorites? Missiles nucléaires?\nComment la Terre va être détruite?"
+    "texte_fr": "Hmm, une éruption volcanique? [1205][1205][1205][1205][000F][1205]Un séisme?\n[000A][000A][000A][000A]Tsunami? Météorites? Missiles nucléaires?\nComment la Terre va être détruite?"
   },
   {
     "id": 47,
@@ -717,7 +717,7 @@
     "nom_orig": "Maya",
     "texte_orig": "If[SP]Joker[SP]is[SP]behind[SP]this[SP]too,[SP]that[SP]Kozy[SP]girl[SP]is\nin[SP]danger.[1205][000F][SP]We[SP]should[SP]go[SP]to[SP]Zodiac.",
     "nom_fr": "Maya",
-    "texte_fr": "Si Joker est concerné, cette Kozy est en\ndanger. [1205][000F]Nous devrions aller au Zodiac."
+    "texte_fr": "Si Joker est concerné, cette Kozy est en\ndanger. [000F][1205]Nous devrions aller au Zodiac."
   },
   {
     "id": 48,
@@ -732,7 +732,7 @@
     "nom_orig": "Maya",
     "texte_orig": "But[SP]wasn't[SP]this[SP]new[SP]Leader[SP]once[SP]one[SP]of\nEikichi-kun's[SP]henchmen?[1205][000F][SP]Does[SP]he[SP]have[SP]some\nkind[SP]of[SP]grudge[SP]against[SP]Eikichi-kun?",
     "nom_fr": "Maya",
-    "texte_fr": "Mais ce nouveau chef n'était pas aux\nordres d'Eikichi? [1205][000F]Est-ce qu'il a une\ndent contre Eikichi ou quelque chose?"
+    "texte_fr": "Mais ce nouveau chef n'était pas aux\nordres d'Eikichi? [000F][1205]Est-ce qu'il a une\ndent contre Eikichi ou quelque chose?"
   },
   {
     "id": 49,
@@ -747,7 +747,7 @@
     "nom_orig": "Maya",
     "texte_orig": "But[SP]what's[SP]this[SP]organization[SP]Joker[SP]is[SP]leader\nof?[1205][000F][SP]I[SP]don't[SP]know[SP]anything[SP]about[SP]its[SP]size[SP]or\nambitions...",
     "nom_fr": "Maya",
-    "texte_fr": "C'est quoi cette organisation que\nJoker dirige? [1205][000F]Je ne sais rien de\nsa taille ou de ses ambitions..."
+    "texte_fr": "C'est quoi cette organisation que\nJoker dirige? [000F][1205]Je ne sais rien de\nsa taille ou de ses ambitions..."
   },
   {
     "id": 50,
@@ -777,7 +777,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]don't[SP]think[SP]we[SP]skipped[SP]any[SP]rumormongers...[1205][000F]\nIt's[SP]weird,[SP]we[SP]really[SP]beat[SP]the[SP]bushes[SP]but[SP]we\ndidn't[SP]learn[SP]a[SP]thing.",
     "nom_fr": "Maya",
-    "texte_fr": "J'ai pas l'impression qu'on ai raté de\n[1205][000F]rumeurs... C'est étrange, on a fouillé\npartout mais on a rien appris."
+    "texte_fr": "J'ai pas l'impression qu'on ai raté de\n[000F][1205]rumeurs... C'est étrange, on a fouillé\npartout mais on a rien appris."
   },
   {
     "id": 52,
@@ -792,7 +792,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hey,[SP]I[SP]know![1205][000F][SP]Let's[SP]try[SP]going[SP]to[SP]the[SP]Kuzunoha\nDetective[SP]Agency.[1205][000F][SP]Maybe[SP]Chief[SP]Todoroki[SP]and\nTamaki[SP]know[SP]something!",
     "nom_fr": "Maya",
-    "texte_fr": "Ah, je sais! [1205][000F][1205][000F]Essayons l'Agence de\nDétective Kuzunoha. Tamaki et le Chef\nTodoroki pourraient avoir une info!"
+    "texte_fr": "Ah, je sais! [000F][1205][000F][1205]Essayons l'Agence de\nDétective Kuzunoha. Tamaki et le Chef\nTodoroki pourraient avoir une info!"
   },
   {
     "id": 53,
@@ -807,7 +807,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]only[SP]natural[SP]the[SP]kids[SP]at[SP]Sevens[SP]who[SP]saw\nthat[SP]poster[SP]would[SP]think[SP]it[SP]was[SP]Lisa.[1205][000F][SP]I[SP]feel\nlike[SP]it[SP]was[SP]purposely[SP]done[SP]that[SP]way.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est normal que les enfants de Seven aient\ncru voir Lisa sur ce poster. [1205][000F]Je pense que\nla ressemblance était volontaire."
+    "texte_fr": "C'est normal que les enfants de Seven aient\ncru voir Lisa sur ce poster. [000F][1205]Je pense que\nla ressemblance était volontaire."
   },
   {
     "id": 54,
@@ -837,7 +837,7 @@
     "nom_orig": "Maya",
     "texte_orig": "If[SP]we[SP]can't[SP]go[SP]in[SP]the[SP]front,[SP]we'll[SP]just[SP]hop\nthe[SP]fence![1205][000F][SP]We[SP]have[SP]to[SP]get[SP]to[SP]Lisa[SP]even[SP]if[SP]it\nmeans[SP]resorting[SP]to[SP]extreme[SP]measures.",
     "nom_fr": "Maya",
-    "texte_fr": "Si on ne peut pas passer par l'entrée, on\n[1205][000F]chevauchera la clôture! On doit trouver\nLisa quitte à employer les grands moyens."
+    "texte_fr": "Si on ne peut pas passer par l'entrée, on\n[000F][1205]chevauchera la clôture! On doit trouver\nLisa quitte à employer les grands moyens."
   },
   {
     "id": 56,
@@ -852,7 +852,7 @@
     "nom_orig": "Maya",
     "texte_orig": "How[SP]much[SP]time[SP]do[SP]we[SP]have[SP]before[SP]they[SP]bomb[SP]the\nnext[SP]target?[1205][000F][SP]We[SP]have[SP]to[SP]hurry...",
     "nom_fr": "Maya",
-    "texte_fr": "On a combien de temps avant qu'ils\nexplosent la cible suivante? [1205][000F]Dépêchons..."
+    "texte_fr": "On a combien de temps avant qu'ils\nexplosent la cible suivante? [000F][1205]Dépêchons..."
   },
   {
     "id": 57,
@@ -867,7 +867,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]don't[SP]know[SP]how[SP]much[SP]time[SP]we[SP]have,[SP]but[SP]from\nhow[SP]King[SP]Leo[SP]was[SP]acting[SP]at[SP]the[SP]concert[SP]hall,\nthey're[SP]in[SP]real[SP]a[SP]hurry[SP]to[SP]fulfill[SP]the[SP]Oracle.",
     "nom_fr": "Maya",
-    "texte_fr": "Aucune idée du temps qu'il nous reste, mais\nau vu du comportement\ndu Roi Lion au concert,\nils sont pressés de réaliser l'Oracle."
+    "texte_fr": "Aucune idée du temps qu'il nous reste, mais\nau vu du comportement\ndu Roi Lion au concert, ils sont pressés de réaliser l'Oracle."
   },
   {
     "id": 58,
@@ -882,7 +882,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]doubt[SP]we'll[SP]have[SP]time[SP]to[SP]search[SP]both[SP]places.\nIt's[SP]either[SP]Smile[SP]Hirasaka[SP]or[SP]the[SP]Sakanoue\nBuilding...[SP]Choose[SP]carefully,[SP][1113]-kun.",
     "nom_fr": "Maya",
-    "texte_fr": "Je doute qu'on ai le temps d'inspecter les\ndeux endroits. C'est le\nSmile Hirasaka ou le\nSakanoue Building... Choisis bien, [1113]."
+    "texte_fr": "Je doute qu'on ai le temps d'inspecter les\ndeux endroits. C'est le\nSmile Hirasaka ou le Sakanoue Building... Choisis bien, [1113]."
   },
   {
     "id": 59,
@@ -897,7 +897,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm...[SP]Pachinko[SP]Silver[SP]or[SP]GOLD...[1205][000F][SP]They[SP]both\nseem[SP]equally[SP]likely[SP]to[SP]me.",
     "nom_fr": "Maya",
-    "texte_fr": "Hm, le Pachinko Silver ou le GOLD.[1205][000F]..\nLes deux me semblent probables."
+    "texte_fr": "Hm, le Pachinko Silver ou le GOLD.[000F][1205]..\nLes deux me semblent probables."
   },
   {
     "id": 60,
@@ -912,7 +912,7 @@
     "nom_orig": "Maya",
     "texte_orig": "King[SP]Leo's[SP]planning[SP]to[SP]bomb[SP]the[SP]Aerospace\nMuseum[SP]too.[1205][000F][SP]If[SP]we[SP]wait[SP]around,[SP]we'll[SP]be[SP]too\nlate.[SP]Let's[SP]get[SP]going.",
     "nom_fr": "Maya",
-    "texte_fr": "Le Roi Loin prévoit aussi d'exploser\n[1205][000F]le Musée de l'Aéronautique. Si on\nattend, il sera trop tard. Allons-y."
+    "texte_fr": "Le Roi Loin prévoit aussi d'exploser\n[000F][1205]le Musée de l'Aéronautique. Si on\nattend, il sera trop tard. Allons-y."
   },
   {
     "id": 61,
@@ -927,7 +927,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Fate[SP]began[SP]its[SP]workings[SP]alongside[SP]that[SP]large\nclock.[SP]Nothing[SP]you[SP]do[SP]now[SP]can[SP]slow[SP]the\nfulfillment[SP]of[SP]the[SP]Oracle.[1205][000F][SP]Heh.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nThe[SP]Oracle[SP]should[SP]go[SP]into[SP]the[SP]details[SP]of[SP]how\nthe[SP]Earth[SP]will[SP]be[SP]annihilated.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est près de la grande horloge que le\ndestin s'est mis en marche. Vous ne pouvez\nplus empêcher l'Oracle de se réaliser. [1205][000F]Hé.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nL'Oracle devrait détailler comment\nla Terre va être annihilée."
+    "texte_fr": "C'est près de la grande horloge que le\ndestin s'est mis en marche. Vous ne pouvez\nplus empêcher l'Oracle de se réaliser. [000F][1205]Hé.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nL'Oracle devrait détailler comment\nla Terre va être annihilée."
   },
   {
     "id": 62,
@@ -972,7 +972,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "So[SP]this[SP]new[SP]Leader[SP]lost[SP]to[SP]Eikichi[SP]and[SP]has[SP]to\nbow[SP]down[SP]to[SP]him,[SP]right?[1205][000F][SP]Then[SP]of[SP]course[SP]he's\ncarrying[SP]a[SP]grudge[SP]or[SP]two.",
     "nom_fr": "Yukino",
-    "texte_fr": "Donc ce nouveau chef a perdu contre\nEikichi et a du se soumettre? [1205][000F]C'est\névident qu'il soit un peu rancunier."
+    "texte_fr": "Donc ce nouveau chef a perdu contre\nEikichi et a du se soumettre? [000F][1205]C'est\névident qu'il soit un peu rancunier."
   },
   {
     "id": 65,
@@ -1017,7 +1017,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "So[SP]NO[SP]ONE[SP]knows[SP]about[SP]the[SP]Masked[SP]Circle?[1205][000F][SP]Or[SP]are\nthey[SP]just[SP]hiding[SP]it[SP]from[SP]us?",
     "nom_fr": "Yukino",
-    "texte_fr": "Donc PERSONNE ne sait ce qu'est le\n[1205][000F]Cercle Masqué? Où bien on nous le cache?"
+    "texte_fr": "Donc PERSONNE ne sait ce qu'est le\n[000F][1205]Cercle Masqué? Où bien on nous le cache?"
   },
   {
     "id": 68,
@@ -1032,7 +1032,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "If[SP]Maya-san's[SP]right[SP]and[SP]the[SP]Masked[SP]Circle\nis[SP]mixed[SP]up[SP]in[SP]this,[SP]aren't[SP]Lisa's[SP]friends\nin[SP]danger?",
     "nom_fr": "Yukino",
-    "texte_fr": "Si Maya a bon et\nque le Cercle Masqué est mêlé\nà ça, les amies de\nLisa sont en danger, non?"
+    "texte_fr": "Si Maya a bon et\nque le Cercle Masqué est mêlé\nà ça, les amies de Lisa sont en danger, non?"
   },
   {
     "id": 69,
@@ -1047,7 +1047,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Depending[SP]on[SP]how[SP]things[SP]go,[SP]we[SP]might[SP]have[SP]to\nrescue[SP]Lisa's[SP]friends[SP]too.[1205][000F][SP]This[SP]could[SP]get\na[SP]little[SP]dicey.",
     "nom_fr": "Yukino",
-    "texte_fr": "Selon comment ça tourne, on pourrait\navoir à sauver les amies de Lisa\n[1205][000F]aussi. Ça peut devenir tendu."
+    "texte_fr": "Selon comment ça tourne, on pourrait\navoir à sauver les amies de Lisa\n[000F][1205]aussi. Ça peut devenir tendu."
   },
   {
     "id": 70,
@@ -1062,7 +1062,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Maya-san[SP]isn't[SP]kidding,[SP]either.[1205][000F][SP]There[SP]was[SP]this\none[SP]assignment[SP]we[SP]did[SP]where[SP]she[SP]really[SP]did[SP]jump\nthe[SP]fence[SP]to[SP]get[SP]into[SP]a[SP]closed-off[SP]building.",
     "nom_fr": "Yukino",
-    "texte_fr": "Maya plaisante pas, tu sais.\n[1205][000F]On a eu un job où\nelle a vraiment sauté par-dessus la clôture\npour entrer dans un bâtiment fermé d'accès."
+    "texte_fr": "Maya plaisante pas, tu sais.\n[000F][1205]On a eu un job où\nelle a vraiment sauté par-dessus la clôture pour entrer dans un bâtiment fermé d'accès."
   },
   {
     "id": 71,
@@ -1077,7 +1077,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "If[SP]we[SP]don't[SP]hurry,[SP]they're[SP]gonna[SP]strike[SP]again.\nCan[SP]we[SP]go[SP]to[SP]Double[SP]Slash[SP]already?[SP]My[SP]friend\nthere[SP]should[SP]be[SP]able[SP]to[SP]figure[SP]out[SP]that[SP]card.",
     "nom_fr": "Yukino",
-    "texte_fr": "Si on se dépêche\npas, ils frapperont encore.\nOn peut filer au Double Slash? Là-bas, mon\namie devrait pouvoir\ndéchiffrer cette carte."
+    "texte_fr": "Si on se dépêche\npas, ils frapperont encore.\nOn peut filer au Double Slash? Là-bas, mon amie devrait pouvoir déchiffrer cette carte."
   },
   {
     "id": 72,
@@ -1092,7 +1092,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "The[SP]Sakanoue[SP]Building[SP]or[SP]Smile[SP]Hirasaka...[1205][000F]\nIdeally[SP]we'd[SP]have[SP]time[SP]to[SP]check[SP]them[SP]both.",
     "nom_fr": "Yukino",
-    "texte_fr": "Le Sakanoue Building\nou le Smile Hirasaka.[1205][000F]..\nSi on pouvait vérifier les deux..."
+    "texte_fr": "Le Sakanoue Building\nou le Smile Hirasaka.[000F][1205]..\nSi on pouvait vérifier les deux..."
   },
   {
     "id": 73,
@@ -1107,7 +1107,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]still[SP]think[SP]GOLD[SP]is[SP]the[SP]next[SP]target.[1205][000F]\nIt's[SP]just[SP]a[SP]hunch,[SP]but...",
     "nom_fr": "Yukino",
-    "texte_fr": "Je pense que GOLD sera la cible.\n[1205][000F]C'est mon instinct, mais..."
+    "texte_fr": "Je pense que GOLD sera la cible.\n[000F][1205]C'est mon instinct, mais..."
   },
   {
     "id": 74,
@@ -1122,7 +1122,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Don't[SP]worry.[1205][000F][SP]This[SP]time,[SP]I'll[SP]make[SP]him[SP]pay.",
     "nom_fr": "Yukino",
-    "texte_fr": "T'inquiètes pas. [1205][000F]Cette fois, il va payer."
+    "texte_fr": "T'inquiètes pas. [000F][1205]Cette fois, il va payer."
   },
   {
     "id": 75,
@@ -1227,7 +1227,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "More[SP]people[SP]seem[SP]to[SP]know[SP]about[SP]the[SP]Masked\nCircle[SP]these[SP]days.[1205][000F][SP]I[SP]wonder[SP]why?",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "De plus en plus de gens semblent au\ncourant du Cercle Masqué. [1205][000F]Mais pourquoi?"
+    "texte_fr": "De plus en plus de gens semblent au\ncourant du Cercle Masqué. [000F][1205]Mais pourquoi?"
   },
   {
     "id": 82,
@@ -1423,7 +1423,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Okay,[SP]that[SP]was[SP]worth[SP]it.[1205][000F][SP]Sure,[SP]I'll[SP]tell[SP]you\nwhat[SP]I[SP]know.[1205][000F][SP]Are[SP]you[SP]ready[SP]for[SP]this?",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "OK, ça valait le coup. [1205][000F][1205][000F]Bien sûr, je vais\nte donner mes infos. T'es bien accroché?"
+    "texte_fr": "OK, ça valait le coup. [000F][1205][000F][1205]Bien sûr, je vais\nte donner mes infos. T'es bien accroché?"
   },
   {
     "id": 91,
@@ -1453,7 +1453,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Huh?[SP]You[SP]saw[SP]a[SP]REAL[SP]ghost[SP]at[SP]the[SP]clock[SP]tower\nin[SP]Sevens!?[SP]Seriously?[SP]You're[SP]not[SP]pulling[SP]my\nleg[SP]here?",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Hein? T'as vu un\nVRAI fantôme dans l'horloge\nde Seven!? Sérieux? Tu\nme fais pas marcher là?"
+    "texte_fr": "Hein? T'as vu un\nVRAI fantôme dans l'horloge\nde Seven!? Sérieux? Tu me fais pas marcher là?"
   },
   {
     "id": 93,
@@ -1483,7 +1483,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "But[SP]now[SP]I[SP]know![1205][000F][SP]Okay,[SP]my[SP]turn!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Maintenant je sais! [1205][000F]À mon tour!"
+    "texte_fr": "Maintenant je sais! [000F][1205]À mon tour!"
   },
   {
     "id": 95,
@@ -1498,7 +1498,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "There's[SP]this[SP]place[SP][E4][NULL][NULL][0006]Tony's[SP]Shop[E4][NULL][NULL][0002][SP]in[SP]Yumezaki.\nRumor[SP]is[SP]you[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002][SP]there![1205][000F]\nHis[SP][E4][NULL][NULL][0006]prices[SP]and[SP]quality[SP]are[SP]okay[E4][NULL][NULL][0002],[SP]I[SP]guess.",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Y'a ce coin, [E4][NULL][NULL][0006]Tony's Shop[E4][NULL][NULL][0002] à Yumezaki. La\nrumeur dit qu'on y\nvend de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]! [1205][000F]Les\n[E4][NULL][NULL][0006]prix et la qualité sont corrects[E4][NULL][NULL][0002], je crois."
+    "texte_fr": "Y'a ce coin, [E4][NULL][NULL][0006]Tony's Shop[E4][NULL][NULL][0002] à Yumezaki. La\nrumeur dit qu'on y\nvend de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]! [000F][1205]Les [E4][NULL][NULL][0006]prix et la qualité sont corrects[E4][NULL][NULL][0002], je crois."
   },
   {
     "id": 96,
@@ -1513,7 +1513,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Hmm?[SP]The[SP]Undie[SP]Boss[SP]at[SP]Kasugayama[SP]High[SP]is\nstepping[SP]down?[1205][000F][SP]That's[SP]amazing![SP]We[SP]can[SP]always\nuse[SP]rumors[SP]about[SP]Cuss[SP]High![SP]Now[SP]for[SP]yours...",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Hmm? Le Boss des Calbutes du lycée Kakasu\nprend sa retraite? [1205][000F]Excellent! Ça sert\ntoujours, une rumeur sur\nKakasu! Quant à latienne..."
+    "texte_fr": "Hmm? Le Boss des Calbutes du lycée Kakasu\nprend sa retraite? [000F][1205]Excellent! Ça sert\ntoujours, une rumeur sur Kakasu! Quant à latienne..."
   },
   {
     "id": 97,
@@ -1558,7 +1558,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Okay,[SP]did[SP]you[SP]know[SP]the[SP][E4][NULL][NULL][0006]Jolly[SP]Roger[E4][NULL][NULL][0002][SP]cafe[SP]in\nKounan[SP][E4][NULL][NULL][0006]sells[SP]real[SP]weapons[E4][NULL][NULL][0002]?[1205][000F][SP]Their[SP][E4][NULL][NULL][0006]selection[SP]is\ngreat,[SP]but[SP]their[SP]resale[SP]prices[SP]are[SP]the[SP]pits[E4][NULL][NULL][0002].",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Bien, tu savais que le café [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à\nKounan [E4][NULL][NULL][0006]vendait de vraies armes[E4][NULL][NULL][0002]?\n[1205][000F]Il y a [E4][NULL][NULL][0006]du très\nbon choix, mais le\nprix de revente estabyssal[E4][NULL][NULL][0002]."
+    "texte_fr": "Bien, tu savais que le café [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à\nKounan [E4][NULL][NULL][0006]vendait de vraies armes[E4][NULL][NULL][0002]?\n[000F][1205]Il y a [E4][NULL][NULL][0006]du très bon choix, mais le prix de revente estabyssal[E4][NULL][NULL][0002]."
   },
   {
     "id": 100,
@@ -1588,7 +1588,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Ooooh,[SP]it's[SP]like[SP]in[SP]the[SP]movies![1205][000F][SP]Everyone[SP]has\ntheir[SP]secrets.",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Ooooh, comme dans les films!\n[1205][000F]Enfin, on a tous nos secrets."
+    "texte_fr": "Ooooh, comme dans les films!\n[000F][1205]Enfin, on a tous nos secrets."
   },
   {
     "id": 102,
@@ -1633,7 +1633,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Huh?[SP]There[SP]really[SP]was[SP]a[SP]secret[SP]lounge[SP]in[SP]Zodiac?\nIt's[SP]like[SP]a[SP]maze,[SP]eh?[SP]Now[SP]that's[SP]impressive\nfootwork.[SP]Here's[SP]what[SP]I[SP]know[SP]in[SP]return...",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Il y avait un salon secret au Zodiac? Comme\ndans un labyrinthe, hein? C'est fou d'avoir\ntrouvé ça. En retour,\nvoilà ce que je sais..."
+    "texte_fr": "Il y avait un salon secret au Zodiac? Comme\ndans un labyrinthe, hein? C'est fou d'avoir\ntrouvé ça. En retour, voilà ce que je sais..."
   },
   {
     "id": 105,
@@ -1648,7 +1648,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "That[SP]store[SP][E4][NULL][NULL][0006]Anima[SP]Mundi[E4][NULL][NULL][0002][SP]around[SP]here[SP]sells[SP][E4][NULL][NULL][0006]real\nweapons[E4][NULL][NULL][0002].[1205][000F][SP]They[SP]have[SP][E4][NULL][NULL][0006]an[SP]amazing[SP]selection,[SP]but\npretty[SP]low[SP]buyback[SP]prices[E4][NULL][NULL][0002].",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Le magasin [E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002] près d'ici vend de\n[E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. [1205][000F]Il y a [E4][NULL][NULL][0006]une sélection\nincroyable, mais des prix\nde rachat très bas[E4][NULL][NULL][0002]."
+    "texte_fr": "Le magasin [E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002] près d'ici vend de\n[E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. [000F][1205]Il y a [E4][NULL][NULL][0006]une sélection\nincroyable, mais des prix de rachat très bas[E4][NULL][NULL][0002]."
   },
   {
     "id": 106,
@@ -1663,7 +1663,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "The[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High[SP]used[SP]to[SP]be[SP]one\nof[SP]the[SP]Undie[SP]Boss'[SP]henchmen?[SP]Wow![SP]The[SP]low\novercomes[SP]the[SP]high![1205][000F][SP]But[SP]I[SP]can[SP]top[SP]that.",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Le nouveau chef de Kakasu était un des\nlarbins du Boss des Calbutes? Wow! David\na battu Goliath! [1205][000F]Mais j'ai encore mieux."
+    "texte_fr": "Le nouveau chef de Kakasu était un des\nlarbins du Boss des Calbutes? Wow! David\na battu Goliath! [000F][1205]Mais j'ai encore mieux."
   },
   {
     "id": 107,
@@ -1678,7 +1678,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Did[SP]you[SP]know[SP]there's[SP]a[SP][E4][NULL][NULL][0006]Rosa[SP]Candida[E4][NULL][NULL][0002][SP]in[SP]Aoba\ntoo?[1205][000F][SP]They[SP]sell[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002][SP]there.[SP]It's[SP][E4][NULL][NULL][0006]super\nhigh[SP]quality,[SP]but[SP]also[SP]super[SP]expensive[E4][NULL][NULL][0002].",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Tu savais qu'il y avait\nun [E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002] à Aoba\n[1205]aussi? [000F]Ils vendent\nde [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]là-bas. La\n[E4][NULL][NULL][0006]qualité et le prix sont très hauts[E4][NULL][NULL][0002]."
+    "texte_fr": "Tu savais qu'il y avait\nun [E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002] à Aoba\n[1205]aussi? [000F]Ils vendent de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]là-bas. La [E4][NULL][NULL][0006]qualité et le prix sont très hauts[E4][NULL][NULL][0002]."
   },
   {
     "id": 108,
@@ -1693,7 +1693,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Whoa![SP]The[SP]lucky[SP]cat[SP]statue[SP]at[SP]the[SP]Kuzunoha\nDetective[SP]Agency[SP]can[SP]talk!?[1205][000F][SP]Squeee![SP]That's\nso[SP]cute![SP]I[SP]wanna[SP]see[SP]it!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Woah! La statue de chat du bonheur à\nl'Agence de Détective Kuzunoha peut\n[1205][000F]parler!? Aaaah! Trop chou! Je veux voir!"
+    "texte_fr": "Woah! La statue de chat du bonheur à\nl'Agence de Détective Kuzunoha peut\n[000F][1205]parler!? Aaaah! Trop chou! Je veux voir!"
   },
   {
     "id": 109,
@@ -1708,7 +1708,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Okay,[SP]here's[SP]mine.[1205][000F][SP][E4][NULL][NULL][0006]London[SP]Clothier[E4][NULL][NULL][0002][SP]in[SP]Kounan\neven[SP]tailors[SP][E4][NULL][NULL][0006]armor[E4][NULL][NULL][0002]![SP]The[SP][E4][NULL][NULL][0006]quality[SP]is[SP]great,\nbut[SP]it's[SP]very[SP]pricey[E4][NULL][NULL][0002].",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Bien, à moi. [1205][000F][E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] à Kounan\nconçoit aussi des [E4][NULL][NULL][0006]armures[E4][NULL][NULL][0002]! La [E4][NULL][NULL][0006]qualité\nest géniale, mais c'est très cher[E4][NULL][NULL][0002]."
+    "texte_fr": "Bien, à moi. [000F][1205][E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] à Kounan\nconçoit aussi des [E4][NULL][NULL][0006]armures[E4][NULL][NULL][0002]! La [E4][NULL][NULL][0006]qualité\nest géniale, mais c'est très cher[E4][NULL][NULL][0002]."
   },
   {
     "id": 110,
@@ -1723,7 +1723,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Say[SP]what?[1205][000F][SP]Tamaki[SP]at[SP]the[SP]detective[SP]agency[SP]is\nactually[SP]a[SP]Devil[SP]Summoner?[1205][000F][SP]What[SP]the[SP]heck\nis[SP]that?",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Quoi? [1205][000F][1205][000F]Tamaki de l'agence de\ndétective est en réalité une Devil\nSummoner? C'est quoi comme truc?"
+    "texte_fr": "Quoi? [000F][1205][000F][1205]Tamaki de l'agence de\ndétective est en réalité une Devil\nSummoner? C'est quoi comme truc?"
   },
   {
     "id": 111,
@@ -1753,7 +1753,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "If[SP]you[SP]win[SP]the[SP][E4][NULL][NULL][0006]magazine[SP]sweepstakes[E4][NULL][NULL][0002],[SP]you[SP]get\n[E4][NULL][NULL][0006]real[SP]weapons[SP]and[SP]items[E4][NULL][NULL][0002].[1205][000F][SP]I[SP]hear[SP][E4][NULL][NULL][0006]it's[SP]easy[SP]to\nwin,[SP]but[SP]the[SP]prizes[SP]are[SP]kinda[SP]lame[E4][NULL][NULL][0002].",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "En gagnant à la [E4][NULL][NULL][0006]lotterie du magazine[E4][NULL][NULL][0002], tu\nauras des [E4][NULL][NULL][0006]objets et de vraies armes[E4][NULL][NULL][0002].[1205][000F][E4][NULL][NULL][0006] Gagner\nest facile, mais les lots sont passables[E4][NULL][NULL][0002]."
+    "texte_fr": "En gagnant à la [E4][NULL][NULL][0006]lotterie du magazine[E4][NULL][NULL][0002], tu\nauras des [E4][NULL][NULL][0006]objets et de vraies armes[E4][NULL][NULL][0002].[000F][1205][E4][NULL][NULL][0006] Gagner\nest facile, mais les lots sont passables[E4][NULL][NULL][0002]."
   },
   {
     "id": 113,
@@ -1783,7 +1783,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Wow,[SP]can[SP]I[SP]join!?[1205][000F][SP]Oh,[SP]but[SP]what[SP]if[SP]he[SP]pulls[SP]down\nmy[SP]pants?[SP]F-Forget[SP]it!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Wow, je peux en être![1205][000F]? Oh, mais s'il\nm'enlevait mon pantalon? O-Oublie!"
+    "texte_fr": "Wow, je peux en être![000F][1205]? Oh, mais s'il\nm'enlevait mon pantalon? O-Oublie!"
   },
   {
     "id": 115,
@@ -1798,7 +1798,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "[E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002][SP]in[SP]Yumezaki[SP]is[SP]secretly[SP]a[SP][E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002]![1205][000F][SP]From[SP]what\nI[SP]hear,[SP]several[SP]people[SP]won[SP]big[SP]at[SP][E4][NULL][NULL][0006]blackjack[E4][NULL][NULL][0002].",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "[E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002] à Yumezaki est un [E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002]\n[1205][000F]secret! Pas mal de gens auraient\ntouché le gros lot au [E4][NULL][NULL][0006] blackjack[E4][NULL][NULL][0002]."
+    "texte_fr": "[E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002] à Yumezaki est un [E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002]\n[000F][1205]secret! Pas mal de gens auraient\ntouché le gros lot au [E4][NULL][NULL][0006] blackjack[E4][NULL][NULL][0002]."
   },
   {
     "id": 116,
@@ -1828,7 +1828,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "But[SP]if[SP]you[SP]keep[SP]your[SP]finger[SP]on[SP]the[SP]pulse[SP]of\nthe[SP]city's[SP]rumors,[SP]you[SP]can[SP]pick[SP]up[SP]on[SP]those\ncases[SP]easily.[SP]And[SP]that's[SP]what[SP]I[SP]do[SP]best!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Mais en étant attentif\naux échos des rumeurs\nde la ville, tu peux résoudre ces affaires\naisément. Et c'est ce que je fais le mieux!"
+    "texte_fr": "Mais en étant attentif\naux échos des rumeurs\nde la ville, tu peux résoudre ces affaires aisément. Et c'est ce que je fais le mieux!"
   },
   {
     "id": 118,
@@ -1873,7 +1873,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Oh,[SP]but[SP]it's[SP]tit[SP]for[SP]tat.[1205][000F][SP]You[SP]have[SP]to[SP]give[SP]me\nsome[SP]kind[SP]of[SP]scoop[SP]in[SP]return.[SP]And[SP]I[SP]don't\naccept[SP]installment[SP]plans!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Oh, mais c'est du donnant-donnant. [1205][000F]Tu\ndois me donner un bon scoop en retour.\nEt je n'accepte pas les versements!"
+    "texte_fr": "Oh, mais c'est du donnant-donnant. [000F][1205]Tu\ndois me donner un bon scoop en retour.\nEt je n'accepte pas les versements!"
   },
   {
     "id": 121,
@@ -1888,7 +1888,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Kozy-senpai[SP]took[SP]off[SP]again.[1205][000F][SP]Oh,[SP]but[SP]she[SP]left\na[SP]message[SP]for[SP]you![1205][000F][SP]She[SP]said[SP]she's[SP]going[SP]to[SP]keep\ndigging[SP]around[SP]about[SP]Joker.",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Kozy est repartie. [1205][000F][1205][000F]Oh, mais elle a\nlaissé un message! Elle vous prévient\nqu'elle continuera d'enquêter sur Joker."
+    "texte_fr": "Kozy est repartie. [000F][1205][000F][1205]Oh, mais elle a\nlaissé un message! Elle vous prévient\nqu'elle continuera d'enquêter sur Joker."
   },
   {
     "id": 122,
@@ -1933,7 +1933,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "I[SP]don't[SP]know[SP]what's[SP]happened,[SP]but[SP]you[SP]don't\nneed[SP]to[SP]worry.[1205][000F][SP]Deer[SP]are[SP]often[SP]worse[SP]than[SP]the\nstranger[SP]itself,[SP]after[SP]all.",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Je sais pas ce qui s'est passé, mais\nt'inquiètes. [1205][000F]Face au danger, elle se fige\npas comme un lapin pris dans les phares."
+    "texte_fr": "Je sais pas ce qui s'est passé, mais\nt'inquiètes. [000F][1205]Face au danger, elle se fige\npas comme un lapin pris dans les phares."
   },
   {
     "id": 125,
@@ -1948,7 +1948,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Hm?[SP]The[SP]Masked[SP]Circle?[1205][000F][SP]Never[SP]heard[SP]of[SP]them\nbefore.[1205][000F][SP]Are[SP]they[SP]tied[SP]to[SP]what[SP]Kozy-senpai[SP]was\ninvestigating?[1205][000F][SP]I[SP]still[SP]haven't[SP]heard[SP]from[SP]her.",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Hm, le Cercle Masqué? [1205][000F][1205][000F][1205][000F]Jamais entendu\nparler. Ils sont liés à l'enquête de Kozy?\nJ'ai toujours aucune nouvelle d'elle."
+    "texte_fr": "Hm, le Cercle Masqué? [000F][1205][000F][1205][000F][1205]Jamais entendu\nparler. Ils sont liés à l'enquête de Kozy?\nJ'ai toujours aucune nouvelle d'elle."
   },
   {
     "id": 126,
@@ -1963,7 +1963,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "They[SP]sound[SP]pretty[SP]suspicious,[SP]though...[1205][000F]\nAre[SP]they[SP]like,[SP]demon[SP]worshippers?[1205][000F][SP]Hmm,[SP]maybe\nthe[SP]fortune[SP]teller[SP]in[SP]Kounan[SP]would[SP]know.",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Ils ont l'air très suspects, par contre.[1205][000F][1205][000F]..\nC'est genre, un culte démoniaque? Hmm, la\nvoyante de Kounan pourrait en savoir plus."
+    "texte_fr": "Ils ont l'air très suspects, par contre.[000F][1205][000F][1205]..\nC'est genre, un culte démoniaque? Hmm, la\nvoyante de Kounan pourrait en savoir plus."
   },
   {
     "id": 127,
@@ -1978,7 +1978,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "I'll[SP]try[SP]looking[SP]into[SP]the[SP]Masked[SP]Circle,[SP]too.[1205][000F]\nWait[SP]until[SP]you[SP]see[SP]what[SP]I[SP]can[SP]put[SP]together!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Je vais surveiller ce Cercle Masqué, moi\n[1205][000F]aussi. Attendez de voir ce que je vais\ntrouver!"
+    "texte_fr": "Je vais surveiller ce Cercle Masqué, moi\n[000F][1205]aussi. Attendez de voir ce que je vais\ntrouver!"
   },
   {
     "id": 128,
@@ -1993,7 +1993,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Have[SP]any[SP]plans[SP]for[SP]the[SP]future,[SP]Senpai?\nI[SP]sure[SP]do![1205][000F][SP]I'll[SP]make[SP]an[SP]exception[SP]and[SP]tell\nyou[SP]about[SP]'em[SP]for[SP]free.",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "T'as des projets d'avenirs, au fait?\nMoi oui! [1205][000F]Je vais faire une exception\net t'en parler gratuitement."
+    "texte_fr": "T'as des projets d'avenirs, au fait?\nMoi oui! [000F][1205]Je vais faire une exception\net t'en parler gratuitement."
   },
   {
     "id": 129,
@@ -2023,7 +2023,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "I[SP]joined[SP]the[SP]school[SP]paper[SP]to[SP]get[SP]some[SP]practice\ndoing[SP]that.[SP]I'm[SP]pretty[SP]good[SP]already,[SP]huh?",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "J'ai rejoint le journal de l'école pour\nm'entraîner un peu. Je\nsuis déjà plutôt douée,\nnon?"
+    "texte_fr": "J'ai rejoint le journal de l'école pour\nm'entraîner un peu. Je\nsuis déjà plutôt douée, non?"
   },
   {
     "id": 131,
@@ -2038,7 +2038,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "I[SP]heard[SP]Lisa-san[SP]was[SP]part[SP]of[SP]Muses.[1205][000F][SP]Why[SP]didn't\nyou[SP]guys[SP]tell[SP]me?[SP]I[SP]could've[SP]had[SP]an[SP]exclusive\ninterview[SP]with[SP]her!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Apparemment Lisa était membre de Muses.\n[1205][000F]Pourquoi vous m'avez pas dit? J'aurais\npu l'interviewer en exclusivité!"
+    "texte_fr": "Apparemment Lisa était membre de Muses.\n[000F][1205]Pourquoi vous m'avez pas dit? J'aurais\npu l'interviewer en exclusivité!"
   },
   {
     "id": 132,
@@ -2053,7 +2053,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "I[SP]haven't[SP]heard[SP]any[SP]new[SP]rumors[SP]lately.[SP]Think\nit's[SP]because[SP]of[SP]all[SP]the[SP]attacks?[1205][000F][SP]I[SP]just[SP]can't\nget[SP]anything[SP]from[SP]any[SP]of[SP]my[SP]contacts...",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "J'ai pas entendu de rumeurs récemment.\nJ'imagine que c'est à\ncause des attaques? [1205][000F]Mes\ncontacts m'apportent\nplus riend'intéressant..."
+    "texte_fr": "J'ai pas entendu de rumeurs récemment.\nJ'imagine que c'est à\ncause des attaques? [000F][1205]Mes contacts m'apportent plus riend'intéressant..."
   },
   {
     "id": 133,
@@ -2083,7 +2083,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Okay.[SP]I'm[SP]always[SP]here,[SP]so[SP]come[SP]see[SP]me[SP]anytime![1205][000F]\nAdieu!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Ok. Je reste ici, donc\nviens quand tu veux! [1205][000F]Ciao!"
+    "texte_fr": "Ok. Je reste ici, donc\nviens quand tu veux! [000F][1205]Ciao!"
   },
   {
     "id": 135,
@@ -2098,7 +2098,7 @@
     "nom_orig": "Kazuya",
     "texte_orig": "'Course[SP]I[SP]heard.[1205][000F][SP]Rumor[SP]has[SP]it[SP]he's[SP]stronger\nthan[SP]the[SP]old[SP]Boss.[1205][000F][SP]Man,[SP]things[SP]sure[SP]are\nchanging[SP]at[SP]Cuss[SP]High.",
     "nom_fr": "Kazuya",
-    "texte_fr": "Bien sûr. [1205][000F][1205][000F]Je connais la rumeur comme\nquoi il est plus fort que l'ancien\nboss. Kakasu va changer, mec."
+    "texte_fr": "Bien sûr. [000F][1205][000F][1205]Je connais la rumeur comme\nquoi il est plus fort que l'ancien\nboss. Kakasu va changer, mec."
   },
   {
     "id": 136,
@@ -2128,7 +2128,7 @@
     "nom_orig": "Kazuya",
     "texte_orig": "B-But[SP]a[SP]masquerade[SP]at[SP]our[SP]age...?[1205][000F][SP]We're[SP]too\nold[SP]for[SP]that[SP]stuff...",
     "nom_fr": "Kazuya",
-    "texte_fr": "M-mais un bal masqué à notre âge?\n[1205][000F]On est trop vieux pour ça..."
+    "texte_fr": "M-mais un bal masqué à notre âge?\n[000F][1205]On est trop vieux pour ça..."
   },
   {
     "id": 138,
@@ -2203,7 +2203,7 @@
     "nom_orig": "Kazuya",
     "texte_orig": "Looks[SP]like[SP]the[SP]Masked[SP]Circle[SP]was[SP]dangerous\nafter[SP]all.[SP]The[SP]concert[SP]hall[SP]was[SP]probably[SP]just\nthe[SP]beginning.[SP]I[SP]bet[SP]they've[SP]got[SP]big[SP]plans.",
     "nom_fr": "Kazuya",
-    "texte_fr": "Le Cercle Masqué\nétait vraiment dangereux, en\nfait. Le concert n'était sûrement qu'un \ndébut. Je parie\nqu'ils préparent pire encore."
+    "texte_fr": "Le Cercle Masqué\nétait vraiment dangereux, en\nfait. Le concert n'était sûrement qu'un début. Je parie qu'ils préparent pire encore."
   },
   {
     "id": 143,
@@ -2218,7 +2218,7 @@
     "nom_orig": "Kazuya",
     "texte_orig": "I[SP]keep[SP]hearing[SP]that[SP]this[SP]Last[SP]Battalion[SP]was\nthe[SP]terrorists.[SP]Does[SP]that[SP]mean[SP]it[SP]wasn't[SP]the\nMasked[SP]Circle?[1205][000F][SP]Which[SP]one[SP]was[SP]it?",
     "nom_fr": "Kazuya",
-    "texte_fr": "Partout j'entend que ce Bataillon est\nle véritable terroriste. C'était pas le\nCercle Masqué? [1205][000F]C'est lequel du coup?"
+    "texte_fr": "Partout j'entend que ce Bataillon est\nle véritable terroriste. C'était pas le\nCercle Masqué? [000F][1205]C'est lequel du coup?"
   },
   {
     "id": 144,
@@ -2233,7 +2233,7 @@
     "nom_orig": "Kazuya",
     "texte_orig": "But[SP]the[SP]kids[SP]who[SP]were[SP]just[SP]here[SP]said[SP]the[SP]five[SP]guys\nin[SP]the[SP]composite[SP]sketches[SP]were[SP]heroes[SP]fighting\nthe[SP]Masked[SP]Circle.[1205][000F][SP]Could[SP]they[SP]be[SP]innocent?",
     "nom_fr": "Kazuya",
-    "texte_fr": "Mais les mômes juste avant ont dit que les\ncinq gars des\nportraits-robots sont des héros\naffrontant le\n[1205]Cercle Masqué. [000F]Sont-ilsinnocents?"
+    "texte_fr": "Mais les mômes juste avant ont dit que les\ncinq gars des\nportraits-robots sont des héros affrontant le [1205]Cercle Masqué. [000F]Sont-ilsinnocents?"
   },
   {
     "id": 145,
@@ -2248,7 +2248,7 @@
     "nom_orig": "Kazuya",
     "texte_orig": "You[SP]know[SP]that[SP]stuff[SP]about[SP]the[SP][1432][NULL][NULL][0014]flames[SP]of\nexpiation[1432][NULL][NULL][0014][SP]in[SP]the[SP]In[SP]Lak'ech?[1205][000F][SP]Could[SP]that\nrefer[SP]to[SP]the[SP]bombings?",
     "nom_fr": "Kazuya",
-    "texte_fr": "Tu connais cette histoire de\n[1432][NULL][NULL][0014]flammes de l'expiation[1432][NULL][NULL][0014] dans l'In\n[1205][000F]Lak'ech? Ça désignerait les bombes?"
+    "texte_fr": "Tu connais cette histoire de\n[1432][NULL][NULL][0014]flammes de l'expiation[1432][NULL][NULL][0014] dans l'In\n[000F][1205]Lak'ech? Ça désignerait les bombes?"
   },
   {
     "id": 146,
@@ -2278,7 +2278,7 @@
     "nom_orig": "Yukiko",
     "texte_orig": "Hey,[SP]Kazuya.[SP]Did[SP]you[SP]hear[SP]about[SP]the[SP]new[SP]Leader\nat[SP]Cuss[SP]High?[1205][000F][SP]They[SP]say[SP]someone[SP]like[SP]that[SP]popped\nup[SP]recently.",
     "nom_fr": "Yukiko",
-    "texte_fr": "Hé, Kazuya. T'as entendu parler du\nnouveau chef de Kakasu? [1205][000F]Apparement\nun type de ce style est apparu."
+    "texte_fr": "Hé, Kazuya. T'as entendu parler du\nnouveau chef de Kakasu? [000F][1205]Apparement\nun type de ce style est apparu."
   },
   {
     "id": 148,
@@ -2293,7 +2293,7 @@
     "nom_orig": "Yukiko",
     "texte_orig": "Doesn't[SP]she,[SP]though?[SP]I[SP]guess[SP]she's[SP]a[SP]fan[SP]of\nperiod[SP]dramas,[SP]but[SP]to[SP]talk[SP]like[SP]one[SP]too...\nGiven[SP]where[SP]we[SP]are,[SP]it's[SP]pretty[SP]funny.",
     "nom_fr": "Yukiko",
-    "texte_fr": "Pas vrai? Elle est\nfan de drames historiques,\nmais de là à\nen adopter le language... C'est\nmarrant compte tenu de où on est."
+    "texte_fr": "Pas vrai? Elle est\nfan de drames historiques,\nmais de là à en adopter le language... C'est marrant compte tenu de où on est."
   },
   {
     "id": 149,
@@ -2338,7 +2338,7 @@
     "nom_orig": "Yukiko",
     "texte_orig": "Hey,[SP]Kazuya.[1205][000F][SP]Have[SP]you[SP]heard[SP]of[SP]the[SP]Masked\nCircle?[1205][000F][SP]They're[SP]some[SP]group[SP]here[SP]in[SP]Sumaru.",
     "nom_fr": "Yukiko",
-    "texte_fr": "Hé, Kazuya. [1205][000F][1205][000F]T'as entendu parler du Cercle\nMasqué? Une sorte de groupe à Sumaru."
+    "texte_fr": "Hé, Kazuya. [000F][1205][000F][1205]T'as entendu parler du Cercle\nMasqué? Une sorte de groupe à Sumaru."
   },
   {
     "id": 152,
@@ -2368,7 +2368,7 @@
     "nom_orig": "Yukiko",
     "texte_orig": "People[SP]have[SP]been[SP]talking[SP]a[SP]lot[SP]about[SP]those\nattacks.[SP]Was[SP]it[SP]the[SP]Masked[SP]Circle?[SP]What[SP]are\nthey[SP]trying[SP]to[SP]accomplish[SP]with[SP]the[SP]bombings?",
     "nom_fr": "Yukiko",
-    "texte_fr": "Les gens parlent beaucoup de ces attaques.\nÉtait-ce le Cercle\nMasqué? Ils veulent faire\nquoi avec tout ces attentats à la bombe?"
+    "texte_fr": "Les gens parlent beaucoup de ces attaques.\nÉtait-ce le Cercle\nMasqué? Ils veulent faire quoi avec tout ces attentats à la bombe?"
   },
   {
     "id": 154,
@@ -2398,7 +2398,7 @@
     "nom_orig": "Yukiko",
     "texte_orig": "They[SP]released[SP]composite[SP]sketches[SP]of[SP]the[SP]culprits,\nso[SP]we[SP]can[SP]rest[SP]easy.[SP]They'll[SP]be[SP]arrested[SP]soon\nenough.[SP]Whew...[SP]my[SP]appetite's[SP]coming[SP]back.",
     "nom_fr": "Yukiko",
-    "texte_fr": "Ils ont publié les portraits-robots des\ncoupables, donc on peut se relaxer. Ils se\nferont arrêter d'ici peu.\nFiou... mon appétitrevient."
+    "texte_fr": "Ils ont publié les portraits-robots des\ncoupables, donc on peut se relaxer. Ils se\nferont arrêter d'ici peu. Fiou... mon appétitrevient."
   },
   {
     "id": 156,
@@ -2413,7 +2413,7 @@
     "nom_orig": "Yukiko",
     "texte_orig": "Geez,[SP]don't[SP]say[SP]stuff[SP]like[SP]that.[SP]If[SP]that[SP]was\ntrue,[SP]it[SP]would[SP]mean[SP]the[SP]rest[SP]of[SP]that[SP]book[SP]is\ntrue[SP]too.[SP]And[SP]I[SP]don't[SP]want[SP]the[SP]world[SP]to[SP]end!",
     "nom_fr": "Yukiko",
-    "texte_fr": "Mec, dit pas ça.\nSi cette partie était vraie,\nalors le reste du livre\ndit vrai aussi. Et je\nveux pas que ce soit la fin du monde!"
+    "texte_fr": "Mec, dit pas ça.\nSi cette partie était vraie,\nalors le reste du livre dit vrai aussi. Et je veux pas que ce soit la fin du monde!"
   },
   {
     "id": 157,
@@ -2428,7 +2428,7 @@
     "nom_orig": "Yukiko",
     "texte_orig": "I[SP]don't[SP]care![SP]Can[SP]we[SP]please[SP]just[SP]get[SP]out[SP]of\nhere?[1205][000F][SP]Who[SP]knows[SP]when[SP]those[SP]soldiers[SP]might\ninvade[SP]here[SP]too!?[E1][E2]\n[E3][E4][NULL][NULL]\"Female[SP]student\nOh,[SP]Lisa![SP]I[SP]saw[SP]the[SP]poster![SP]Geez,[SP]don't[SP]tease\nus[SP]like[SP]that.[1205][000F][SP]I[SP]totally[SP]figured[SP]it[SP]out[SP]anyway\nas[SP]soon[SP]as[SP]I[SP]saw[SP]it!",
     "nom_fr": "Yukiko",
-    "texte_fr": "M'en fous! On peut pas juste partir\nd'ici? [1205][000F][1205][000F]Qui sait quand\nles soldats vont venir\nattaquer ici aussi!?[E1][E2] [E3][E4][NULL][NULL]\"Lycéenne\n Oh, Lisa!\nJ'ai vu le poster! Roh, fais pas genre.\nJ'aicompris à la seconde où je l'ai vu!"
+    "texte_fr": "M'en fous! On peut pas juste partir\nd'ici? [000F][1205][000F][1205]Qui sait quand\nles soldats vont venir\nattaquer ici aussi!?[E1][E2] [E3][E4][NULL][NULL]\"Lycéenne\n Oh, Lisa!\nJ'ai vu le poster! Roh, fais pas genre.\nJ'aicompris à la seconde où je l'ai vu!"
   },
   {
     "id": 158,
@@ -2443,7 +2443,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "So[SP]when's[SP]the[SP]debut?[1205][000F][SP]You[SP]should've[SP]told[SP]us!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "C'est quand le concert?\n[1205][000F]T'aurais du nous dire!"
+    "texte_fr": "C'est quand le concert?\n[000F][1205]T'aurais du nous dire!"
   },
   {
     "id": 159,
@@ -2503,7 +2503,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "Geez,[SP]this[SP]is[SP]so[SP]lame.[1205][000F][SP]They[SP]were[SP]all[SP]sold[SP]out\nof[SP]Muses[SP]tickets.",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Bouh, c'est trop nul. [1205][000F]Les tickets\npour Muses sont tous épuisés."
+    "texte_fr": "Bouh, c'est trop nul. [000F][1205]Les tickets\npour Muses sont tous épuisés."
   },
   {
     "id": 163,
@@ -2518,7 +2518,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "It's[SP]a[SP]full[SP]house.[SP]No[SP]one[SP]else[SP]can[SP]get[SP]in.[1205][000F]\nI'm[SP]so[SP]bummed...",
     "nom_fr": "Lycéenne",
-    "texte_fr": "C'est rempli. Personne d'autre\npeut entrer. [1205][000F]Je suis anéantie..."
+    "texte_fr": "C'est rempli. Personne d'autre\npeut entrer. [000F][1205]Je suis anéantie..."
   },
   {
     "id": 164,
@@ -2533,7 +2533,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "Long[SP]time[SP]no[SP]see,[SP][1113]-kun.[1205][000F][SP]Remember[SP]me?[1205][000F]\nBleheheh.[SP]I'm[SP]Fuyuko[SP]Tsukikage,[SP]the[SP]one[SP]who\nwhispered[SP]ghost[SP]stories[SP]to[SP]you[SP]at[SP]Sevens...",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Ça fait un moment, [1113]. [1205][000F][1205][000F]Tu te souviens de\nmoi? Bléhé. Je suis Fuyuko Tsukikage, je te\nracontais des histoires\nde fantômes à Seven..."
+    "texte_fr": "Ça fait un moment, [1113]. [000F][1205][000F][1205]Tu te souviens de\nmoi? Bléhé. Je suis Fuyuko Tsukikage, je te\nracontais des histoires de fantômes à Seven..."
   },
   {
     "id": 165,
@@ -2548,7 +2548,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "My[SP]nickname's[SP]Final[SP]Girl.[1205][000F][SP]Bleheheh.[1205][000F][SP]I've[SP]got\nan[SP]intense[SP]one[SP]for[SP]you[SP]today...[1205][000F][SP]I[SP]wanted[SP]you[SP]to\nhear[SP]it[SP]so[SP]much,[SP]I[SP]hunted[SP]you[SP]down.[SP]Bleheheh.",
     "nom_fr": "Fuyuko",
-    "texte_fr": "On me surnomme Final\n[1205][000F][1205][000F][1205][000F]Girl. Bléhéhé. J'ai une\nsacrée histoire pour toi...\nJe voulais tant te\nla partager que\nje t'ai pourchassé. Bléhéhé."
+    "texte_fr": "On me surnomme Final\n[000F][1205][000F][1205][000F][1205]Girl. Bléhéhé. J'ai une\nsacrée histoire pour toi... Je voulais tant te la partager que je t'ai pourchassé. Bléhéhé."
   },
   {
     "id": 166,
@@ -2593,7 +2593,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "Why,[SP]you[SP]ask?[1205][000F][SP]Bleheheheh...[1205][000F][SP]To[SP]run[SP]people\nover![SP]It's[SP]actually[SP]a[SP]cursed[SP]taxi![1205][000F]\nBlehhheheheheh!",
     "nom_fr": "Fuyuko",
-    "texte_fr": "Pourquoi, tu te\n[1205][000F][1205][000F][1205][000F]dis? Bléhéhé... Pour faucher\ndes gens! C'était\nun taxi maudit! Bléhéhéhéhé!"
+    "texte_fr": "Pourquoi, tu te\n[000F][1205][000F][1205][000F][1205]dis? Bléhéhé... Pour faucher\ndes gens! C'était un taxi maudit! Bléhéhéhéhé!"
   },
   {
     "id": 169,
@@ -2608,7 +2608,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "Well,[SP][1113]-kun?[1205][000F][SP]Do[SP]you[SP]have[SP]the[SP]guts...[1205][000F]\nto[SP]hear[SP]my[SP]bloodcurdling[SP]story[SP]one[SP]more[SP]time?",
     "nom_fr": "Fuyuko",
-    "texte_fr": "Alors, [1113]? [1205][000F][1205][000F]As-tu les tripes... pour\nréécouter mon histoire à glacer le sang?"
+    "texte_fr": "Alors, [1113]? [000F][1205][000F][1205]As-tu les tripes... pour\nréécouter mon histoire à glacer le sang?"
   },
   {
     "id": 170,
@@ -2681,7 +2681,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "Why,[SP]you[SP]ask?[1205][000F][SP]Bleheheheh...[1205][000F][SP]To[SP]run[SP]people\nover![SP]It's[SP]actually[SP]a[SP]cursed[SP]taxi![1205][000F]\nBlehhheheheheh!",
     "nom_fr": "Fuyuko",
-    "texte_fr": "Pourquoi, tu te\n[1205][000F][1205][000F][1205][000F]dis? Bléhéhé... Pour faucher\ndes gens! C'était\nun taxi maudit! Bléhéhéhéhé!"
+    "texte_fr": "Pourquoi, tu te\n[000F][1205][000F][1205][000F][1205]dis? Bléhéhé... Pour faucher\ndes gens! C'était un taxi maudit! Bléhéhéhéhé!"
   },
   {
     "id": 174,
@@ -2725,7 +2725,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "Blehhheheh![1205][000F][SP]Wasn't[SP]it?[1205][000F][SP]It'll[SP]turn[SP]your[SP]hair\nwhite![1205][000F][SP]Oh...[SP]But[SP]if[SP]that[SP]scared[SP]you,[SP]I[SP]couldn't\npossibly[SP]tell[SP]you[SP]this[SP]one...[1205][000F][SP]What[SP]a[SP]shame.",
     "nom_fr": "Fuyuko",
-    "texte_fr": "Bléhhhéhé! [1205][000F][1205][000F][1205][000F][1205][000F]Pas vrai? T'en auras des cheveux\nblancs! Oh... Mais si ça t'a fait peur, je\nne peux pas te la raconter... Quel dommage."
+    "texte_fr": "Bléhhhéhé! [000F][1205][000F][1205][000F][1205][000F][1205]Pas vrai? T'en auras des cheveux\nblancs! Oh... Mais si ça t'a fait peur, je\nne peux pas te la raconter... Quel dommage."
   },
   {
     "id": 176,
@@ -2740,7 +2740,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "Gyah![1205][000F][SP]Y-You[SP]have[SP]ice[SP]water[SP]in[SP]your[SP]veins,\n[1113]-kun...[1205][000F][SP]Looks[SP]like[SP]nothing[SP]can[SP]faze\nyou[SP]after[SP]all.[1205][000F][SP]Then[SP]I[SP]have[SP]a[SP]favor[SP]to[SP]ask...",
     "nom_fr": "Fuyuko",
-    "texte_fr": "Gyah! [1205][000F][1205][000F][1205][000F]T-Tu as des glaçons dans les veines,\n[1113]... Rien ne semble te perturber. Du\ncoup, j'ai une faveur à te demander..."
+    "texte_fr": "Gyah! [000F][1205][000F][1205][000F][1205]T-Tu as des glaçons dans les veines,\n[1113]... Rien ne semble te perturber. Du\ncoup, j'ai une faveur à te demander..."
   },
   {
     "id": 177,
@@ -2755,7 +2755,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "The[SP]story[SP]I[SP]just[SP]told[SP]you[SP]is[SP]true.[1205][000F][SP]I[SP]saw[SP]the\nreal[SP][E4][NULL][NULL][0006]Cursed[SP]Taxi[E4][NULL][NULL][0002][SP]myself![SP]It[SP]was[SP]parked[SP]at[SP]the\n[E4][NULL][NULL][0006]abandoned[SP]factory[E4][NULL][NULL][0002]!",
     "nom_fr": "Fuyuko",
-    "texte_fr": "L'histoire que je t'ai racontée est\nvraie. [1205][000F]J'ai vu le vrai [E4][NULL][NULL][0006]Taxi Maudit[E4][NULL][NULL][0002]!\nIl était garé à [E4][NULL][NULL][0006]l'usine abandonnée[E4][NULL][NULL][0002]!"
+    "texte_fr": "L'histoire que je t'ai racontée est\nvraie. [000F][1205]J'ai vu le vrai [E4][NULL][NULL][0006]Taxi Maudit[E4][NULL][NULL][0002]!\nIl était garé à [E4][NULL][NULL][0006]l'usine abandonnée[E4][NULL][NULL][0002]!"
   },
   {
     "id": 178,
@@ -2770,7 +2770,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "If[SP]I[SP]sent[SP]this[SP]into[SP]my[SP]favorite[SP]magazine,\n[1432][NULL][NULL][0014]May,[1432][NULL][NULL][0014][SP]they'd[SP]definitely[SP]be[SP]interested.[1205][000F]\nProblem[SP]is,[SP]they'll[SP]want[SP]proof!",
     "nom_fr": "Fuyuko",
-    "texte_fr": "Si j'envoie ça à mon magazine\nfavori, [1432][NULL][NULL][0014]May,[1432][NULL][NULL][0014] ils seront intéressés.\n[1205][000F]Problème, ils voudront une preuve!"
+    "texte_fr": "Si j'envoie ça à mon magazine\nfavori, [1432][NULL][NULL][0014]May,[1432][NULL][NULL][0014] ils seront intéressés.\n[000F][1205]Problème, ils voudront une preuve!"
   },
   {
     "id": 179,
@@ -2785,7 +2785,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "You're[SP]the[SP]only[SP]one[SP]fearless[SP]enough[SP]that[SP]I\ncan[SP]ask[SP]this[SP]of.[1205][000F][SP]Bring[SP]me[SP]evidence[SP]that[SP]the\nCursed[SP]Taxi[SP]exists![SP]I'll[SP]return[SP]the[SP]favor!",
     "nom_fr": "Fuyuko",
-    "texte_fr": "T'es le seul type assez intrépide à qui je\npeux le demander. [1205][000F]Amène-moi une preuve que\nle Taxi Maudit existe! je te le revaudrai!"
+    "texte_fr": "T'es le seul type assez intrépide à qui je\npeux le demander. [000F][1205]Amène-moi une preuve que\nle Taxi Maudit existe! je te le revaudrai!"
   },
   {
     "id": 180,
@@ -2830,7 +2830,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "I'll[SP]be[SP]counting[SP]on[SP]you.[1205][000F][SP]The[SP]Cursed[SP]Taxi[SP]will\nbe[SP]parked[SP]at[SP]the[SP]abandoned[SP]factory...",
     "nom_fr": "Fuyuko",
-    "texte_fr": "Je compte sur toi. [1205][000F]Le Taxi Maudit\nstationnera dans l'usine abandonnée..."
+    "texte_fr": "Je compte sur toi. [000F][1205]Le Taxi Maudit\nstationnera dans l'usine abandonnée..."
   },
   {
     "id": 183,
@@ -2845,7 +2845,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "Ah![SP]There[SP]it[SP]is![SP]Proof[SP]that[SP]the[SP]Cursed[SP]Taxi\nex...[SP]ists...[1205][000F][SP]Wait.[1205][000F][SP]Is[SP]this...[1205][000F][SP]a[SP][E4][NULL][NULL][0006]Taxi[SP]Hat[E4][NULL][NULL][0002]?",
     "nom_fr": "Fuyuko",
-    "texte_fr": "Enfin! La preuve que le Taxi Maudit ex...\niste... [1205][1205]Stop. [1205][000F][000F][000F]C'est... un [E4][NULL][NULL][0006]Chapeau de Taxi[E4][NULL][NULL][0002]?"
+    "texte_fr": "Enfin! La preuve que le Taxi Maudit ex...\niste... [1205][1205]Stop. [000F][1205][000F][000F]C'est... un [E4][NULL][NULL][0006]Chapeau de Taxi[E4][NULL][NULL][0002]?"
   },
   {
     "id": 184,
@@ -2860,7 +2860,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "Gyaaaaaaaaah![1205][000F][SP]Wrong[SP]one![SP]I[SP]mean,[SP]wrong[SP]demon!\nThat[SP]wasn't[SP]it!",
     "nom_fr": "Fuyuko",
-    "texte_fr": "Gyaaaaah! [1205][000F]C'est pas le bon!\nEnfin, pas le bon démon!"
+    "texte_fr": "Gyaaaaah! [000F][1205]C'est pas le bon!\nEnfin, pas le bon démon!"
   },
   {
     "id": 185,
@@ -2920,7 +2920,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "Huh?[1205][000F][SP]I[SP]told[SP]you[SP]it[SP]was[SP]a[SP]cursed[SP]taxi,[SP]but[SP]not\na[SP]cursed[SP]escort[SP]taxi?[1205][000F][SP]Did[SP]I[SP]now...?\nBleheheheh.",
     "nom_fr": "Fuyuko",
-    "texte_fr": "Hein? [1205][000F][1205][000F]J'ai dis que\nc'était un taxi maudit, pas\nun taxi d'escorte\nmaudit? Ah bon...? Bléhéhé."
+    "texte_fr": "Hein? [000F][1205][000F][1205]J'ai dis que\nc'était un taxi maudit, pas\nun taxi d'escorte maudit? Ah bon...? Bléhéhé."
   },
   {
     "id": 189,
@@ -2935,7 +2935,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "Ah,[SP]that[SP]sweaty[SP][E4][NULL][NULL][0006]Yacht[SP]Hat[E4][NULL][NULL][0002]...[1205][000F][SP]That's[SP]the[SP]one.\nThis[SP]is[SP]undeniable[SP]proof[SP]that[SP]the[SP]Cursed[SP]Escort\nactually[SP]existed!",
     "nom_fr": "Fuyuko",
-    "texte_fr": "Ah, ce [E4][NULL][NULL][0006]Chapeau de Yacht[E4][NULL][NULL][0002] tout suant.[1205][000F]..\nC'est le bon. La preuve indéniable\nque l'Escorte Maudite a existée!"
+    "texte_fr": "Ah, ce [E4][NULL][NULL][0006]Chapeau de Yacht[E4][NULL][NULL][0002] tout suant.[000F][1205]..\nC'est le bon. La preuve indéniable\nque l'Escorte Maudite a existée!"
   },
   {
     "id": 190,
@@ -2950,7 +2950,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "Thank[SP]you[SP]so[SP]much,[SP][1113]-kun![1205][000F][SP]Here,[SP]this\n[E4][NULL][NULL][0004][U+1433][NULL][NULL][0004]Sacrifice[SP]Card[E4][NULL][NULL][0002][SP]is[SP]yours.[SP]Put[SP]it[SP]to[SP]good\nuse...[1205][000F][SP]Bleheheheheh.",
     "nom_fr": "Fuyuko",
-    "texte_fr": "Merci beaucoup, [1113]! Tiens,\n[1205][000F][1205][000F]cette [E4][NULL][NULL][0004][NULL][NULL][0004]Carte de Sacrifice[E4][NULL][NULL][0002] est à toi.\nFais-en bon usage... Bléhéhéhéhé.[U+1433]"
+    "texte_fr": "Merci beaucoup, [1113]! Tiens,\n[000F][1205][000F][1205]cette [E4][NULL][NULL][0004][NULL][NULL][0004]Carte de Sacrifice[E4][NULL][NULL][0002] est à toi.\nFais-en bon usage... Bléhéhéhéhé.[U+1433]"
   },
   {
     "id": 191,
@@ -2965,7 +2965,7 @@
     "nom_orig": "Fuyuko",
     "texte_orig": "Bleheheh...[SP]Now[SP]I[SP]can[SP]submit[SP]the[SP]details[SP]of\nthe[SP]Cursed[SP]Escort[SP]to[SP][1432][NULL][NULL][0014]May[1432][NULL][NULL][0014]...[1205][000F][SP]I'll[SP]finally\nbecome[SP]a[SP]Mayian[SP]like[SP]my[SP]friends![1205][000F][SP]Bleheheheheh!",
     "nom_fr": "Fuyuko",
-    "texte_fr": "Bléhéhé... Je vais pouvoir envoyer les\nélèments de cette affaire à [1432][NULL][NULL][0014]May[1432][NULL][NULL][0014].[1205][000F][1205][000F].. Je vais\ndevenir une Mayae\ncomme mes amis! Bléhéhéhéhé!"
+    "texte_fr": "Bléhéhé... Je vais pouvoir envoyer les\nélèments de cette affaire à [1432][NULL][NULL][0014]May[1432][NULL][NULL][0014].[000F][1205][000F][1205].. Je vais\ndevenir une Mayae comme mes amis! Bléhéhéhéhé!"
   },
   {
     "id": 192,
@@ -3066,7 +3066,7 @@
     "nom_orig": "Part-timer",
     "texte_orig": "We[SP]offer[SP]a[SP]variety[SP]of[SP]dishes,[SP]from[SP]hearty[SP]meals\nto[SP]plain[SP]hors[SP]d'oeuvres.[1205][000F][SP]Come[SP]now,[SP]don't[SP]shy\nfrom[SP]ordering[SP]to[SP]your[SP]heart's[SP]content.",
     "nom_fr": "Intérimaire",
-    "texte_fr": "Nos repas sont variés,\ndes plats copieux aux\nsimples hors-d'oeuvres.\n[1205][000F]Allez, n'hésitez pas\nà commander tout ce qui vous plaît."
+    "texte_fr": "Nos repas sont variés,\ndes plats copieux aux\nsimples hors-d'oeuvres. [000F][1205]Allez, n'hésitez pas à commander tout ce qui vous plaît."
   },
   {
     "id": 196,
@@ -3081,7 +3081,7 @@
     "nom_orig": "Part-timer",
     "texte_orig": "On[SP]my[SP]word,[SP]I[SP]do[SP]have[SP]a[SP]fondness[SP]for[SP]historical\nfilms,[SP]but[SP]I[SP]cannot[SP]recall[SP]going[SP]so[SP]far[SP]as[SP]to\naffect[SP]these[SP]cadences.[SP]How[SP]curious...",
     "nom_fr": "Intérimaire",
-    "texte_fr": "Je déclare sur l'honneur\nmon amour des films\nhistoriques, mais jamais\nau point d'affecter\nma cadence de travail. Étrange..."
+    "texte_fr": "Je déclare sur l'honneur\nmon amour des films\nhistoriques, mais jamais au point d'affecter ma cadence de travail. Étrange..."
   },
   {
     "id": 197,
@@ -3096,7 +3096,7 @@
     "nom_orig": "Part-timer",
     "texte_orig": "The[SP]school[SP]in[SP]Hirasaka[SP]will[SP]be[SP]holding[SP]a\nball[SP]soon.[1205][000F][SP]My[SP]heart[SP]would[SP]leap[SP]to[SP]take[SP]part,\nbut[SP]alas,[SP]my[SP]duties[SP]here[SP]take[SP]precedence...",
     "nom_fr": "Intérimaire",
-    "texte_fr": "L'école à Hirasaka organisera bientôt un\nbal. [1205][000F]Mon coeur bat à l'idée d'y participer,\nmais hélas, mon devoir est ma priorité..."
+    "texte_fr": "L'école à Hirasaka organisera bientôt un\nbal. [000F][1205]Mon coeur bat à l'idée d'y participer,\nmais hélas, mon devoir est ma priorité..."
   },
   {
     "id": 198,
@@ -3216,7 +3216,7 @@
     "nom_orig": "Part-timer",
     "texte_orig": "I[SP]am[SP]most[SP]grateful[SP]for[SP]your[SP]patronage.[1205][000F]\nI[SP]shall[SP]look[SP]forward[SP]to[SP]the[SP]day[SP]you[SP]decide\nto[SP]brighten[SP]our[SP]establishment[SP]once[SP]more.",
     "nom_fr": "Intérimaire",
-    "texte_fr": "Je vous suis obligée de votre appui.\n[1205][000F]Je suis impatiente que vous honoriez\nnotre établissement en y revenant."
+    "texte_fr": "Je vous suis obligée de votre appui.\n[000F][1205]Je suis impatiente que vous honoriez\nnotre établissement en y revenant."
   },
   {
     "id": 206,
@@ -3231,7 +3231,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "Ahaha,[SP]she[SP]really[SP]does[SP]talk[SP]like[SP]a[SP]Victorian\nmaid.[1205][000F][SP]Huh?[SP]Oh,[SP]I[SP]mean[SP]that[SP]part-timer.",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Ahaha, elle parle comme une servante\nVictorienne. [1205][000F]Hein? Oh, je parle de\nl'intérimaire."
+    "texte_fr": "Ahaha, elle parle comme une servante\nVictorienne. [000F][1205]Hein? Oh, je parle de\nl'intérimaire."
   },
   {
     "id": 207,
@@ -3246,7 +3246,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "She's[SP]a[SP]huge[SP]period[SP]drama[SP]nut,[SP]so[SP]I[SP]told[SP]my\nfriends[SP]she[SP]probably[SP]talks[SP]that[SP]way[SP]in[SP]real\nlife.[SP]And[SP]sure[SP]enough![SP]Color[SP]me[SP]surprised.",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Elle est fan de\ndrames historiques, donc j'ai\ndit à mes amies\nqu'elle parlait comme ça dans\nla vraie vie. Et c'est le cas! Tiens donc."
+    "texte_fr": "Elle est fan de\ndrames historiques, donc j'ai\ndit à mes amies qu'elle parlait comme ça dans la vraie vie. Et c'est le cas! Tiens donc."
   },
   {
     "id": 208,

--- a/traduction/event_scripts/script_343.json
+++ b/traduction/event_scripts/script_343.json
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]can't[SP]blame[SP]Ginko[SP]for[SP]worrying...[1205][001E][SP]I[SP]feel\nlike[SP]the[SP]weight[SP]of[SP]the[SP]world[SP]is[SP]being[SP]forced\non[SP]our[SP]shoulders.[SP]It[SP]kind[SP]of[SP]sucks.",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'en veux pas à Ginko de s'inquiéter...[1205][001E]\nJ'ai l'impression de sentir tout le poids\ndu monde sur mes épaules. Et ça craint."
+    "texte_fr": "J'en veux pas à Ginko de s'inquiéter...[001E][1205]\nJ'ai l'impression de sentir tout le poids\ndu monde sur mes épaules. Et ça craint."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Was[SP]that[SP]the[SP]Taurus[SP]Temple[SP]in[SP]Kounan?[SP][1205][000F]I'm[SP]a\nTaurus...[SP]so[SP]my[SP]shadow's[SP]probably[SP]there.[1205][000F]\nWe[SP]gotta[SP]hurry[SP]and[SP]get[SP]that[SP]crystal[SP]skull.",
     "nom_fr": "Ginko",
-    "texte_fr": "C'était pas le Temple de Taurus à Kounan?\n[1205][000F][1205][000F]Je suis un Taureau... donc mon ombre doit\ny être. Récupérons le crâne en vitesse."
+    "texte_fr": "C'était pas le Temple de Taurus à Kounan?\n[000F][1205][000F][1205]Je suis un Taureau... donc mon ombre doit\ny être. Récupérons le crâne en vitesse."
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Quit[SP]joking[SP]around,[SP]Eikichi![1205][000F][SP]I'm[SP]never[SP]gonna\nforgive[SP]that[SP]guy.[1205][000F][SP]I[SP]won't[SP]stop[SP]until[SP]I've\nbeaten[SP]his[SP]sneering[SP]face[SP]to[SP]a[SP]pulp!",
     "nom_fr": "Ginko",
-    "texte_fr": "Arrête de plaisanter, Eikichi! [1205][000F][1205][000F]Je\npardonnerai jamais à\nce type. Je m'arrêterai\npas avant d'avoir tabassé sa sale tête!"
+    "texte_fr": "Arrête de plaisanter, Eikichi! [000F][1205][000F][1205]Je\npardonnerai jamais à\nce type. Je m'arrêterai pas avant d'avoir tabassé sa sale tête!"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "That[SP]goes[SP]double[SP]for[SP]that[SP]Sasaki[SP]loser...[1205][001E]\nI[SP]wonder[SP]how[SP]many[SP]people[SP]lost[SP]everything[SP]for\ntheir[SP]dreams[SP]so[SP]far...",
     "nom_fr": "Ginko",
-    "texte_fr": "Ce sera double ration pour ce naze de\nSasaki...[1205][001E] Qui sait combien de gens\nont tout perdu pour leurs rêves..."
+    "texte_fr": "Ce sera double ration pour ce naze de\nSasaki...[001E][1205] Qui sait combien de gens\nont tout perdu pour leurs rêves..."
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Leo[SP]Temple...[1205][000F][SP]That[SP]means[SP]your[SP]shadow[SP]might\nbe[SP]waiting[SP]for[SP]us[SP]in[SP]Aoba.[1205][000F][SP]Be[SP]careful,\n[1113]-kun.",
     "nom_fr": "Maya",
-    "texte_fr": "Le Temple de Leo.[1205][000F][1205][000F].. Cela veut dire que ton\nombre nous attend à Aoba. Sois prudent,\n[1113]."
+    "texte_fr": "Le Temple de Leo.[000F][1205][000F][1205].. Cela veut dire que ton\nombre nous attend à Aoba. Sois prudent,\n[1113]."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We've[SP]already[SP]gotten[SP]the[SP]crystal[SP]skull[SP]from\nLeo[SP]Temple.[1205][000F][SP]Which[SP]ones[SP]are[SP]left?",
     "nom_fr": "Maya",
-    "texte_fr": "On a déjà le crâne de crystal du Temple\nde Leo. [1205][000F]Il nous manque lesquels?"
+    "texte_fr": "On a déjà le crâne de crystal du Temple\nde Leo. [000F][1205]Il nous manque lesquels?"
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Jun",
     "texte_orig": "There[SP]should[SP]be[SP]a[SP]crystal[SP]skull[SP]at[SP]the[SP]temple\nin[SP]Hirasaka[SP]too.[1205][000F][SP]We[SP]can't[SP]let[SP]either[SP]the[SP]Masked\nCircle[SP]or[SP]the[SP]Last[SP]Battalion[SP]get[SP]it...",
     "nom_fr": "Jun",
-    "texte_fr": "Un crâne devrait aussi se trouver au temple\nd'Hirasaka. [1205][000F]On ne peut\npas laisser le Cercle\nMasqué ou le Bataillon s'en emparer..."
+    "texte_fr": "Un crâne devrait aussi se trouver au temple\nd'Hirasaka. [000F][1205]On ne peut\npas laisser le Cercle Masqué ou le Bataillon s'en emparer..."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Jun",
     "texte_orig": "We've[SP]already[SP]retrieved[SP]the[SP]crystal[SP]skull[SP]from\nthe[SP]temple[SP]in[SP]Hirasaka.[1205][000F][SP]Let's[SP]go[SP]after[SP]the\nothers[SP]now.",
     "nom_fr": "Jun",
-    "texte_fr": "Nous avons déjà récupéré le crâne\nde crystal du temple d'Hirasaka.\n[1205][000F]Allons chercher les autres."
+    "texte_fr": "Nous avons déjà récupéré le crâne\nde crystal du temple d'Hirasaka.\n[000F][1205]Allons chercher les autres."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Jun",
     "texte_orig": "It[SP]was[SP]me[SP]who[SP]made[SP]Ginji[SP]Sasaki[SP]an[SP]executive...[1205][000F]\nIt's[SP]ultimately[SP]my[SP]responsibility[SP]that[SP]he[SP]stole\nthe[SP]Ideal[SP]Energy[SP]from[SP]Lisa's[SP]friends...",
     "nom_fr": "Jun",
-    "texte_fr": "C'est moi qui ai fait de Ginji Sasaki un\n[1205][000F]exécutif... Je suis responsable du vol\nde l'Énergie Idéale des amies de Lisa..."
+    "texte_fr": "C'est moi qui ai fait de Ginji Sasaki un\n[000F][1205]exécutif... Je suis responsable du vol\nde l'Énergie Idéale des amies de Lisa..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Jun",
     "texte_orig": "My[SP]false[SP]memories[SP]and[SP]true[SP]memories[SP]conflicted\nwith[SP]each[SP]other,[SP]causing[SP]me[SP]to[SP]subconsciously\nreach[SP]out[SP]to[SP]Lisa...[1205][000F][SP]My[SP]sins[SP]will[SP]never[SP]fade...",
     "nom_fr": "Jun",
-    "texte_fr": "Mes vrais et\nfaux souvenirs s'entrechoquent,\net me rapprochent\ninconsciemment de Lisa...\n[1205][000F]Mes péchés ne s'effaceront jamais..."
+    "texte_fr": "Mes vrais et\nfaux souvenirs s'entrechoquent,\net me rapprochent inconsciemment de Lisa... [000F][1205]Mes péchés ne s'effaceront jamais..."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Ack![SP]This[SP]is[SP]terrible![1205][000A][SP]The[SP]city's[SP]flying![1205][000F]\nAieeeee![SP]Everyone[SP]panic!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Ack! C'est terrible! [1205][000A][1205]La ville\nvole! [000F]Aaaaah! C'est la panique!"
+    "texte_fr": "Ack! C'est terrible! [000A][1205][1205]La ville\nvole! [000F]Aaaaah! C'est la panique!"
   },
   {
     "id": 18,
@@ -463,7 +463,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Okay,[SP]that[SP]was[SP]worth[SP]it.[1205][000F][SP]Sure,[SP]I'll[SP]tell[SP]you\nwhat[SP]I[SP]know.[1205][000F][SP]Are[SP]you[SP]ready[SP]for[SP]this?",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "OK, ça valait le coup. [1205][000F][1205][000F]Bien sûr, je vais\nte donner mes infos. T'es bien accroché?"
+    "texte_fr": "OK, ça valait le coup. [000F][1205][000F][1205]Bien sûr, je vais\nte donner mes infos. T'es bien accroché?"
   },
   {
     "id": 27,
@@ -493,7 +493,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Huh?[SP]You[SP]saw[SP]a[SP]REAL[SP]ghost[SP]at[SP]the[SP]clock[SP]tower\nin[SP]Sevens!?[SP]Seriously?[SP]You're[SP]not[SP]pulling[SP]my\nleg[SP]here?",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Hein? T'as vu un\nVRAI fantôme dans l'horloge\nde Seven!? Sérieux? Tu\nme fais pas marcher là?"
+    "texte_fr": "Hein? T'as vu un\nVRAI fantôme dans l'horloge\nde Seven!? Sérieux? Tu me fais pas marcher là?"
   },
   {
     "id": 29,
@@ -523,7 +523,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "But[SP]now[SP]I[SP]know![1205][000F][SP]Okay,[SP]my[SP]turn!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Maintenant je sais! [1205][000F]À mon tour!"
+    "texte_fr": "Maintenant je sais! [000F][1205]À mon tour!"
   },
   {
     "id": 31,
@@ -538,7 +538,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "There's[SP]this[SP]place[SP][E4][NULL][NULL][0006]Tony's[SP]Shop[E4][NULL][NULL][0002][SP]in[SP]Yumezaki.\nRumor[SP]is[SP]you[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002][SP]there![1205][000F]\nHis[SP][E4][NULL][NULL][0006]prices[SP]and[SP]quality[SP]are[SP]okay[E4][NULL][NULL][0002],[SP]I[SP]guess.",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Y'a ce coin, [E4][NULL][NULL][0006]Tony's Shop[E4][NULL][NULL][0002] à Yumezaki. La\nrumeur dit qu'on y\nvend de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]! [1205][000F]Les\n[E4][NULL][NULL][0006]prix et la qualité sont corrects[E4][NULL][NULL][0002], je crois."
+    "texte_fr": "Y'a ce coin, [E4][NULL][NULL][0006]Tony's Shop[E4][NULL][NULL][0002] à Yumezaki. La\nrumeur dit qu'on y\nvend de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]! [000F][1205]Les [E4][NULL][NULL][0006]prix et la qualité sont corrects[E4][NULL][NULL][0002], je crois."
   },
   {
     "id": 32,
@@ -553,7 +553,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Hmm?[SP]The[SP]Undie[SP]Boss[SP]at[SP]Kasugayama[SP]High[SP]is\nstepping[SP]down?[1205][000F][SP]That's[SP]amazing![SP]We[SP]can[SP]always\nuse[SP]rumors[SP]about[SP]Cuss[SP]High![SP]Now[SP]for[SP]yours...",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Hmm? Le Boss des Calbutes du lycée Kakasu\nprend sa retraite? [1205][000F]Excellent! Ça sert\ntoujours, une rumeur sur\nKakasu! Quant à latienne..."
+    "texte_fr": "Hmm? Le Boss des Calbutes du lycée Kakasu\nprend sa retraite? [000F][1205]Excellent! Ça sert\ntoujours, une rumeur sur Kakasu! Quant à latienne..."
   },
   {
     "id": 33,
@@ -598,7 +598,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Okay,[SP]did[SP]you[SP]know[SP]the[SP][E4][NULL][NULL][0006]Jolly[SP]Roger[E4][NULL][NULL][0002][SP]cafe[SP]in\nKounan[SP][E4][NULL][NULL][0006]sells[SP]real[SP]weapons[E4][NULL][NULL][0002]?[1205][000F][SP]Their[SP][E4][NULL][NULL][0006]selection[SP]is\ngreat,[SP]but[SP]their[SP]resale[SP]prices[SP]are[SP]the[SP]pits[E4][NULL][NULL][0002].",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Bien, tu savais que le café [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à\nKounan [E4][NULL][NULL][0006]vendait de vraies armes[E4][NULL][NULL][0002]?\n[1205][000F]Il y a [E4][NULL][NULL][0006]du très\nbon choix, mais le\nprix de revente estabyssal[E4][NULL][NULL][0002]."
+    "texte_fr": "Bien, tu savais que le café [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à\nKounan [E4][NULL][NULL][0006]vendait de vraies armes[E4][NULL][NULL][0002]?\n[000F][1205]Il y a [E4][NULL][NULL][0006]du très bon choix, mais le prix de revente estabyssal[E4][NULL][NULL][0002]."
   },
   {
     "id": 36,
@@ -628,7 +628,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Ooooh,[SP]it's[SP]like[SP]in[SP]the[SP]movies![1205][000F][SP]Everyone[SP]has\ntheir[SP]secrets.",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Ooooh, comme dans les films!\n[1205][000F]Enfin, on a tous nos secrets."
+    "texte_fr": "Ooooh, comme dans les films!\n[000F][1205]Enfin, on a tous nos secrets."
   },
   {
     "id": 38,
@@ -673,7 +673,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Huh?[SP]There[SP]really[SP]was[SP]a[SP]secret[SP]lounge[SP]in[SP]Zodiac?\nIt's[SP]like[SP]a[SP]maze,[SP]eh?[SP]Now[SP]that's[SP]impressive\nfootwork.[SP]Here's[SP]what[SP]I[SP]know[SP]in[SP]return...",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Il y avait un salon secret au Zodiac? Comme\ndans un labyrinthe, hein? C'est fou d'avoir\ntrouvé ça. En retour,\nvoilà ce que je sais..."
+    "texte_fr": "Il y avait un salon secret au Zodiac? Comme\ndans un labyrinthe, hein? C'est fou d'avoir\ntrouvé ça. En retour, voilà ce que je sais..."
   },
   {
     "id": 41,
@@ -688,7 +688,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "That[SP]store[SP][E4][NULL][NULL][0006]Anima[SP]Mundi[E4][NULL][NULL][0002][SP]around[SP]here[SP]sells[SP][E4][NULL][NULL][0006]real\nweapons[E4][NULL][NULL][0002].[1205][000F][SP]They[SP]have[SP][E4][NULL][NULL][0006]an[SP]amazing[SP]selection,[SP]but\npretty[SP]low[SP]buyback[SP]prices[E4][NULL][NULL][0002].",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Le magasin [E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002] près d'ici vend de\n[E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. [1205][000F]Il y a [E4][NULL][NULL][0006]une sélection\nincroyable, mais des prix\nde rachat très bas[E4][NULL][NULL][0002]."
+    "texte_fr": "Le magasin [E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002] près d'ici vend de\n[E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. [000F][1205]Il y a [E4][NULL][NULL][0006]une sélection\nincroyable, mais des prix de rachat très bas[E4][NULL][NULL][0002]."
   },
   {
     "id": 42,
@@ -703,7 +703,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "The[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High[SP]used[SP]to[SP]be[SP]one\nof[SP]the[SP]Undie[SP]Boss'[SP]henchmen?[SP]Wow![SP]The[SP]low\novercomes[SP]the[SP]high![1205][000F][SP]But[SP]I[SP]can[SP]top[SP]that.",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Le nouveau chef de Kakasu était un des\nlarbins du Boss des Calbutes? Wow! David\na battu Goliath! [1205][000F]Mais j'ai encore mieux."
+    "texte_fr": "Le nouveau chef de Kakasu était un des\nlarbins du Boss des Calbutes? Wow! David\na battu Goliath! [000F][1205]Mais j'ai encore mieux."
   },
   {
     "id": 43,
@@ -718,7 +718,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Did[SP]you[SP]know[SP]there's[SP]a[SP][E4][NULL][NULL][0006]Rosa[SP]Candida[E4][NULL][NULL][0002][SP]in[SP]Aoba\ntoo?[1205][000F][SP]They[SP]sell[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002][SP]there.[SP]It's[SP][E4][NULL][NULL][0006]super\nhigh[SP]quality,[SP]but[SP]also[SP]super[SP]expensive[E4][NULL][NULL][0002].",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Tu savais qu'il y avait\nun [E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002] à Aoba\n[1205]aussi? [000F]Ils vendent\nde [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]là-bas. La\n[E4][NULL][NULL][0006]qualité et le prix sont très hauts[E4][NULL][NULL][0002]."
+    "texte_fr": "Tu savais qu'il y avait\nun [E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002] à Aoba\n[1205]aussi? [000F]Ils vendent de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]là-bas. La [E4][NULL][NULL][0006]qualité et le prix sont très hauts[E4][NULL][NULL][0002]."
   },
   {
     "id": 44,
@@ -733,7 +733,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Whoa![SP]The[SP]lucky[SP]cat[SP]statue[SP]at[SP]the[SP]Kuzunoha\nDetective[SP]Agency[SP]can[SP]talk!?[1205][000F][SP]Squeee![SP]That's\nso[SP]cute![SP]I[SP]wanna[SP]see[SP]it!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Woah! La statue de chat du bonheur à\nl'Agence de Détective Kuzunoha peut\n[1205][000F]parler!? Aaaah! Trop chou! Je veux voir!"
+    "texte_fr": "Woah! La statue de chat du bonheur à\nl'Agence de Détective Kuzunoha peut\n[000F][1205]parler!? Aaaah! Trop chou! Je veux voir!"
   },
   {
     "id": 45,
@@ -748,7 +748,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Okay,[SP]here's[SP]mine.[1205][000F][SP][E4][NULL][NULL][0006]London[SP]Clothier[E4][NULL][NULL][0002][SP]in[SP]Kounan\neven[SP]tailors[SP][E4][NULL][NULL][0006]armor[E4][NULL][NULL][0002]![SP]The[SP][E4][NULL][NULL][0006]quality[SP]is[SP]great,\nbut[SP]it's[SP]very[SP]pricey[E4][NULL][NULL][0002].",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Bien, à moi. [1205][000F][E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] à Kounan\nconçoit aussi des [E4][NULL][NULL][0006]armures[E4][NULL][NULL][0002]! La [E4][NULL][NULL][0006]qualité\nest géniale, mais c'est très cher[E4][NULL][NULL][0002]."
+    "texte_fr": "Bien, à moi. [000F][1205][E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] à Kounan\nconçoit aussi des [E4][NULL][NULL][0006]armures[E4][NULL][NULL][0002]! La [E4][NULL][NULL][0006]qualité\nest géniale, mais c'est très cher[E4][NULL][NULL][0002]."
   },
   {
     "id": 46,
@@ -763,7 +763,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Say[SP]what?[1205][000F][SP]Tamaki[SP]at[SP]the[SP]detective[SP]agency[SP]is\nactually[SP]a[SP]Devil[SP]Summoner?[1205][000F][SP]What[SP]the[SP]heck\nis[SP]that?",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Quoi? [1205][000F][1205][000F]Tamaki de l'agence de\ndétective est en réalité une Devil\nSummoner? C'est quoi comme truc?"
+    "texte_fr": "Quoi? [000F][1205][000F][1205]Tamaki de l'agence de\ndétective est en réalité une Devil\nSummoner? C'est quoi comme truc?"
   },
   {
     "id": 47,
@@ -793,7 +793,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "If[SP]you[SP]win[SP]the[SP][E4][NULL][NULL][0006]magazine[SP]sweepstakes[E4][NULL][NULL][0002],[SP]you[SP]get\n[E4][NULL][NULL][0006]real[SP]weapons[SP]and[SP]items[E4][NULL][NULL][0002].[1205][000F][SP]I[SP]hear[SP][E4][NULL][NULL][0006]it's[SP]easy[SP]to\nwin,[SP]but[SP]the[SP]prizes[SP]are[SP]kinda[SP]lame[E4][NULL][NULL][0002].",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "En gagnant à la [E4][NULL][NULL][0006]lotterie du magazine[E4][NULL][NULL][0002], tu\nauras des [E4][NULL][NULL][0006]objets et de vraies armes[E4][NULL][NULL][0002].[1205][000F][E4][NULL][NULL][0006] Gagner\nest facile, mais les lots sont passables[E4][NULL][NULL][0002]."
+    "texte_fr": "En gagnant à la [E4][NULL][NULL][0006]lotterie du magazine[E4][NULL][NULL][0002], tu\nauras des [E4][NULL][NULL][0006]objets et de vraies armes[E4][NULL][NULL][0002].[000F][1205][E4][NULL][NULL][0006] Gagner\nest facile, mais les lots sont passables[E4][NULL][NULL][0002]."
   },
   {
     "id": 49,
@@ -823,7 +823,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Wow,[SP]can[SP]I[SP]join!?[1205][000F][SP]Oh,[SP]but[SP]what[SP]if[SP]he[SP]pulls[SP]down\nmy[SP]pants?[SP]F-Forget[SP]it!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Wow, je peux en être![1205][000F]? Oh, mais s'il\nm'enlevait mon pantalon? O-Oublie!"
+    "texte_fr": "Wow, je peux en être![000F][1205]? Oh, mais s'il\nm'enlevait mon pantalon? O-Oublie!"
   },
   {
     "id": 51,
@@ -838,7 +838,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "[E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002][SP]in[SP]Yumezaki[SP]is[SP]secretly[SP]a[SP][E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002]![1205][000F][SP]From[SP]what\nI[SP]hear,[SP]several[SP]people[SP]won[SP]big[SP]at[SP][E4][NULL][NULL][0006]blackjack[E4][NULL][NULL][0002].",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "[E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002] à Yumezaki est un [E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002]\n[1205][000F]secret! Pas mal de gens auraient\ntouché le gros lot au [E4][NULL][NULL][0006] blackjack[E4][NULL][NULL][0002]."
+    "texte_fr": "[E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002] à Yumezaki est un [E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002]\n[000F][1205]secret! Pas mal de gens auraient\ntouché le gros lot au [E4][NULL][NULL][0006] blackjack[E4][NULL][NULL][0002]."
   },
   {
     "id": 52,
@@ -853,7 +853,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Huh!?[1205][000F][SP]Wait,[SP]so[SP]the[SP]reason[SP]for[SP]those[SP]attacks\nwas[SP]to[SP]make[SP]the[SP]temples[SP]appear?",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Hein![1205][000F]? Attend, donc c'était pour faire\napparaître ces temples les attaques?"
+    "texte_fr": "Hein![000F][1205]? Attend, donc c'était pour faire\napparaître ces temples les attaques?"
   },
   {
     "id": 53,
@@ -868,7 +868,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Then[SP]it[SP]really[SP]was[SP]part[SP]of[SP]the[SP]Oracle?[1205][000A][SP]And[SP]the\nMasked[SP]Circle[SP]was[SP]behind[SP]it?[1205][000A][SP]Oh,[SP]do[SP]I[SP]need[SP]to\nspill[SP]first[SP]before[SP]you[SP]tell[SP]me[SP]more?[1205][000F][SP]Gotcha!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "C'était vraiment dans\nl'Oracle? [1205][000A][1205][000A][1205]Et le Cercle\nMasqué était derrière tout ça? Oh, je dois\nparler aussi pour en\nsavoir plus, hein? [000F]Pigé!"
+    "texte_fr": "C'était vraiment dans\nl'Oracle? [000A][1205][000A][1205][1205]Et le Cercle\nMasqué était derrière tout ça? Oh, je dois parler aussi pour en savoir plus, hein? [000F]Pigé!"
   },
   {
     "id": 54,
@@ -913,7 +913,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Please[SP]let[SP]me[SP]know[SP]if[SP]you[SP]happen[SP]to[SP]run[SP]across\nher![1205][000F][SP]I'm[SP]begging[SP]you!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "S'il vous plaît, prévenez-moi si\nvous la croisez! [1205][000F]Je vous en prie!"
+    "texte_fr": "S'il vous plaît, prévenez-moi si\nvous la croisez! [000F][1205]Je vous en prie!"
   },
   {
     "id": 57,
@@ -928,7 +928,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Huh!?[1205][000F][SP]You[SP]found[SP]Kozy-senpai?[1205][000F][SP]Thank[SP]goodness...",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Hein? [1205][000F][1205][000F]Vous avez trouvé Kozy? Dieu merci..."
+    "texte_fr": "Hein? [000F][1205][000F][1205]Vous avez trouvé Kozy? Dieu merci..."
   },
   {
     "id": 58,
@@ -943,7 +943,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Whoa,[SP]but[SP]why's[SP]she[SP]so[SP]scrawny?[1205][000F][SP]She[SP]must[SP]have\ngone[SP]through[SP]hell,[SP]poor[SP]girl...[1205][000F][SP]I[SP]feel[SP]so\nawful[SP]for[SP]her...",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Woah, pourquoi elle est aussi\n[1205][000F][1205][000F]efflanquée? Elle a du vivre l'enfer, la\npauvre... Je me sens mal pour elle..."
+    "texte_fr": "Woah, pourquoi elle est aussi\n[000F][1205][000F][1205]efflanquée? Elle a du vivre l'enfer, la\npauvre... Je me sens mal pour elle..."
   },
   {
     "id": 59,
@@ -973,7 +973,7 @@
     "nom_orig": "Rumormonger[SP]Chikarin",
     "texte_orig": "Okay.[SP]I'm[SP]always[SP]here,[SP]so[SP]come[SP]see[SP]me[SP]anytime![1205][000F]\nAdieu!",
     "nom_fr": "Commère Chikarin",
-    "texte_fr": "Ok. Je reste ici, donc\nviens quand tu veux! [1205][000F]Ciao!"
+    "texte_fr": "Ok. Je reste ici, donc\nviens quand tu veux! [000F][1205]Ciao!"
   },
   {
     "id": 61,
@@ -988,7 +988,7 @@
     "nom_orig": "Kazuya",
     "texte_orig": "Look[SP]at[SP]this.[SP]The[SP]whole[SP]city's[SP]taken[SP]off.[1205][000F]\nWe're[SP]on[SP]the[SP]real[SP]Xibalba,[SP]and[SP]we're[SP]really\ngonna[SP]evolve[SP]into[SP]Idealians.",
     "nom_fr": "Kazuya",
-    "texte_fr": "Regarde ça. Toute la ville s'est\nenvolée. [1205][000F]On est vraiment sur Xibalba,\net on va vraiment évoluer en Idéaliens."
+    "texte_fr": "Regarde ça. Toute la ville s'est\nenvolée. [000F][1205]On est vraiment sur Xibalba,\net on va vraiment évoluer en Idéaliens."
   },
   {
     "id": 62,
@@ -1003,7 +1003,7 @@
     "nom_orig": "Kazuya",
     "texte_orig": "Nah.[SP]We[SP]wouldn't[SP]survive[SP]that[SP]up[SP]here[SP]either.[1205][000F]\nI[SP]bet[SP]it's[SP]gonna[SP]have[SP]something[SP]to[SP]do[SP]with[SP]the\ngravitational[SP]pull[SP]of[SP]the[SP]planets.",
     "nom_fr": "Kazuya",
-    "texte_fr": "Nan. On pourrait même pas survivre\n[1205][000F]aussi haut. Ça doit être lié à la\nforce gravitationnelle des planètes."
+    "texte_fr": "Nan. On pourrait même pas survivre\n[000F][1205]aussi haut. Ça doit être lié à la\nforce gravitationnelle des planètes."
   },
   {
     "id": 63,
@@ -1018,7 +1018,7 @@
     "nom_orig": "Kazuya",
     "texte_orig": "I[SP]got[SP]this[SP]secondhand,[SP]but[SP]when[SP]the[SP]Grand[SP]Cross\nis[SP]done,[SP]the[SP]balance[SP]of[SP]gravity[SP]between[SP]the\nplanets[SP]is[SP]going[SP]to[SP]be[SP]thrown[SP]off.",
     "nom_fr": "Kazuya",
-    "texte_fr": "L'info est pas de moi, mais quand la Croix\nCosmique se réalisera, l'équilibre\ngravitationnel entre\nles planètes disparaîtra."
+    "texte_fr": "L'info est pas de moi, mais quand la Croix\nCosmique se réalisera, l'équilibre\ngravitationnel entre les planètes disparaîtra."
   },
   {
     "id": 64,
@@ -1048,7 +1048,7 @@
     "nom_orig": "Yukiko",
     "texte_orig": "But[SP]if[SP]the[SP]Grand[SP]Cross[SP]happens,[SP]won't[SP]the[SP]Earth\nbe[SP]annihilated?[1205][000F][SP]How's[SP]that[SP]work[SP]exactly?",
     "nom_fr": "Yukiko",
-    "texte_fr": "Mais si la Croix Cosmique se réalise, la\nTerre sera pas\n[1205][000F]annihilée? Comment ça marche?"
+    "texte_fr": "Mais si la Croix Cosmique se réalise, la\nTerre sera pas\n[000F][1205]annihilée? Comment ça marche?"
   },
   {
     "id": 66,
@@ -1063,7 +1063,7 @@
     "nom_orig": "Yukiko",
     "texte_orig": "Hey,[SP]Kazuya.[SP]I've[SP]been[SP]thinking.[1205][000F][SP]Maybe[SP]the\nworld[SP]will[SP]be[SP]destroyed[SP]by[SP]cosmic[SP]rays.[1205][000F][SP]Y'know,\nthe[SP]invisible[SP]stuff[SP]that's[SP]everywhere[SP]in[SP]space?",
     "nom_fr": "Yukiko",
-    "texte_fr": "Hé, Kazuya. Je me disais. [1205][000F][1205][000F]Le monde sera\npeut-être détruit par des rayonnements\ncosmiques. Tu sais,\nles machins invisiblesdans l'espace?"
+    "texte_fr": "Hé, Kazuya. Je me disais. [000F][1205][000F][1205]Le monde sera\npeut-être détruit par des rayonnements\ncosmiques. Tu sais, les machins invisiblesdans l'espace?"
   },
   {
     "id": 67,
@@ -1078,7 +1078,7 @@
     "nom_orig": "Yukiko",
     "texte_orig": "Earth[SP]is[SP]at[SP]the[SP]center[SP]of[SP]the[SP]Grand[SP]Cross,\nright?[1205][000F][SP]So[SP]maybe[SP]the[SP]cosmic[SP]rays[SP]from[SP]other\nplanets[SP]are[SP]gonna[SP]get[SP]focused[SP]on[SP]Earth.[1205][000F][SP]Well?",
     "nom_fr": "Yukiko",
-    "texte_fr": "La Terre est au\ncentre de la Croix Cosmique,\n[1205][000F][1205][000F]non? Les rayons des autres planètes\npourraient se concentrer\nsur la Terre. Alors?"
+    "texte_fr": "La Terre est au\ncentre de la Croix Cosmique,\n[000F][1205][000F][1205]non? Les rayons des autres planètes pourraient se concentrer sur la Terre. Alors?"
   },
   {
     "id": 68,
@@ -1123,7 +1123,7 @@
     "nom_orig": "Yukiko",
     "texte_orig": "Huh!?[1205][000A][SP]Wow,[SP]that's[SP]really[SP]bad.[1205][000F][SP]Centrifugal\nforces[SP]would[SP]blow[SP]away[SP]everything[SP]on[SP]Earth.\nIt's[SP]gonna[SP]be[SP]a[SP]wasteland[SP]down[SP]there...",
     "nom_fr": "Yukiko",
-    "texte_fr": "Hein![1205][000A][1205]? [000F]Wow, c'est vraiment pas bon. La\nforce centrifuge va tout balayer sur\nTerre. Il ne restera que la désolation..."
+    "texte_fr": "Hein![000A][1205][1205]? [000F]Wow, c'est vraiment pas bon. La\nforce centrifuge va tout balayer sur\nTerre. Il ne restera que la désolation..."
   },
   {
     "id": 71,
@@ -1244,7 +1244,7 @@
     "nom_orig": "Part-timer",
     "texte_orig": "How[SP]wondrous[SP]that[SP]our[SP]fair[SP]city[SP]has[SP]actually\ntaken[SP]flight.[1205][000F][SP]It[SP]would[SP]seem[SP]the[SP]soothsaying\nin[SP]that[SP]book[SP]was[SP]true...",
     "nom_fr": "Intérimaire",
-    "texte_fr": "L'envol de la ville est assez\nmerveilleux. [1205][000F]Le caractère divinatoire\nde cet ouvrage n'était point feint."
+    "texte_fr": "L'envol de la ville est assez\nmerveilleux. [000F][1205]Le caractère divinatoire\nde cet ouvrage n'était point feint."
   },
   {
     "id": 76,
@@ -1259,7 +1259,7 @@
     "nom_orig": "Part-timer",
     "texte_orig": "But[SP]it[SP]also[SP]foretells[SP]our[SP]evolution.[1205][000F][SP]I[SP]know[SP]not\nthe[SP]nature[SP]of[SP]an[SP]Idealian,[SP]but[SP]I[SP]am[SP]atingle\nat[SP]the[SP]thought[SP]of[SP]becoming[SP]one.",
     "nom_fr": "Intérimaire",
-    "texte_fr": "Mais il prédit aussi notre évolution. [1205][000F]Je\nne sais rien de la nature Idéalienne,\nmais l'idée d'y adhérer est excitante."
+    "texte_fr": "Mais il prédit aussi notre évolution. [000F][1205]Je\nne sais rien de la nature Idéalienne,\nmais l'idée d'y adhérer est excitante."
   },
   {
     "id": 77,
@@ -1274,7 +1274,7 @@
     "nom_orig": "Part-timer",
     "texte_orig": "I[SP]am[SP]most[SP]grateful[SP]for[SP]your[SP]patronage.[1205][000F]\nI[SP]shall[SP]look[SP]forward[SP]to[SP]the[SP]day[SP]you[SP]decide\nto[SP]brighten[SP]our[SP]establishment[SP]once[SP]more.",
     "nom_fr": "Intérimaire",
-    "texte_fr": "Je vous suis obligée de votre appui.\n[1205][000F]Je suis impatiente que vous honoriez\nnotre établissement en y revenant."
+    "texte_fr": "Je vous suis obligée de votre appui.\n[000F][1205]Je suis impatiente que vous honoriez\nnotre établissement en y revenant."
   },
   {
     "id": 78,

--- a/traduction/event_scripts/script_344.json
+++ b/traduction/event_scripts/script_344.json
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Ohhhhhohoh...[1205][000F][SP]I[SP]get[SP]it...[SP]I[SP]think[SP]Yukino-san\nhas[SP]a[SP]thing[SP]for[SP]that[SP]Fujii[SP]guy.",
     "nom_fr": "Ginko",
-    "texte_fr": "Ohhhhhohoh.[1205][000F].. Je vois... Je crois que\nYukino en pince pour ce gars, Fujii."
+    "texte_fr": "Ohhhhhohoh.[000F][1205].. Je vois... Je crois que\nYukino en pince pour ce gars, Fujii."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "...Pretty[SP]obvious,[SP]huh?[1205][000F][SP]I[SP]can't[SP]believe[SP]Maya-san\nnever[SP]noticed,[SP]working[SP]that[SP]close[SP]to[SP]them...",
     "nom_fr": "Ginko",
-    "texte_fr": "... Évident, hein? [1205][000F]Vu qu'elle\nbosse avec eux, je trouve ça fou\nque Maya l'ai jamais remarqué."
+    "texte_fr": "... Évident, hein? [000F][1205]Vu qu'elle\nbosse avec eux, je trouve ça fou\nque Maya l'ai jamais remarqué."
   },
   {
     "id": 7,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Maybe[SP]if[SP]we[SP]ask[SP]someone[SP]here,[SP]we[SP]can[SP]find[SP]out\nwho[SP]brought[SP]the[SP]In[SP]Lak'ech[SP]here[SP]to[SP]begin[SP]with.",
     "nom_fr": "Ginko",
-    "texte_fr": "En demandant à\nquelqu'un, on pourrait trouver\nqui a amené l'In Lak'Ech\nici en premier lieu."
+    "texte_fr": "En demandant à\nquelqu'un, on pourrait trouver\nqui a amené l'In Lak'Ech ici en premier lieu."
   },
   {
     "id": 10,
@@ -237,7 +237,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I'm[SP]sorry,[SP][1113]...[1205][000F][SP]I...[SP]would[SP]rather[SP]not\nstay[SP]here...[1205][000F][SP]Too[SP]many[SP]memories[SP]of[SP]Yukki[SP]and\nFujii-san...",
     "nom_fr": "Maya",
-    "texte_fr": "Désolée, [1113].[1205][000F][1205].[000F]. Je... ne veux\npas rester ici... J'ai trop de\nsouvenirs de Yukki et Fujii ici..."
+    "texte_fr": "Désolée, [1113].[000F][1205][1205].[000F]. Je... ne veux\npas rester ici... J'ai trop de\nsouvenirs de Yukki et Fujii ici..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Maya",
     "texte_orig": "S-Sorry...[SP]It's[SP]just,[SP]whenever[SP]I'm[SP]here,\nI[SP]remember[SP]Fujii-san...[1205][000F][SP]I[SP]have[SP]to[SP]get[SP]a\nhold[SP]of[SP]myself...",
     "nom_fr": "Maya",
-    "texte_fr": "P-pardon... C'est juste que\nquand je viens ici, je repense à\n[1205][000F]Fujii... Je dois me reprendre..."
+    "texte_fr": "P-pardon... C'est juste que\nquand je viens ici, je repense à\n[000F][1205]Fujii... Je dois me reprendre..."
   },
   {
     "id": 17,
@@ -312,7 +312,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Huh...[1205][000F][SP]Maybe[SP]that's[SP]why[SP]she[SP]always[SP]acts[SP]so\nfunny[SP]around[SP]him.[1205][000F][SP]Strange,[SP]huh?",
     "nom_fr": "Maya",
-    "texte_fr": "Hm.[1205][000F][1205].[000F]. C'est peut-être pour ça qu'elle\nest bizarre avec lui. Étrange, non?"
+    "texte_fr": "Hm.[000F][1205][1205].[000F]. C'est peut-être pour ça qu'elle\nest bizarre avec lui. Étrange, non?"
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "O-Oh[SP]yeah...[1205][000F][SP]L-Lemme[SP]introduce[SP]you[SP]guys...[1205][000F]\nTh...[SP]This[SP]is[SP]my[SP]boss,[SP]Fujii-san.[1205][000F][SP]He's[SP]a\nfreetographer...[SP]I-I[SP]mean...",
     "nom_fr": "Yukino",
-    "texte_fr": "A-ah oui.[1205][000F][1205][000F][1205][000F].. J-j'fais les présentations...\nC... C'est mon boss, Fujii. Il est\nfreetographeur... J-J'veux dire..."
+    "texte_fr": "A-ah oui.[000F][1205][000F][1205][000F][1205].. J-j'fais les présentations...\nC... C'est mon boss, Fujii. Il est\nfreetographeur... J-J'veux dire..."
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Huh?[1205][000A][SP]My[SP]face[SP]is[SP]red?[1205][000F][SP]Sh-Shut[SP]up...![SP]It[SP]isn't\nreally...[SP]uh...[SP]is[SP]it...?[1205][000F][SP]Haha...[SP]Hahahahaha...",
     "nom_fr": "Yukino",
-    "texte_fr": "Hé?[1205][1205][1205][000A] Moi, toute rouge? [000F][000F]F-ferme-là...! C'est\npas... heu...\npeut-être? Haha... Hahahaha..."
+    "texte_fr": "Hé?[1205][1205][000A][1205] Moi, toute rouge? [000F][000F]F-ferme-là...! C'est\npas... heu...\npeut-être? Haha... Hahahaha..."
   },
   {
     "id": 23,
@@ -387,7 +387,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "The[SP]mountain...?[SP]You[SP]mean[SP]the[SP]one[SP]you[SP]always\ngo[SP]to?[SP]Uh...[1205][001E][SP]Things[SP]are[SP]pretty[SP]bad[SP]around[SP]town\nright[SP]now.[SP]I[SP]think[SP]you[SP]should[SP]hold[SP]off...",
     "nom_fr": "Yukino",
-    "texte_fr": "La montagne...? Tu parles\nde celle où tu vas\nsouvent? Heu...[1205][001E] Ça craint beaucoup autour \nde Sumaru là. Tu\ndevrais éviter, je pense..."
+    "texte_fr": "La montagne...? Tu parles\nde celle où tu vas\nsouvent? Heu...[001E][1205] Ça craint beaucoup autour \nde Sumaru là. Tu\ndevrais éviter, je pense..."
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "*sigh*[1205][001E][SP]Hey,[SP][1113],[SP]could[SP]you[SP]help[SP]me[SP]argue\nmy[SP]case[SP]here?[1205]([SP]I[SP]just[SP]don't[SP]think[SP]Fujii-san\nshould[SP]go[SP]right[SP]now...",
     "nom_fr": "Yukino",
-    "texte_fr": "*soupir*[1205][001E] Hé, [1113], tu pourrais\n[1205]m'épauler un peu là? Je pense vraiment\npas que Fujii devrait y aller..."
+    "texte_fr": "*soupir*[001E][1205] Hé, [1113], tu pourrais\n[1205]m'épauler un peu là? Je pense vraiment\npas que Fujii devrait y aller..."
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Oh...[1205][001E][SP]Fujii-san[SP]left[SP]for[SP]his[SP]shoot...",
     "nom_fr": "Yukino",
-    "texte_fr": "Oh...[1205][001E] Fujii est parti travailler..."
+    "texte_fr": "Oh...[001E][1205] Fujii est parti travailler..."
   },
   {
     "id": 28,
@@ -597,7 +597,7 @@
     "nom_orig": "Journalist",
     "texte_orig": "We[SP]actually[SP]received[SP]a[SP]great[SP]submission[SP]from\nthe[SP]public.[SP]We're[SP]publishing[SP]it[SP]right[SP]away.\nIt's[SP]keeping[SP]me[SP]busy,[SP]I'll[SP]tell[SP]you[SP]that!",
     "nom_fr": "Journaliste",
-    "texte_fr": "On vient de nous\nproposer un super manuscrit\nvenu du public. On commence déjà à le \npublier. Ça m'occupe bien, je peux le dire!"
+    "texte_fr": "On vient de nous\nproposer un super manuscrit\nvenu du public. On commence déjà à le publier. Ça m'occupe bien, je peux le dire!"
   },
   {
     "id": 40,
@@ -702,7 +702,7 @@
     "nom_orig": "Fujii",
     "texte_orig": "When[SP]you're[SP]young,[SP]a[SP]relationship[SP]between[SP]a[SP]man\nand[SP]a[SP]woman[SP]tends[SP]toward[SP]romance...[SP]But[SP]that's\nnot[SP]the[SP]only[SP]possibility.",
     "nom_fr": "Fujii",
-    "texte_fr": "Quand on est\njeune, les relations homme-femme\npeuvent tendre vers la romance... Mais ce\nn'est pas la seule possibilité."
+    "texte_fr": "Quand on est\njeune, les relations homme-femme\npeuvent tendre vers la romance... Mais ce n'est pas la seule possibilité."
   },
   {
     "id": 47,
@@ -732,7 +732,7 @@
     "nom_orig": "Fujii",
     "texte_orig": "The[SP]face[SP]of[SP]the[SP]mountain[SP]changes[SP]every[SP]day.[1205][000F]\nIf[SP]I[SP]wait[SP]any[SP]longer,[SP]I[SP]won't[SP]be[SP]able[SP]to\ncapture[SP]it[SP]at[SP]its[SP]most[SP]beautiful--right[SP]now.",
     "nom_fr": "Fujii",
-    "texte_fr": "La montagne change de visage chaque jour.\n[1205][000F]Si j'attend trop, j'échouerais à capturer\nl'apogée de sa beauté, qui est imminente."
+    "texte_fr": "La montagne change de visage chaque jour.\n[000F][1205]Si j'attend trop, j'échouerais à capturer\nl'apogée de sa beauté, qui est imminente."
   },
   {
     "id": 49,
@@ -777,7 +777,7 @@
     "nom_orig": "Fujii",
     "texte_orig": "It[SP]doesn't[SP]seem[SP]like[SP]they're[SP]making[SP]any[SP]headway\non[SP]the[SP]case,[SP]but[SP]I[SP]think[SP]the[SP]mountain's[SP]safe.\nUnless[SP]they're[SP]on[SP]a[SP]treasure[SP]hunt[SP]or[SP]something.",
     "nom_fr": "Fujii",
-    "texte_fr": "Ils n'ont pas l'air\nde beaucoup avancer dans\nl'affaire, mais la montagne doit être sûre.\nSauf s'ils font une\nchasse au trésor ou autre."
+    "texte_fr": "Ils n'ont pas l'air\nde beaucoup avancer dans\nl'affaire, mais la montagne doit être sûre. Sauf s'ils font une chasse au trésor ou autre."
   },
   {
     "id": 52,
@@ -792,7 +792,7 @@
     "nom_orig": "???",
     "texte_orig": "Oh,[SP]so[SP]you're[SP][1112]![1205][000F][SP]Yukino[SP]and[SP]Maya[SP]have\ntold[SP]me[SP]a[SP]lot[SP]about[SP]you.",
     "nom_fr": "???",
-    "texte_fr": "Oh, tu es [1112]! [1205][000F]Yukino et Maya\nm'ont beaucoup parlé de toi."
+    "texte_fr": "Oh, tu es [1112]! [000F][1205]Yukino et Maya\nm'ont beaucoup parlé de toi."
   },
   {
     "id": 53,
@@ -807,7 +807,7 @@
     "nom_orig": "???",
     "texte_orig": "...Where[SP]are[SP]my[SP]manners?[1205][000F][SP]I'm[SP]Shunsuke[SP]Fujii.[1205][000F]\nPleased[SP]to[SP]meet[SP]you.",
     "nom_fr": "???",
-    "texte_fr": "... Où sont mes manières? [1205][000F][1205][000F]Je\nsuis Fujii Shunsuke. Enchanté."
+    "texte_fr": "... Où sont mes manières? [000F][1205][000F][1205]Je\nsuis Fujii Shunsuke. Enchanté."
   },
   {
     "id": 54,

--- a/traduction/event_scripts/script_345.json
+++ b/traduction/event_scripts/script_345.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Fujii-san...[1205][000F][SP]He[SP]saw[SP]the[SP]stars[SP]through[SP]his\nviewfinder...[1205][000F][SP]That's[SP]how[SP]he[SP]was[SP]able[SP]to[SP]take\nsuch[SP]amazing[SP]pictures...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Fujii..[1205][000F][1205][000F]. Il voyait les étoiles à\ntravers son objectif... C'est pourquoi\nil a pu prendre de si belles photos..."
+    "texte_fr": "Fujii..[000F][1205][000F][1205]. Il voyait les étoiles à\ntravers son objectif... C'est pourquoi\nil a pu prendre de si belles photos..."
   },
   {
     "id": 1,
@@ -117,7 +117,7 @@
     "nom_orig": "Jun",
     "texte_orig": "People[SP]often[SP]compare[SP]their[SP]goals[SP]to[SP]the[SP]stars.[1205][000F]\nThey[SP]shine[SP]brightly[SP]even[SP]after[SP]the[SP]sun[SP]goes\ndown...[SP]fixed[SP]stars[SP]in[SP]a[SP]dark[SP]expanse.",
     "nom_fr": "Jun",
-    "texte_fr": "On compare souvent nos buts aux étoiles.\n[1205][000F]Elles brillent même après le crépuscule...\ndes étoiles fixes dans une étendue noire."
+    "texte_fr": "On compare souvent nos buts aux étoiles.\n[000F][1205]Elles brillent même après le crépuscule...\ndes étoiles fixes dans une étendue noire."
   },
   {
     "id": 8,
@@ -162,6 +162,6 @@
     "nom_orig": "Journalist",
     "texte_orig": "Is[SP]Fujii-san[SP]still[SP]at[SP]Mt.[SP]Katatsumuri?[1205][000F][SP]Isn't\nthe[SP]world[SP]going[SP]to[SP]end[SP]soon?[1205][000F][SP]Hoo[SP]boy...",
     "nom_fr": "",
-    "texte_fr": "Fujii-san est toujours au Mont Katatsumuri ?[1205][000F]\nLe monde ne va pas bientôt finir ?[1205][000F]\nOh là là..."
+    "texte_fr": "Fujii-san est toujours au Mont Katatsumuri ?[000F][1205]\nLe monde ne va pas bientôt finir ?[000F][1205]\nOh là là..."
   }
 ]

--- a/traduction/event_scripts/script_346.json
+++ b/traduction/event_scripts/script_346.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "If[SP]we[SP]don't[SP]take[SP]care[SP]of[SP]them,[SP]I'll[SP]never\nmanage[SP]to[SP]make[SP]my[SP]debut[SP]as[SP]a[SP]rock[SP]star.[SP]I[SP]guess\nI[SP]won't[SP]be[SP]on[SP]these[SP]stages[SP]for[SP]a[SP]while[SP]yet...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Si on se charge pas\nd'eux, ma carrière de rock\nstar débutera jamais. Mon arrivée sur cette\nscène se fera un peu attendre, j'imagine..."
+    "texte_fr": "Si on se charge pas\nd'eux, ma carrière de rock\nstar débutera jamais. Mon arrivée sur cette scène se fera un peu attendre, j'imagine..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey...[1205][001E][SP]What[SP]are[SP]those[SP]two[SP]talking[SP]about?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé...[1205][001E] De quoi parlent ces deux-là?"
+    "texte_fr": "Hé...[001E][1205] De quoi parlent ces deux-là?"
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Look,[SP][1113]![SP]Isn't[SP]that[SP]Brown[SP]from[SP]TV!?[1205][000F]\nI[SP]can't[SP]believe[SP]Yukino[SP]knows[SP]him!",
     "nom_fr": "Ginko",
-    "texte_fr": "Regarde, [1113]! C'est pas Brown de\n[1205][000F]la télé? Yukino le connaît, jure!?"
+    "texte_fr": "Regarde, [1113]! C'est pas Brown de\n[000F][1205]la télé? Yukino le connaît, jure!?"
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "So[SP]Brown[SP]heard[SP]the[SP]rumor[SP]the[SP]kids[SP]were[SP]spreading\ntoo,[SP]huh?[1205][000F][SP]That's[SP]pretty[SP]cool.",
     "nom_fr": "Ginko",
-    "texte_fr": "Donc Brown a entendu la rumeur que les\npetits répandaient? [1205][000F]C'est très cool."
+    "texte_fr": "Donc Brown a entendu la rumeur que les\npetits répandaient? [000F][1205]C'est très cool."
   },
   {
     "id": 8,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It[SP]sure[SP]is[SP]neat[SP]to[SP]having[SP]a[SP]celebrity[SP]for\na[SP]friend![SP]Hehe,[SP]I[SP]didn't[SP]think[SP]Yukki[SP]was\nthat[SP]cool.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est sympa d'avoir\nune célébrité comme ami.\nHéhé, je pensais pas que Yukki était si\ncool..."
+    "texte_fr": "C'est sympa d'avoir\nune célébrité comme ami.\nHéhé, je pensais pas que Yukki était si cool..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]bet[SP]the[SP]TV[SP]stations[SP]are[SP]busy[SP]at[SP]times[SP]like\nthis.[SP]I[SP]just[SP]wish[SP]they[SP]wouldn't[SP]sensationalize\nso[SP]much...[SP]What[SP]if[SP]that[SP]turns[SP]into[SP]a[SP]rumor?",
     "nom_fr": "Maya",
-    "texte_fr": "Les chaînes télé\ndoivent être débordées, là.\nSi ça pouvait faire moins dans le \nsensationnel... Imaginez que\nça devienne unerumeur?"
+    "texte_fr": "Les chaînes télé\ndoivent être débordées, là.\nSi ça pouvait faire moins dans le sensationnel... Imaginez que ça devienne unerumeur?"
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Of[SP]course[SP]there[SP]are[SP]times[SP]when[SP]the[SP]media[SP]plays\na[SP]part[SP]in[SP]spreading[SP]rumors.[SP]I've[SP]seen[SP]it[SP]happen\nseveral[SP]times[SP]during[SP]my[SP]career[SP]at[SP]Kismet...",
     "nom_fr": "Maya",
-    "texte_fr": "Évidemment, les médias\njouent parfois un rôle\ndans la progapation de rumeurs. J'ai pu\nl'observer souvent durant\nma carrière àKismet..."
+    "texte_fr": "Évidemment, les médias\njouent parfois un rôle\ndans la progapation de rumeurs. J'ai pu l'observer souvent durant ma carrière àKismet..."
   },
   {
     "id": 14,
@@ -267,7 +267,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Heheheh...[SP]The[SP]resonance[SP]I[SP]felt[SP]from[SP]him[SP]was\na[SP]lot[SP]like[SP]yours,[SP]Eikichi.[1205][000F][SP]I[SP]guess[SP]birds[SP]of\na[SP]feather[SP]flock[SP]together.",
     "nom_fr": "Maya",
-    "texte_fr": "Héhé... J'ai senti une résonance très\nsimilaire à la tienne, Eikichi. [1205][000F]Qui\nse ressemble s'assemble, j'imagine."
+    "texte_fr": "Héhé... J'ai senti une résonance très\nsimilaire à la tienne, Eikichi. [000F][1205]Qui\nse ressemble s'assemble, j'imagine."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Maya",
     "texte_orig": "There's[SP]a[SP]Persona-user[SP]here...[1205][000F][SP]And[SP]a[SP]strong\none[SP]at[SP]that...[1205][000F][SP]He[SP]could[SP]cause[SP]trouble[SP]for[SP]us\nif[SP]we[SP]let[SP]him[SP]go[SP]free...",
     "nom_fr": "Maya",
-    "texte_fr": "Il y a un manieur de Persona ici.[1205][000F][1205][000F]..\nTrès fort, de surcroît... Il pourrait\ncauser problème si on fait rien..."
+    "texte_fr": "Il y a un manieur de Persona ici.[000F][1205][000F][1205]..\nTrès fort, de surcroît... Il pourrait\ncauser problème si on fait rien..."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "What[SP]is[SP]Maya[SP]talking[SP]about?[SP]We're[SP]just\nfriends,[SP]that's[SP]all.[1205][000F][SP]I[SP]wonder[SP]if[SP]he's[SP]been\ngiving[SP]people[SP]the[SP]wrong[SP]idea...",
     "nom_fr": "Yukino",
-    "texte_fr": "De quoi parle Maya? On est juste amis,\nc'est tout. [1205][000F]Je me demande s'il n'a pas\ndonné la mauvaise impression..."
+    "texte_fr": "De quoi parle Maya? On est juste amis,\nc'est tout. [000F][1205]Je me demande s'il n'a pas\ndonné la mauvaise impression..."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Hidehiko's[SP]a[SP]lot[SP]sharper[SP]than[SP]he[SP]looks.\nI[SP]bet[SP]he[SP]has[SP]his[SP]own[SP]suspicions[SP]about[SP]these\nincidents.",
     "nom_fr": "Yukino",
-    "texte_fr": "Hidehiko est plus fin\nqu'il n'en a l'air. Je\nparie qu'il a ses\nthéories sur les incidents."
+    "texte_fr": "Hidehiko est plus fin\nqu'il n'en a l'air. Je\nparie qu'il a ses théories sur les incidents."
   },
   {
     "id": 21,
@@ -327,7 +327,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Oh,[SP]we[SP]know[SP]full[SP]well[SP]who[SP]wrote[SP]it.[SP]I[SP]can't\nbelieve[SP]the[SP]Masked[SP]Circle[SP]is[SP]devoted[SP]to[SP]it[SP]to\nthe[SP]point[SP]of[SP]committing[SP]crimes,[SP]though.",
     "nom_fr": "Yukino",
-    "texte_fr": "Oh, on sait bien qui l'a écrit. Je suis\nétonnée que le Cercle Masqué y soit dévoué\nau point de commettre\ndes crimes, ceci dit."
+    "texte_fr": "Oh, on sait bien qui l'a écrit. Je suis\nétonnée que le Cercle Masqué y soit dévoué\nau point de commettre des crimes, ceci dit."
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Someone[SP]said[SP]the[SP]actress[SP]who[SP]was[SP]here[SP]is[SP]gone\nnow?[1205][000F][SP]Where[SP]did[SP]she[SP]go?",
     "nom_fr": "Yukino",
-    "texte_fr": "Quelqu'un a dit que l'actrice\nétait partie. [1205][000F]Où est-elle allée?"
+    "texte_fr": "Quelqu'un a dit que l'actrice\nétait partie. [000F][1205]Où est-elle allée?"
   },
   {
     "id": 23,
@@ -387,7 +387,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "He[SP]comes[SP]on[SP]a[SP]little[SP]strong,[SP]but[SP]he's[SP]no[SP]slouch\nin[SP]a[SP]fight,[SP]and[SP]I[SP]think[SP]he[SP]knows[SP]about[SP]what's\ngoing[SP]on.[SP]Maybe[SP]you[SP]should[SP]talk[SP]to[SP]him.",
     "nom_fr": "Yukino",
-    "texte_fr": "Il peut sembler poussif, mais il sait se\nbattre, et je pense qu'il\nsait déjà à peu près\nce qui arrive. Tu\npourrais aller lui parler."
+    "texte_fr": "Il peut sembler poussif, mais il sait se\nbattre, et je pense qu'il\nsait déjà à peu près ce qui arrive. Tu pourrais aller lui parler."
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Brown",
     "texte_orig": "Her[SP]missing[SP]heir![1205][000F][SP]Juuuuust[SP]kidding!\nHAHAHAHAHAHAHA!",
     "nom_fr": "Brown",
-    "texte_fr": "Son héritière disparue!\n[1205][000F]J'rigoooole! HAHAHAHAHAHA!"
+    "texte_fr": "Son héritière disparue!\n[000F][1205]J'rigoooole! HAHAHAHAHAHA!"
   },
   {
     "id": 28,
@@ -492,7 +492,7 @@
     "nom_orig": "Brown",
     "texte_orig": "Huh?[SP]The[SP]rumors?[1205][001E][SP]Hey,[SP]relax.[SP]The[SP]five[SP]people\non[SP]the[SP]composite[SP]sketches[SP]and[SP]yours[SP]truly[SP]are\nsuperheroes,[SP]right?[SP]Nothin'[SP]to[SP]worry[SP]about!",
     "nom_fr": "Brown",
-    "texte_fr": "Hein? Les rumeurs?[1205][001E] Hé,\nrelax. Moi et les cinq\npersonnes sur les portraits-robots sommes \ndes super-héros, pas\nvrai? Donc aucun souci!"
+    "texte_fr": "Hein? Les rumeurs?[001E][1205] Hé,\nrelax. Moi et les cinq\npersonnes sur les portraits-robots sommes des super-héros, pas vrai? Donc aucun souci!"
   },
   {
     "id": 33,
@@ -552,7 +552,7 @@
     "nom_orig": "Brown",
     "texte_orig": "Huh?[1205][000F][SP]Where's[SP]Yukino?[SP]Isn't[SP]she[SP]with[SP]you?",
     "nom_fr": "Brown",
-    "texte_fr": "Hein? [1205][000F]Où est Yukino? Pas avec vous?"
+    "texte_fr": "Hein? [000F][1205]Où est Yukino? Pas avec vous?"
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "???",
     "texte_orig": "Ohhhh...[SP]So[SP]you're[SP][1113]?[1205][000F][SP]Tell[SP]me,[SP]how[SP]scary\nis[SP]Yukino?[1205][000F][SP]I[SP]know[SP]she's[SP]kicked[SP]my[SP]ass[SP]on\nmultiple[SP]occasions.",
     "nom_fr": "???",
-    "texte_fr": "Ohhhh... Tu es [1113]? [1205][000F][1205][000F]Dis-moi,\nYukino fait peur? Elle m'a déjà cassé\nla gueule à plusieurs reprises."
+    "texte_fr": "Ohhhh... Tu es [1113]? [000F][1205][000F][1205]Dis-moi,\nYukino fait peur? Elle m'a déjà cassé\nla gueule à plusieurs reprises."
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Hey![1205][000F][SP]I[SP]heard[SP]that!",
     "nom_fr": "Yukino",
-    "texte_fr": "Hé! [1205][000F]J'ai entendu!"
+    "texte_fr": "Hé! [000F][1205]J'ai entendu!"
   },
   {
     "id": 39,
@@ -612,7 +612,7 @@
     "nom_orig": "Brown",
     "texte_orig": "Ah...[SP]So[SP]you[SP]guys[SP]have[SP]met[SP]Philemon,[SP]too.[1205][000F]\nYou're[SP]investigating[SP]the[SP]strange[SP]stuff[SP]around\ntown,[SP]right?[1205][000F][SP]Well,[SP]keep[SP]it[SP]up.",
     "nom_fr": "Brown",
-    "texte_fr": "Ah... Vous avez rencontré Philémon, vous\n[1205][000F][1205][000F]aussi. Vous enquêtez sur les bizarreries\nen ville, hein? Bien, bon courage."
+    "texte_fr": "Ah... Vous avez rencontré Philémon, vous\n[000F][1205][000F][1205]aussi. Vous enquêtez sur les bizarreries\nen ville, hein? Bien, bon courage."
   },
   {
     "id": 41,
@@ -627,7 +627,7 @@
     "nom_orig": "???",
     "texte_orig": "Yo![SP]Long[SP]time[SP]no[SP]see![1205][000F][SP]Wait,[SP]I[SP]don't[SP]know[SP]you.[1205][000F]\nYo![SP]Long[SP]time[SP]no[SP]meet![1205][000F][SP]Heeheehee![1205][000F][SP]Alright,\nallow[SP]me[SP]to[SP]introduce[SP]myself...",
     "nom_fr": "???",
-    "texte_fr": "Yo! Ça fait une paye! [1205][000F][1205][000F][1205][000F][1205][000F]Attend, je te connais\npas. Yo! Ça fait pas une paye! Héhéhééé!\nBien, laissez-moi me présenter..."
+    "texte_fr": "Yo! Ça fait une paye! [000F][1205][000F][1205][000F][1205][000F][1205]Attend, je te connais\npas. Yo! Ça fait pas une paye! Héhéhééé!\nBien, laissez-moi me présenter..."
   },
   {
     "id": 42,
@@ -712,7 +712,7 @@
     "nom_orig": "Brown",
     "texte_orig": "I[SP]felt[SP]another[SP]Persona[SP]since[SP]the[SP]moment[SP]you\nwalked[SP]in[SP]here![SP]I[SP]know[SP]exactly[SP]who[SP]you[SP]are[SP]and\nwhat[SP]you're[SP]after![SP]Surprised?[SP]Hyahahahaha!",
     "nom_fr": "Brown",
-    "texte_fr": "Depuis votre arrivée, je sentais une autre\nPersona! Je sais exactement\nqui vous êtes et\nce que vous cherchez! Surpris? Hyahahaha!"
+    "texte_fr": "Depuis votre arrivée, je sentais une autre\nPersona! Je sais exactement\nqui vous êtes et ce que vous cherchez! Surpris? Hyahahaha!"
   },
   {
     "id": 47,
@@ -757,7 +757,7 @@
     "nom_orig": "???",
     "texte_orig": "Seriously!?[SP]I'm...[SP]I'm[SP]Brown.[SP]Can't[SP]you[SP]tell?[1205][000F]\nYou[SP]mean[SP]to[SP]say[SP]you[SP]don't[SP]watch[SP]my[SP]show?[1205][000F][SP]Yikes,\nI[SP]think[SP]it[SP]just[SP]got[SP]a[SP]couple[SP]degrees[SP]colder.",
     "nom_fr": "???",
-    "texte_fr": "Sérieux!? Je... Je suis\nBrown. [1205][1205]Tu vois pas? [000F][000F]Tu\nveux dire que tu\nregardes pas mon émission? Eh\nbeh, il fait bien plus froid ici d'un coup."
+    "texte_fr": "Sérieux!? Je... Je suis\nBrown. [1205][1205]Tu vois pas? [000F][000F]Tu\nveux dire que tu regardes pas mon émission? Eh beh, il fait bien plus froid ici d'un coup."
   },
   {
     "id": 50,
@@ -772,7 +772,7 @@
     "nom_orig": "???",
     "texte_orig": "Alright![SP]Lemme[SP]introduce[SP]myself[SP]properly[SP]so[SP]you\ncan[SP]tell[SP]your[SP]grandkids[SP]about[SP]it[SP]someday.[1205][000F]\nI'm[SP]Uesugi.[SP]Nice[SP]to[SP]meet[SP]ya.",
     "nom_fr": "???",
-    "texte_fr": "Bien! Laisse-moi me présenter proprement,\nque tu le racontes à tes petits-enfants\n[1205][000F]un jour. Je suis Uesugi. Enchanté."
+    "texte_fr": "Bien! Laisse-moi me présenter proprement,\nque tu le racontes à tes petits-enfants\n[000F][1205]un jour. Je suis Uesugi. Enchanté."
   },
   {
     "id": 51,
@@ -787,7 +787,7 @@
     "nom_orig": "Brown",
     "texte_orig": "I[SP]felt[SP]another[SP]Persona[SP]since[SP]the[SP]moment[SP]you\nwalked[SP]in[SP]here![SP]I[SP]know[SP]exactly[SP]who[SP]you[SP]are[SP]and\nwhat[SP]you're[SP]after![SP]Surprised?[SP]Hyahahahaha!",
     "nom_fr": "Brown",
-    "texte_fr": "Depuis votre arrivée, je sentais une autre\nPersona! Je sais exactement\nqui vous êtes et\nce que vous cherchez! Surpris? Hyahahaha!"
+    "texte_fr": "Depuis votre arrivée, je sentais une autre\nPersona! Je sais exactement\nqui vous êtes et ce que vous cherchez! Surpris? Hyahahaha!"
   },
   {
     "id": 52,
@@ -832,7 +832,7 @@
     "nom_orig": "Junko[SP]Kurosu",
     "texte_orig": "Hm?[SP]Are[SP]you[SP]here[SP]for[SP]my[SP]autograph?[1205][000F][SP]I'm[SP]the\nworld-famous[SP]Junko[SP]Kurosu,[SP]a[SP]genius[SP]thespian\nsurpassing[SP]even[SP]Marilyn[SP]Monroe!",
     "nom_fr": "Junko Kurosu",
-    "texte_fr": "Hm? Tu veux mon autographe? Je suis la\n[1205][000F]très renommée Junko Kurosu, comédienne\nde génie surpassant même Marilyn Monroe!"
+    "texte_fr": "Hm? Tu veux mon autographe? Je suis la\n[000F][1205]très renommée Junko Kurosu, comédienne\nde génie surpassant même Marilyn Monroe!"
   },
   {
     "id": 55,
@@ -847,7 +847,7 @@
     "nom_orig": "Junko[SP]Kurosu",
     "texte_orig": "Well?[SP]Out[SP]with[SP]it.[1205][001E][SP]I[SP]know[SP]you[SP]must[SP]have[SP]an\nautograph[SP]book[SP]or[SP]something[SP]of[SP]the[SP]kind.",
     "nom_fr": "Junko Kurosu",
-    "texte_fr": "Alors? Crache le morceau.[1205][001E] Tu dois bien\navoir un carnet d'autographes ou autre."
+    "texte_fr": "Alors? Crache le morceau.[001E][1205] Tu dois bien\navoir un carnet d'autographes ou autre."
   },
   {
     "id": 56,
@@ -892,7 +892,7 @@
     "nom_orig": "???",
     "texte_orig": "Hm?[SP]Are[SP]you[SP]here[SP]for[SP]my[SP]autograph?[1205][000F][SP]I'm[SP]the\nworld-famous[SP]Junko[SP]Kurosu,[SP]a[SP]genius[SP]thespian\nsurpassing[SP]even[SP]Marilyn[SP]Monroe!",
     "nom_fr": "???",
-    "texte_fr": "Hm? Tu veux mon autographe? Je suis la\n[1205][000F]très renommée Junko Kurosu, comédienne\nde génie surpassant même Marilyn Monroe!"
+    "texte_fr": "Hm? Tu veux mon autographe? Je suis la\n[000F][1205]très renommée Junko Kurosu, comédienne\nde génie surpassant même Marilyn Monroe!"
   },
   {
     "id": 59,
@@ -907,7 +907,7 @@
     "nom_orig": "Junko[SP]Kurosu",
     "texte_orig": "Well?[SP]Out[SP]with[SP]it.[1205][001E][SP]I[SP]know[SP]you[SP]must[SP]have[SP]an\nautograph[SP]book[SP]or[SP]something[SP]of[SP]the[SP]kind.",
     "nom_fr": "Junko Kurosu",
-    "texte_fr": "Alors? Crache le morceau.[1205][001E] Tu dois bien\navoir un carnet d'autographes ou autre."
+    "texte_fr": "Alors? Crache le morceau.[001E][1205] Tu dois bien\navoir un carnet d'autographes ou autre."
   },
   {
     "id": 60,
@@ -952,7 +952,7 @@
     "nom_orig": "Junko[SP]Kurosu",
     "texte_orig": "These[SP]constant[SP]terrorist[SP]attacks...[SP]What[SP]a\nviolent[SP]world[SP]we[SP]live[SP]in[SP]now.[SP]I[SP]hear[SP]that[SP]the\nculprits[SP]are[SP]five[SP]youngsters...[SP]Just[SP]awful.",
     "nom_fr": "Junko Kurosu",
-    "texte_fr": "Ces incessantes\nattaques terroristes... Quel\nmonde violent que le nôtre. Les coupables\nseraient cinq jeunes gens... Déplorable."
+    "texte_fr": "Ces incessantes\nattaques terroristes... Quel\nmonde violent que le nôtre. Les coupables seraient cinq jeunes gens... Déplorable."
   },
   {
     "id": 63,
@@ -967,7 +967,7 @@
     "nom_orig": "Junko[SP]Kurosu",
     "texte_orig": "I[SP]heard[SP]they[SP]released[SP]composite[SP]sketches[SP]of[SP]the\nfive[SP]youths[SP]responsible.[1205][000F][SP]They've[SP]caused[SP]quite[SP]a\npanic...[SP]It's[SP]the[SP]chair[SP]if[SP]they're[SP]caught,[SP]mm?",
     "nom_fr": "Junko Kurosu",
-    "texte_fr": "Ils auraient partagé les portraits-robots\ndes cinq jeunes coupables. [1205][000F]Vu la panique\ncausée... Ça finira sur la\nchaise s'ilsse font avoir, mm?"
+    "texte_fr": "Ils auraient partagé les portraits-robots\ndes cinq jeunes coupables. [000F][1205]Vu la panique\ncausée... Ça finira sur la chaise s'ilsse font avoir, mm?"
   },
   {
     "id": 64,
@@ -982,7 +982,7 @@
     "nom_orig": "Junko[SP]Kurosu",
     "texte_orig": "Were[SP]you[SP]eavesdropping?[SP]Where[SP]are[SP]your[SP]manners?[1205][001E]\nThis[SP]isn't[SP]subject[SP]matter[SP]a[SP]child[SP]should[SP]hear.",
     "nom_fr": "Junko Kurosu",
-    "texte_fr": "Tu écoutais? Où sont tes manières?[1205][001E] Les\nenfants ne devraient\npas entendre ces choses."
+    "texte_fr": "Tu écoutais? Où sont tes manières?[001E][1205] Les\nenfants ne devraient\npas entendre ces choses."
   },
   {
     "id": 65,
@@ -997,7 +997,7 @@
     "nom_orig": "Receptionist",
     "texte_orig": "Isn't[SP]Ms.[SP]Kurosu[SP]young[SP]and[SP]beautiful?[SP]Try[SP]to\nguess[SP]her[SP]age.[SP]You'd[SP]be[SP]surprised![SP]I'd[SP]heard\nactresses[SP]age[SP]well,[SP]but[SP]she's[SP]something[SP]else.",
     "nom_fr": "Réception",
-    "texte_fr": "Mme Kurosu est si\njeune et belle. Devinez son\nâge, vous serez surpris! On dit que les\nactrices mûrissent bien.\nC'est flagrant chezelle."
+    "texte_fr": "Mme Kurosu est si\njeune et belle. Devinez son\nâge, vous serez surpris! On dit que les actrices mûrissent bien. C'est flagrant chezelle."
   },
   {
     "id": 66,
@@ -1012,7 +1012,7 @@
     "nom_orig": "Receptionist",
     "texte_orig": "Ms.[SP]Kurosu[SP]was[SP]carping[SP]about[SP]the[SP]terrorists\nbeing[SP]five[SP]young[SP]people.[SP]You[SP]think[SP]it's[SP]true?\nI[SP]heard[SP]it[SP]was[SP]the[SP]Masked[SP]Circle...",
     "nom_fr": "Réception",
-    "texte_fr": "Mme Kurosu pestait sur\nl'âge des cinq jeunes\nterroristes. C'est vrai vous pensez? J'ai\nentendu que c'était le Cercle Masqué..."
+    "texte_fr": "Mme Kurosu pestait sur\nl'âge des cinq jeunes\nterroristes. C'est vrai vous pensez? J'ai entendu que c'était le Cercle Masqué..."
   },
   {
     "id": 67,
@@ -1102,7 +1102,7 @@
     "nom_orig": "Staff",
     "texte_orig": "What's[SP]going[SP]on?[1205][000F][SP]We[SP]can't[SP]get[SP]authorization[SP]to\nfilm[SP]that[SP]mini-concert![SP]This[SP]is[SP]unheard[SP]of!",
     "nom_fr": "Personnel",
-    "texte_fr": "Il se passe quoi? [1205][000F]On est pas autorisés à\nfilmer ce mini-concert!?\nC'est du jamais vu!"
+    "texte_fr": "Il se passe quoi? [000F][1205]On est pas autorisés à\nfilmer ce mini-concert!?\nC'est du jamais vu!"
   },
   {
     "id": 73,

--- a/traduction/event_scripts/script_347.json
+++ b/traduction/event_scripts/script_347.json
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Oh[SP]yeah...[1205][000A][SP]I[SP]was[SP]wondering[SP]something,[SP]Jun.[1205][000F]\nThe[SP]city's[SP]flying[SP]now,[SP]right?[1205][000F][SP]So[SP]why[SP]isn't\nthe[SP]air[SP]thinner[SP]or[SP]colder?",
     "nom_fr": "Ginko",
-    "texte_fr": "Dis...[1205][1205][1205][000A] J'avais une question, Jun. [000F][000F]Si\nla ville vole, pourquoi la pression et\nla température sont pas plus basses?"
+    "texte_fr": "Dis...[1205][1205][000A][1205] J'avais une question, Jun. [000F][000F]Si\nla ville vole, pourquoi la pression et\nla température sont pas plus basses?"
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Isn't[SP]Kudan[SP]the[SP]monster[SP]with[SP]a[SP]cow's[SP]body[SP]and\nhuman[SP]head?[1205][000F][SP]I[SP]heard[SP]a[SP]story[SP]like[SP]that[SP]once.",
     "nom_fr": "Maya",
-    "texte_fr": "Kudan c'est pas ce monstre-vache à tête\nhumaine? [1205][000F]J'ai entendue\nune histoire comme ça."
+    "texte_fr": "Kudan c'est pas ce monstre-vache à tête\nhumaine? [000F][1205]J'ai entendue\nune histoire comme ça."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]too[SP]bad...[SP]We[SP]had[SP]it[SP]all[SP]wrong.[1205][000F][SP]Kudan\nwas[SP]just[SP]a[SP]nickname[SP]for[SP]his[SP]friend...",
     "nom_fr": "Maya",
-    "texte_fr": "Mince... On avait faux sur tout. [1205][000F]Kudan\nétait juste le surnom de son ami..."
+    "texte_fr": "Mince... On avait faux sur tout. [000F][1205]Kudan\nétait juste le surnom de son ami..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Man...[1205][000F][SP]Some[SP]journalist[SP]I[SP]am[SP]for[SP]not[SP]asking\nmore[SP]closely[SP]about[SP]it.[SP]I[SP]need[SP]to[SP]go[SP]back\nto[SP]J-school...",
     "nom_fr": "Maya",
-    "texte_fr": "Pff.[1205][000F].. Je me prétend journaliste\net ne me renseigne pas assez. Je\ndois retourner à mon école..."
+    "texte_fr": "Pff.[000F][1205].. Je me prétend journaliste\net ne me renseigne pas assez. Je\ndois retourner à mon école..."
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Receptionist",
     "texte_orig": "Aww,[SP]where[SP]did[SP]those[SP]two[SP]go...?[1205][000F][SP]First[SP]Ms.\nKurosu,[SP]the[SP]actress,[SP]and[SP]now[SP]even[SP]Brown's\ngone[SP]missing.",
     "nom_fr": "Réception",
-    "texte_fr": "Aww, où sont passés ces deux-là.[1205][000F]..? D'abord\nMme Kurosu, l'actrice,\npuis Brown ont disparu."
+    "texte_fr": "Aww, où sont passés ces deux-là.[000F][1205]..? D'abord\nMme Kurosu, l'actrice,\npuis Brown ont disparu."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Staff",
     "texte_orig": "Hey,[SP]what's[SP]going[SP]on?[1205][000F][SP]The[SP]city's[SP]flying,[SP]there\nare[SP]temples[SP]popping[SP]up[SP]all[SP]over...[SP]Someone[SP]tell\nme[SP]what's[SP]happening!",
     "nom_fr": "Personnel",
-    "texte_fr": "Hé, il se passe quoi? [1205][000F]La ville vole,\ndes temples apparaissent partout...\nQu'on m'explique tout ce bazar!"
+    "texte_fr": "Hé, il se passe quoi? [000F][1205]La ville vole,\ndes temples apparaissent partout...\nQu'on m'explique tout ce bazar!"
   },
   {
     "id": 10,
@@ -222,7 +222,7 @@
     "nom_orig": "Receptionist",
     "texte_orig": "I'm[SP]sorry,[SP]but[SP]the[SP]upper[SP]floors[SP]are[SP]restricted\nto[SP]employees[SP]only.[SP]Please[SP]refrain[SP]from[SP]using\nthe[SP]elevator.",
     "nom_fr": "Réception",
-    "texte_fr": "Navré, mais les étages supérieurs sont\nréservés aux employés. Merci de ne pas\nutiliser l'ascenseur. C'est un modèle de \nSumaru TV. Chaque détail\na été répliqué avec\nsoin. Lundi, 19H-20H [NULL][NULL]La\nMinute de Brown![NULL][NULL] Une\némission de variété présentée par le\npolyvalent Brown. \nMardi, 22H-23H [NULL][NULL]TV-Shopping[NULL][NULL]\nUn programme de télé-achat qui présente et\nvend des produits. \nMercredi, 11H-12H [NULL][NULL]C votre\navis?[NULL][NULL] Une émission où on analyse et imagine\ndes solutions à\ndes problématiques variées. \nJeudi, 18H-18:30H [NULL][NULL]Lightron, Combattant du\nCarat[NULL][NULL] Un dessin animé où un jeune\njusticier setransforme en Combattant Doré pour affronter\nle mal. Vendredi, 20H-21H\n[NULL][NULL]Je suis en direct![NULL][NULL]\nUne émission-débat présentée\npar Junko Kurosu.\nSon franc-parler semble attirer bien des fans. Samedi,\n21H-22H [NULL][NULL]Le Jour où Joe a Basculé[NULL][NULL]\nUn drame avec un assassin qui possède sept\npersonalités différentes."
+    "texte_fr": "Navré, mais les étages supérieurs sont\nréservés aux employés. Merci de ne pas\nutiliser l'ascenseur. C'est un modèle de Sumaru TV. Chaque détail a été répliqué avec soin. Lundi, 19H-20H [NULL][NULL]La Minute de Brown![NULL][NULL] Une émission de variété présentée par le polyvalent Brown. Mardi, 22H-23H [NULL][NULL]TV-Shopping[NULL][NULL] Un programme de télé-achat qui présente et vend des produits. Mercredi, 11H-12H [NULL][NULL]C votre avis?[NULL][NULL] Une émission où on analyse et imagine des solutions à des problématiques variées. Jeudi, 18H-18:30H [NULL][NULL]Lightron, Combattant du Carat[NULL][NULL] Un dessin animé où un jeune justicier setransforme en Combattant Doré pour affronter le mal. Vendredi, 20H-21H [NULL][NULL]Je suis en direct![NULL][NULL] Une émission-débat présentée par Junko Kurosu. Son franc-parler semble attirer bien des fans. Samedi, 21H-22H [NULL][NULL]Le Jour où Joe a Basculé[NULL][NULL] Un drame avec un assassin qui possède sept personalités différentes."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Pale[SP]man",
     "texte_orig": "Scariest[SP]story[SP]I[SP]ever[SP]heard...[1205][000F][SP]What[SP]kind[SP]of\nstory,[SP]you[SP]ask?[1205][000F][SP]No![1205][000F][SP]I'm[SP]trying[SP]to[SP]forget\nabout[SP][E4][NULL][NULL][0006]Kudan[E4][NULL][NULL][0002][SP]at[SP]the[SP]abandoned[SP]factory...",
     "nom_fr": "Homme pâle",
-    "texte_fr": "Jamais entendu un truc aussi badant.[1205][000F][1205][000F][1205][000F].. Tu\nveux savoir quoi? Non! J'essaie d'oublier\n[E4][NULL][NULL][0006]Kudan[E4][NULL][NULL][0002] dans l'usine abandonnée..."
+    "texte_fr": "Jamais entendu un truc aussi badant.[000F][1205][000F][1205][000F][1205].. Tu\nveux savoir quoi? Non! J'essaie d'oublier\n[E4][NULL][NULL][0006]Kudan[E4][NULL][NULL][0002] dans l'usine abandonnée..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Pale[SP]man",
     "texte_orig": "I[SP]wonder[SP]what[SP]happened[SP]with[SP]Kudan[SP]and[SP]the\nabandoned[SP]factory...[1205][000F][SP]Sorry,[SP]just[SP]talking[SP]to\nmyself[SP]there.",
     "nom_fr": "Homme pâle",
-    "texte_fr": "Je me demande ce qui est arrivé à\nKudan dans l'usine abandonnée.[1205][000F]..\nPardon, je parle tout seul."
+    "texte_fr": "Je me demande ce qui est arrivé à\nKudan dans l'usine abandonnée.[000F][1205]..\nPardon, je parle tout seul."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Pale[SP]man",
     "texte_orig": "What[SP]the[SP]hell[SP]is[SP]this?[1205][000F][SP]Ugh,[SP]that's[SP]disgusting![1205][000F]\nHuh?[SP]What[SP]do[SP]you[SP]mean,[SP]I[SP]asked[SP]for[SP]this?[1205][000F]\nThis[SP]is[SP]Kudan...?",
     "nom_fr": "Homme pâle",
-    "texte_fr": "Qu'est-ce que? [1205][000F][1205][000F][1205][000F]Urk, c'est immonde!\nHein? Comment ça, c'est moi qui\nl'ai demandé? C'est Kudan, ça...?"
+    "texte_fr": "Qu'est-ce que? [000F][1205][000F][1205][000F][1205]Urk, c'est immonde!\nHein? Comment ça, c'est moi qui\nl'ai demandé? C'est Kudan, ça...?"
   },
   {
     "id": 18,
@@ -327,7 +327,7 @@
     "nom_orig": "Pale[SP]man",
     "texte_orig": "Ugh...[1205][000F][SP]Thinking[SP]about[SP]that[SP]makes[SP]me[SP]even[SP]more\nscared.[SP]Gahhh...[1205][000F][SP]I[SP]don't[SP]wanna[SP]think[SP]about\nKudan[SP]anymore...",
     "nom_fr": "Homme pâle",
-    "texte_fr": "Ugh.[1205][000F][1205][000F].. Y penser m'effraie encore plus.\nGahhh... Plus envie de penser à Kudan..."
+    "texte_fr": "Ugh.[000F][1205][000F][1205].. Y penser m'effraie encore plus.\nGahhh... Plus envie de penser à Kudan..."
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Pale[SP]man",
     "texte_orig": "Sorry[SP]about[SP]the[SP]misunderstanding.[1205][000F][SP]I[SP]was[SP]scared,\ntoo![SP]I[SP]hope[SP]you[SP]forgive[SP]me.[1205][000F][SP]But[SP]wow...[SP]I[SP]can't\nbelieve[SP]this[SP]is[SP]happening...",
     "nom_fr": "Homme pâle",
-    "texte_fr": "Désolé du malentendu. [1205][000F][1205][000F]J'avais peur aussi!\nVous m'excuserez, j'espère. Mais wow, je\npeux pas croire ce qui s'est passé..."
+    "texte_fr": "Désolé du malentendu. [000F][1205][000F][1205]J'avais peur aussi!\nVous m'excuserez, j'espère. Mais wow, je\npeux pas croire ce qui s'est passé..."
   },
   {
     "id": 23,
@@ -357,6 +357,6 @@
     "nom_orig": "Pale[SP]man",
     "texte_orig": "Things[SP]appearing[SP]out[SP]of[SP]thin[SP]air...[1205][000F][SP]Nothing\nturns[SP]into[SP]something...[1205][000F][SP]Maybe[SP]the[SP]human[SP]mouth\nis[SP]scarier[SP]than[SP]anything[SP]else[SP]in[SP]the[SP]world.",
     "nom_fr": "",
-    "texte_fr": "Des choses qui apparaissent de nulle part...[1205][000F]\nLe néant qui devient quelque chose...[1205][000F] Peut-être\nque la bouche humaine est la chose la plus terrifiante au monde."
+    "texte_fr": "Des choses qui apparaissent de nulle part...[000F][1205]\nLe néant qui devient quelque chose...[000F][1205] Peut-être\nque la bouche humaine est la chose la plus terrifiante au monde."
   }
 ]

--- a/traduction/event_scripts/script_348.json
+++ b/traduction/event_scripts/script_348.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "How[SP]about[SP]if[SP]I[SP]sign[SP]an[SP]autograph[SP]for[SP]you\ninstead,[SP]as[SP]a[SP]future[SP]rock[SP]star![1205][000F][SP]Do[SP]you[SP]have\nany[SP]paper?[1205][000F][SP]Maybe[SP]I[SP]could[SP]sign[SP]your[SP]back?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Et si je te signais un autographe plutôt,\nen tant que future rock star! [1205][000F][1205][000F]Tu as du\npapier? Je peux signer sur ton dos sinon?"
+    "texte_fr": "Et si je te signais un autographe plutôt,\nen tant que future rock star! [000F][1205][000F][1205]Tu as du\npapier? Je peux signer sur ton dos sinon?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey...[1205][000F][SP]I'm[SP]not[SP]supposed[SP]to[SP]be[SP]standing[SP]here...[1205][000F]\nIs[SP]the[SP]BIT[SP]flagged?[SP]Please[SP]check!",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, je suis pas censée me tenir là.[1205][000F][1205][000F].. Le\nBIT est bien indiqué? Vérifiez merci!"
+    "texte_fr": "Hé, je suis pas censée me tenir là.[000F][1205][000F][1205].. Le\nBIT est bien indiqué? Vérifiez merci!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Firefighter",
     "texte_orig": "Anywhere[SP]a[SP]crowd[SP]goes,[SP]trouble[SP]follows...[SP]All\nthe[SP]more[SP]so[SP]at[SP]a[SP]concert[SP]with[SP]screaming[SP]fans!\nWe[SP]must[SP]always[SP]be[SP]prepared[SP]for[SP]the[SP]worst!",
     "nom_fr": "Pompier",
-    "texte_fr": "Dès qu'il y a\nfoule, des problèmes arrivent...\nSurtout dans un concert rempli de fans \ndéchaînés! On doit\ntoujours se préparer aupire!"
+    "texte_fr": "Dès qu'il y a\nfoule, des problèmes arrivent...\nSurtout dans un concert rempli de fans déchaînés! On doit toujours se préparer aupire!"
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "......![1205][0014][SP]Come[SP]on,[SP]Yukki![SP]Say[SP]it!",
     "nom_fr": "Maya",
-    "texte_fr": "......![1205][0014] Allez Yukki! Dis-le!"
+    "texte_fr": "......![0014][1205] Allez Yukki! Dis-le!"
   },
   {
     "id": 6,

--- a/traduction/event_scripts/script_349.json
+++ b/traduction/event_scripts/script_349.json
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What's[SP]Eikichi[SP]mean[SP]about[SP]those[SP]voices[SP]and\nstuff?[SP][1205][000F]Do[SP]you[SP]know,[SP][1113]?",
     "nom_fr": "Ginko",
-    "texte_fr": "Il raconte quoi Eikichi avec ses\ndélires de voix? [1205][000F]Tu sais toi,[1113]?"
+    "texte_fr": "Il raconte quoi Eikichi avec ses\ndélires de voix? [000F][1205]Tu sais toi,[1113]?"
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Rumors[SP]and[SP]reality...[1205][000F][SP]Dreams[SP]and[SP]reality...[1205][000F]\nHopes[SP]and[SP]reality...[1205][000F][SP]I[SP]can't[SP]tell[SP]them[SP]apart\nanymore.[1205][000F][SP]Everything's[SP]so[SP]screwed[SP]up.",
     "nom_fr": "Ginko",
-    "texte_fr": "Rumeurs et réalité.[1205][000F][1205][000F][1205][000F][1205][000F].. Rêves et réalité...\nEspoirs et réalité... J'arrive plus à les\ndistinguer. Tout est tellement tordu."
+    "texte_fr": "Rumeurs et réalité.[000F][1205][000F][1205][000F][1205][000F][1205].. Rêves et réalité...\nEspoirs et réalité... J'arrive plus à les\ndistinguer. Tout est tellement tordu."
   },
   {
     "id": 8,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It[SP]seems[SP]people[SP]who[SP]confuse[SP]their[SP]repressed\nsubconscious[SP]with[SP]the[SP]voice[SP]of[SP]a[SP]demon[SP]or[SP]god\nor[SP]whatever[SP]are[SP]labeled[SP]insane[SP]these[SP]days.",
     "nom_fr": "Maya",
-    "texte_fr": "De nos jours, ceux qui confondent leur\nsubconscient réfoulé avec\nla voix d'un démon,\nd'un dieu ou autre, sont traités de fous."
+    "texte_fr": "De nos jours, ceux qui confondent leur\nsubconscient réfoulé avec\nla voix d'un démon, d'un dieu ou autre, sont traités de fous."
   },
   {
     "id": 12,
@@ -327,7 +327,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Maki...[1205][000F][SP]Mark...[1205][000F][SP]Kei...[1205][000F][SP]Yuka...[1205][000F][SP]Hidehiko...[1205][000F]\nEriko...[1205][000F][SP]Reiji...[1205][000F][SP]and...",
     "nom_fr": "Yukino",
-    "texte_fr": "Maki.[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][000F].. Mark... Kai... Yuka...\nHidehiko... Eriko... Reiji... et..."
+    "texte_fr": "Maki.[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1205].. Mark... Kai... Yuka...\nHidehiko... Eriko... Reiji... et..."
   },
   {
     "id": 22,
@@ -342,7 +342,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Time[SP]is[SP]cruel...[1205][000F][SP]I...[1205][000F][SP]I[SP]can't[SP]be[SP]the[SP]person[SP]I\nwas[SP]then,[SP]not[SP]anymore.",
     "nom_fr": "Yukino",
-    "texte_fr": "Le temps est cruel. [1205][000F][1205][000F]Je ne serait\nplus jamais la personne que j'étais."
+    "texte_fr": "Le temps est cruel. [000F][1205][000F][1205]Je ne serait\nplus jamais la personne que j'étais."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Pretentious[SP]man",
     "texte_orig": "I[SP]heard[SP]that[SP]Garcon[SP]used[SP]to[SP]be[SP]in[SP]the[SP]French\nmilitary.[SP]They[SP]call[SP]him[SP]the[SP][1432][NULL][NULL][0014]Garcon[SP]from[SP]Hell.[1432][NULL][NULL][0014][1205][000F]\nMaybe[SP]he[SP]really[SP]does[SP]sell[SP]weapons[SP]here...",
     "nom_fr": "Homme prétentieux",
-    "texte_fr": "Apparemment Garcon était dans l'armée\nFrançaise. On l'appelle [1432][NULL][NULL][0014]Garcon de l'Enfer[1432][NULL][NULL][0014]\n[1205][000F]Peut-être qu'il vend\nvraiment des armes ici..."
+    "texte_fr": "Apparemment Garcon était dans l'armée\nFrançaise. On l'appelle [1432][NULL][NULL][0014]Garcon de l'Enfer[1432][NULL][NULL][0014]\n[000F][1205]Peut-être qu'il vend vraiment des armes ici..."
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Pretentious[SP]man",
     "texte_orig": "You[SP]see,[SP]honey?[1205][000F][SP]Didn't[SP]I[SP]tell[SP]you[SP]we[SP]shouldn't\ngo[SP]to[SP]the[SP]concert?[SP]I[SP]just[SP]knew[SP]something[SP]awful\nwould[SP]happen.",
     "nom_fr": "Homme prétentieux",
-    "texte_fr": "Tu vois, chérie? [1205][000F]Je t'avais dit\nqu'on devait éviter ce concert, Je\nsavais que ça allait mal tourner."
+    "texte_fr": "Tu vois, chérie? [000F][1205]Je t'avais dit\nqu'on devait éviter ce concert, Je\nsavais que ça allait mal tourner."
   },
   {
     "id": 25,
@@ -462,7 +462,7 @@
     "nom_orig": "Pretentious[SP]man",
     "texte_orig": "We'll[SP]be[SP]blessed[SP]with[SP]new,[SP]perfect[SP]selves.[1205][000F]\nHow[SP]wonderful[SP]it[SP]shall[SP]be...",
     "nom_fr": "Homme prétentieux",
-    "texte_fr": "Nous nous réincarneront en êtres\n[1205][000F]parfaits. Ce sera merveilleux..."
+    "texte_fr": "Nous nous réincarneront en êtres\n[000F][1205]parfaits. Ce sera merveilleux..."
   },
   {
     "id": 31,
@@ -522,7 +522,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "Oh,[SP]you[SP]just[SP]couldn't[SP]get[SP]tickets.[SP]Uh...[SP]whose\nconcert[SP]were[SP]we[SP]talking[SP]about?[SP]I[SP]remember[SP]one\ngirl,[SP]but...[SP]there[SP]were[SP]others,[SP]right?",
     "nom_fr": "Femme active",
-    "texte_fr": "Oh, t'as pas pu avoir de tickets. Euh... On\nparlait du concert de qui? Je me rappelle\nd'une fille, mais il\ny en avait d'autres non?"
+    "texte_fr": "Oh, t'as pas pu avoir de tickets. Euh... On\nparlait du concert de qui? Je me rappelle\nd'une fille, mais il y en avait d'autres non?"
   },
   {
     "id": 35,
@@ -552,7 +552,7 @@
     "nom_orig": "Working[SP]woman",
     "texte_orig": "God,[SP]don't[SP]tell[SP]me[SP]you[SP]believe[SP]in[SP]that[SP]crap![1205][000F]\nHahaha...[SP]It's[SP]like[SP]still[SP]thinking[SP]Santa[SP]Claus\nis[SP]real![SP]It's[SP]sooooo[SP]adorable!",
     "nom_fr": "Femme active",
-    "texte_fr": "Pitié, me dit pas que tu crois à ces\n[1205][000F]conneries! Hahaha... C'est comme\ncroire au Père Noël! A--do--rable!!!"
+    "texte_fr": "Pitié, me dit pas que tu crois à ces\n[000F][1205]conneries! Hahaha... C'est comme\ncroire au Père Noël! A--do--rable!!!"
   },
   {
     "id": 37,
@@ -687,7 +687,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Bonjour,[SP]Monsieur.[SP]Welcome[SP]to[SP]Clair[SP]de[SP]Lune.[1205][000F]\nWhat[SP]can[SP]I[SP]get[SP]you[SP]today?\n[1208][0007][1210][U+03BC]Buy[SP]weapons\n[1210][U+0358]Buy[SP]accessories\n[1210][U+03BC]Sell[SP]items\nDine[SP]in\nTalk[SP]to[SP]the[SP]Garcon\nNever[SP]mind\nLeave",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Bienvenue au Clair de Lune.\n[1205][000F]Que puis-je faire pour vous?\n[1208][0007][1210]Acheter armes\n[1210]Acheter accessoires\n[1210]Vendre objets\nDîner ici\nParler au Garçon\nNon merci\nQuitter[U+03BC][U+0358][U+03BC]",
+    "texte_fr": "Bienvenue au Clair de Lune.\n[000F][1205]Que puis-je faire pour vous?\n[1208][0007][1210]Acheter armes\n[1210]Acheter accessoires\n[1210]Vendre objets\nDîner ici\nParler au Garçon\nNon merci\nQuitter[U+03BC][U+0358][U+03BC]",
     "question_orig": "Bonjour,[SP]Monsieur.[SP]Welcome[SP]to[SP]Clair[SP]de[SP]Lune.[1205][000F]\nWhat[SP]can[SP]I[SP]get[SP]you[SP]today?",
     "choix_orig": [
       "[1210]Buy[SP]weapons",
@@ -981,7 +981,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "I[SP]will[SP]always[SP]be[SP]awaiting[SP]your[SP]visits,[SP]with\nwhite[SP]napkins[SP]and[SP]clean[SP]wine[SP]glasses.[SP]So[SP]long\nas[SP]this[SP]restaurant[SP]has[SP]a[SP]place[SP]in[SP]your[SP]heart...",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Je vous attendrai toujours ici, avec des\nserviettes propres et des\nverres de vin. Tant\nque cet endroit a\nune place dans votrecœur..."
+    "texte_fr": "Je vous attendrai toujours ici, avec des\nserviettes propres et des\nverres de vin. Tant que cet endroit a une place dans votrecœur..."
   },
   {
     "id": 60,
@@ -1026,7 +1026,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Au[SP]revoir...[1205][000F][SP]I[SP]shall[SP]await[SP]your[SP]return.",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Au revoirJ'attendrai votre retour.[1205][000F]"
+    "texte_fr": "Au revoirJ'attendrai votre retour.[000F][1205]"
   },
   {
     "id": 63,

--- a/traduction/event_scripts/script_350.json
+++ b/traduction/event_scripts/script_350.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]got[SP]a[SP]minute?[1205][000F][SP]Something's[SP]been[SP]bugging[SP]me...\nDon't[SP]you[SP]think[SP]my[SP]shadow[SP]is[SP]the[SP]only[SP]one[SP]that\ndoesn't[SP]look[SP]like[SP]me?",
     "nom_fr": "Eikichi",
-    "texte_fr": "T'as une minute? [1205][000F]Quelque chose me\ntracasse... Tu trouves pas que mon Ombre\nest la seule qui ne me ressemble pas?"
+    "texte_fr": "T'as une minute? [000F][1205]Quelque chose me\ntracasse... Tu trouves pas que mon Ombre\nest la seule qui ne me ressemble pas?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]real[SP]me[SP]is[SP]more[SP]elegant...[SP]more[SP]beautiful...[1205][000F]\nThat[SP]guy[SP]looks[SP]like[SP]a[SP]different[SP]person.[SP]I[SP]wish\nthey[SP]paid[SP]better[SP]attention.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le vrai moi est\nplus élégant... plus beau..[1205].\n[000F]Ce type ressemble à quelqu'un d'autre. Ils\nauraient pu faire plus attention."
+    "texte_fr": "Le vrai moi est\nplus élégant... plus beau..[1205].\n[000F]Ce type ressemble à quelqu'un d'autre. Ils auraient pu faire plus attention."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Heh...[1205][000A][SP]You[SP]don't[SP]get[SP]it,[SP]Ginko.[1205][000F][SP]If[SP]it[SP]really\nhad[SP]as[SP]much[SP]power[SP]as[SP]I[SP]do,[SP]our[SP]whole[SP]team\nwould[SP]have[SP]been[SP]wiped[SP]out.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Heh.[1205]..[1205][000A] Tu comprends pas, Ginko. [000F]Si elle\navait autant de puissance que moi,\ntoute l'équipe aurait été anéantie."
+    "texte_fr": "Heh.[1205]..[000A][1205] Tu comprends pas, Ginko. [000F]Si elle\navait autant de puissance que moi,\ntoute l'équipe aurait été anéantie."
   },
   {
     "id": 3,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Those[SP]were[SP]the[SP]versions[SP]of[SP]us[SP]everyone[SP]else\nimagined...[1205][000F][SP]Maybe[SP]if[SP]those[SP]sketches[SP]hadn't[SP]gone\nout,[SP]they'd[SP]have[SP]looked[SP]completely[SP]different.",
     "nom_fr": "Maya",
-    "texte_fr": "C'était la version\nde nous qu'imaginaient les\n[1205]autres.[000F].. Si ces croquis n'avaient pas\ncirculé, elles auraient\neu l'air tout autres."
+    "texte_fr": "C'était la version\nde nous qu'imaginaient les\n[1205]autres.[000F].. Si ces croquis n'avaient pas circulé, elles auraient eu l'air tout autres."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It's[SP]not[SP]that[SP]it[SP]tasted[SP]bad,[SP]but...[1205][000F][SP]Maybe[SP]it's\nan[SP]acquired[SP]taste...[1205][000F][SP]Uuuugh...[SP]I[SP]dont'[SP]feel\nso[SP]good...",
     "nom_fr": "Maya",
-    "texte_fr": "C'est pas mauvais,\nmais... [1205][000F][1205][000F]C'est peut-être un\ngoût acquis... Beurk... Je\nme sens pas bien..."
+    "texte_fr": "C'est pas mauvais,\nmais... [000F][1205][000F][1205]C'est peut-être un\ngoût acquis... Beurk... Je me sens pas bien..."
   },
   {
     "id": 8,
@@ -177,7 +177,7 @@
     "nom_orig": "Jun",
     "texte_orig": "It's[SP]the[SP]same[SP]with[SP]the[SP]shadows.[1205][000F][SP]Two[SP]rumors\nwere[SP]spread[SP]about[SP]the[SP]people[SP]in[SP]the[SP]mugshots.",
     "nom_fr": "Jun",
-    "texte_fr": "C'est pareil pour les Ombres. [1205][000F]Deux rumeurs\nont circulé sur les personnes des photos."
+    "texte_fr": "C'est pareil pour les Ombres. [000F][1205]Deux rumeurs\nont circulé sur les personnes des photos."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Both[SP]came[SP]true,[SP]so[SP]another[SP]personality[SP]which[SP]had\nnot[SP]previously[SP]existed[SP]came[SP]into[SP]being.[1205][000F][SP]Those\nshadows[SP]are[SP]the[SP][1432][NULL][NULL][0014]us[1432][NULL][NULL][0014][SP]that[SP]the[SP]people[SP]imagined.",
     "nom_fr": "Jun",
-    "texte_fr": "Les deux se sont réalisées, donc une autre\npersonnalité inexistante a vu le jour. Ces\n[1205][000F]Ombres sont le\n[1432][NULL][NULL][0014]nous[1432][NULL][NULL][0014] qu'imaginaient les gens."
+    "texte_fr": "Les deux se sont réalisées, donc une autre\npersonnalité inexistante a vu le jour. Ces\n[000F][1205]Ombres sont le [1432][NULL][NULL][0014]nous[1432][NULL][NULL][0014] qu'imaginaient les gens."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Jun",
     "texte_orig": "And[SP]can[SP]you[SP]be[SP]so[SP]sure[SP]that[SP]we're[SP]real,[SP]and\nthe[SP]shadows[SP]we[SP]defeated[SP]were[SP]the[SP]impostors?[1205][000F]\nMaybe[SP]it's[SP]the[SP]opposite.",
     "nom_fr": "Jun",
-    "texte_fr": "Êtes-vous certains que nous sommes\nréels et que les Ombres étaient\nimposteurs? [1205][000F]C'est peut-être l'inverse."
+    "texte_fr": "Êtes-vous certains que nous sommes\nréels et que les Ombres étaient\nimposteurs? [000F][1205]C'est peut-être l'inverse."
   },
   {
     "id": 14,
@@ -252,7 +252,7 @@
     "nom_orig": "Pretentious[SP]man",
     "texte_orig": "Ohhh,[SP]I-I[SP]knew[SP]this[SP]would[SP]happen.[1205][000F][SP]B-But[SP]I\nthought[SP]you'd[SP]be[SP]surprised![SP]You[SP]like[SP]surprises!",
     "nom_fr": "Homme prétentieux",
-    "texte_fr": "Ohhh, j-je savais. [1205][000F]M-Mais je voulais\nvous surprendre! Vous aimez ça!"
+    "texte_fr": "Ohhh, j-je savais. [000F][1205]M-Mais je voulais\nvous surprendre! Vous aimez ça!"
   },
   {
     "id": 17,
@@ -297,7 +297,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Bonjour,[SP]Monsieur.[SP]Welcome[SP]to[SP]Clair[SP]de[SP]Lune.[1205][000F]\nWhat[SP]can[SP]I[SP]get[SP]you[SP]today?\n[1208][0007][1210][U+03BC]Buy[SP]weapons\n[1210][U+0358]Buy[SP]accessories\n[1210][U+03BC]Sell[SP]items\nDine[SP]in\nTalk[SP]to[SP]the[SP]Garcon\nNever[SP]mind\nLeave",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Bienvenue au Clair de Lune.\n[1205][000F]Que puis-je pour vous?\n[1208][0007][1210]Acheter armes\n[1210]Acheter accessoires\n[1210]Vendre objets\nDîner ici\nParler\nNon merci\nQuitter[U+03BC][U+0358][U+03BC]",
+    "texte_fr": "Bienvenue au Clair de Lune.\n[000F][1205]Que puis-je pour vous?\n[1208][0007][1210]Acheter armes\n[1210]Acheter accessoires\n[1210]Vendre objets\nDîner ici\nParler\nNon merci\nQuitter[U+03BC][U+0358][U+03BC]",
     "question_orig": "Bonjour,[SP]Monsieur.[SP]Welcome[SP]to[SP]Clair[SP]de[SP]Lune.[1205][000F]\nWhat[SP]can[SP]I[SP]get[SP]you[SP]today?",
     "choix_orig": [
       "[1210]Buy[SP]weapons",
@@ -384,7 +384,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Bonjour,[SP]Monsieur.[SP]Welcome[SP]to[SP]Clair[SP]de[SP]Lune.[1205][000F]\nWhat[SP]can[SP]I[SP]get[SP]you[SP]today?\n[1208][0007][1210][U+03BC]Buy[SP]weapons\n[1210][U+0358]Buy[SP]accessories\n[1210][U+03BC]Sell[SP]items\nDine[SP]in\nTalk[SP]to[SP]the[SP]Garcon\nNever[SP]mind\nLeave",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Bienvenue au Clair de Lune.\n[1205][000F]Que puis-je pour vous?\n[1208][0007][1210]Acheter armes\n[1210]Acheter accessoires\n[1210]Vendre objets\nDîner ici\nParler\nNon merci\nQuitter[U+03BC][U+0358][U+03BC]",
+    "texte_fr": "Bienvenue au Clair de Lune.\n[000F][1205]Que puis-je pour vous?\n[1208][0007][1210]Acheter armes\n[1210]Acheter accessoires\n[1210]Vendre objets\nDîner ici\nParler\nNon merci\nQuitter[U+03BC][U+0358][U+03BC]",
     "question_orig": "Bonjour,[SP]Monsieur.[SP]Welcome[SP]to[SP]Clair[SP]de[SP]Lune.[1205][000F]\nWhat[SP]can[SP]I[SP]get[SP]you[SP]today?",
     "choix_orig": [
       "[1210]Buy[SP]weapons",
@@ -486,7 +486,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Perhaps[SP]it[SP]is[SP]destiny[SP]that[SP]I[SP]evolve[SP]into[SP]an\nIdealian[SP]here.[1205][000F][SP]I[SP]may[SP]as[SP]well[SP]embrace[SP]it...\nIt's[SP]better[SP]than[SP]death.",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "C'est peut-être mon destin de devenir\nun Idéalien ici. [1205][000F]Autant l'accepter...\nC'est mieux que la mort."
+    "texte_fr": "C'est peut-être mon destin de devenir\nun Idéalien ici. [000F][1205]Autant l'accepter...\nC'est mieux que la mort."
   },
   {
     "id": 27,
@@ -501,7 +501,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "We[SP]provide[SP]excellent[SP]service[SP]and[SP]an[SP]assortment\nof[SP]the[SP]latest[SP]armaments[SP]to[SP]suit[SP]the[SP]customer's\nneeds.[1205][000F][SP]Allow[SP]me[SP]to[SP]show[SP]you[SP]our[SP]selection.",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Nous offrons un service d'excellence et un\nassortiment des dernières armes. \n[1205]Permettez-moi de\n[000F]vous présenter notresélection."
+    "texte_fr": "Nous offrons un service d'excellence et un\nassortiment des dernières armes. \n[1205]Permettez-moi de [000F]vous présenter notresélection."
   },
   {
     "id": 28,
@@ -531,7 +531,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Legendary[SP]gun?[1205][000F][SP]You've[SP]come[SP]for[SP]it[SP]too?[1205][000F][SP]Ah...\nNever[SP]mind.[SP]Excuse[SP]me.",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Le pistolet légendaire? [1205][000F][1205][000F]Vous\naussi? Ah... Excusez-moi."
+    "texte_fr": "Le pistolet légendaire? [000F][1205][000F][1205]Vous\naussi? Ah... Excusez-moi."
   },
   {
     "id": 30,
@@ -546,7 +546,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "I[SP]don't[SP]know[SP]where[SP]it[SP]started,[SP]but[SP]there[SP]is[SP]a\nrumor[SP]circulating[SP]that[SP][E4][NULL][NULL][0006]our[SP]restaurant[SP]carries\na[SP]legendary[SP]gun[E4][NULL][NULL][0002].[SP]As[SP]if[SP]that[SP]were[SP]true...",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Je ne sais pas d'où\nça vient, mais une rumeur\ncourt que [E4][NULL][NULL][0006]notre\nrestaurant possède un pistolet\nlégendaire[E4][NULL][NULL][0002]. Comme si c'était vrai..."
+    "texte_fr": "Je ne sais pas d'où\nça vient, mais une rumeur\ncourt que [E4][NULL][NULL][0006]notre restaurant possède un pistolet légendaire[E4][NULL][NULL][0002]. Comme si c'était vrai..."
   },
   {
     "id": 31,
@@ -606,7 +606,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Au[SP]revoir...[1205][000F][SP]I[SP]shall[SP]await[SP]your[SP]return.",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Au revoir.[1205][000F].. J'attendrai votre retour."
+    "texte_fr": "Au revoir.[000F][1205].. J'attendrai votre retour."
   },
   {
     "id": 35,
@@ -621,7 +621,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Please...[1205][000F][SP]We[SP]really[SP]have[SP]no[SP]such[SP]thing[SP]as[SP]this\nlegendary[SP]gun...",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Je vous en prie.[1205][000F].. Nous n'avons\npas ce pistolet légendaire..."
+    "texte_fr": "Je vous en prie.[000F][1205].. Nous n'avons\npas ce pistolet légendaire..."
   },
   {
     "id": 36,
@@ -651,7 +651,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "My,[SP]my...[1205][000F][SP]I[SP]can[SP]never[SP]put[SP]one[SP]over[SP]on[SP]you,[SP]can\nI,[SP]Ms.[SP]Maya?[1205][000F][SP]Very[SP]well,[SP]but[SP]you[SP]must[SP]keep[SP]what\nI[SP]am[SP]about[SP]to[SP]tell[SP]you[SP]a[SP]secret.",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Oh là là.[1205][000F][1205][000F].. Je ne peux vous duper,\nn'est-ce pas, Mlle Maya? Soit. Mais ce\nque je vais dire doit rester un secret."
+    "texte_fr": "Oh là là.[000F][1205][000F][1205].. Je ne peux vous duper,\nn'est-ce pas, Mlle Maya? Soit. Mais ce\nque je vais dire doit rester un secret."
   },
   {
     "id": 38,
@@ -666,7 +666,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Yes,[SP]we[SP]do[SP]have[SP]the[SP]legendary[SP]gun[SP]in[SP]stock.[1205][000F]\nAnd[SP]yes,[SP]it[SP]has[SP]historical[SP]significance,[SP]so[SP]I\nam[SP]relucant[SP]to[SP]let[SP]go[SP]of[SP]it.",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Oui, nous avons le pistolet légendaire.\n[1205][000F]Il a une valeur historique, c'est\npourquoi j'hésite à m'en séparer."
+    "texte_fr": "Oui, nous avons le pistolet légendaire.\n[000F][1205]Il a une valeur historique, c'est\npourquoi j'hésite à m'en séparer."
   },
   {
     "id": 39,
@@ -681,7 +681,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What![SP]Don't[SP]say[SP]that![1205][000F][SP]Please?[SP]Pleeease?[1205][000F]\nIf[SP]you[SP]have[SP]it,[SP]sell[SP]it[SP]to[SP]us!",
     "nom_fr": "Maya",
-    "texte_fr": "Quoi! S'il vous plaît? [1205][000F][1205][000F]Pllleease?\nSi vous l'avez, vendez-le-nous!"
+    "texte_fr": "Quoi! S'il vous plaît? [000F][1205][000F][1205]Pllleease?\nSi vous l'avez, vendez-le-nous!"
   },
   {
     "id": 40,
@@ -711,7 +711,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "I[SP]propose[SP]a[SP]deal.[1205][000F][SP]If[SP]you[SP]sample[SP]an[SP]experimental\ndish[SP]of[SP]ours,[SP]I[SP]will[SP]sell[SP]you[SP]the[SP]legendary[SP]gun.",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Je vous propose un marché. [1205][000F]Goûtez\nun plat expérimental et je vous\nvends le pistolet légendaire."
+    "texte_fr": "Je vous propose un marché. [000F][1205]Goûtez\nun plat expérimental et je vous\nvends le pistolet légendaire."
   },
   {
     "id": 42,
@@ -726,7 +726,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What?[1205][000F][SP]Really!?[1205][000F][SP]Of[SP]course![SP]I'll[SP]eat[SP]anything![1205][000F]\nJust[SP]bring[SP]it[SP]out!",
     "nom_fr": "Maya",
-    "texte_fr": "Quoi? [1205][000F][1205][000F][1205][000F]Vraiment!? Bien sûr!\nJe mange tout! Apportez-le!"
+    "texte_fr": "Quoi? [000F][1205][000F][1205][000F][1205]Vraiment!? Bien sûr!\nJe mange tout! Apportez-le!"
   },
   {
     "id": 43,
@@ -771,7 +771,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Yes.[1205][000F][SP]If[SP]I[SP]recall[SP]correctly,[SP]this[SP]was[SP]one[SP]of\nyour[SP]least[SP]favorite[SP]foods.[1205][000F][SP]That[SP]is[SP]why[SP]I[SP]am\nasking[SP]you[SP]to[SP]do[SP]this.[1205][000F][SP]I[SP]won't[SP]force[SP]you...",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Oui. [1205][000F][1205][000F][1205][000F]Si je me souviens, c'était l'un de\nvos aliments les moins appréciés. C'est\npour cela. Je ne vous force pas..."
+    "texte_fr": "Oui. [000F][1205][000F][1205][000F][1205]Si je me souviens, c'était l'un de\nvos aliments les moins appréciés. C'est\npour cela. Je ne vous force pas..."
   },
   {
     "id": 46,
@@ -842,7 +842,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "What[SP]a[SP]good[SP]friend[SP]you[SP]have.[1205][000F][SP]Well[SP]then,[SP]please\ndig[SP]in[SP]to[SP]our[SP]spaghetti[SP]di[SP]kusaya.",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Quel bon ami vous avez. [1205][000F]Alors, veuillez\nvous régaler de nos spaghetti di kusaya."
+    "texte_fr": "Quel bon ami vous avez. [000F][1205]Alors, veuillez\nvous régaler de nos spaghetti di kusaya."
   },
   {
     "id": 50,
@@ -887,7 +887,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Such[SP]bravery...[1205][000F][SP]How[SP]was[SP]the[SP]taste?",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Quel courage.[1205][000F].. Et le goût?"
+    "texte_fr": "Quel courage.[000F][1205].. Et le goût?"
   },
   {
     "id": 53,
@@ -902,7 +902,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1113]...[1205][000F][SP]Take[SP]over...",
     "nom_fr": "Maya",
-    "texte_fr": "[1113].[1205][000F].. À toi..."
+    "texte_fr": "[1113].[000F][1205].. À toi..."
   },
   {
     "id": 54,
@@ -958,7 +958,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Thank[SP]you[SP]very[SP]much.[1205][000F][SP]Now,[SP]as[SP]promised,[SP]I[SP]will\nsell[SP]you[SP]the[SP]legendary[SP]gun.",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Merci. [1205][000F]Comme promis, je vous\nvends le pistolet légendaire."
+    "texte_fr": "Merci. [000F][1205]Comme promis, je vous\nvends le pistolet légendaire."
   },
   {
     "id": 57,
@@ -988,7 +988,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Don't[SP]worry.[1205][000F][SP]We'll[SP]hold[SP]it[SP]for[SP]you[SP]and\nyou[SP]alone.",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Ne vous inquiétez pas. [1205][000F]Rien que pour vous."
+    "texte_fr": "Ne vous inquiétez pas. [000F][1205]Rien que pour vous."
   },
   {
     "id": 59,
@@ -1003,7 +1003,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "How[SP]disappointing...[1205][000F][SP]But[SP]never[SP]mind.[1205][000F][SP]A[SP]promise\nis[SP]a[SP]promise.[1205][000F][SP]I[SP]will[SP]sell[SP]you[SP]the[SP]legendary[SP]gun.",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Déception..[1205][000F][1205][000F][1205]. [000F]Peu importe. Une\npromesse est une promesse. Je vous\nvends le pistolet légendaire."
+    "texte_fr": "Déception..[000F][1205][000F][1205][1205]. [000F]Peu importe. Une\npromesse est une promesse. Je vous\nvends le pistolet légendaire."
   },
   {
     "id": 60,
@@ -1033,7 +1033,7 @@
     "nom_orig": "Garcon[SP]Soejima",
     "texte_orig": "Don't[SP]worry.[1205][000F][SP]We'll[SP]hold[SP]it[SP]for[SP]you[SP]and\nyou[SP]alone.",
     "nom_fr": "Garçon Soejima",
-    "texte_fr": "Ne vous inquiétez pas. [1205][000F]Rien que pour vous."
+    "texte_fr": "Ne vous inquiétez pas. [000F][1205]Rien que pour vous."
   },
   {
     "id": 62,
@@ -1063,7 +1063,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Oh,[SP]thankyouthankyouthankyou![1205][000F][SP]I[SP]owe[SP]you[SP]one,\n[1113]!",
     "nom_fr": "Maya",
-    "texte_fr": "Oh, mercimercimercii! [1205][000F]Je\nte revaudrai ça, [1113]!"
+    "texte_fr": "Oh, mercimercimercii! [000F][1205]Je\nte revaudrai ça, [1113]!"
   },
   {
     "id": 64,

--- a/traduction/event_scripts/script_351.json
+++ b/traduction/event_scripts/script_351.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "P-Pssst...[1205][000F][SP]Is[SP]that[SP]dude[SP]looking[SP]at[SP]women's\nclothing?[1205][000F][SP]Is[SP]he[SP]planning[SP]to[SP]buy[SP]some?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ch-Chut.[1205][000F][1205][000F].. Ce type lorgne les vêtements\nféminins? Il compte en acheter?"
+    "texte_fr": "Ch-Chut.[000F][1205][000F][1205].. Ce type lorgne les vêtements\nféminins? Il compte en acheter?"
   },
   {
     "id": 1,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "She[SP]was[SP]in[SP]the[SP]Masked[SP]Circle[SP]too...[1205][000F][SP]Oh[SP]no...\nIs[SP]that[SP]what's[SP]going[SP]to[SP]happen[SP]to[SP]Sheba[SP]and\nMee-ho?",
     "nom_fr": "Ginko",
-    "texte_fr": "Elle était dans le\nCercle masqué.[1205][000F].. Oh non...\nC'est ce qui va arriver à Sheba et Mee-ho?"
+    "texte_fr": "Elle était dans le\nCercle masqué.[000F][1205].. Oh non...\nC'est ce qui va arriver à Sheba et Mee-ho?"
   },
   {
     "id": 7,
@@ -282,7 +282,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]bet[SP]he's[SP]out[SP]covering[SP]some[SP]story[SP]even[SP]now...[1205][000F]\nI[SP]hope[SP]he[SP]doesn't[SP]get[SP]caught[SP]in[SP]a[SP]bombing[SP]or\nanything...",
     "nom_fr": "Yukino",
-    "texte_fr": "Il est sûrement\nen reportage... [1205][000F]J'espère qu'il\nne se retrouvera pas dans un attentat..."
+    "texte_fr": "Il est sûrement\nen reportage... [000F][1205]J'espère qu'il\nne se retrouvera pas dans un attentat..."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Fujii-san...[1205][000F][SP]I[SP]wonder[SP]if[SP]he's[SP]at[SP]the[SP]mountain\neven[SP]as[SP]we[SP]speak...",
     "nom_fr": "Yukino",
-    "texte_fr": "Fujii-san.[1205][000F].. Je me demande\ns'il est à la montagne là..."
+    "texte_fr": "Fujii-san.[000F][1205].. Je me demande\ns'il est à la montagne là..."
   },
   {
     "id": 20,
@@ -327,7 +327,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Welcome.[1205][000A][SP]Like[SP]what[SP]you[SP]see?[1205][000A][SP]We[SP]only[SP]carry[SP]the\nmost[SP]beautiful[SP]clothing[SP]here.[1205][000F][SP]So[SP]feel[SP]free[SP]to\nbuy[SP]with[SP]confidence.\n[1208][0006]Buy[SP]armor\n[1210][U+036A]Buy[SP]accessories\nSell[SP]items\nTalk[SP]to[SP]the[SP]saleswoman\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Bienvenue.[1205][1205][000A] Quelque chose vous plaît?[1205][000A] Nous\nne proposons que\n[000F]les plus beaux vêtements. N'hésitez pas à\nacheter en toute confiance.\n[1208][0006]Acheter armures\n[1210]Acheter accessoires\nVendre objets\nPapoter\nNon\nQuitter[U+036A]",
+    "texte_fr": "Bienvenue.[1205][000A][1205] Quelque chose vous plaît?[000A][1205] Nous\nne proposons que\n[000F]les plus beaux vêtements. N'hésitez pas à\nacheter en toute confiance.\n[1208][0006]Acheter armures\n[1210]Acheter accessoires\nVendre objets\nPapoter\nNon\nQuitter[U+036A]",
     "question_orig": "Welcome.[1205][000A][SP]Like[SP]what[SP]you[SP]see?[1205][000A][SP]We[SP]only[SP]carry[SP]the\nmost[SP]beautiful[SP]clothing[SP]here.[1205][000F][SP]So[SP]feel[SP]free[SP]to\nbuy[SP]with[SP]confidence.",
     "choix_orig": [
       "Buy[SP]armor",
@@ -572,7 +572,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "What[SP]do[SP]think[SP]of[SP]this[SP]red[SP]dress?[1205][000F][SP]It[SP]resists\nheat,[SP]you[SP]know.[SP]Both[SP]stylish[SP]and[SP]practical.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Que pensez-vous de cette robe rouge? [1205][000F]Elle\nrésiste à la chaleur. Chic et pratique."
+    "texte_fr": "Que pensez-vous de cette robe rouge? [000F][1205]Elle\nrésiste à la chaleur. Chic et pratique."
   },
   {
     "id": 33,
@@ -632,7 +632,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "People[SP]say[SP]these[SP]are[SP]terrorist[SP]attacks,[SP]but\nare[SP]they[SP]really?[SP]There[SP]haven't[SP]been[SP]any[SP]demands\nor[SP]announcements[SP]from[SP]the[SP]bombers...",
     "nom_fr": "Vendeuse",
-    "texte_fr": "On dit que ce\nsont des attaques terroristes,\nmais vraiment? Il n'y a eu aucune \nrevendication ni annonce\ndes poseurs debombes..."
+    "texte_fr": "On dit que ce\nsont des attaques terroristes,\nmais vraiment? Il n'y a eu aucune revendication ni annonce des poseurs debombes..."
   },
   {
     "id": 37,
@@ -812,7 +812,7 @@
     "nom_orig": "Chatty[SP]woman",
     "texte_orig": "O-Oh[SP]my[SP]goodness![SP]They[SP]were[SP]flying![1205][000F][SP]There[SP]were\nsoldiers[SP]flying[SP]through[SP]the[SP]sky![SP]I[SP]saw[SP]it[SP]with\nmy[SP]own[SP]eyes![SP]Long[SP]spears[SP]and[SP]black[SP]armor...",
     "nom_fr": "Bavarde",
-    "texte_fr": "M-Mon Dieu! Ils\nvolaient! [1205][000F]Des soldats volaient\ndans le ciel! Je l'ai\nvu de mes propres yeux!\nDe longues lances et des armures noires..."
+    "texte_fr": "M-Mon Dieu! Ils\nvolaient! [000F][1205]Des soldats volaient\ndans le ciel! Je l'ai vu de mes propres yeux! De longues lances et des armures noires..."
   },
   {
     "id": 49,
@@ -842,7 +842,7 @@
     "nom_orig": "Wealthy[SP]woman",
     "texte_orig": "No,[SP]I[SP]came[SP]to[SP]see[SP]a[SP]concert,[SP]but[SP]it[SP]was[SP]sold\nout...[1205][000F][SP]So[SP]I[SP]was[SP]about[SP]to[SP]go[SP]home.",
     "nom_fr": "Femme aisée",
-    "texte_fr": "Non, je venais voir un concert, mais\n[1205][000F]c'était complet... J'allais rentrer."
+    "texte_fr": "Non, je venais voir un concert, mais\n[000F][1205]c'était complet... J'allais rentrer."
   },
   {
     "id": 51,
@@ -992,7 +992,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "I[SP]had[SP]to[SP]do[SP]this...[1205][000F][SP]I[SP]only[SP]love[SP]men![SP]What[SP]else\nwas[SP]I[SP]supposed[SP]to[SP]do!?",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "J'étais obligée.[1205][000F].. J'aime les\nhommes! Que pouvais-je faire!?"
+    "texte_fr": "J'étais obligée.[000F][1205].. J'aime les\nhommes! Que pouvais-je faire!?"
   },
   {
     "id": 61,
@@ -1067,7 +1067,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Hey![1205][000A][SP]That's[SP]the[SP]dressing[SP]room.[1205][000A][SP]Don't[SP]go[SP]in\nthere[SP]if[SP]you[SP]don't[SP]need[SP]to[SP]use[SP]it.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Hé![1205][000A] C'est la cabine d'essayage.[1205][000A] N'entrez\npas si vous n'en avez pas l'utilité."
+    "texte_fr": "Hé![000A][1205] C'est la cabine d'essayage.[000A][1205] N'entrez\npas si vous n'en avez pas l'utilité."
   },
   {
     "id": 66,

--- a/traduction/event_scripts/script_352.json
+++ b/traduction/event_scripts/script_352.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "My[SP]mom[SP]wouldn't[SP]wear[SP]clothes[SP]like[SP]these...[1205][000F]\nHey,[SP]does[SP]your[SP]mom[SP]wear[SP]this[SP]stuff,[SP]Ginko?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ma mère ne mettrait pas ces fringues.[1205][000F]..\nHé, ta mère en porte, Ginko?"
+    "texte_fr": "Ma mère ne mettrait pas ces fringues.[000F][1205]..\nHé, ta mère en porte, Ginko?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "No[SP]way.[SP]She's[SP]always[SP]dressed[SP]in[SP]a[SP]kimono.[1205][000F]\nNot[SP]even[SP]native[SP]Japanese[SP]women[SP]have[SP]as[SP]many\nkimonos[SP]as[SP]her.",
     "nom_fr": "Ginko",
-    "texte_fr": "Pas question. Elle est toujours en kimono.\n[1205][000F]Même les Japonaises n'en ont pas autant\nqu'elle."
+    "texte_fr": "Pas question. Elle est toujours en kimono.\n[000F][1205]Même les Japonaises n'en ont pas autant\nqu'elle."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hey,[SP]Jun.[1205][000A][SP]Does[SP]your[SP]mom[SP]wear[SP]clothes[SP]like[SP]these?",
     "nom_fr": "Maya",
-    "texte_fr": "Hé, Jun.[1205][000A] Ta mère\nporte ce genre de vêtements?"
+    "texte_fr": "Hé, Jun.[000A][1205] Ta mère\nporte ce genre de vêtements?"
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Welcome.[1205][000A][SP]Like[SP]what[SP]you[SP]see?[1205][000A][SP]We[SP]only[SP]carry[SP]the\nmost[SP]beautiful[SP]clothing[SP]here.[1205][000F][SP]So[SP]feel[SP]free[SP]to\nbuy[SP]with[SP]confidence.\n[1208][0006]Buy[SP]armor\n[1210][U+036A]Buy[SP]accessories\nSell[SP]items\nTalk[SP]to[SP]the[SP]saleswoman\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Bienvenue.[1205][1205][000A] Quelque chose vous plaît?[1205][000A] Que \ndes\nvêtements superbes. [000F]Achetez sans crainte.\n[1208][0006]Acheter armure\n[1210]Acheter accessoires\nVendre objets\nParler à la vendeuse\nLaisser tomber\nQuitter la boutique[U+036A]",
+    "texte_fr": "Bienvenue.[1205][000A][1205] Quelque chose vous plaît?[000A][1205] Que \ndes\nvêtements superbes. [000F]Achetez sans crainte.\n[1208][0006]Acheter armure\n[1210]Acheter accessoires\nVendre objets\nParler à la vendeuse\nLaisser tomber\nQuitter la boutique[U+036A]",
     "question_orig": "Welcome.[1205][000A][SP]Like[SP]what[SP]you[SP]see?[1205][000A][SP]We[SP]only[SP]carry[SP]the\nmost[SP]beautiful[SP]clothing[SP]here.[1205][000F][SP]So[SP]feel[SP]free[SP]to\nbuy[SP]with[SP]confidence.",
     "choix_orig": [
       "Buy[SP]armor",
@@ -242,7 +242,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Are[SP]you[SP]thrilled[SP]to[SP]become[SP]an[SP]Idealian[SP]soon?[1205][000F]\nHeheheh...[SP]You're[SP]misreading[SP]the[SP]whole\nsituation.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Vous êtes impatients de devenir\ndes Idéaliens? [1205][000F]Hihi... Vous faites\nfausse route, j'en ai peur."
+    "texte_fr": "Vous êtes impatients de devenir\ndes Idéaliens? [000F][1205]Hihi... Vous faites\nfausse route, j'en ai peur."
   },
   {
     "id": 11,
@@ -257,7 +257,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Dandelions[SP]will[SP]always[SP]be[SP]dandelions.[1205][000F][SP]They[SP]can\nevolve[SP]into[SP]Idealians,[SP]but[SP]they'll[SP]never[SP]be[SP]as\nbeautiful[SP]as[SP]we[SP]roses.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Un pissenlit reste un pissenlit. [1205][000F]Ils\npeuvent devenir des Idéaliens, mais\njamais aussi beaux que nous, les roses."
+    "texte_fr": "Un pissenlit reste un pissenlit. [000F][1205]Ils\npeuvent devenir des Idéaliens, mais\njamais aussi beaux que nous, les roses."
   },
   {
     "id": 12,
@@ -302,7 +302,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "And[SP]so![1205][000A][SP]I[SP]present[SP]our[SP]newest[SP]armor.[1205][000F][SP]While[SP]you\nmay[SP]only[SP]be[SP]a[SP]dandelion,[SP]equip[SP]this[SP]and[SP]you'll\nbe[SP]one[SP]step[SP]closer[SP]to[SP]a[SP]beautiful[SP]rose.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "C'est pourquoi![1205][1205][000A] Voici notre nouvelle\n[000F]armure. Même un pissenlit, en la portant,\nse rapprochera d'une belle rose."
+    "texte_fr": "C'est pourquoi![1205][000A][1205] Voici notre nouvelle\n[000F]armure. Même un pissenlit, en la portant,\nse rapprochera d'une belle rose."
   },
   {
     "id": 15,
@@ -332,7 +332,7 @@
     "nom_orig": "Chatty[SP]woman",
     "texte_orig": "Hey,[SP]have[SP]you[SP]heard?[1205][000F][SP]The[SP]Last[SP]Battalion[SP]just\nstormed[SP]into[SP]that[SP]weird[SP]building.",
     "nom_fr": "Femme bavarde",
-    "texte_fr": "Vous avez entendu? [1205][000F]Le Bataillon\nvient d'envahir ce bâtiment bizarre."
+    "texte_fr": "Vous avez entendu? [000F][1205]Le Bataillon\nvient d'envahir ce bâtiment bizarre."
   },
   {
     "id": 17,
@@ -347,7 +347,7 @@
     "nom_orig": "Chatty[SP]woman",
     "texte_orig": "I[SP]wonder[SP]what[SP]they're[SP]doing[SP]in[SP]there...[1205][000F]\nDon't[SP]you?[1205][000F][SP]You[SP]want[SP]to[SP]know[SP]too,[SP]right?",
     "nom_fr": "Femme bavarde",
-    "texte_fr": "Je me demande ce qu'ils font dedans.[1205][000F][1205][000F]..\nPas vous? Vous voulez savoir, non?"
+    "texte_fr": "Je me demande ce qu'ils font dedans.[000F][1205][000F][1205]..\nPas vous? Vous voulez savoir, non?"
   },
   {
     "id": 18,
@@ -362,7 +362,7 @@
     "nom_orig": "Wealthy[SP]woman",
     "texte_orig": "I've[SP]always[SP]wanted[SP]to[SP]be[SP]rich.[1205][000F][SP]I[SP]talk[SP]like[SP]this\nand[SP]wear[SP]expensive[SP]clothes,[SP]but[SP]really,[SP]we're\nin[SP]the[SP]red...[1205][000F][SP]I[SP]work[SP]to[SP]repay[SP]my[SP]debt...",
     "nom_fr": "Femme aisée",
-    "texte_fr": "J'ai toujours voulu être\n[1205][000F][1205][000F]riche. Je parle ainsi\net porte des habits\ncoûteux, mais en vrai je\nsuis dans le rouge. Je bosse pour payer."
+    "texte_fr": "J'ai toujours voulu être\n[000F][1205][000F][1205]riche. Je parle ainsi\net porte des habits coûteux, mais en vrai je suis dans le rouge. Je bosse pour payer."
   },
   {
     "id": 19,
@@ -392,7 +392,7 @@
     "nom_orig": "Wealthy[SP]woman",
     "texte_orig": "Will[SP]I[SP]at[SP]least[SP]be[SP]happy?[1205][000F][SP]Will[SP]I[SP]find[SP]true\njoy...[SP]a[SP]purpose[SP]to[SP]my[SP]life?",
     "nom_fr": "Femme aisée",
-    "texte_fr": "Serai-je heureuse? [1205][000F]Trouverai-je\nla vraie joie, un sens à ma vie?"
+    "texte_fr": "Serai-je heureuse? [000F][1205]Trouverai-je\nla vraie joie, un sens à ma vie?"
   },
   {
     "id": 21,
@@ -422,7 +422,7 @@
     "nom_orig": "Saleswoman",
     "texte_orig": "Hey![1205][000A][SP]That's[SP]the[SP]dressing[SP]room.[1205][000A][SP]Don't[SP]go[SP]in\nthere[SP]if[SP]you[SP]don't[SP]need[SP]to[SP]use[SP]it.",
     "nom_fr": "Vendeuse",
-    "texte_fr": "Hé![1205][000A] C'est la cabine d'essayage.[1205][000A] N'entrez\npas si vous n'en avez pas besoin."
+    "texte_fr": "Hé![000A][1205] C'est la cabine d'essayage.[000A][1205] N'entrez\npas si vous n'en avez pas besoin."
   },
   {
     "id": 23,

--- a/traduction/event_scripts/script_353.json
+++ b/traduction/event_scripts/script_353.json
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "That's...[1205][000F][SP]What[SP]do[SP]we[SP]do?[1205][000F][SP]We[SP]can't[SP]stop[SP]it...",
     "nom_fr": "Ginko",
-    "texte_fr": "... [1205][000F][1205][000F]Qu'est-ce qu'on fait? Rien à faire..."
+    "texte_fr": "... [000F][1205][000F][1205]Qu'est-ce qu'on fait? Rien à faire..."
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]hope[SP]you're[SP]right,[SP]Eikichi...[1205][000F][SP]But[SP]everyone's\nbuying[SP]the[SP]book.[SP]If[SP]it[SP]keeps[SP]coming[SP]true,\npeople[SP]will[SP]believe[SP]it[SP]more[SP]and[SP]more...",
     "nom_fr": "Ginko",
-    "texte_fr": "J'espère, Eikichi... [1205][000F]Mais tout le monde\nachète le livre. S'il se réalise encore,\nles gens vont y croire de plus en plus..."
+    "texte_fr": "J'espère, Eikichi... [000F][1205]Mais tout le monde\nachète le livre. S'il se réalise encore,\nles gens vont y croire de plus en plus..."
   },
   {
     "id": 11,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1432][NULL][NULL][0014]Joker,[1432][NULL][NULL][0014][SP]huh?[1205][000F][SP]What's[SP]the[SP]Masked[SP]Circle's[SP]game,\nmaking[SP]Lisa[SP]sing[SP]a[SP]song[SP]like[SP]that...?",
     "nom_fr": "Maya",
-    "texte_fr": "[1432][NULL][NULL][0014]Joker,[1432][NULL][NULL][0014] hein? [1205][000F]Quel jeu joue le Cercle\nmasqué en faisant chanter ça à Lisa...?"
+    "texte_fr": "[1432][NULL][NULL][0014]Joker,[1432][NULL][NULL][0014] hein? [000F][1205]Quel jeu joue le Cercle\nmasqué en faisant chanter ça à Lisa...?"
   },
   {
     "id": 13,
@@ -297,7 +297,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "It's[SP]all[SP]becoming[SP]clear.[1205][000F][SP]The[SP]Masked[SP]Circle\nhad[SP]their[SP]fingers[SP]all[SP]over[SP]this[SP]incident.\nWe're[SP]finally[SP]on[SP]their[SP]trail.",
     "nom_fr": "Yukino",
-    "texte_fr": "Tout s'éclaircit. [1205][000F]Le Cercle masqué était\nderrière tout ça. On\nest enfin sur leur piste."
+    "texte_fr": "Tout s'éclaircit. [000F][1205]Le Cercle masqué était\nderrière tout ça. On\nest enfin sur leur piste."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Maybe[SP]Eikichi[SP]understands[SP]Lisa[SP]better[SP]than\nany[SP]of[SP]us.[1205][000F][SP]It's[SP]kind[SP]of[SP]funny[SP]watching[SP]them.",
     "nom_fr": "Yukino",
-    "texte_fr": "Eikichi comprend peut-être Lisa mieux\n[1205][000F]que nous. C'est marrant à regarder."
+    "texte_fr": "Eikichi comprend peut-être Lisa mieux\n[000F][1205]que nous. C'est marrant à regarder."
   },
   {
     "id": 21,
@@ -342,7 +342,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Rumors[SP]sure[SP]spread[SP]fast[SP]when[SP]they're[SP]shown[SP]on\nTV...[1205][000F][SP]It's[SP]a[SP]bad[SP]break[SP]for[SP]us.[SP]And[SP]at[SP]the[SP]worst\npossible[SP]time...",
     "nom_fr": "Yukino",
-    "texte_fr": "Les rumeurs vont vite à la télé...\n[1205][000F]C'est une mauvaise nouvelle pour\nnous. Et au pire moment..."
+    "texte_fr": "Les rumeurs vont vite à la télé...\n[000F][1205]C'est une mauvaise nouvelle pour\nnous. Et au pire moment..."
   },
   {
     "id": 23,
@@ -417,7 +417,7 @@
     "nom_orig": "Aloof[SP]man",
     "texte_orig": "I[SP]heard[SP]a[SP]mysterious[SP]gang[SP]of[SP]five[SP]was[SP]spotted\nat[SP]the[SP]concert[SP]hall.[SP]I[SP]heard[SP]they're[SP]the[SP]ones\nwho[SP]thwarted[SP]the[SP]attack...[1205][000F][SP]But[SP]who[SP]are[SP]they?",
     "nom_fr": "Homme distant",
-    "texte_fr": "Un groupe mystérieux de\ncinq personnes a été\nvu à l'amphithéâtre. Ce\nseraient eux qui ont\ndéjoué l'attaque.[1205].[000F]. Mais qui sont-ils?"
+    "texte_fr": "Un groupe mystérieux de\ncinq personnes a été\nvu à l'amphithéâtre. Ce seraient eux qui ont déjoué l'attaque.[1205].[000F]. Mais qui sont-ils?"
   },
   {
     "id": 28,
@@ -917,7 +917,7 @@
     "nom_orig": "Sister[SP]#1",
     "texte_orig": "Heeheehee.[SP]Us[SP]seven[SP]sisters[SP]are[SP]all[SP]pretty\ninto[SP]the[SP]In[SP]Lak'ech[SP]too.[1205][000F][SP]But[SP]I[SP]wonder[SP]if[SP]the\nthings[SP]it[SP]says[SP]are[SP]true.",
     "nom_fr": "Sœur n°1",
-    "texte_fr": "Hihihi. Nous sept sœurs on est\ntoutes assez fan de l'In Lak'ech\n[1205][000F]aussi. Mais ce qu'il dit est vrai?"
+    "texte_fr": "Hihihi. Nous sept sœurs on est\ntoutes assez fan de l'In Lak'ech\n[000F][1205]aussi. Mais ce qu'il dit est vrai?"
   },
   {
     "id": 56,
@@ -962,7 +962,7 @@
     "nom_orig": "Sister[SP]#1",
     "texte_orig": "I'd[SP]better[SP]start[SP]preparing[SP]for[SP]our[SP]latest[SP]grand\nopening[SP]at[SP]the[SP]Xibalba[SP]branch![1205][000F][SP]Heeheehee.",
     "nom_fr": "Sœur n°1",
-    "texte_fr": "Faut que je prépare la grande ouverture\nde la branche Xibalba! [1205][000F]Hihihi."
+    "texte_fr": "Faut que je prépare la grande ouverture\nde la branche Xibalba! [000F][1205]Hihihi."
   },
   {
     "id": 59,
@@ -1092,7 +1092,7 @@
     "nom_orig": "Sister[SP]#1",
     "texte_orig": "Our[SP]resale[SP]prices[SP]are[SP]around[SP]half[SP]the[SP]original\nprice.[SP]You[SP]can't[SP]sell[SP]anything[SP]you[SP]have[SP]equipped,\nand[SP]some[SP]special[SP]items[SP]are[SP]off-limits[SP]too.",
     "nom_fr": "Sœur n°1",
-    "texte_fr": "Nos prix de rachat\nsont environ la moitié du\nprix d'origine. Les objets équipés ne sont\npas vendables, ni\ncertains objets spéciaux."
+    "texte_fr": "Nos prix de rachat\nsont environ la moitié du\nprix d'origine. Les objets équipés ne sont pas vendables, ni certains objets spéciaux."
   },
   {
     "id": 67,

--- a/traduction/event_scripts/script_354.json
+++ b/traduction/event_scripts/script_354.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Tch,[SP]listen[SP]to[SP]that[SP]guy![1205][000A][SP]He[SP]thinks[SP]he[SP]was\nchosen?[1205][000F][SP]He[SP]just[SP]happened[SP]to[SP]be[SP]living[SP]in\nSumaru![1205][000A][SP]He[SP]oughtta[SP]get[SP]off[SP]his[SP]high[SP]horse!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tch, il s'entend ce type![1205][1205][000A] Il se\n[000F]croit élu? Il vit juste à Sumaru par\nhasard![1205][000A] Qu'il redescende sur terre!"
+    "texte_fr": "Tch, il s'entend ce type![1205][000A][1205] Il se\n[000F]croit élu? Il vit juste à Sumaru par\nhasard![000A][1205] Qu'il redescende sur terre!"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Yeah,[SP]Jun...[1205][001E][SP]Leave[SP]it[SP]to[SP]Maya-san.\nShe[SP]can[SP]crash[SP]anything.",
     "nom_fr": "Ginko",
-    "texte_fr": "Ouais, Jun...[1205][001E] Laisse faire\nMaya. Elle peut tout crasher."
+    "texte_fr": "Ouais, Jun...[001E][1205] Laisse faire\nMaya. Elle peut tout crasher."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Jun",
     "texte_orig": "It's[SP]not[SP]like[SP]a[SP]normal[SP]vehicle...[1205][001E][SP]I[SP]don't[SP]know\nif[SP]we[SP]can[SP]control[SP]it.[1205][001E][SP]If[SP]worse[SP]comes[SP]to[SP]worst,\nwe[SP]may[SP]have[SP]to[SP]crash[SP]it[SP]to[SP]stop[SP]it...",
     "nom_fr": "Jun",
-    "texte_fr": "C'est pas un véhicule ordinaire...[1205][001E] Je\nsais pas si on peut le contrôler.[1205][001E] Au\npire, faudra le crasher pour l'arrêter..."
+    "texte_fr": "C'est pas un véhicule ordinaire...[001E][1205] Je\nsais pas si on peut le contrôler.[001E][1205] Au\npire, faudra le crasher pour l'arrêter..."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Aloof[SP]man",
     "texte_orig": "Do[SP]you[SP]want[SP]to[SP]become[SP]an[SP]Idealian,[SP]too?[1205][000F]\nI'd[SP]prefer[SP]not[SP]to.[1205][000F][SP]I'd[SP]rather[SP]pursue[SP]my\nown[SP]happiness.",
     "nom_fr": "Homme distant",
-    "texte_fr": "Vous voulez devenir un Idéalien? [1205][000F][1205][000F]Pas moi.\nJe préfère poursuivre mon propre bonheur."
+    "texte_fr": "Vous voulez devenir un Idéalien? [000F][1205][000F][1205]Pas moi.\nJe préfère poursuivre mon propre bonheur."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Aloof[SP]man",
     "texte_orig": "That's[SP]all[SP]fine.[1205][000A][SP]All[SP]I[SP]need[SP]to[SP]be[SP]happy[SP]is\ncoffee[SP]and[SP]cigarettes.[1205][000F][SP]Haha,[SP]is[SP]that[SP]settling\nfor[SP]too[SP]little?",
     "nom_fr": "Homme distant",
-    "texte_fr": "Tout ça c'est bien.[1205][1205][000A] Il\nme faut juste café et\n[000F]cigarettes. Haha, c'est trop peu ambitieux?"
+    "texte_fr": "Tout ça c'est bien.[1205][000A][1205] Il\nme faut juste café et\n[000F]cigarettes. Haha, c'est trop peu ambitieux?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Pale[SP]man",
     "texte_orig": "Heheheh...[1205][0008][SP]I've[SP]been[SP]waiting[SP]for[SP]you,[SP]Xibalba.[1205][000A]\nThe[SP]ship[SP]of[SP]the[SP]gods[SP]in[SP]hell.[1205][000A][SP]We[SP]were[SP]promised\nevolution![1205][000A][SP]A[SP]new[SP]life![1205][000A][SP]To[SP]become[SP]Idealians!",
     "nom_fr": "Homme blême",
-    "texte_fr": "Heheheh...[1205][0008] Je\nt'attendais, Xibalba.[1205][000A] Vaisseau\ndes dieux des enfers.[1205][000A] On nous avait promis\nl'évolution![1205][000A] Nouvelle\nvie![1205][000A] Devenir Idéaliens!"
+    "texte_fr": "Heheheh...[0008][1205] Je\nt'attendais, Xibalba.[000A][1205] Vaisseau\ndes dieux des enfers.[000A][1205] On nous avait promis l'évolution![000A][1205] Nouvelle vie![000A][1205] Devenir Idéaliens!"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Pale[SP]man",
     "texte_orig": "The[SP]Earth[SP]will[SP]be[SP]destroyed.[1205][000A][SP]Too[SP]bad,[SP]so[SP]sad.[1205][000A]\nWe[SP]were[SP]chosen[SP]and[SP]the[SP]ones[SP]down[SP]there[SP]weren't.",
     "nom_fr": "Homme blême",
-    "texte_fr": "La Terre sera détruite.[1205][000A] Dommage.[1205][000A]\nNous sommes élus, pas eux là-bas."
+    "texte_fr": "La Terre sera détruite.[000A][1205] Dommage.[000A][1205]\nNous sommes élus, pas eux là-bas."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Pale[SP]man",
     "texte_orig": "My[SP]heart[SP]bleeds[SP]for[SP]them.[SP]But[SP]who[SP]can[SP]help[SP]it?[1205][000A]\nWe[SP]are[SP]the[SP]chosen[SP]ones![SP]Heheheh!",
     "nom_fr": "Homme blême",
-    "texte_fr": "J'ai de la peine pour eux. Mais qu'y\nfaire?[1205][000A] Nous sommes les élus! Heheheh!"
+    "texte_fr": "J'ai de la peine pour eux. Mais qu'y\nfaire?[000A][1205] Nous sommes les élus! Heheheh!"
   },
   {
     "id": 10,
@@ -332,7 +332,7 @@
     "nom_orig": "Sister[SP]#1",
     "texte_orig": "Ever[SP]since[SP]the[SP]city[SP]took[SP]to[SP]the[SP]sky,[SP]my[SP]sisters\nhave[SP]been[SP]on[SP]the[SP]horn[SP]nonstop.[1205][000F][SP]They're[SP]worried\nwe[SP]won't[SP]be[SP]able[SP]to[SP]take[SP]our[SP]chain[SP]nationwide.",
     "nom_fr": "Sœur n°1",
-    "texte_fr": "Depuis que la ville a décollé, mes sœurs\nm'appellent sans arrêt. [1205][000F]Elles s'inquiètent\nde ne pas pouvoir ouvrir nos franchises."
+    "texte_fr": "Depuis que la ville a décollé, mes sœurs\nm'appellent sans arrêt. [000F][1205]Elles s'inquiètent\nde ne pas pouvoir ouvrir nos franchises."
   },
   {
     "id": 17,
@@ -347,7 +347,7 @@
     "nom_orig": "Sister[SP]#1",
     "texte_orig": "Nonsense,[SP]I[SP]say![1205][000F][SP]If[SP]we[SP]can't[SP]take[SP]over[SP]the\ncountry,[SP]we'll[SP]take[SP]over[SP]Xibalba!",
     "nom_fr": "Sœur n°1",
-    "texte_fr": "Sottises! [1205][000F]Si on peut pas conquérir\nle pays, on conquerra Xibalba!"
+    "texte_fr": "Sottises! [000F][1205]Si on peut pas conquérir\nle pays, on conquerra Xibalba!"
   },
   {
     "id": 18,
@@ -362,7 +362,7 @@
     "nom_orig": "Sister[SP]#1",
     "texte_orig": "We'll[SP]scoop[SP]up[SP]our[SP]shattered[SP]dreams[SP]from[SP]the\nland[SP]below[SP]and[SP]rebuild[SP]them[SP]on[SP]Xibalba![1205][000F]\nHeeheeheehee!",
     "nom_fr": "Sœur n°1",
-    "texte_fr": "On ramassera nos rêves brisés en bas et on\nles reconstruira sur Xibalba! [1205][000F]Hihihihihi!"
+    "texte_fr": "On ramassera nos rêves brisés en bas et on\nles reconstruira sur Xibalba! [000F][1205]Hihihihihi!"
   },
   {
     "id": 19,
@@ -492,7 +492,7 @@
     "nom_orig": "Sister[SP]#1",
     "texte_orig": "Our[SP]resale[SP]prices[SP]are[SP]around[SP]half[SP]the[SP]original\nprice.[SP]You[SP]can't[SP]sell[SP]anything[SP]you[SP]have[SP]equipped,\nand[SP]some[SP]special[SP]items[SP]are[SP]off-limits[SP]too.",
     "nom_fr": "Sœur n°1",
-    "texte_fr": "Nos prix de rachat\nsont environ la moitié du\nprix d'origine. Les objets équipés ne sont\npas vendables, ni\ncertains objets spéciaux."
+    "texte_fr": "Nos prix de rachat\nsont environ la moitié du\nprix d'origine. Les objets équipés ne sont pas vendables, ni certains objets spéciaux."
   },
   {
     "id": 27,

--- a/traduction/event_scripts/script_355.json
+++ b/traduction/event_scripts/script_355.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Huuuh?[SP]THAT[SP]lady's[SP]a[SP]model...?[1205][000F][SP]I-I[SP]thought\nmodels[SP]were[SP]more...[SP]slender[SP]and...[SP]willowy...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hein? ELLE est mannequin.[1205][000F]..? Je les\nvoyais plus... fines et... élancées..."
+    "texte_fr": "Hein? ELLE est mannequin.[000F][1205]..? Je les\nvoyais plus... fines et... élancées..."
   },
   {
     "id": 1,
@@ -176,7 +176,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![1205][000F][SP]Eikichi's[SP]getting[SP]on[SP]my[SP]last[SP]nerve!\nHe[SP]talks[SP]big,[SP]but[SP]he[SP]doesn't[SP]know[SP]anything!",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei! [1205][000F]Eikichi me tape sur les nerfs!\nIl fait le fier, mais il sait rien!"
+    "texte_fr": "Kehhei! [000F][1205]Eikichi me tape sur les nerfs!\nIl fait le fier, mais il sait rien!"
   },
   {
     "id": 11,
@@ -206,7 +206,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "It[SP]wasn't[SP]like[SP]them[SP]to[SP]steal[SP]someone[SP]else's\ndreams...[1205][000F][SP]If[SP]they're[SP]really[SP]Joker,[SP]then...[1205][000F][SP]Why...?",
     "nom_fr": "Ginko",
-    "texte_fr": "Ce n'est pas leur\ngenre de voler des rêves.[1205][000F][1205][000F]..\nSi c'est vraiment Joker... Pourquoi...?"
+    "texte_fr": "Ce n'est pas leur\ngenre de voler des rêves.[000F][1205][000F][1205]..\nSi c'est vraiment Joker... Pourquoi...?"
   },
   {
     "id": 13,
@@ -326,7 +326,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That's[SP]why,[SP]even[SP]though[SP]we[SP]take[SP]only[SP]a[SP]small\namount[SP]of[SP]Ideal[SP]Energy,[SP]they[SP]become[SP]shadowmen.\nLike[SP]fruit[SP]with[SP]all[SP]the[SP]juices[SP]squeezed[SP]out.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est pourquoi, même en prélevant peu\nd'Énergie Idéale, ils\ndeviennent des Ombres.\nComme un fruit dont on a tout extrait."
+    "texte_fr": "C'est pourquoi, même en prélevant peu\nd'Énergie Idéale, ils\ndeviennent des Ombres. Comme un fruit dont on a tout extrait."
   },
   {
     "id": 21,
@@ -371,7 +371,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Ether[SP]esthetics...[1205][000F][SP]Is[SP]this[SP]a[SP]put-on?[SP]I[SP]mean,\nthere's[SP]no[SP]way[SP]to[SP]know,[SP]but...",
     "nom_fr": "Yukino",
-    "texte_fr": "L'esthétique éthérique.[1205][000F].. C'est du\nflan? Aucun moyen de savoir, mais..."
+    "texte_fr": "L'esthétique éthérique.[000F][1205].. C'est du\nflan? Aucun moyen de savoir, mais..."
   },
   {
     "id": 24,
@@ -581,7 +581,7 @@
     "nom_orig": "Middle-aged[SP]woman",
     "texte_orig": "I...[SP]I[SP]don't[SP]have[SP]any[SP]plans[SP]after[SP]becoming\nbeautiful,[SP]but...[1205][000F][SP]I[SP]think[SP]I'll[SP]be[SP]able[SP]to\ncome[SP]up[SP]with[SP]something[SP]after[SP]that!",
     "nom_fr": "Femme d'âge mûr",
-    "texte_fr": "J-Je n'ai aucun projet après\ndevenir belle, mais.[1205][000F].. Je trouverai\nbien quelque chose d'ici là!"
+    "texte_fr": "J-Je n'ai aucun projet après\ndevenir belle, mais.[000F][1205].. Je trouverai\nbien quelque chose d'ici là!"
   },
   {
     "id": 38,
@@ -656,7 +656,7 @@
     "nom_orig": "Model",
     "texte_orig": "I'm[SP]working[SP]as[SP]a[SP]model.[SP]I[SP]finally[SP]got[SP]my[SP]dream\njob![1205][000F][SP]He[SP]must[SP]have[SP]been[SP]a[SP]god[SP]or[SP]something...",
     "nom_fr": "Mannequin",
-    "texte_fr": "Je suis mannequin. J'ai eu le boulot de\n[1205][000F]mes rêves! C'était un dieu ou quoi..."
+    "texte_fr": "Je suis mannequin. J'ai eu le boulot de\n[000F][1205]mes rêves! C'était un dieu ou quoi..."
   },
   {
     "id": 43,
@@ -716,7 +716,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "I'm...[SP]a[SP]model...[1205][000F][SP]Why[SP]do[SP]I[SP]only[SP]get[SP]jobs...\nfor[SP]diet[SP]ads...?[SP]This[SP]is[SP]so[SP]stupid...[SP]I[SP]don't\ncare[SP]anymore...",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Je suis... [1205][000F]mannequin... Pourquoi\nque des pubs de régime...? C'est\nnul... M'en fous maintenant..."
+    "texte_fr": "Je suis... [000F][1205]mannequin... Pourquoi\nque des pubs de régime...? C'est\nnul... M'en fous maintenant..."
   },
   {
     "id": 47,
@@ -731,7 +731,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Joker...[1205][000F][SP]ordered[SP]me[SP]to...[1205][000F][SP]protect[SP]the[SP]people\nof[SP]the[SP]city...[1205][000F][SP]But...[SP]I[SP]don't[SP]want[SP]to...",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Joker.[1205][000F][1205][000F][1205][000F].. m'a ordonné de... protéger les\ngens de la ville... Mais... j'veux pas..."
+    "texte_fr": "Joker.[000F][1205][000F][1205][000F][1205].. m'a ordonné de... protéger les\ngens de la ville... Mais... j'veux pas..."
   },
   {
     "id": 48,
@@ -943,7 +943,7 @@
     "nom_orig": "Esthetician",
     "texte_orig": "That[SP]concludes[SP]our[SP]treatment.[SP]How[SP]would[SP]you[SP]say\nthe[SP]Ether[SP]esthetics[SP]made[SP]you[SP]feel?[SP]Good?[SP]Great?",
     "nom_fr": "Esthéticienne",
-    "texte_fr": "Le soin est\nterminé. Comment vous sentez-vous\naprès l'esthétique éthérique?\nBien? Très bien?"
+    "texte_fr": "Le soin est\nterminé. Comment vous sentez-vous\naprès l'esthétique éthérique? Bien? Très bien?"
   },
   {
     "id": 60,

--- a/traduction/event_scripts/script_356.json
+++ b/traduction/event_scripts/script_356.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]probably[SP]not[SP]just[SP]you,[SP]Ginko.[1205][000A][SP]I[SP]mean,[SP]in\nall[SP]our[SP]lives,[SP]how[SP]much[SP]do[SP]we[SP]know[SP]for[SP]sure\nthat[SP]we've[SP]never[SP]actually[SP]seen?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est pas que toi, Ginko.[1205][000A] Dans toute\nnotre vie, combien de choses\nsommes-nous sûrs d'avoir vraiment vues?"
+    "texte_fr": "C'est pas que toi, Ginko.[000A][1205] Dans toute\nnotre vie, combien de choses\nsommes-nous sûrs d'avoir vraiment vues?"
   },
   {
     "id": 1,
@@ -117,7 +117,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Here's[SP]what[SP]I[SP]think.[1205][000A][SP]It's[SP]actually[SP]wonderful\nthat[SP]rumors[SP]are[SP]coming[SP]true.[1205][000A][SP]The[SP]problem[SP]is\nthe[SP]content[SP]of[SP]the[SP]rumors...",
     "nom_fr": "Jun",
-    "texte_fr": "Voici ce que je pense.[1205][000A] C'est merveilleux\nque des rumeurs deviennent vraies.[1205][000A] Le\nproblème c'est leur contenu..."
+    "texte_fr": "Voici ce que je pense.[000A][1205] C'est merveilleux\nque des rumeurs deviennent vraies.[000A][1205] Le\nproblème c'est leur contenu..."
   },
   {
     "id": 8,
@@ -222,7 +222,7 @@
     "nom_orig": "Young[SP]woman",
     "texte_orig": "Was[SP]there[SP]a[SP]line[SP]about[SP]Xibalba[SP]returning[SP]back\ndown[SP]to[SP]Earth[SP]in[SP]that[SP]Oracle?[1205][000F][SP]Well...[1205][000A][SP]I[SP]suppose\nit[SP]doesn't[SP]matter...",
     "nom_fr": "Jeune femme",
-    "texte_fr": "Xibalba revient sur Terre dans\ncet Oracle? Enfin...[1205][1205][000A] Je suppose\n[000F]que ça n'a pas d'importance..."
+    "texte_fr": "Xibalba revient sur Terre dans\ncet Oracle? Enfin...[1205][000A][1205] Je suppose\n[000F]que ça n'a pas d'importance..."
   },
   {
     "id": 15,
@@ -252,7 +252,7 @@
     "nom_orig": "Middle-aged[SP]woman",
     "texte_orig": "Then[SP]again...[1205][000F][SP]Is[SP]that[SP]really[SP]the[SP]best[SP]way...?[1205][000F]\nHaving[SP]my[SP]purpose[SP]just[SP]giftwrapped[SP]for[SP]me[SP]like\nthat...[SP]Will[SP]that[SP]really[SP]make[SP]me[SP]happy...?",
     "nom_fr": "Femme d'âge mûr",
-    "texte_fr": "Mais quand même.[1205][000F][1205][000F].. Est-ce la meilleure\nfaçon...? Qu'on me remette mon but sur un\nplateau comme ça...\nÇa me rendra vraimentheureuse...?"
+    "texte_fr": "Mais quand même.[000F][1205][000F][1205].. Est-ce la meilleure\nfaçon...? Qu'on me remette mon but sur un\nplateau comme ça... Ça me rendra vraimentheureuse...?"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Ughhh...[1205][000A][SP]Uuugh...[1205][000A][SP]Aghh...",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Urgh...[1205][000A] Ugh...[1205][000A] Ugh..."
+    "texte_fr": "Urgh...[000A][1205] Ugh...[000A][1205] Ugh..."
   },
   {
     "id": 18,
@@ -464,7 +464,7 @@
     "nom_orig": "Esthetician",
     "texte_orig": "Okay![SP]Just[SP]relax...[1205][000F][SP]and[SP]let[SP]our[SP]shop's[SP]unique\ntreatment[SP]wash[SP]over[SP]you...[SP]Ether[SP]esthetics!",
     "nom_fr": "Esthéticienne",
-    "texte_fr": "Okay! Détendez-vous.[1205][000F].. laissez notre\ntraitement vous envelopper... Esthétique\nÉther!"
+    "texte_fr": "Okay! Détendez-vous.[000F][1205].. laissez notre\ntraitement vous envelopper... Esthétique\nÉther!"
   },
   {
     "id": 29,
@@ -524,7 +524,7 @@
     "nom_orig": "Esthetician",
     "texte_orig": "In[SP]that[SP]case,[SP]I'll[SP]have[SP]to[SP]add[SP]new[SP]effects[SP]to\nour[SP]Ether[SP]esthetics...[1205][000F][SP]E-Er...[1205][000F][SP]I'll[SP]have[SP]to\nFIND[SP]new[SP]ones,[SP]I[SP]meant...",
     "nom_fr": "Esthéticienne",
-    "texte_fr": "Dans ce cas, j'ajouterai de nouveaux\neffets à l'esthétique Éther.[1205][000F][1205][000F].. E-Euh...\nDes NOUVEAUX, je voulais dire..."
+    "texte_fr": "Dans ce cas, j'ajouterai de nouveaux\neffets à l'esthétique Éther.[000F][1205][000F][1205].. E-Euh...\nDes NOUVEAUX, je voulais dire..."
   },
   {
     "id": 33,

--- a/traduction/event_scripts/script_359.json
+++ b/traduction/event_scripts/script_359.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Wow,[SP]cool,[SP]Maya-san![1205][000F][SP]You're[SP]so[SP]good[SP]at[SP]your[SP]job.\nYou[SP]even[SP]use[SP]the[SP]Internet?",
     "nom_fr": "[NULL][E4][NULL][NULL]\"Eikichi",
-    "texte_fr": "Waouh, Maya! [1205][000F]T'es vraiment douée.\nTu utilises même Internet?"
+    "texte_fr": "Waouh, Maya! [000F][1205]T'es vraiment douée.\nTu utilises même Internet?"
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]weird[SP]to[SP]talk[SP]to[SP]someone[SP]and[SP]not[SP]know[SP]what\nthey[SP]look[SP]or[SP]sound[SP]like.[1205][000F][SP]Can[SP]you[SP]really[SP]trust\nsomeone[SP]like[SP]that?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est bizarre de parler à quelqu'un\nsans savoir à quoi il ressemble. [1205][000F]On\npeut vraiment lui faire confiance?"
+    "texte_fr": "C'est bizarre de parler à quelqu'un\nsans savoir à quoi il ressemble. [000F][1205]On\npeut vraiment lui faire confiance?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Oh,[SP]Miss[SP]Elly...[1205][001E][SP]I[SP]hope[SP]I[SP]can[SP]light[SP]your\nfire[SP]someday.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Oh, Miss Elly...[1205][001E] J'espère\nallumer ta flamme un jour."
+    "texte_fr": "Oh, Miss Elly...[001E][1205] J'espère\nallumer ta flamme un jour."
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Tch,[SP]I[SP]can't[SP]stand[SP]it![1205][000F][SP]Can't[SP]we[SP]do[SP]anything\nfor[SP]those[SP]two?[SP]Why[SP]did[SP]we[SP]come[SP]here[SP]in[SP]the\nfirst[SP]place?[1205][000F][SP]Dammit!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tch, j'en peux plus! [1205][000F][1205][000F]On peut rien\nfaire pour ces deux-là? On est\nvenus pour quoi alors? Merde!"
+    "texte_fr": "Tch, j'en peux plus! [000F][1205][000F][1205]On peut rien\nfaire pour ces deux-là? On est\nvenus pour quoi alors? Merde!"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "H-Hey,[SP][1113]...[1205][001E][SP]I[SP]heard[SP]from[SP]Maya[SP]just\nnow...[1205][001E][SP]She[SP]heard[SP]me[SP]and[SP]Sasaki-san[SP]talking...",
     "nom_fr": "Ginko",
-    "texte_fr": "H-Hé, [1113]...[1205][001E] Maya vient de me dire...[1205][001E]\nElle nous a entendus, Sasaki et moi..."
+    "texte_fr": "H-Hé, [1113]...[001E][1205] Maya vient de me dire...[001E][1205]\nElle nous a entendus, Sasaki et moi..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Sorry-ia...[1205][001E][SP]Actually,[SP]I...[SP]Well,[SP]besides[SP]you,\n[1113]...",
     "nom_fr": "Ginko",
-    "texte_fr": "Désolée...[1205][001E] En fait, moi...\nEn dehors de toi, [1113]..."
+    "texte_fr": "Désolée...[001E][1205] En fait, moi...\nEn dehors de toi, [1113]..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "S-Sorry...[1205][001E][SP]This[SP]isn't[SP]the[SP]time.[SP]Let's[SP]talk\nlater...",
     "nom_fr": "Ginko",
-    "texte_fr": "Désolée...[1205][001E] Pas maintenant.\nOn en parle après..."
+    "texte_fr": "Désolée...[001E][1205] Pas maintenant.\nOn en parle après..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Wait[SP]for[SP]me,[SP]you[SP]guys.[1205][000F][SP]I'll[SP]bring[SP]you[SP]back[SP]to\nnormal...[1205][000F][SP]I[SP]will...",
     "nom_fr": "Ginko",
-    "texte_fr": "Attendez. [1205][000F][1205][000F]Je vais vous ramener\nà la normale... Je le ferai..."
+    "texte_fr": "Attendez. [000F][1205][000F][1205]Je vais vous ramener\nà la normale... Je le ferai..."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "*sniff*[1205][000F][SP]And[SP]then[SP]we'll[SP]go[SP]have[SP]fun[SP]at[SP]Mu,[SP]or[SP]go\nshopping,[SP]or[SP]whatever[SP]you[SP]want.",
     "nom_fr": "Ginko",
-    "texte_fr": "*snif* Après on ira à Mu, faire du\n[1205][000F]shopping, tout ce que vous voulez."
+    "texte_fr": "*snif* Après on ira à Mu, faire du\n[000F][1205]shopping, tout ce que vous voulez."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP][1113]...[1205][000F][SP]You[SP]think[SP]King[SP]Leo[SP]might[SP]know\nhow[SP]to[SP]return[SP]them[SP]to[SP]normal?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, [1113].[1205][000F].. Le Roi Lion sait\npeut-être les ramener à la normale?"
+    "texte_fr": "Hé, [1113].[000F][1205].. Le Roi Lion sait\npeut-être les ramener à la normale?"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "But[SP]we[SP]saved[SP]the[SP]kids[SP]at[SP]the[SP]museum[SP]because\nyou[SP]told[SP]us[SP]where[SP]to[SP]go,[SP]Elly.[1205][000F][SP]You're[SP]amazing!",
     "nom_fr": "Ginko",
-    "texte_fr": "Mais on a sauvé les gosses au musée\ngrâce à toi, Elly. [1205][000F]T'es incroyable!"
+    "texte_fr": "Mais on a sauvé les gosses au musée\ngrâce à toi, Elly. [000F][1205]T'es incroyable!"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh!?[1205][000F][SP]You[SP]were[SP]basing[SP]it[SP]all[SP]on[SP]a[SP]hunch?[1205][000F][SP]Oh...\nWell[SP]then.",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein![1205][000F][1205][000F]? C'était juste une\nintuition? Oh... Bon alors."
+    "texte_fr": "Hein![000F][1205][000F][1205]? C'était juste une\nintuition? Oh... Bon alors."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Sheba[SP]and[SP]Mee-ho's[SP]shadows[SP]are[SP]getting[SP]darker...[1205][000F]\nWhat[SP]should[SP]I[SP]do!?[1205][000F][SP]Wait,[SP]guys![1205][000F][SP]Hold[SP]on![1205][000F][SP]Keep\nfighting,[SP]you[SP]two!",
     "nom_fr": "Ginko",
-    "texte_fr": "Les ombres de Sheba et Mee-ho\n[1205][000F][1205][000F][1205][000F][1205][000F]s'assombrissent... Que faire!? Attendez!\nTenez bon! Battez-vous toutes les deux!"
+    "texte_fr": "Les ombres de Sheba et Mee-ho\n[000F][1205][000F][1205][000F][1205][000F][1205]s'assombrissent... Que faire!? Attendez!\nTenez bon! Battez-vous toutes les deux!"
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]want[SP]to[SP]get[SP]my[SP]friends[SP]back...[1205][000F][SP]I[SP]want[SP]the\ncity[SP]back[SP]to[SP]normal,[SP]too...[1205][000F][SP]I[SP]just[SP]want[SP]things\nto[SP]be[SP]how[SP]they[SP]were...",
     "nom_fr": "Ginko",
-    "texte_fr": "Je veux retrouver mes amies.[1205][000F][1205][000F].. Je veux\nque la ville redevienne normale... Je\nveux juste comme avant..."
+    "texte_fr": "Je veux retrouver mes amies.[000F][1205][000F][1205].. Je veux\nque la ville redevienne normale... Je\nveux juste comme avant..."
   },
   {
     "id": 16,
@@ -312,7 +312,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yeah,[SP]I[SP]know[SP]the[SP]Internet[SP]makes[SP]it[SP]hard[SP]to\nknow[SP]what[SP]the[SP]other[SP]person[SP]looks[SP]like[SP]or[SP]who\nthey[SP]are.[1205][000F][SP]But[SP]it's[SP]okay.[1205][000F][SP]I[SP]trust[SP]Baofu.",
     "nom_fr": "Maya",
-    "texte_fr": "Ouais, sur Internet on sait pas à qui on a\naffaire. Mais c'est bon. [1205][000F][1205][000F]J'ai confiance en\nBaofu."
+    "texte_fr": "Ouais, sur Internet on sait pas à qui on a\naffaire. Mais c'est bon. [000F][1205][000F][1205]J'ai confiance en\nBaofu."
   },
   {
     "id": 21,
@@ -342,7 +342,7 @@
     "nom_orig": "Maya",
     "texte_orig": "[1432][NULL][NULL][0014]All[SP]descend[SP]with[SP]smiles[SP]to[SP]the[SP]netherworld[1432][NULL][NULL][0014]...[1205][001E]\nThere's[SP]a[SP]hint[SP]in[SP]there[SP]somewhere.[SP]Keep[SP]thinking\nabout[SP]it,[SP][1113]-kun.",
     "nom_fr": "Maya",
-    "texte_fr": "[1432][NULL][NULL][0014]Tous descendent en souriant aux\nenfers[1432][NULL][NULL][0014]...[1205][001E] Il y a un indice là-dedans.\nContinue d'y réfléchir, [1113]-kun."
+    "texte_fr": "[1432][NULL][NULL][0014]Tous descendent en souriant aux\nenfers[1432][NULL][NULL][0014]...[001E][1205] Il y a un indice là-dedans.\nContinue d'y réfléchir, [1113]-kun."
   },
   {
     "id": 23,
@@ -372,7 +372,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]can't[SP]dawdle.[SP]We[SP]have[SP]to[SP]find[SP]the[SP]next\ntarget![1205][000F][SP]I'm[SP]counting[SP]on[SP]you,[SP][1113]-kun!",
     "nom_fr": "Maya",
-    "texte_fr": "Vite, faut trouver la prochaine cible!\n[1205][000F]Je compte sur toi, [1113]-kun!"
+    "texte_fr": "Vite, faut trouver la prochaine cible!\n[000F][1205]Je compte sur toi, [1113]-kun!"
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]can't[SP]dawdle.[SP]We[SP]have[SP]to[SP]find[SP]the[SP]next\ntarget![1205][000F][SP]I'm[SP]counting[SP]on[SP]you,[SP][1113]-kun!",
     "nom_fr": "Maya",
-    "texte_fr": "Vite, Faut trouver la prochaine cible!\n[1205][000F]Je compte sur toi, [1113]-kun!"
+    "texte_fr": "Vite, Faut trouver la prochaine cible!\n[000F][1205]Je compte sur toi, [1113]-kun!"
   },
   {
     "id": 26,
@@ -447,7 +447,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Maya's[SP]a[SP]curious[SP]person.[SP]She's[SP]good[SP]with[SP]new\nthings.[1205][000F][SP]Me,[SP]on[SP]the[SP]other[SP]hand...[SP]Let's[SP]just\nsay[SP]computers[SP]are[SP]not[SP]my[SP]friends.",
     "nom_fr": "Yukino",
-    "texte_fr": "Maya est curieuse. Elle est à l'aise avec\n[1205][000F]les nouveautés. Moi en revanche... Disons\nque les ordis et moi, ça fait deux."
+    "texte_fr": "Maya est curieuse. Elle est à l'aise avec\n[000F][1205]les nouveautés. Moi en revanche... Disons\nque les ordis et moi, ça fait deux."
   },
   {
     "id": 30,
@@ -477,7 +477,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Chatting[SP]is[SP]like[SP]talking[SP]on[SP]the[SP]phone,[SP]or\nwriting[SP]letters.[SP]It's[SP]a[SP]way[SP]to[SP]exchange\nmessages[SP]in[SP]real[SP]time.",
     "nom_fr": "Yukino",
-    "texte_fr": "Le chat c'est comme\ntéléphoner ou écrire des\nlettres. On échange des messages en temps\nréel."
+    "texte_fr": "Le chat c'est comme\ntéléphoner ou écrire des\nlettres. On échange des messages en temps réel."
   },
   {
     "id": 32,
@@ -522,7 +522,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Eriko,[SP]we[SP]know[SP]the[SP]next[SP]target[SP]is[SP]in[SP]Yumezaki,\nbut[SP]can[SP]you[SP]give[SP]us[SP]any[SP]more[SP]specifics?[1205][000F][SP]Like,\nis[SP]it[SP]Pachinko[SP]Silver,[SP]or[SP]GOLD,[SP]or...?",
     "nom_fr": "Yukino",
-    "texte_fr": "Eriko, on sait que la prochaine cible\nest à Yumezaki, mais tu peux préciser?\n[1205][000F]C'est le Pachinko Silver, GOLD, ou...?"
+    "texte_fr": "Eriko, on sait que la prochaine cible\nest à Yumezaki, mais tu peux préciser?\n[000F][1205]C'est le Pachinko Silver, GOLD, ou...?"
   },
   {
     "id": 35,
@@ -537,7 +537,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Eikichi's[SP]right.[SP]No[SP]one[SP]should[SP]be[SP]allowed[SP]to\nsteal[SP]someone[SP]else's[SP]dream.[1205][000F][SP]We[SP]need[SP]to[SP]teach\nKing[SP]Leo[SP]that!",
     "nom_fr": "Yukino",
-    "texte_fr": "Eikichi a raison. Personne n'a le\ndroit de voler le rêve des autres.\n[1205][000F]Il faut l'apprendre au Roi Lion!"
+    "texte_fr": "Eikichi a raison. Personne n'a le\ndroit de voler le rêve des autres.\n[000F][1205]Il faut l'apprendre au Roi Lion!"
   },
   {
     "id": 36,
@@ -567,7 +567,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]bet[SP]both[SP]the[SP]Masked[SP]Circle[SP]and[SP]Last[SP]Battalion\nhave[SP]things[SP]to[SP]do[SP]before[SP]the[SP]Grand[SP]Cross![1205][000F]\nWe[SP]should[SP]hurry[SP]to[SP]Mt.[SP]Katatsumuri[SP]too.",
     "nom_fr": "Yukino",
-    "texte_fr": "Le Cercle masqué et le Bataillon ont des\nchoses à faire avant la Croix Cosmique! On\n[1205][000F]devrait se dépêcher\nvers le Mt. Katatsumuri."
+    "texte_fr": "Le Cercle masqué et le Bataillon ont des\nchoses à faire avant la Croix Cosmique! On\n[000F][1205]devrait se dépêcher vers le Mt. Katatsumuri."
   },
   {
     "id": 38,
@@ -597,7 +597,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "Hey.[1205][000F][SP]Surfing[SP]the[SP]net[SP]this[SP]early[SP]in[SP]the[SP]day?\nMust[SP]have[SP]a[SP]lot[SP]of[SP]time[SP]on[SP]your[SP]hands.[SP]Whatevs.\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]the[SP]lazy[SP]boy\nNever[SP]mind\nLeave",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "Hé. [1205][000F]Tu surfes sur le net à cette heure?\nT'as que ça à faire. Bof.\n[1208][0004]Manger\nParler au gamin\nNon merci\nPartir",
+    "texte_fr": "Hé. [000F][1205]Tu surfes sur le net à cette heure?\nT'as que ça à faire. Bof.\n[1208][0004]Manger\nParler au gamin\nNon merci\nPartir",
     "question_orig": "Hey.[1205][000F][SP]Surfing[SP]the[SP]net[SP]this[SP]early[SP]in[SP]the[SP]day?\nMust[SP]have[SP]a[SP]lot[SP]of[SP]time[SP]on[SP]your[SP]hands.[SP]Whatevs.",
     "choix_orig": [
       "Dine[SP]in",
@@ -650,7 +650,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "Sure...[1205][000F][SP]Was[SP]that[SP]it?\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]the[SP]lazy[SP]boy\nNever[SP]mind\nLeave",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "Ouais.[1205][000F].. C'est tout?\n[1208][0004]Manger\nParler au gamin\nNon merci\nPartir",
+    "texte_fr": "Ouais.[000F][1205].. C'est tout?\n[1208][0004]Manger\nParler au gamin\nNon merci\nPartir",
     "question_orig": "Sure...[1205][000F][SP]Was[SP]that[SP]it?",
     "choix_orig": [
       "Dine[SP]in",
@@ -703,7 +703,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "What's[SP]this[SP]about[SP]Muses?[1205][000F][SP]Ginji[SP]Sasaki's[SP]pretty\npopular.[SP]If[SP]you[SP]like[SP]that[SP]stuff.[1205][000F][SP]You[SP]go[SP]to[SP]any\nstore[SP]in[SP]Sumaru,[SP]you'll[SP]hear[SP]one[SP]of[SP]his[SP]songs.",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "Les Muses? [1205][000F][1205][000F]Ginji Sasaki est populaire. Si\nt'aimes ça. Dans n'importe quel magasin\nde Sumaru, t'entends une de ses chansons."
+    "texte_fr": "Les Muses? [000F][1205][000F][1205]Ginji Sasaki est populaire. Si\nt'aimes ça. Dans n'importe quel magasin\nde Sumaru, t'entends une de ses chansons."
   },
   {
     "id": 44,
@@ -718,7 +718,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "You[SP]shouldn't[SP]be[SP]swayed[SP]by[SP]fads[SP]so[SP]easily.[1205][000F]\nAlhough[SP]life[SP]is[SP]meaningless...[1205][000F][SP]You[SP]could[SP]die\nanytime[SP]and[SP]it'd[SP]make[SP]no[SP]difference.",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "Faut pas se laisser emporter par les\n[1205][000F][1205][000F]modes. Bon, la vie n'a aucun sens...\nT'aurais beau mourir, ça changerait rien."
+    "texte_fr": "Faut pas se laisser emporter par les\n[000F][1205][000F][1205]modes. Bon, la vie n'a aucun sens...\nT'aurais beau mourir, ça changerait rien."
   },
   {
     "id": 45,
@@ -763,7 +763,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "Guess[SP]the[SP]world[SP]would[SP]be[SP]boring[SP]without[SP]chumps\nlike[SP]that,[SP]though.[1205][000F][SP]That's[SP]why[SP]you'd[SP]be[SP]better\noff[SP]dead.[1205][000F][SP]See?[SP]I[SP]like[SP]to[SP]think[SP]positive.",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "Mais le monde serait ennuyeux sans ces\ncrétins. [1205][000F][1205][000F]C'est pour ça que tu ferais\nmieux de mourir. Voir? Je pense positif."
+    "texte_fr": "Mais le monde serait ennuyeux sans ces\ncrétins. [000F][1205][000F][1205]C'est pour ça que tu ferais\nmieux de mourir. Voir? Je pense positif."
   },
   {
     "id": 48,
@@ -778,7 +778,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "Everyone's[SP]got[SP]their[SP]panties[SP]in[SP]a[SP]twist[SP]over\nthe[SP]attacks.[1205][000F][SP]The[SP]terrorists[SP]are[SP]eating[SP]that\nshit[SP]up,[SP]I[SP]promise.[1205][000F][SP]Just[SP]ignore[SP]them.",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "Tout le monde panique pour les attaques.\n[1205][000F][1205][000F]Les terroristes adorent ça, je vous le\ndis. Ignorez-les, c'est tout."
+    "texte_fr": "Tout le monde panique pour les attaques.\n[000F][1205][000F][1205]Les terroristes adorent ça, je vous le\ndis. Ignorez-les, c'est tout."
   },
   {
     "id": 49,
@@ -808,7 +808,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "Dying[SP]in[SP]an[SP]explosion[SP]would[SP]be[SP]quick[SP]and\npainless,[SP]I[SP]bet.[1205][000F][SP]See,[SP]there's[SP]a[SP]bright[SP]side\nto[SP]everything.",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "Mourir dans une explosion ce serait rapide\n[1205][000F]et sans douleur. Tout a un bon côté."
+    "texte_fr": "Mourir dans une explosion ce serait rapide\n[000F][1205]et sans douleur. Tout a un bon côté."
   },
   {
     "id": 51,
@@ -868,7 +868,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "Kinda[SP]careless[SP]of[SP]them.[1205][000F][SP]If[SP]I[SP]did[SP]it,[SP]I'd[SP]make\nsure[SP]no[SP]one[SP]saw[SP]my[SP]face.",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "Assez négligents. [1205][000F]Moi\nj'aurais pas montré ma tête."
+    "texte_fr": "Assez négligents. [000F][1205]Moi\nj'aurais pas montré ma tête."
   },
   {
     "id": 55,
@@ -883,7 +883,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "I[SP]know[SP]a[SP]lot[SP]about[SP]weapons,[SP]so[SP]I[SP]wish[SP]I[SP]worked\nin[SP]a[SP]weapon[SP]store...[1205][000F][SP]I[SP]can[SP]be[SP]positive[SP]when\nI[SP]feel[SP]like[SP]it.",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "Je connais les\narmes, j'aurais voulu devenir\narmurier.[1205].[000F]. Je peux être positif quand je\nveux."
+    "texte_fr": "Je connais les\narmes, j'aurais voulu devenir\narmurier.[1205].[000F]. Je peux être positif quand je veux."
   },
   {
     "id": 56,
@@ -913,7 +913,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "That's[SP]stupid.[1205][000F][SP]No[SP]one[SP]knows[SP]what's[SP]going\nto[SP]happen[SP]in[SP]the[SP]future.[SP]Not[SP]even[SP]one[SP]second\nfrom[SP]now.",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "C'est stupide. [1205][000F]Personne\nsait ce qui arrivera\ndans le futur. Même pas dans une seconde."
+    "texte_fr": "C'est stupide. [000F][1205]Personne\nsait ce qui arrivera\ndans le futur. Même pas dans une seconde."
   },
   {
     "id": 58,
@@ -928,7 +928,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "That's[SP]why[SP]you[SP]gotta[SP]stay[SP]alive[SP]to[SP]find[SP]out.\nThough[SP]you[SP]probably[SP]find[SP]out[SP]when[SP]you[SP]die,\ntoo.[1205][000F][SP]I'm[SP]all[SP]kinds[SP]of[SP]positive[SP]today.",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "C'est pour ça qu'il faut rester en vie.\nMême si on le découvre aussi en mourant.\n[1205][000F]Je suis très positif aujourd'hui."
+    "texte_fr": "C'est pour ça qu'il faut rester en vie.\nMême si on le découvre aussi en mourant.\n[000F][1205]Je suis très positif aujourd'hui."
   },
   {
     "id": 59,
@@ -943,7 +943,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "This[SP]city's[SP]toast[SP]with[SP]those[SP]guys[SP]wandering\naround.[1205][000F][SP]What's[SP]the[SP]point[SP]in[SP]working[SP]a[SP]job?[1205][000F]\nBut[SP]if[SP]they[SP]find[SP]me,[SP]will[SP]they[SP]kill[SP]me?",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "La ville est foutue avec ces types qui\n[1205][000F][1205][000F]rôdent. À quoi ça sert de bosser? Mais\ns'ils me trouvent, ils vont me tuer?"
+    "texte_fr": "La ville est foutue avec ces types qui\n[000F][1205][000F][1205]rôdent. À quoi ça sert de bosser? Mais\ns'ils me trouvent, ils vont me tuer?"
   },
   {
     "id": 60,
@@ -1003,7 +1003,7 @@
     "nom_orig": "Older[SP]office[SP]worker",
     "texte_orig": "I[SP]understand...[1205][000F][SP]I[SP]get[SP]it[SP]now![1205][000F][SP]Haha![SP]I[SP]figured\nout[SP]computers![SP]I[SP]finally[SP]know[SP]how[SP]to[SP]use\nthese[SP]things!",
     "nom_fr": "Vieux salarié",
-    "texte_fr": "Je comprends.[1205][000F][1205][000F].. J'ai compris!\nHaha! J'ai pigé les ordinateurs!\nJe sais enfin comment ça marche!"
+    "texte_fr": "Je comprends.[000F][1205][000F][1205].. J'ai compris!\nHaha! J'ai pigé les ordinateurs!\nJe sais enfin comment ça marche!"
   },
   {
     "id": 64,
@@ -1033,7 +1033,7 @@
     "nom_orig": "Older[SP]office[SP]worker",
     "texte_orig": "They[SP]won't[SP]be[SP]calling[SP]me[SP]a[SP]has-been[SP]anymore![1205][000F]\nOf[SP]course[SP]I[SP]can[SP]use[SP]a[SP]computer!",
     "nom_fr": "Vieux salarié",
-    "texte_fr": "Ils m'appelleront plus has-been! Bien\n[1205][000F]sûr que je sais utiliser un ordinateur!"
+    "texte_fr": "Ils m'appelleront plus has-been! Bien\n[000F][1205]sûr que je sais utiliser un ordinateur!"
   },
   {
     "id": 66,
@@ -1078,7 +1078,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "If[SP]I'd[SP]known,[SP]I[SP]wouldn't[SP]have[SP]bothered[SP]asking\nJoker[SP]to[SP]grant[SP]this[SP]as[SP]my[SP]ideal.[1205][000F][SP]At[SP]least[SP]I[SP]can\ndo[SP]some[SP]hacking[SP]to[SP]earn[SP]a[SP]little[SP]spare[SP]cash.",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Si j'avais su, j'aurais pas demandé ça à\nJoker comme idéal. [1205][000F]Au moins je peux faire\ndu hacking pour gagner un peu d'argent."
+    "texte_fr": "Si j'avais su, j'aurais pas demandé ça à\nJoker comme idéal. [000F][1205]Au moins je peux faire\ndu hacking pour gagner un peu d'argent."
   },
   {
     "id": 69,
@@ -1123,7 +1123,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Hmph.[SP]That's[SP]no[SP]fun.[1205][000F][SP]I[SP]wanted[SP]to[SP]see[SP]a[SP]much\nbigger[SP]boom.",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Pff. C'est nul. [1205][000F]Je voulais\nune explosion géante."
+    "texte_fr": "Pff. C'est nul. [000F][1205]Je voulais\nune explosion géante."
   },
   {
     "id": 72,
@@ -1153,7 +1153,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Joker[SP]wants[SP]us[SP]to[SP]fight[SP]THOSE[SP]guys?[SP]Hah![1205][000F]\nWhat[SP]do[SP]I[SP]care[SP]about[SP]the[SP]people[SP]of[SP]Sumaru?",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Joker veut qu'on se batte contre EUX?\n[1205][000F]Hah! Qu'est-ce que je me fiche de Sumaru?"
+    "texte_fr": "Joker veut qu'on se batte contre EUX?\n[000F][1205]Hah! Qu'est-ce que je me fiche de Sumaru?"
   },
   {
     "id": 74,
@@ -1168,7 +1168,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "I'm[SP]going[SP]to[SP]run.[1205][000F][SP]So[SP]what[SP]if[SP]Joker[SP]taught[SP]me\nto[SP]use[SP]a[SP]computer?[SP]That's[SP]not[SP]worth[SP]my[SP]life!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Je vais fuir. [1205][000F]Et alors si Joker m'a appris\nà utiliser un ordi? Ça vaut pas ma vie!"
+    "texte_fr": "Je vais fuir. [000F][1205]Et alors si Joker m'a appris\nà utiliser un ordi? Ça vaut pas ma vie!"
   },
   {
     "id": 75,
@@ -1183,7 +1183,7 @@
     "nom_orig": "Elly",
     "texte_orig": "Ah...[1205][001E][SP]So[SP]you're[SP][1113],[SP]yes?",
     "nom_fr": "Elly",
-    "texte_fr": "Ah...[1205][001E] Vous êtes [1113]?"
+    "texte_fr": "Ah...[001E][1205] Vous êtes [1113]?"
   },
   {
     "id": 76,
@@ -1213,7 +1213,7 @@
     "nom_orig": "Elly",
     "texte_orig": "He[SP]was[SP]cool[SP]and[SP]quiet,[SP]but[SP]very[SP]strong,\nand[SP]kind.[1205][001E][SP]He[SP]was[SP]my...",
     "nom_fr": "Elly",
-    "texte_fr": "Il était calme mais très fort,\net gentil.[1205][001E] Il était mon..."
+    "texte_fr": "Il était calme mais très fort,\net gentil.[001E][1205] Il était mon..."
   },
   {
     "id": 78,
@@ -1228,7 +1228,7 @@
     "nom_orig": "Elly",
     "texte_orig": "Sorry,[SP]Yukino.[1205][000F][SP]The[SP]available[SP]data[SP]so[SP]far\ndoesn't[SP]point[SP]to[SP]a[SP]clear[SP]target.",
     "nom_fr": "Elly",
-    "texte_fr": "Désolée, Yukino. [1205][000F]Les données ne\ndonnent pas une cible précise."
+    "texte_fr": "Désolée, Yukino. [000F][1205]Les données ne\ndonnent pas une cible précise."
   },
   {
     "id": 79,
@@ -1258,7 +1258,7 @@
     "nom_orig": "Elly",
     "texte_orig": "Some[SP]children[SP]were[SP]here,[SP]claiming[SP]you[SP]were\nheroes[SP]fighting[SP]the[SP]Masked[SP]Circle.[1205][000F][SP]I'm[SP]quite\nimpressed.",
     "nom_fr": "Elly",
-    "texte_fr": "Des enfants vous on appelés héros contre le\nCercle masqué. [1205][000F]Je suis assez impressionnée."
+    "texte_fr": "Des enfants vous on appelés héros contre le\nCercle masqué. [000F][1205]Je suis assez impressionnée."
   },
   {
     "id": 81,
@@ -1288,7 +1288,7 @@
     "nom_orig": "Elly",
     "texte_orig": "I[SP]actually[SP]didn't[SP]know[SP]whether[SP]it[SP]would[SP]be[SP]in\nYumezaki[SP]or[SP]Kounan,[SP]so[SP]I[SP]just...[SP]went[SP]with[SP]my\ngut,[SP]as[SP]they[SP]say.[1205][000F][SP]Teehee.",
     "nom_fr": "Elly",
-    "texte_fr": "En réalité je savais pas si c'était\nYumezaki ou Kounan, alors j'ai...\nsuivi mon instinct. [1205][000F]Hihihi."
+    "texte_fr": "En réalité je savais pas si c'était\nYumezaki ou Kounan, alors j'ai...\nsuivi mon instinct. [000F][1205]Hihihi."
   },
   {
     "id": 83,
@@ -1423,7 +1423,7 @@
     "nom_orig": "Shadowman[SP]Miho",
     "texte_orig": "Ugh...[1205][000F][SP]Li...sa...[1205][000F][SP]Uuuughhh...",
     "nom_fr": "Ombre Miho",
-    "texte_fr": "Ugh.[1205][000F][1205][000F].. Li... sa... Uuuughhh..."
+    "texte_fr": "Ugh.[000F][1205][000F][1205].. Li... sa... Uuuughhh..."
   },
   {
     "id": 92,
@@ -1453,7 +1453,7 @@
     "nom_orig": "???",
     "texte_orig": "Looks[SP]like[SP]this[SP]is[SP]your[SP]first[SP]time[SP]here.[1205][000F]\nName's[SP]Baofu.[SP]I[SP]run[SP]this[SP]website.[E1][E2]Baofu\nAn[SP]online[SP]rumormonger[SP]with[SP]his[SP]own[SP]rumor[SP]site.\nNothing[SP]is[SP]known[SP]about[SP]him,[SP]but[SP]he[SP]seems[SP]to\nbe[SP]gathering[SP]rumors[SP]for[SP]a[SP]specific[SP]purpose.",
     "nom_fr": "???",
-    "texte_fr": "C'est ta première fois\nici. Moi c'est Baofu.\n[1205][000F]Je gère ce site.[E1][E2]\nBaofu Colporteur de rumeurs\nen ligne avec son propre site.\nRien n'estconnu de lui, mais il semble collectecter\ndes rumeurs dans un but précis."
+    "texte_fr": "C'est ta première fois\nici. Moi c'est Baofu.\n[000F][1205]Je gère ce site.[E1][E2]\nBaofu Colporteur de rumeurs\nen ligne avec son propre site.\nRien n'estconnu de lui, mais il semble collectecter\ndes rumeurs dans un but précis."
   },
   {
     "id": 94,
@@ -1483,7 +1483,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Either's[SP]fine.[1205][000F][SP]If[SP]you[SP]know[SP]anything,[SP]will[SP]you\ntell[SP]me[SP]for[SP]some[SP]info[SP]in[SP]trade?",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Peu importe. [1205][000F]Si tu sais quelque\nchose, tu me le dis contre des infos?"
+    "texte_fr": "Peu importe. [000F][1205]Si tu sais quelque\nchose, tu me le dis contre des infos?"
   },
   {
     "id": 96,
@@ -1498,7 +1498,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "You're[SP]interested[SP]in[SP]rumors,[SP]aren't[SP]you?[1205][000F]\nSo[SP]am[SP]I.[1205][000F][SP]If[SP]you[SP]want,[SP]send[SP]me[SP]something.\nI'll[SP]be[SP]waiting[SP]to[SP]hear[SP]something[SP]worthwhile.",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Les rumeurs t'intéressent,\nnon? [1205][000F][1205][000F]Moi aussi. Si\ntu veux, envoie-moi\nquelque chose. J'attends\nquelque chose qui en vaut la peine."
+    "texte_fr": "Les rumeurs t'intéressent,\nnon? [000F][1205][000F][1205]Moi aussi. Si\ntu veux, envoie-moi quelque chose. J'attends quelque chose qui en vaut la peine."
   },
   {
     "id": 97,
@@ -1513,7 +1513,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Hey,[SP]you're[SP]back.",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Tiens, de retour. Choisissez une option.\nDemander des rumeurs\nParler à Baofu\nAnnuler\n Choisissez un sujet.\nRumeurs armureries\nRumeurs armures\nAutres rumeurs\nRien\n Choisissez une région.\nRengedai\nYumezaki\nAoba\nKounan\nAucune\n Choisissez une région.\nRengedai\nYumezaki\nAoba\nKounan\nAucune\n Choisissez un sujet.\nConcours magazines\nRumeurs Mu\nArmes légendaires\nAucun\n Vérifié.\nSoumettre.\nPatientez après envoi.",
+    "texte_fr": "Tiens, de retour. Choisissez une option.\nDemander des rumeurs\nParler à Baofu Annuler Choisissez un sujet. Rumeurs armureries Rumeurs armures Autres rumeurs Rien Choisissez une région. Rengedai Yumezaki Aoba Kounan Aucune Choisissez une région. Rengedai Yumezaki Aoba Kounan Aucune Choisissez un sujet. Concours magazines Rumeurs Mu Armes légendaires Aucun Vérifié. Soumettre. Patientez après envoi.",
     "choix_fr": [
       ""
     ]
@@ -1546,7 +1546,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Location:[1205][000F][E4][NULL][NULL][0006][SP]Aoba[SP]-[SP]Clair[SP]de[SP]Lune[E4][NULL][NULL][0002][1205][000F]\nRumor:[1205][000F][E4][NULL][NULL][0006][SP]You[SP]can[SP]buy[SP]real[SP]weapons[E4][NULL][NULL][0002][1205][000F]\nComments:[1205][000F][E4][NULL][NULL][0006][SP]Good[SP]stock.[SP]Low[SP]trade-in[SP]value.[E4][NULL][NULL][0002]",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Lieu:[E4][NULL][NULL][0006] Aoba - Clair de Lune[E4][NULL][NULL][0002] Rumeur:[E4][NULL][NULL][0006]\n[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]On y a de vraies armes[E4][NULL][NULL][0002] Commentaires:[E4][NULL][NULL][0006]\nBon stock. Faible revente.[E4][NULL][NULL][0002]"
+    "texte_fr": "Lieu:[E4][NULL][NULL][0006] Aoba - Clair de Lune[E4][NULL][NULL][0002] Rumeur:[E4][NULL][NULL][0006]\n[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]On y a de vraies armes[E4][NULL][NULL][0002] Commentaires:[E4][NULL][NULL][0006]\nBon stock. Faible revente.[E4][NULL][NULL][0002]"
   },
   {
     "id": 100,
@@ -1591,7 +1591,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Location:[1205][000F][E4][NULL][NULL][0006][SP]Kounan[SP]-[SP]Jolly[SP]Roger[E4][NULL][NULL][0002][1205][000F]\nRumor:[1205][000F][E4][NULL][NULL][0006][SP]You[SP]can[SP]buy[SP]real[SP]weapons[E4][NULL][NULL][0002][1205][000F]\nComments:[1205][000F][E4][NULL][NULL][0006][SP]Bad[SP]stock.[SP]High[SP]trade-in[SP]value.[E4][NULL][NULL][0002]",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Lieu:[E4][NULL][NULL][0006] Kounan - Jolly Roger[E4][NULL][NULL][0002] Rumeur:[E4][NULL][NULL][0006]\n[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]On y a de vraies armes[E4][NULL][NULL][0002] Commentaires:[E4][NULL][NULL][0006]\nMauvais stock. Bonne revente.[E4][NULL][NULL][0002]"
+    "texte_fr": "Lieu:[E4][NULL][NULL][0006] Kounan - Jolly Roger[E4][NULL][NULL][0002] Rumeur:[E4][NULL][NULL][0006]\n[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]On y a de vraies armes[E4][NULL][NULL][0002] Commentaires:[E4][NULL][NULL][0006]\nMauvais stock. Bonne revente.[E4][NULL][NULL][0002]"
   },
   {
     "id": 103,
@@ -1606,7 +1606,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Oho...[1205][0014][SP]so[SP]the[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High[SP]used[SP]to\nbe[SP]one[SP]of[SP]the[SP]old[SP]Boss'[SP]henchmen.[1205][000F][SP]O[SP]irony.[1205][000F]\nWell,[SP]here's[SP]my[SP]end[SP]of[SP]the[SP]deal.",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Oho.[1205][1205]..[1205][0014] le nouveau chef du Lycée\nKakasu était un sbire de l'ancien\n[000F][000F]Boss. Quelle ironie. Voilà ma part."
+    "texte_fr": "Oho.[1205][1205]..[0014][1205] le nouveau chef du Lycée\nKakasu était un sbire de l'ancien\n[000F][000F]Boss. Quelle ironie. Voilà ma part."
   },
   {
     "id": 104,
@@ -1621,7 +1621,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Location:[1205][000F][E4][NULL][NULL][0006][SP]Aoba[SP]-[SP]Rosa[SP]Candida[E4][NULL][NULL][0002][1205][000F]\nRumor:[1205][000F][E4][NULL][NULL][0006][SP]You[SP]can[SP]buy[SP]real[SP]weapons[E4][NULL][NULL][0002][1205][000F]\nComments:[1205][000F][E4][NULL][NULL][0006][SP]Low[SP]price.[SP]Low[SP]quality.[E4][NULL][NULL][0002]",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Lieu:[E4][NULL][NULL][0006] Aoba - Rosa Candida[E4][NULL][NULL][0002] Rumeur:[E4][NULL][NULL][0006] On y a de\n[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]vraies armes[E4][NULL][NULL][0002] Notes:[E4][NULL][NULL][0006]\nPrix bas. Qualité basse.[E4][NULL][NULL][0002]"
+    "texte_fr": "Lieu:[E4][NULL][NULL][0006] Aoba - Rosa Candida[E4][NULL][NULL][0002] Rumeur:[E4][NULL][NULL][0006] On y a de\n[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]vraies armes[E4][NULL][NULL][0002] Notes:[E4][NULL][NULL][0006]\nPrix bas. Qualité basse.[E4][NULL][NULL][0002]"
   },
   {
     "id": 105,
@@ -1636,7 +1636,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "...[1205][0014]The[SP]cat[SP]statue[SP]at[SP]the[SP]detective[SP]agency\ntalks.[1205][000F][SP]Where[SP]do[SP]you[SP]get[SP]this[SP]stuff?[1205][000F][SP]Fine,\nI'll[SP]give[SP]you[SP]something[SP]in[SP]return.",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": ".[1205][1205]..[1205][0014] La statue de chat à l'agence\n[000F][000F]parle. D'où tu sors ça? Bon,\nvoilà quelque chose en échange."
+    "texte_fr": ".[1205][1205]..[0014][1205] La statue de chat à l'agence\n[000F][000F]parle. D'où tu sors ça? Bon,\nvoilà quelque chose en échange."
   },
   {
     "id": 106,
@@ -1651,7 +1651,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Location:[1205][000F][E4][NULL][NULL][0006][SP]Kounan[SP]-[SP]London[SP]Clothier[E4][NULL][NULL][0002][1205][000F]\nRumor:[1205][000F][E4][NULL][NULL][0006][SP]You[SP]can[SP]buy[SP]real[SP]armor[E4][NULL][NULL][0002][1205][000F]\nComments:[1205][000F][E4][NULL][NULL][0006][SP]Quality[SP]and[SP]price[SP]average.[E4][NULL][NULL][0002]",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Lieu:[E4][NULL][NULL][0006] Kounan - London Clothier[E4][NULL][NULL][0002]\n[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]Rumeur:[E4][NULL][NULL][0006] On y a de vraies armures[E4][NULL][NULL][0002]\nNotes:[E4][NULL][NULL][0006] Qualité et prix moyens.[E4][NULL][NULL][0002]"
+    "texte_fr": "Lieu:[E4][NULL][NULL][0006] Kounan - London Clothier[E4][NULL][NULL][0002]\n[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]Rumeur:[E4][NULL][NULL][0006] On y a de vraies armures[E4][NULL][NULL][0002]\nNotes:[E4][NULL][NULL][0006] Qualité et prix moyens.[E4][NULL][NULL][0002]"
   },
   {
     "id": 107,
@@ -1681,7 +1681,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "We're[SP]like[SP]those[SP]nerve[SP]cells.[1205][000F][SP]And[SP]it's[SP]the\nInternet[SP]that[SP]connects[SP]us.",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Nous sommes ces neurones. [1205][000F]Et\nc'est Internet qui nous connecte."
+    "texte_fr": "Nous sommes ces neurones. [000F][1205]Et\nc'est Internet qui nous connecte."
   },
   {
     "id": 109,
@@ -1696,7 +1696,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "If[SP]Earth[SP]is[SP]one[SP]brain...[1205][000F][SP]What[SP]are[SP]rumors?[1205][000F]\nA[SP]piece[SP]of[SP]the[SP]subconscious,[SP]floating[SP]in\nmemory?[1205][000F][SP]Your[SP]uncontrollable[SP]true[SP]self?",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Si la Terre pense..[1205][000F][1205][000F][1205]. [000F]Que sont les\nrumeurs? Des bribes de subconscient dans\nla mémoire? Ton vrai moi incontrôlable?"
+    "texte_fr": "Si la Terre pense..[000F][1205][000F][1205][1205]. [000F]Que sont les\nrumeurs? Des bribes de subconscient dans\nla mémoire? Ton vrai moi incontrôlable?"
   },
   {
     "id": 110,
@@ -1711,7 +1711,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "If[SP]so,[SP]maybe[SP]I'd[SP]put[SP]a[SP]little[SP]more[SP]stock[SP]in\nthe[SP]collective[SP]unconsciousness[SP]theory.[1205][000F]\nWe're[SP]all[SP]connected.",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Si c'est le cas, je croirais plus en\nla théorie de l'inconscient collectif.\n[1205][000F]Nous sommes tous connectés."
+    "texte_fr": "Si c'est le cas, je croirais plus en\nla théorie de l'inconscient collectif.\n[000F][1205]Nous sommes tous connectés."
   },
   {
     "id": 111,
@@ -1756,7 +1756,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "It's[SP]harder[SP]to[SP]see[SP]what's[SP]really[SP]valuable.[1205][000F]\nThat[SP]stuff's[SP]invisible[SP]to[SP]the[SP]eye...[SP]But[SP]you\ngotta[SP]chase[SP]it[SP]down.[1205][000F][SP]Wouldn't[SP]you[SP]agree?",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Plus difficile de voir ce qui a de la\n[1205][000F][1205][000F]valeur. Ça se voit pas à l'œil nu...\nMais faut le traquer. Tu es d'accord?"
+    "texte_fr": "Plus difficile de voir ce qui a de la\n[000F][1205][000F][1205]valeur. Ça se voit pas à l'œil nu...\nMais faut le traquer. Tu es d'accord?"
   },
   {
     "id": 114,
@@ -1831,7 +1831,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "The[SP]Internet's[SP]full[SP]of[SP]interesting[SP]stuff.[1205][000F][SP]I'm\naddicted[SP]to[SP]Baofu's[SP]site,[SP]Zipper.[1205][000F][SP]He[SP]collects\nall[SP]kinds[SP]of[SP]local[SP]rumors.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Internet regorge de trucs cool.\n[1205][000F][1205][000F]Comme le site Zipper de Baofu. Il\ncollecte toutes les rumeurs locales."
+    "texte_fr": "Internet regorge de trucs cool.\n[000F][1205][000F][1205]Comme le site Zipper de Baofu. Il\ncollecte toutes les rumeurs locales."
   },
   {
     "id": 119,
@@ -1846,7 +1846,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]wonder[SP]if[SP]he's[SP]posted[SP]the[SP]one[SP]about[SP]London\nClothier[SP]in[SP]Kounan[SP]selling[SP]real[SP]armor[SP]yet...[1205][000F]\nYou[SP]should[SP]check[SP]on[SP]that[SP]computer[SP]to[SP]see.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Il a posté la rumeur sur le London\nClothier de Kounan qui vend de vraies\n[1205][000F]armures? Vérifie sur cet ordi."
+    "texte_fr": "Il a posté la rumeur sur le London\nClothier de Kounan qui vend de vraies\n[000F][1205]armures? Vérifie sur cet ordi."
   },
   {
     "id": 120,
@@ -1861,7 +1861,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Hey,[SP]I[SP]heard[SP]some[SP]Masked[SP]Circle[SP]group[SP]is[SP]doing\nall[SP]this.[SP]Is[SP]that[SP]true?[1205][000F][SP]I[SP]don't[SP]like[SP]it...\nI[SP]thought[SP]Sumaru[SP]was[SP]supposed[SP]to[SP]be[SP]peaceful...",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Hé, j'ai entendu que c'est un groupe, le\nCercle masqué, qui fait\n[1205][000F]ça. C'est vrai? J'aime\npas ça... Sumaru devait être paisible..."
+    "texte_fr": "Hé, j'ai entendu que c'est un groupe, le\nCercle masqué, qui fait\n[000F][1205]ça. C'est vrai? J'aime pas ça... Sumaru devait être paisible..."
   },
   {
     "id": 121,
@@ -1876,7 +1876,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Don't[SP]bother[SP]me.[1205][000F][SP]I'm[SP]writing[SP]up[SP]a[SP]forum[SP]post\nabout[SP]my[SP]theories[SP]on[SP]who[SP]the[SP]terrorists[SP]are.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Ne me dérange pas. [1205][000F]J'écris un post\nsur mes théories sur les terroristes."
+    "texte_fr": "Ne me dérange pas. [000F][1205]J'écris un post\nsur mes théories sur les terroristes."
   },
   {
     "id": 122,
@@ -1891,7 +1891,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Let's[SP]see...[1205][000F][SP][1432][NULL][NULL][0014]I'm[SP]super[SP]sure[SP]it[SP]was[SP]the[SP]Masked\nCircle,[SP]guys![SP]^_^v[1432][NULL][NULL][0014][1205][000F][SP]Hehe...[SP]Gonna[SP]use[SP]my[SP]girl\nmode[SP]for[SP]this...",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Voyons..[1205][000F][1205][000F]. [1432][NULL][NULL][0014]C'est sûrement le Cercle masqué,\nles gars! ^_^v[1432][NULL][NULL][0014] Hehe...\nMode fille pour ça..."
+    "texte_fr": "Voyons..[000F][1205][000F][1205]. [1432][NULL][NULL][0014]C'est sûrement le Cercle masqué,\nles gars! ^_^v[1432][NULL][NULL][0014] Hehe...\nMode fille pour ça..."
   },
   {
     "id": 123,
@@ -1921,7 +1921,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Aaaand...[SP]send.[1205][000F][SP]Heheh...[1205][000A][SP]Girl[SP]mode[SP]gets[SP]'em\nevery[SP]time.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Envoyé. Ha.[1205].[000F].[1205][000A] Le mode\nfille marche à coup sûr."
+    "texte_fr": "Envoyé. Ha.[1205].[000F].[000A][1205] Le mode\nfille marche à coup sûr."
   },
   {
     "id": 125,
@@ -1936,7 +1936,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Hey.[1205][000A][SP]I[SP]hear[SP]everything[SP]that's[SP]been[SP]happening\nis[SP]mentioned[SP]in[SP]the[SP]Oracle[SP]of[SP]In[SP]Lak'ech.\nIs[SP]that[SP]true?[1205][000F][SP]Sounds[SP]like[SP]a[SP]stretch[SP]to[SP]me.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Hé.[1205][1205][000A] Paraît que tout ce qui se passe est\ndans l'Oracle de l'In Lak'ech. C'est\nvrai? [000F]Ça me semble tiré par les cheveux."
+    "texte_fr": "Hé.[1205][000A][1205] Paraît que tout ce qui se passe est\ndans l'Oracle de l'In Lak'ech. C'est\nvrai? [000F]Ça me semble tiré par les cheveux."
   },
   {
     "id": 126,
@@ -1951,7 +1951,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Man,[SP]I've[SP]never[SP]seen[SP]soldiers[SP]like[SP]those,[SP]not\neven[SP]in[SP]the[SP]movies...[SP]Or[SP]weapons[SP]like[SP]theirs\neither...[1205][000F][SP]I[SP]can't[SP]believe[SP]they're[SP]real.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "J'ai jamais vu des soldats pareils, même\nau cinéma... Ni des armes comme ca...\n[1205][000F]J'arrive pas à croire que c'est réel."
+    "texte_fr": "J'ai jamais vu des soldats pareils, même\nau cinéma... Ni des armes comme ca...\n[000F][1205]J'arrive pas à croire que c'est réel."
   },
   {
     "id": 127,
@@ -1966,7 +1966,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]heard[SP]that[SP]ghost[SP]Hanako[SP]has[SP]been[SP]sighted\nat[SP]Sevens...[1205][000F][SP]Can't[SP]believe[SP]she[SP]really[SP]exists.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît que le fantôme Hanako a été vu\n[1205][000F]au Lycée Seven Sisters... J'en doute."
+    "texte_fr": "Paraît que le fantôme Hanako a été vu\n[000F][1205]au Lycée Seven Sisters... J'en doute."
   },
   {
     "id": 128,
@@ -1996,7 +1996,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "A[SP]girl[SP]I[SP]met[SP]online[SP]told[SP]me[SP]there's[SP]an[SP]idol\nsinger's[SP]ghost[SP]at[SP]Aoba[SP]Park.[1205][000F][SP]Maybe[SP]I[SP]should\ngo[SP]take[SP]a[SP]picture.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "On dit en ligne que le fantôme\nd'une idole est au parc Aoba.\n[1205][000F]J'devrais aller prendre une photo."
+    "texte_fr": "On dit en ligne que le fantôme\nd'une idole est au parc Aoba.\n[000F][1205]J'devrais aller prendre une photo."
   },
   {
     "id": 130,
@@ -2011,7 +2011,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Have[SP]you[SP]heard[SP]of[SP]the[SP]Cursed[SP]Taxi?[1205][000F][SP]It[SP]goes[SP]out\nat[SP]night[SP]to[SP]run[SP]people[SP]over.[1205][000F][SP]I[SP]hear[SP]in[SP]the[SP]day,\nit's[SP]parked[SP]at[SP]the[SP]abandoned[SP]factory.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "T'as entendu parler du Taxi maudit? [1205][000F][1205][000F]Il\nsort la nuit pour renverser des gens. Le\njour, il serait garé à l'usine abandonnée."
+    "texte_fr": "T'as entendu parler du Taxi maudit? [000F][1205][000F][1205]Il\nsort la nuit pour renverser des gens. Le\njour, il serait garé à l'usine abandonnée."
   },
   {
     "id": 131,
@@ -2026,7 +2026,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Someone[SP]posted[SP]a[SP]retraction[SP]online[SP]about[SP]that\nCursed[SP]Taxi[SP]at[SP]the[SP]abandoned[SP]factory.[1205][000F][SP]Says[SP]it\nwas[SP]actually[SP]a[SP]Cursed[SP]Escort.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Quelqu'un a posté un démenti sur le\nTaxi maudit à l'usine abandonnée. [1205][000F]En\nfait c'était une Berline maudite."
+    "texte_fr": "Quelqu'un a posté un démenti sur le\nTaxi maudit à l'usine abandonnée. [000F][1205]En\nfait c'était une Berline maudite."
   },
   {
     "id": 132,
@@ -2086,7 +2086,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Yeah...[SP]I[SP]mean,[SP]it's[SP]really[SP]scary[SP]when[SP]they[SP]put\nit[SP]that[SP]way...[1205][000F][SP]Hm?[1205][000A][SP]Oh,[SP]I[SP]was[SP]talking[SP]about\nKudan.[1205][000F][SP]*sigh*[SP]Best[SP]to[SP]put[SP]it[SP]out[SP]of[SP]mind.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Ouais... C'est vraiment flippant dit\ncomme ça..[1205]. [1205][000F][000F]Hm?[1205][000A] Oh, je parlais de Kudan.\n*soupir* Mieux vaut ne pas y penser."
+    "texte_fr": "Ouais... C'est vraiment flippant dit\ncomme ça..[1205]. [000F][1205][000F]Hm?[000A][1205] Oh, je parlais de Kudan.\n*soupir* Mieux vaut ne pas y penser."
   },
   {
     "id": 136,
@@ -2131,7 +2131,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "What[SP]the[SP]hell's[SP]a[SP]Dresser[SP]Hag?[1205][000F][SP]Some[SP]kind[SP]of\nmonster?",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "C'est quoi une commode? [1205][000F]Un monstre?."
+    "texte_fr": "C'est quoi une commode? [000F][1205]Un monstre?."
   },
   {
     "id": 139,
@@ -2146,7 +2146,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "It[SP]brings[SP]kind[SP]of[SP]a[SP]strange[SP]image[SP]to[SP]mind...[1205][000F]\nI[SP]wish[SP]I[SP]could[SP]see[SP]the[SP]real[SP]thing.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Ça évoque une image bizarre...\n[1205][000F]J'aimerais voir la vraie chose."
+    "texte_fr": "Ça évoque une image bizarre...\n[000F][1205]J'aimerais voir la vraie chose."
   },
   {
     "id": 140,
@@ -2266,7 +2266,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]go[SP]to\nClair[SP]de[SP]Lune[SP]in[SP]Aoba.[1205][000F][SP]Their[SP]selection's[SP]bad,\nbut[SP]the[SP]buyback[SP]prices[SP]are[SP]nice.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît qu'on peut acheter de vraies\narmes au Clair de Lune à Aoba. [1205][000F]Mauvais\nstock, mais bons prix de revente."
+    "texte_fr": "Paraît qu'on peut acheter de vraies\narmes au Clair de Lune à Aoba. [000F][1205]Mauvais\nstock, mais bons prix de revente."
   },
   {
     "id": 148,
@@ -2281,7 +2281,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]go[SP]to\nClair[SP]de[SP]Lune[SP]in[SP]Aoba.[1205][000F][SP]It's[SP]cheap[SP]stuff,\nbut[SP]not[SP]such[SP]great[SP]quality.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît qu'on peut acheter de vraies\narmes au Clair de Lune à Aoba. [1205][000F]Pas\ncher, mais qualité médiocre."
+    "texte_fr": "Paraît qu'on peut acheter de vraies\narmes au Clair de Lune à Aoba. [000F][1205]Pas\ncher, mais qualité médiocre."
   },
   {
     "id": 149,
@@ -2296,7 +2296,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]go[SP]to\nClair[SP]de[SP]Lune[SP]in[SP]Aoba.[1205][000F][SP]They've[SP]got[SP]good[SP]stuff,\nbut[SP]it's[SP]expensive[SP]as[SP]hell.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît qu'on peut acheter de vraies\narmes au Clair de Lune à Aoba. [1205][000F]Bonne\nqualité, mais c'est hors de prix."
+    "texte_fr": "Paraît qu'on peut acheter de vraies\narmes au Clair de Lune à Aoba. [000F][1205]Bonne\nqualité, mais c'est hors de prix."
   },
   {
     "id": 150,
@@ -2311,7 +2311,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]go[SP]to\nClair[SP]de[SP]Lune[SP]in[SP]Aoba.[1205][000F][SP]Their[SP]selection's[SP]good,\nbut[SP]the[SP]buyback[SP]prices[SP]are[SP]real[SP]low.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît qu'on peut acheter de vraies\narmes au Clair de Lune à Aoba. [1205][000F]Bon\nstock, mais prix de revente très bas."
+    "texte_fr": "Paraît qu'on peut acheter de vraies\narmes au Clair de Lune à Aoba. [000F][1205]Bon\nstock, mais prix de revente très bas."
   },
   {
     "id": 151,
@@ -2326,7 +2326,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]go[SP]to\nClair[SP]de[SP]Lune[SP]in[SP]Aoba.[1205][000F][SP]Their[SP]quality[SP]and\nprices[SP]are[SP]average.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît qu'on peut acheter des\narmes au Clair de Lune à Aoba.\n[1205][000F]Qualité et prix dans la moyenne."
+    "texte_fr": "Paraît qu'on peut acheter des\narmes au Clair de Lune à Aoba.\n[000F][1205]Qualité et prix dans la moyenne."
   },
   {
     "id": 152,
@@ -2356,7 +2356,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Like[SP]just[SP]now,[SP]I[SP]saw[SP]you[SP]can[SP]buy[SP]weapons[SP]at\nJolly[SP]Roger.[1205][000F][SP]Their[SP]quality[SP]and[SP]prices[SP]are\nnothing[SP]out[SP]of[SP]the[SP]ordinary...",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Comme là, j'ai vu qu'on peut acheter\n[1205][000F]des armes au Jolly Roger. Qualité et\nprix pas extraordinaires..."
+    "texte_fr": "Comme là, j'ai vu qu'on peut acheter\n[000F][1205]des armes au Jolly Roger. Qualité et\nprix pas extraordinaires..."
   },
   {
     "id": 154,
@@ -2386,7 +2386,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Like[SP]just[SP]now,[SP]I[SP]saw[SP]you[SP]can[SP]buy[SP]weapons[SP]at\nJolly[SP]Roger.[1205][000F][SP]They're[SP]cheap,[SP]but[SP]the[SP]quality\nis[SP]lousy.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Là, j'ai vu qu'on peut acheter des armes au\n[1205][000F]Jolly Roger. Pas cher, mais qualité nulle."
+    "texte_fr": "Là, j'ai vu qu'on peut acheter des armes au\n[000F][1205]Jolly Roger. Pas cher, mais qualité nulle."
   },
   {
     "id": 156,
@@ -2416,7 +2416,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Like[SP]just[SP]now,[SP]I[SP]saw[SP]you[SP]can[SP]buy[SP]weapons[SP]at\nJolly[SP]Roger.[1205][000F][SP]Their[SP]selection's[SP]good,[SP]but\nthe[SP]buyback[SP]prices[SP]there[SP]suck.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Comme là, j'ai vu qu'on peut acheter\n[1205][000F]des armes au Jolly Roger. Bon stock,\nmais prix de revente nuls."
+    "texte_fr": "Comme là, j'ai vu qu'on peut acheter\n[000F][1205]des armes au Jolly Roger. Bon stock,\nmais prix de revente nuls."
   },
   {
     "id": 158,
@@ -2506,7 +2506,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]at[SP]the[SP]Rosa[SP]Candida\nin[SP]Rengedai.[1205][000F][SP]It's[SP]cheap,[SP]but[SP]sounds[SP]like\nit's[SP]not[SP]worth[SP]paying[SP]for.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît qu'ils vendent des armures au Rosa\n[1205][000F]Candida de Rengedai. Pas cher, mais bof."
+    "texte_fr": "Paraît qu'ils vendent des armures au Rosa\n[000F][1205]Candida de Rengedai. Pas cher, mais bof."
   },
   {
     "id": 164,
@@ -2521,7 +2521,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]at[SP]the[SP]Rosa[SP]Candida\nin[SP]Rengedai.[1205][000F][SP]It's[SP]well-made,[SP]but[SP]expensive.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît qu'on vend des armures au Rosa\nCandida de Rengedai. [1205][000F]Bien fait, mais cher."
+    "texte_fr": "Paraît qu'on vend des armures au Rosa\nCandida de Rengedai. [000F][1205]Bien fait, mais cher."
   },
   {
     "id": 165,
@@ -2536,7 +2536,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I've[SP]never[SP]heard[SP]of[SP]armor[SP]as[SP]a[SP]fashion[SP]trend...\nBut[SP]Anima[SP]Mundi[SP]sells[SP]it.[1205][000F][SP]The[SP]quality[SP]and\nprice[SP]of[SP]their[SP]stuff[SP]is[SP]normal.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "J'avais jamais entendu parler d'armure\ncomme tendance mode... [1205][000F]Mais Anima Mundi\nen vend. Qualité et prix normaux."
+    "texte_fr": "J'avais jamais entendu parler d'armure\ncomme tendance mode... [000F][1205]Mais Anima Mundi\nen vend. Qualité et prix normaux."
   },
   {
     "id": 166,
@@ -2566,7 +2566,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I've[SP]never[SP]heard[SP]of[SP]armor[SP]as[SP]a[SP]fashion[SP]trend...\nBut[SP]Anima[SP]Mundi[SP]sells[SP]it.[1205][000F][SP]Their[SP]selection's\ngood,[SP]but[SP]they[SP]don't[SP]pay[SP]much[SP]for[SP]your[SP]stuff.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "J'avais jamais entendu parler d'armure\ncomme tendance mode... [1205][000F]Mais Anima Mundi en\nvend. Bon stock, mais prix de revente bas."
+    "texte_fr": "J'avais jamais entendu parler d'armure\ncomme tendance mode... [000F][1205]Mais Anima Mundi en\nvend. Bon stock, mais prix de revente bas."
   },
   {
     "id": 168,
@@ -2581,7 +2581,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I've[SP]never[SP]heard[SP]of[SP]armor[SP]as[SP]a[SP]fashion[SP]trend...\nBut[SP]Anima[SP]Mundi[SP]sells[SP]it.[1205][000F][SP]The[SP]quality[SP]of\ntheir[SP]stuff[SP]is[SP]nice,[SP]but[SP]it's[SP]expensive.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "J'avais jamais entendu parler d'armure\ncomme tendance mode... [1205][000F]Mais Anima Mundi\nen vend. Bonne qualité, mais c'est cher."
+    "texte_fr": "J'avais jamais entendu parler d'armure\ncomme tendance mode... [000F][1205]Mais Anima Mundi\nen vend. Bonne qualité, mais c'est cher."
   },
   {
     "id": 169,
@@ -2626,7 +2626,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]there.[1205][000F][SP]They[SP]don't\nhave[SP]the[SP]widest[SP]selection,[SP]but[SP]their[SP]resale\nprices[SP]are[SP]excellent.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît qu'ils vendent de vraies\n[1205][000F]armures là-bas. Choix limité,\nmais prix de revente excellents."
+    "texte_fr": "Paraît qu'ils vendent de vraies\n[000F][1205]armures là-bas. Choix limité,\nmais prix de revente excellents."
   },
   {
     "id": 172,
@@ -2671,7 +2671,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]there.[1205][000F][SP]Their\nquality[SP]and[SP]prices[SP]are[SP]normal.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît qu'ils vendent des\n[1205][000F]armures. Qualité et prix normaux."
+    "texte_fr": "Paraît qu'ils vendent des\n[000F][1205]armures. Qualité et prix normaux."
   },
   {
     "id": 175,
@@ -2716,7 +2716,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]there.[1205][000F][SP]They[SP]have\ngood-quality[SP]stuff,[SP]but[SP]it'll[SP]cost[SP]you.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît qu'ils vendent des armures\n[1205][000F]là-bas. Bonne qualité, mais cher."
+    "texte_fr": "Paraît qu'ils vendent des armures\n[000F][1205]là-bas. Bonne qualité, mais cher."
   },
   {
     "id": 178,
@@ -2761,7 +2761,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]there.[1205][000F][SP]You[SP]don't\ngo[SP]to[SP]them[SP]for[SP]quality,[SP]but[SP]hey,[SP]it's[SP]cheap.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît qu'ils vendent des armures\n[1205][000F]là-bas. Pas de qualité, mais pas cher."
+    "texte_fr": "Paraît qu'ils vendent des armures\n[000F][1205]là-bas. Pas de qualité, mais pas cher."
   },
   {
     "id": 181,
@@ -2806,7 +2806,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]there.[1205][000F][SP]They[SP]have\nan[SP]excellent[SP]selection,[SP]but[SP]really[SP]low[SP]buyback\nprices.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît qu'ils vendent de vraies armures\n[1205][000F]là-bas. Excellent stock, mais revente très\nbasse."
+    "texte_fr": "Paraît qu'ils vendent de vraies armures\n[000F][1205]là-bas. Excellent stock, mais revente très\nbasse."
   },
   {
     "id": 184,
@@ -2821,7 +2821,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]heard[SP]there[SP]was[SP]a[SP]tailor[SP]who[SP]makes[SP]armor.\nTurns[SP]out[SP]it[SP]was[SP]London[SP]Clothier.[1205][000F][SP]The[SP]selection\nthere[SP]is[SP]good,[SP]but[SP]the[SP]buyback[SP]prices[SP]aren't.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "J'ai entendu parler d'un tailleur qui fait\ndes armures. [1205][000F]C'était le London Clothier.\nBon stock, mais mauvais prix de revente."
+    "texte_fr": "J'ai entendu parler d'un tailleur qui fait\ndes armures. [000F][1205]C'était le London Clothier.\nBon stock, mais mauvais prix de revente."
   },
   {
     "id": 185,
@@ -2836,7 +2836,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]heard[SP]there[SP]was[SP]a[SP]tailor[SP]who[SP]makes[SP]armor.\nTurns[SP]out[SP]it[SP]was[SP]London[SP]Clothier.[1205][000F][SP]His[SP]stuff\nis[SP]cheap,[SP]but[SP]not[SP]very[SP]good.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "J'ai entendu qu'un tailleur fait\ndes armures. C'était le London\n[1205][000F]Clothier. Pas cher, mais bof."
+    "texte_fr": "J'ai entendu qu'un tailleur fait\ndes armures. C'était le London\n[000F][1205]Clothier. Pas cher, mais bof."
   },
   {
     "id": 186,
@@ -2851,7 +2851,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]heard[SP]there[SP]was[SP]a[SP]tailor[SP]who[SP]makes[SP]armor.\nTurns[SP]out[SP]it[SP]was[SP]London[SP]Clothier.[1205][000F][SP]His[SP]stuff\nis[SP]top-notch,[SP]but[SP]it'll[SP]set[SP]you[SP]back.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "J'ai entendu parler d'un tailleur qui\nfait des armures. C'était le London\n[1205][000F]Clothier. Excellent, mais ça coûte cher."
+    "texte_fr": "J'ai entendu parler d'un tailleur qui\nfait des armures. C'était le London\n[000F][1205]Clothier. Excellent, mais ça coûte cher."
   },
   {
     "id": 187,
@@ -2866,7 +2866,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]heard[SP]there[SP]was[SP]a[SP]tailor[SP]who[SP]makes[SP]armor.\nTurns[SP]out[SP]it[SP]was[SP]London[SP]Clothier.[1205][000F][SP]His[SP]prices\nand[SP]quality[SP]are[SP]both[SP]average.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "J'ai entendu qu'un tailleur fait\ndes armures. C'était le London\n[1205][000F]Clothier. Prix et qualité moyenne."
+    "texte_fr": "J'ai entendu qu'un tailleur fait\ndes armures. C'était le London\n[000F][1205]Clothier. Prix et qualité moyenne."
   },
   {
     "id": 188,
@@ -2881,7 +2881,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]heard[SP]there[SP]was[SP]a[SP]tailor[SP]who[SP]makes[SP]armor.\nTurns[SP]out[SP]it[SP]was[SP]London[SP]Clothier.[1205][000F][SP]The[SP]selection\nthere[SP]is[SP]bad,[SP]but[SP]the[SP]buyback[SP]prices[SP]are[SP]nice.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "J'ai entendu parler d'un tailleur qui fait\ndes armures. [1205][000F]C'était le London Clothier.\nMauvais stock, mais bons prix de revente."
+    "texte_fr": "J'ai entendu parler d'un tailleur qui fait\ndes armures. [000F][1205]C'était le London Clothier.\nMauvais stock, mais bons prix de revente."
   },
   {
     "id": 189,
@@ -2896,7 +2896,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "[1432][NULL][NULL][0014]Enter[SP]the[SP]magazine[SP]sweepstakes[SP]for[SP]your[SP]chance\nto[SP]win[SP]real[SP]weapons[1432][NULL][NULL][0014]...[1205][000F][SP]Huh.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "[1432][NULL][NULL][0014]Participez au concours du magazine\npour gagner des armes[1432][NULL][NULL][0014].[1205][000F].. Ah."
+    "texte_fr": "[1432][NULL][NULL][0014]Participez au concours du magazine\npour gagner des armes[1432][NULL][NULL][0014].[000F][1205].. Ah."
   },
   {
     "id": 190,
@@ -2926,7 +2926,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "They[SP]say[SP]you[SP]won't[SP]win[SP]that[SP]often,[SP]but[SP]you[SP]get\npretty[SP]good[SP]prizes[SP]when[SP]you[SP]do.[1205][000F][SP]Well,[SP]can't\nhurt[SP]to[SP]try...",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "On gagne pas souvent,\nmais les lots sont pas\nmal quand ça arrive. [1205][000F]Ça coûte rien\nd'essayer..."
+    "texte_fr": "On gagne pas souvent,\nmais les lots sont pas\nmal quand ça arrive. [000F][1205]Ça coûte rien d'essayer..."
   },
   {
     "id": 192,
@@ -2941,7 +2941,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "[1432][NULL][NULL][0014]Enter[SP]the[SP]magazine[SP]sweepstakes[SP]for[SP]your[SP]chance\nto[SP]win[SP]real[SP]weapons[1432][NULL][NULL][0014]...[1205][000F][SP]Huh.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "[1432][NULL][NULL][0014]Participez au concours du magazine\npour gagner des armes[1432][NULL][NULL][0014].[1205][000F].. Ah."
+    "texte_fr": "[1432][NULL][NULL][0014]Participez au concours du magazine\npour gagner des armes[1432][NULL][NULL][0014].[000F][1205].. Ah."
   },
   {
     "id": 193,
@@ -2971,7 +2971,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "They[SP]say[SP]you'll[SP]hardly[SP]ever[SP]win,[SP]but[SP]you[SP]get\nsuper[SP]rare[SP]prizes[SP]when[SP]you[SP]do.[1205][000F][SP]Well,[SP]can't\nhurt[SP]to[SP]try...",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "On gagne presque jamais, mais les lots sont\nultra rares. [1205][000F]Ça coûte rien d'essayer..."
+    "texte_fr": "On gagne presque jamais, mais les lots sont\nultra rares. [000F][1205]Ça coûte rien d'essayer..."
   },
   {
     "id": 195,
@@ -2986,7 +2986,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "[1432][NULL][NULL][0014]Enter[SP]the[SP]magazine[SP]sweepstakes[SP]for[SP]your[SP]chance\nto[SP]win[SP]real[SP]weapons[1432][NULL][NULL][0014]...[1205][000F][SP]Huh.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "[1432][NULL][NULL][0014]Participez au concours du magazine\npour gagner des armes[1432][NULL][NULL][0014].[1205][000F].. Ah."
+    "texte_fr": "[1432][NULL][NULL][0014]Participez au concours du magazine\npour gagner des armes[1432][NULL][NULL][0014].[000F][1205].. Ah."
   },
   {
     "id": 196,
@@ -3016,7 +3016,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "They[SP]say[SP]it's[SP]real[SP]easy[SP]to[SP]win,[SP]but[SP]the[SP]prizes\nare[SP]incredibly[SP]lame.[1205][000F][SP]Well,[SP]can't[SP]hurt[SP]to[SP]try...",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Paraît que gagner est facile, mais les\nlots sont nuls. [1205][000F]Ça coûte rien d'essayer..."
+    "texte_fr": "Paraît que gagner est facile, mais les\nlots sont nuls. [000F][1205]Ça coûte rien d'essayer..."
   },
   {
     "id": 198,
@@ -3031,7 +3031,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Hm?[1205][000A][SP]There's[SP]actual[SP]gambling[SP]at[SP]Mu?[1205][000F][SP]Who[SP]posted\nthis?[1205][000F][SP]Though[SP]I[SP]have[SP]heard[SP]that[SP]rumor[SP]before.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Hm?[1205][1205][1205][000A] Des jeux d'argent à Mu? [000F][000F]Qui a posté\nça? J'avais déjà entendu cette rumeur."
+    "texte_fr": "Hm?[1205][1205][000A][1205] Des jeux d'argent à Mu? [000F][000F]Qui a posté\nça? J'avais déjà entendu cette rumeur."
   },
   {
     "id": 199,
@@ -3061,7 +3061,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Hm?[1205][000A][SP]There's[SP]actual[SP]gambling[SP]at[SP]Mu?[1205][000F][SP]Who[SP]posted\nthis?[1205][000F][SP]Though[SP]I[SP]have[SP]heard[SP]that[SP]rumor[SP]before.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Hm?[1205][1205][1205][000A] Des jeux d'argent à Mu? [000F][000F]Qui a posté\nça? J'avais déjà entendu cette rumeur."
+    "texte_fr": "Hm?[1205][1205][000A][1205] Des jeux d'argent à Mu? [000F][000F]Qui a posté\nça? J'avais déjà entendu cette rumeur."
   },
   {
     "id": 201,
@@ -3091,7 +3091,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Hm?[1205][000A][SP]There's[SP]actual[SP]gambling[SP]at[SP]Mu?[1205][000F][SP]Who[SP]posted\nthis?[1205][000F][SP]Though[SP]I[SP]have[SP]heard[SP]that[SP]rumor[SP]before.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Hm?[1205][1205][1205][000A] Des jeux d'argent à Mu? [000F][000F]Qui a posté\nça? J'avais déjà entendu cette rumeur."
+    "texte_fr": "Hm?[1205][1205][000A][1205] Des jeux d'argent à Mu? [000F][000F]Qui a posté\nça? J'avais déjà entendu cette rumeur."
   },
   {
     "id": 203,
@@ -3121,7 +3121,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "A[SP]legendary[SP]weapon...?[1205][000F][SP]Sounds[SP]like[SP]something\nout[SP]of[SP]a[SP]video[SP]game.[SP]You[SP]really[SP]expect[SP]to\nfind[SP]something[SP]like[SP]that[SP]at[SP]a[SP]ramen[SP]shop?",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Une arme légendaire.[1205][000F]..? On dirait un\njeu vidéo. Tu t'attends vraiment à\ntrouver ça dans un resto de ramen?"
+    "texte_fr": "Une arme légendaire.[000F][1205]..? On dirait un\njeu vidéo. Tu t'attends vraiment à\ntrouver ça dans un resto de ramen?"
   },
   {
     "id": 205,
@@ -3136,7 +3136,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Clair[SP]de[SP]Lune's[SP]that[SP]restaurant,[SP]right?[1205][000F]\nThere[SP]was[SP]a[SP]rumor[SP]they[SP]had[SP]a[SP]legendary[SP]weapon.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Clair de Lune, c'est ce resto, non? [1205][000F]On\ndit qu'ils ont une arme légendaire."
+    "texte_fr": "Clair de Lune, c'est ce resto, non? [000F][1205]On\ndit qu'ils ont une arme légendaire."
   },
   {
     "id": 206,
@@ -3151,7 +3151,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]get[SP]it.[1205][000F][SP]The[SP]Count[SP]at[SP]Time[SP]Castle[SP]just[SP]wants\nto[SP]sell[SP]his[SP]legendary[SP]weapon[SP]for[SP]as[SP]much[SP]as\nhe[SP]can![SP]I'm[SP]gonna[SP]post[SP]about[SP]that[SP]right[SP]now.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Je comprends. [1205][000F]Le Comte du Time Castle veut\njuste vendre son arme légendaire le plus\ncher! Je vais poster ça tout de suite."
+    "texte_fr": "Je comprends. [000F][1205]Le Comte du Time Castle veut\njuste vendre son arme légendaire le plus\ncher! Je vais poster ça tout de suite."
   },
   {
     "id": 207,
@@ -3166,7 +3166,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]did[SP]some[SP]checking,[SP]and[SP]the[SP]weapon[SP]that's\nsupposed[SP]to[SP]be[SP]at[SP]Time[SP]Castle[SP]isn't[SP]there\nyet.[1205][000F][SP]The[SP]owner[SP]hasn't[SP]gone[SP]to[SP]pick[SP]it[SP]up.",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "J'ai vérifié, et l'arme censée être au\nTime Castle n'y est pas encore. Le\n[1205][000F]propriétaire n'est pas allé la chercher."
+    "texte_fr": "J'ai vérifié, et l'arme censée être au\nTime Castle n'y est pas encore. Le\n[000F][1205]propriétaire n'est pas allé la chercher."
   },
   {
     "id": 208,
@@ -3181,7 +3181,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "What!?[1205][000A][SP]So[SP]demons[SP]actually[SP]exist?[1205][000A][SP]B-But[SP]they\nstole[SP]the[SP]legendary[SP]weapon[SP]from[SP]Time[SP]Castle!",
     "nom_fr": "Homme corpulent",
-    "texte_fr": "Quoi!?[1205][000A] Les démons existent?[1205][000A] Mais ils ont\nvolé l'arme légendaire du Time Castle!"
+    "texte_fr": "Quoi!?[000A][1205] Les démons existent?[000A][1205] Mais ils ont\nvolé l'arme légendaire du Time Castle!"
   },
   {
     "id": 209,

--- a/traduction/event_scripts/script_360.json
+++ b/traduction/event_scripts/script_360.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We[SP]have[SP]to[SP]get[SP]that[SP]skull[SP]back[SP]to[SP]turn[SP]Ken[SP]and\nthe[SP]others[SP]back[SP]to[SP]normal...[1205][000F][SP]Anyway,[SP]we[SP]still\nhaven't[SP]dealt[SP]with[SP]the[SP]temple[SP]in[SP]Yumezaki.",
     "nom_fr": "[NULL][E4][NULL][NULL]\"Eikichi",
-    "texte_fr": "Il faut récupérer ce crâne pour ramener\nKen et les autres à la normale.[1205][000F]..\nTemple de Yumezaki toujours en suspens."
+    "texte_fr": "Il faut récupérer ce crâne pour ramener\nKen et les autres à la normale.[000F][1205]..\nTemple de Yumezaki toujours en suspens."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "That[SP]faker...[1205][000F][SP]Even[SP]I[SP]haven't[SP]gotten[SP]that[SP]close\nto[SP]Miyabi![1205][000F][SP]I[SP]wish[SP]I[SP]could[SP]have[SP]punched[SP]him[SP]out\neven[SP]harder!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ce faussaire.[1205][000F][1205][000F].. Même moi, jamais si près de\nMiyabi! J'aurais voulu\nle frapper plus fort!"
+    "texte_fr": "Ce faussaire.[000F][1205][000F][1205].. Même moi, jamais si près de\nMiyabi! J'aurais voulu\nle frapper plus fort!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Don't[SP]worry,[SP]we'll[SP]save[SP]them.[1205][000A][SP]Maya[SP]thinks\nit's[SP]possible.[1205][000F][SP]And...[1205][000A][SP]um...[1205][000A][SP]I'm[SP]here,[SP]too!",
     "nom_fr": "Eikichi",
-    "texte_fr": "T'inquiète, on les sauvera.[1205][1205][000A] Maya\nest sure. [000F]Et...[1205][000A] euh...[1205][000A] Je suis là!"
+    "texte_fr": "T'inquiète, on les sauvera.[1205][000A][1205] Maya\nest sure. [000F]Et...[000A][1205] euh...[000A][1205] Je suis là!"
   },
   {
     "id": 3,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "B-But[SP]I[SP]won't[SP]give[SP]up...[1205][000F][SP]I[SP]know[SP]we[SP]can[SP]still\nmake[SP]it![SP]I[SP]can[SP]still[SP]save[SP]them![1205][000F][SP]Help[SP]me[SP]do[SP]this,\n[1113].",
     "nom_fr": "Ginko",
-    "texte_fr": "M-Mais je lâche pas.[1205][000F][1205][000F].. On peut encore y\narriver! Les sauver! Aide-moi, [1113]."
+    "texte_fr": "M-Mais je lâche pas.[000F][1205][000F][1205].. On peut encore y\narriver! Les sauver! Aide-moi, [1113]."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We're[SP]not[SP]done[SP]with[SP]the[SP]temple[SP]in[SP]Kounan[SP]yet.[1205][000F]\nThat[SP]crystal[SP]skull[SP]has[SP]Sheba[SP]and[SP]Mee-ho's\ndreams[SP]in[SP]it...[1205][000F][SP]I'll[SP]make[SP]them[SP]pay!",
     "nom_fr": "Ginko",
-    "texte_fr": "Pas fini avec le temple de Kounan.\n[1205][000F][1205][000F]Ce crâne contient les rêves de\nSheba et Mee-ho... Ils vont payer!"
+    "texte_fr": "Pas fini avec le temple de Kounan.\n[000F][1205][000F][1205]Ce crâne contient les rêves de\nSheba et Mee-ho... Ils vont payer!"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "The[SP]crystal[SP]skull[SP]my[SP]shadow[SP]was[SP]carrying[SP]was\nthe[SP]same[SP]one[SP]Prince[SP]Taurus[SP]had,[SP]right?[1205][000F][SP]That's\nwhere[SP]my[SP]friends'[SP]dreams[SP]are...",
     "nom_fr": "Ginko",
-    "texte_fr": "Le crâne que portait mon ombre\nc'était celui du Prince Taurus, non?\n[1205][000F]Là sont les rêves de mes amies..."
+    "texte_fr": "Le crâne que portait mon ombre\nc'était celui du Prince Taurus, non?\n[000F][1205]Là sont les rêves de mes amies..."
   },
   {
     "id": 8,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "You[SP]might[SP]not[SP]get[SP]your[SP]friends[SP]back[SP]either.[1205][000F]\nAnd[SP]if[SP]not...[SP]what[SP]are[SP]we[SP]fighting[SP]for...?",
     "nom_fr": "",
-    "texte_fr": "Tu ne retrouveras peut-être pas\ntes amis non plus. [1205][000F]Et si c'est le\ncas... pour quoi se bat-on...?"
+    "texte_fr": "Tu ne retrouveras peut-être pas\ntes amis non plus. [000F][1205]Et si c'est le\ncas... pour quoi se bat-on...?"
   },
   {
     "id": 11,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]crystal[SP]skull[SP]of[SP]fire...[1205][000F][SP]The[SP]one[SP]King[SP]Leo\nused...[1205][000F][SP]So[SP]many[SP]people's[SP]dreams[SP]are[SP]inside[SP]it.[1205][000F]\nWe[SP]have[SP]to[SP]return[SP]them[SP]to[SP]their[SP]owners.",
     "nom_fr": "Maya",
-    "texte_fr": "Le crâne de cristal de feu.[1205][000F][1205][000F][1205][000F].. Celui de King\nLeo... Tant de rêves sont à l'intérieur. Il\nfaut les rendre à leurs propriétaires."
+    "texte_fr": "Le crâne de cristal de feu.[000F][1205][000F][1205][000F][1205].. Celui de King\nLeo... Tant de rêves sont à l'intérieur. Il\nfaut les rendre à leurs propriétaires."
   },
   {
     "id": 13,
@@ -282,7 +282,7 @@
     "nom_orig": "Jun",
     "texte_orig": "We've[SP]got[SP]the[SP]crystal[SP]skull[SP]from[SP]Aquarius\nTemple.[1205][000F][SP]If[SP]I[SP]can[SP]get[SP]everyone[SP]back[SP]their\ndreaming[SP]hearts...[1205][000F][SP]I[SP]won't[SP]care[SP]if[SP]I[SP]die...",
     "nom_fr": "Jun",
-    "texte_fr": "On a le crâne de cristal du Temple\n[1205][000F][1205][000F]Aquarius. Si je peux rendre à tous leur\ncœur rêveur... Peu m'importe si je meurs..."
+    "texte_fr": "On a le crâne de cristal du Temple\n[000F][1205][000F][1205]Aquarius. Si je peux rendre à tous leur\ncœur rêveur... Peu m'importe si je meurs..."
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Jun",
     "texte_orig": "The[SP]ritual[SP]of[SP]the[SP]sacrifice[SP]should[SP]trigger[SP]the\nGrand[SP]Cross...[1205][001E][SP]We[SP]have[SP]to[SP]catch[SP]up[SP]with[SP]them\nbefore[SP]they[SP]go[SP]through[SP]with[SP]it.",
     "nom_fr": "Jun",
-    "texte_fr": "Le rituel du sacrifice devrait déclencher\nla Grande Croix...[1205][001E] Il faut les rattraper\navant qu'ils passent à l'acte."
+    "texte_fr": "Le rituel du sacrifice devrait déclencher\nla Grande Croix...[001E][1205] Il faut les rattraper\navant qu'ils passent à l'acte."
   },
   {
     "id": 20,
@@ -342,7 +342,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "Hey.[1205][000F][SP]Surfing[SP]the[SP]net[SP]this[SP]early[SP]in[SP]the[SP]day?\nMust[SP]have[SP]a[SP]lot[SP]of[SP]time[SP]on[SP]your[SP]hands.[SP]Whatevs.\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]the[SP]lazy[SP]boy\nNever[SP]mind\nLeave",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "Hé. [1205][000F]Tu surfs si tôt?\nT'as du temps à perdre. Bref.\n[1208][0004]Manger ici\nParler au gamin\nLaisser tomber\nQuitter",
+    "texte_fr": "Hé. [000F][1205]Tu surfs si tôt?\nT'as du temps à perdre. Bref.\n[1208][0004]Manger ici\nParler au gamin\nLaisser tomber\nQuitter",
     "question_orig": "Hey.[1205][000F][SP]Surfing[SP]the[SP]net[SP]this[SP]early[SP]in[SP]the[SP]day?\nMust[SP]have[SP]a[SP]lot[SP]of[SP]time[SP]on[SP]your[SP]hands.[SP]Whatevs.",
     "choix_orig": [
       "Dine[SP]in",
@@ -395,7 +395,7 @@
     "nom_orig": "Lazy[SP]boy",
     "texte_orig": "Sure...[1205][000F][SP]Was[SP]that[SP]it?\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]the[SP]lazy[SP]boy\nNever[SP]mind\nLeave",
     "nom_fr": "Gamin fainéant",
-    "texte_fr": "Ouais.[1205][000F].. Tout?\n[1208][0004]Manger ici\nParler\nLaisser tomber\nQuitter",
+    "texte_fr": "Ouais.[000F][1205].. Tout?\n[1208][0004]Manger ici\nParler\nLaisser tomber\nQuitter",
     "question_orig": "Sure...[1205][000F][SP]Was[SP]that[SP]it?",
     "choix_orig": [
       "Dine[SP]in",
@@ -493,7 +493,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Heehehehe...[1205][000F][SP]If[SP]we're[SP]on[SP]Xibalba,[SP]we'll[SP]be\nevolving[SP]soon![1205][000F][SP]Why[SP]did[SP]Joker[SP]have[SP]to[SP]ask[SP]us\nto[SP]do[SP]this[SP]now!?",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Héhéhéhé.[1205][000F][1205][000F].. Sur Xibalba\non va bientôt évoluer!\nPourquoi Joker nous fait ça maintenant!?"
+    "texte_fr": "Héhéhéhé.[000F][1205][000F][1205].. Sur Xibalba\non va bientôt évoluer!\nPourquoi Joker nous fait ça maintenant!?"
   },
   {
     "id": 30,
@@ -508,7 +508,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "I-I[SP]can't[SP]fight[SP]the[SP]Last[SP]Battalion[SP]knowing\nthat![1205][000F][SP]I'm[SP]going[SP]to[SP]survive.[1205][000F][SP]I'll[SP]survive[SP]and\nbecome[SP]an[SP]Idealian!",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "J-Je peux pas combattre le Bataillon\n[1205][000F][1205][000F]sachant ça! Je vais survivre. Je\nsurvivrai et deviendrai Idéalien!"
+    "texte_fr": "J-Je peux pas combattre le Bataillon\n[000F][1205][000F][1205]sachant ça! Je vais survivre. Je\nsurvivrai et deviendrai Idéalien!"
   },
   {
     "id": 31,
@@ -523,7 +523,7 @@
     "nom_orig": "???",
     "texte_orig": "Looks[SP]like[SP]this[SP]is[SP]your[SP]first[SP]time[SP]here.[1205][000F]\nName's[SP]Baofu.[SP]I[SP]run[SP]this[SP]website.[E1][E2]Baofu\nAn[SP]online[SP]rumormonger[SP]with[SP]his[SP]own[SP]rumor[SP]site.\nNothing[SP]is[SP]known[SP]about[SP]him,[SP]but[SP]he[SP]seems[SP]to\nbe[SP]gathering[SP]rumors[SP]for[SP]a[SP]specific[SP]purpose.",
     "nom_fr": "???",
-    "texte_fr": "Première visite. Moi c'est Baofu. [1205][000F]Je gère\nce site.[E1][E2] Baofu Colporteur en ligne avec son\npropre site. On sait rien de lui,\nmais ilcollecte des rumeurs dans un but précis."
+    "texte_fr": "Première visite. Moi c'est Baofu. [000F][1205]Je gère\nce site.[E1][E2] Baofu Colporteur en ligne avec son\npropre site. On sait rien de lui,\nmais ilcollecte des rumeurs dans un but précis."
   },
   {
     "id": 32,
@@ -553,7 +553,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Either's[SP]fine.[1205][000F][SP]If[SP]you[SP]know[SP]anything,[SP]will[SP]you\ntell[SP]me[SP]for[SP]some[SP]info[SP]in[SP]trade?",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Les deux me vont. [1205][000F]Si tu sais quelque\nchose, tu me le dis contre une info?"
+    "texte_fr": "Les deux me vont. [000F][1205]Si tu sais quelque\nchose, tu me le dis contre une info?"
   },
   {
     "id": 34,
@@ -568,7 +568,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "You're[SP]interested[SP]in[SP]rumors,[SP]aren't[SP]you?[1205][000F]\nSo[SP]am[SP]I.[1205][000F][SP]If[SP]you[SP]want,[SP]send[SP]me[SP]something.\nI'll[SP]be[SP]waiting[SP]to[SP]hear[SP]something[SP]worthwhile.",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Les rumeurs t'intéressent, non? [1205][000F][1205][000F]Moi aussi.\nEnvoie-moi quelque chose. J'attends du\nconcret."
+    "texte_fr": "Les rumeurs t'intéressent, non? [000F][1205][000F][1205]Moi aussi.\nEnvoie-moi quelque chose. J'attends du\nconcret."
   },
   {
     "id": 35,
@@ -583,7 +583,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Hey,[SP]you're[SP]back.",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Te revoilà. Choisis une option.\nDemander des rumeurs\nParler avec Baofu\nAnnuler\n Choisis un sujet.\nRumeurs armureries\nRumeurs armures\nAutres rumeurs\nRien\n Choisis une région.\nRengedai\nYumezaki\nAoba\nKounan\nAucune\n Choisis une région.\nRengedai\nYumezaki\nAoba\nKounan\nAucune\n Choisis un sujet.\nRumeurs concours\nRumeurs Mu\nRumeurs armes légendaires\nAucune\n Vérifié.\nSoumettre les infos.\nAprès envoi, patientez.",
+    "texte_fr": "Te revoilà. Choisis une option.\nDemander des rumeurs\nParler avec Baofu Annuler Choisis un sujet. Rumeurs armureries Rumeurs armures Autres rumeurs Rien Choisis une région. Rengedai Yumezaki Aoba Kounan Aucune Choisis une région. Rengedai Yumezaki Aoba Kounan Aucune Choisis un sujet. Rumeurs concours Rumeurs Mu Rumeurs armes légendaires Aucune Vérifié. Soumettre les infos. Après envoi, patientez.",
     "choix_fr": [
       ""
     ]
@@ -616,7 +616,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Location:[1205][000F][E4][NULL][NULL][0006][SP]Aoba[SP]-[SP]Clair[SP]de[SP]Lune[E4][NULL][NULL][0002][1205][000F]\nRumor:[1205][000F][E4][NULL][NULL][0006][SP]You[SP]can[SP]buy[SP]real[SP]weapons[E4][NULL][NULL][0002][1205][000F]\nComments:[1205][000F][E4][NULL][NULL][0006][SP]Good[SP]stock.[SP]Low[SP]trade-in[SP]value.[E4][NULL][NULL][0002]",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Endroit:[E4][NULL][NULL][0006] Aoba - Clair de Lune[E4][NULL][NULL][0002] Rumeur:[E4][NULL][NULL][0006]\n[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]On y a de vraies armes[E4][NULL][NULL][0002] Commentaires:[E4][NULL][NULL][0006]\nBon stock. Faible reprise.[E4][NULL][NULL][0002]"
+    "texte_fr": "Endroit:[E4][NULL][NULL][0006] Aoba - Clair de Lune[E4][NULL][NULL][0002] Rumeur:[E4][NULL][NULL][0006]\n[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]On y a de vraies armes[E4][NULL][NULL][0002] Commentaires:[E4][NULL][NULL][0006]\nBon stock. Faible reprise.[E4][NULL][NULL][0002]"
   },
   {
     "id": 38,
@@ -661,7 +661,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Location:[1205][000F][E4][NULL][NULL][0006][SP]Kounan[SP]-[SP]Jolly[SP]Roger[E4][NULL][NULL][0002][1205][000F]\nRumor:[1205][000F][E4][NULL][NULL][0006][SP]You[SP]can[SP]buy[SP]real[SP]weapons[E4][NULL][NULL][0002][1205][000F]\nComments:[1205][000F][E4][NULL][NULL][0006][SP]Bad[SP]stock.[SP]High[SP]trade-in[SP]value.[E4][NULL][NULL][0002]",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Endroit:[E4][NULL][NULL][0006] Kounan - Jolly Roger[E4][NULL][NULL][0002]\n[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]Rumeur:[E4][NULL][NULL][0006] On y a de vraies armes[E4][NULL][NULL][0002]\nNotes:[E4][NULL][NULL][0006] Mauvais stock. Bonne reprise.[E4][NULL][NULL][0002]"
+    "texte_fr": "Endroit:[E4][NULL][NULL][0006] Kounan - Jolly Roger[E4][NULL][NULL][0002]\n[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]Rumeur:[E4][NULL][NULL][0006] On y a de vraies armes[E4][NULL][NULL][0002]\nNotes:[E4][NULL][NULL][0006] Mauvais stock. Bonne reprise.[E4][NULL][NULL][0002]"
   },
   {
     "id": 41,
@@ -676,7 +676,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Oho...[1205][0014][SP]so[SP]the[SP]new[SP]Leader[SP]at[SP]Cuss[SP]High[SP]used[SP]to\nbe[SP]one[SP]of[SP]the[SP]old[SP]Boss'[SP]henchmen.[1205][000F][SP]O[SP]irony.[1205][000F]\nWell,[SP]here's[SP]my[SP]end[SP]of[SP]the[SP]deal.",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Oh ho.[1205][1205]..[1205][0014] Le nouveau chef du lycée\nKakasu était un sbire de l'ancien\n[000F][000F]Boss. Ô ironie. Voilà ma part."
+    "texte_fr": "Oh ho.[1205][1205]..[0014][1205] Le nouveau chef du lycée\nKakasu était un sbire de l'ancien\n[000F][000F]Boss. Ô ironie. Voilà ma part."
   },
   {
     "id": 42,
@@ -691,7 +691,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Location:[1205][000F][E4][NULL][NULL][0006][SP]Aoba[SP]-[SP]Rosa[SP]Candida[E4][NULL][NULL][0002][1205][000F]\nRumor:[1205][000F][E4][NULL][NULL][0006][SP]You[SP]can[SP]buy[SP]real[SP]weapons[E4][NULL][NULL][0002][1205][000F]\nComments:[1205][000F][E4][NULL][NULL][0006][SP]Low[SP]price.[SP]Low[SP]quality.[E4][NULL][NULL][0002]",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Endroit:[E4][NULL][NULL][0006] Aoba - Rosa Candida[E4][NULL][NULL][0002]\n[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]Rumeur:[E4][NULL][NULL][0006] On y a de\nvraies armes[E4][NULL][NULL][0002] Notes:[E4][NULL][NULL][0006]\nPrix bas. Qualité basse.[E4][NULL][NULL][0002]"
+    "texte_fr": "Endroit:[E4][NULL][NULL][0006] Aoba - Rosa Candida[E4][NULL][NULL][0002]\n[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]Rumeur:[E4][NULL][NULL][0006] On y a de\nvraies armes[E4][NULL][NULL][0002] Notes:[E4][NULL][NULL][0006] Prix bas. Qualité basse.[E4][NULL][NULL][0002]"
   },
   {
     "id": 43,
@@ -706,7 +706,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "...[1205][0014]The[SP]cat[SP]statue[SP]at[SP]the[SP]detective[SP]agency\ntalks.[1205][000F][SP]Where[SP]do[SP]you[SP]get[SP]this[SP]stuff?[1205][000F][SP]Fine,\nI'll[SP]give[SP]you[SP]something[SP]in[SP]return.",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": ".[1205][1205]..[1205][0014] La statue de chat\n[000F][000F]de l'agence parle. Où tu\ntrouves ça? Tiens,\nquelque chose en échange."
+    "texte_fr": ".[1205][1205]..[0014][1205] La statue de chat\n[000F][000F]de l'agence parle. Où tu\ntrouves ça? Tiens, quelque chose en échange."
   },
   {
     "id": 44,
@@ -721,7 +721,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Location:[1205][000F][E4][NULL][NULL][0006][SP]Kounan[SP]-[SP]London[SP]Clothier[E4][NULL][NULL][0002][1205][000F]\nRumor:[1205][000F][E4][NULL][NULL][0006][SP]You[SP]can[SP]buy[SP]real[SP]armor[E4][NULL][NULL][0002][1205][000F]\nComments:[1205][000F][E4][NULL][NULL][0006][SP]Quality[SP]and[SP]price[SP]average.[E4][NULL][NULL][0002]",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Endroit:[E4][NULL][NULL][0006] Kounan - London Clothier[E4][NULL][NULL][0002]\n[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]Rumeur:[E4][NULL][NULL][0006] On y a de vraies armures[E4][NULL][NULL][0002]\nNotes:[E4][NULL][NULL][0006] Qualité et prix moyens.[E4][NULL][NULL][0002]"
+    "texte_fr": "Endroit:[E4][NULL][NULL][0006] Kounan - London Clothier[E4][NULL][NULL][0002]\n[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]Rumeur:[E4][NULL][NULL][0006] On y a de vraies armures[E4][NULL][NULL][0002]\nNotes:[E4][NULL][NULL][0006] Qualité et prix moyens.[E4][NULL][NULL][0002]"
   },
   {
     "id": 45,
@@ -766,7 +766,7 @@
     "nom_orig": "Rumormonger[SP]Baofu",
     "texte_orig": "Location:[1205][000F][E4][NULL][NULL][0006][SP]Rengedai[SP]-[SP]Time[SP]Castle[E4][NULL][NULL][0002][1205][000F]\nRumor:[1205][000F][E4][NULL][NULL][0006][SP]Legendary[SP]weapon[SP]sold[SP]there[E4][NULL][NULL][0002][1205][000F]\nComments:[1205][000F][E4][NULL][NULL][0006][SP]Given[SP]away[SP]to[SP]a[SP]woman?[E4][NULL][NULL][0002][E1][E2]>[SP]Notes:\nIt[SP]seems[SP]the[SP]owner[SP]gave[SP]it[SP]away[SP]to[SP]a[SP]woman\nwith[SP]short[SP]hair.[1205][000F][SP]No[SP]one[SP]knows[SP]who[SP]this\nwoman[SP]might[SP]be.",
     "nom_fr": "Colporteur Baofu",
-    "texte_fr": "Endroit:[E4][NULL][NULL][0006] Rengedai - Time Castle[E4][NULL][NULL][0002] Rumeur:[E4][NULL][NULL][0006]\n[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]Arme légendaire vendue là[E4][NULL][NULL][0002] Commentaires:[E4][NULL][NULL][0006]\nDonnée à une femme?[E4][NULL][NULL][0002][E1][E2] Notes: Le\npropriol'aurait donnée à une femme aux cheveux\ncourts. Personne ne sait qui c'est."
+    "texte_fr": "Endroit:[E4][NULL][NULL][0006] Rengedai - Time Castle[E4][NULL][NULL][0002] Rumeur:[E4][NULL][NULL][0006]\n[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]Arme légendaire vendue là[E4][NULL][NULL][0002] Commentaires:[E4][NULL][NULL][0006]\nDonnée à une femme?[E4][NULL][NULL][0002][E1][E2] Notes: Le\npropriol'aurait donnée à une femme aux cheveux\ncourts. Personne ne sait qui c'est."
   },
   {
     "id": 48,
@@ -856,7 +856,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Wow,[SP]listen[SP]to[SP]what[SP]I[SP]found[SP]out.[1205][000F][SP]When[SP]the\nGrand[SP]Cross[SP]is[SP]complete,[SP]the[SP]gravity[SP]of[SP]the\nplanets[SP]will[SP]cause[SP]the[SP]stars[SP]to[SP]collide.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Wow, écoutez ça. [1205][000F]Quand la Grande Croix sera\ncomplète, la gravité fera percuter les\nétoiles."
+    "texte_fr": "Wow, écoutez ça. [000F][1205]Quand la Grande Croix sera\ncomplète, la gravité fera percuter les\nétoiles."
   },
   {
     "id": 54,
@@ -871,7 +871,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "But[SP]I[SP]thought[SP]just[SP]the[SP]Earth[SP]was[SP]supposed[SP]to\nbe[SP]destroyed.[1205][000F][SP]If[SP]that[SP]happens,[SP]won't[SP]we[SP]be\nin[SP]trouble[SP]up[SP]here[SP]too?",
     "nom_fr": "Homme gros",
-    "texte_fr": "Je croyais que c'était juste la\nTerre qui serait détruite. [1205][000F]Si ça\narrive, on est en danger ici aussi?"
+    "texte_fr": "Je croyais que c'était juste la\nTerre qui serait détruite. [000F][1205]Si ça\narrive, on est en danger ici aussi?"
   },
   {
     "id": 55,
@@ -886,7 +886,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Ooh,[SP]here's[SP]another[SP]theory[SP]online.[1205][000F][SP]When[SP]the\nGrand[SP]Cross[SP]is[SP]done,[SP]gravity[SP]will[SP]become[SP]much\nheavier[SP]and[SP]the[SP]continents[SP]will[SP]sink.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Oh, une autre théorie en ligne. [1205][000F]Quand la\nGrande Croix sera là, la gravité sera si\nforte que les continents couleront."
+    "texte_fr": "Oh, une autre théorie en ligne. [000F][1205]Quand la\nGrande Croix sera là, la gravité sera si\nforte que les continents couleront."
   },
   {
     "id": 56,
@@ -961,7 +961,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]heard[SP]that[SP]ghost[SP]Hanako[SP]has[SP]been[SP]sighted\nat[SP]Sevens...[1205][000F][SP]Can't[SP]believe[SP]she[SP]really[SP]exists.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Le fantôme Hanako aperçu au Seven...\n[1205][000F]Je crois pas qu'elle existe vraiment."
+    "texte_fr": "Le fantôme Hanako aperçu au Seven...\n[000F][1205]Je crois pas qu'elle existe vraiment."
   },
   {
     "id": 61,
@@ -991,7 +991,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "A[SP]girl[SP]I[SP]met[SP]online[SP]told[SP]me[SP]there's[SP]an[SP]idol\nsinger's[SP]ghost[SP]at[SP]Aoba[SP]Park.[1205][000F][SP]Maybe[SP]I[SP]should\ngo[SP]take[SP]a[SP]picture.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Une fille en ligne m'a dit qu'il\ny a le fantôme d'une idole au\n[1205][000F]parc Aoba. Je devrais aller voir."
+    "texte_fr": "Une fille en ligne m'a dit qu'il\ny a le fantôme d'une idole au\n[000F][1205]parc Aoba. Je devrais aller voir."
   },
   {
     "id": 63,
@@ -1006,7 +1006,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Have[SP]you[SP]heard[SP]of[SP]the[SP]Cursed[SP]Taxi?[1205][000F][SP]It[SP]goes[SP]out\nat[SP]night[SP]to[SP]run[SP]people[SP]over.[1205][000F][SP]I[SP]hear[SP]in[SP]the[SP]day,\nit's[SP]parked[SP]at[SP]the[SP]abandoned[SP]factory.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Vous connaissez le Taxi Maudit? [1205][000F][1205][000F]Il\nsort la nuit écraser des gens. Le\njour, garé à la fabrique abandonnée."
+    "texte_fr": "Vous connaissez le Taxi Maudit? [000F][1205][000F][1205]Il\nsort la nuit écraser des gens. Le\njour, garé à la fabrique abandonnée."
   },
   {
     "id": 64,
@@ -1021,7 +1021,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Someone[SP]posted[SP]a[SP]retraction[SP]online[SP]about[SP]that\nCursed[SP]Taxi[SP]at[SP]the[SP]abandoned[SP]factory.[1205][000F][SP]Says[SP]it\nwas[SP]actually[SP]a[SP]Cursed[SP]Escort.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Quelqu'un a posté un démenti sur le\nTaxi Maudit à la fabrique abandonnée.\n[1205][000F]Il dit que c'était une Escorte Maudite."
+    "texte_fr": "Quelqu'un a posté un démenti sur le\nTaxi Maudit à la fabrique abandonnée.\n[000F][1205]Il dit que c'était une Escorte Maudite."
   },
   {
     "id": 65,
@@ -1081,7 +1081,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Yeah...[SP]I[SP]mean,[SP]it's[SP]really[SP]scary[SP]when[SP]they[SP]put\nit[SP]that[SP]way...[1205][000F][SP]Hm?[1205][000A][SP]Oh,[SP]I[SP]was[SP]talking[SP]about\nKudan.[1205][000F][SP]*sigh*[SP]Best[SP]to[SP]put[SP]it[SP]out[SP]of[SP]mind.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Ouais... Je veux dire,\nça fait vraiment peur\ndit comme ça.[1205][000F][1205][000F].. Hm?[1205][000A]\nOh, je parlais de Kudan.\n*soupir* Mieux vaut ne plus y penser."
+    "texte_fr": "Ouais... Je veux dire,\nça fait vraiment peur\ndit comme ça.[000F][1205][000F][1205].. Hm?[000A][1205] Oh, je parlais de Kudan. *soupir* Mieux vaut ne plus y penser."
   },
   {
     "id": 69,
@@ -1111,7 +1111,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]wonder[SP]what[SP]tracks[SP]are[SP]on[SP]it...?[1205][000F][SP]I[SP]need[SP]to\nget[SP]ahold[SP]of[SP]a[SP]copy[SP]and[SP]find[SP]out[SP]for[SP]myself.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Je me demande quels morceaux.[1205][000F].. Il faut\nque j'en procure un pour le découvrir."
+    "texte_fr": "Je me demande quels morceaux.[000F][1205].. Il faut\nque j'en procure un pour le découvrir."
   },
   {
     "id": 71,
@@ -1126,7 +1126,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "What[SP]the[SP]hell's[SP]a[SP]Dresser[SP]Hag?[1205][000F][SP]Some[SP]kind[SP]of\nmonster?",
     "nom_fr": "Homme gros",
-    "texte_fr": "C'est quoi la Vieille\n[1205][000F]du Tiroir? Un monstre?"
+    "texte_fr": "C'est quoi la Vieille\n[000F][1205]du Tiroir? Un monstre?"
   },
   {
     "id": 72,
@@ -1261,7 +1261,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]go[SP]to\nClair[SP]de[SP]Lune[SP]in[SP]Aoba.[1205][000F][SP]Their[SP]selection's[SP]bad,\nbut[SP]the[SP]buyback[SP]prices[SP]are[SP]nice.",
     "nom_fr": "Homme gros",
-    "texte_fr": "J'ai entendu qu'on peut acheter de\nvraies armes au Clair de Lune à Aoba.\n[1205][000F]Mauvais choix, mais bon prix de reprise."
+    "texte_fr": "J'ai entendu qu'on peut acheter de\nvraies armes au Clair de Lune à Aoba.\n[000F][1205]Mauvais choix, mais bon prix de reprise."
   },
   {
     "id": 81,
@@ -1276,7 +1276,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]go[SP]to\nClair[SP]de[SP]Lune[SP]in[SP]Aoba.[1205][000F][SP]It's[SP]cheap[SP]stuff,\nbut[SP]not[SP]such[SP]great[SP]quality.",
     "nom_fr": "Homme gros",
-    "texte_fr": "J'ai entendu qu'on peut acheter de\nvraies armes au Clair de Lune à Aoba.\n[1205][000F]Pas cher, mais qualité médiocre."
+    "texte_fr": "J'ai entendu qu'on peut acheter de\nvraies armes au Clair de Lune à Aoba.\n[000F][1205]Pas cher, mais qualité médiocre."
   },
   {
     "id": 82,
@@ -1291,7 +1291,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]go[SP]to\nClair[SP]de[SP]Lune[SP]in[SP]Aoba.[1205][000F][SP]They've[SP]got[SP]good[SP]stuff,\nbut[SP]it's[SP]expensive[SP]as[SP]hell.",
     "nom_fr": "Homme gros",
-    "texte_fr": "J'ai entendu qu'on peut acheter\nde vraies armes au Clair de Lune\n[1205][000F]à Aoba. Bonne qualité, mais cher."
+    "texte_fr": "J'ai entendu qu'on peut acheter\nde vraies armes au Clair de Lune\n[000F][1205]à Aoba. Bonne qualité, mais cher."
   },
   {
     "id": 83,
@@ -1306,7 +1306,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]go[SP]to\nClair[SP]de[SP]Lune[SP]in[SP]Aoba.[1205][000F][SP]Their[SP]selection's[SP]good,\nbut[SP]the[SP]buyback[SP]prices[SP]are[SP]real[SP]low.",
     "nom_fr": "Homme gros",
-    "texte_fr": "J'ai entendu qu'on peut acheter de\nvraies armes au Clair de Lune à Aoba.\n[1205][000F]Bon choix, mais mauvais prix de reprise."
+    "texte_fr": "J'ai entendu qu'on peut acheter de\nvraies armes au Clair de Lune à Aoba.\n[000F][1205]Bon choix, mais mauvais prix de reprise."
   },
   {
     "id": 84,
@@ -1321,7 +1321,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]you[SP]can[SP]buy[SP]real[SP]weapons[SP]if[SP]you[SP]go[SP]to\nClair[SP]de[SP]Lune[SP]in[SP]Aoba.[1205][000F][SP]Their[SP]quality[SP]and\nprices[SP]are[SP]average.",
     "nom_fr": "Homme gros",
-    "texte_fr": "On peut acheter de vraies armes au Clair de\nLune à Aoba. [1205][000F]Qualité\net prix dans la moyenne."
+    "texte_fr": "On peut acheter de vraies armes au Clair de\nLune à Aoba. [000F][1205]Qualité\net prix dans la moyenne."
   },
   {
     "id": 85,
@@ -1351,7 +1351,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Like[SP]just[SP]now,[SP]I[SP]saw[SP]you[SP]can[SP]buy[SP]weapons[SP]at\nJolly[SP]Roger.[1205][000F][SP]Their[SP]quality[SP]and[SP]prices[SP]are\nnothing[SP]out[SP]of[SP]the[SP]ordinary...",
     "nom_fr": "Homme gros",
-    "texte_fr": "Tiens, j'ai vu qu'on peut acheter\n[1205][000F]des armes au Jolly Roger. Qualité\net prix dans la moyenne..."
+    "texte_fr": "Tiens, j'ai vu qu'on peut acheter\n[000F][1205]des armes au Jolly Roger. Qualité\net prix dans la moyenne..."
   },
   {
     "id": 87,
@@ -1381,7 +1381,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Like[SP]just[SP]now,[SP]I[SP]saw[SP]you[SP]can[SP]buy[SP]weapons[SP]at\nJolly[SP]Roger.[1205][000F][SP]They're[SP]cheap,[SP]but[SP]the[SP]quality\nis[SP]lousy.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Tiens, j'ai vu qu'on\npeut acheter des armes au\n[1205]Jolly Roger. [000F]Pas\ncher, mais qualité médiocre."
+    "texte_fr": "Tiens, j'ai vu qu'on\npeut acheter des armes au\n[1205]Jolly Roger. [000F]Pas cher, mais qualité médiocre."
   },
   {
     "id": 89,
@@ -1441,7 +1441,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Like[SP]just[SP]now,[SP]I[SP]saw[SP]you[SP]can[SP]buy[SP]weapons[SP]at\nJolly[SP]Roger.[1205][000F][SP]Their[SP]selection[SP]sucks,[SP]but\nthe[SP]buyback[SP]prices[SP]are[SP]good.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Tiens, j'ai vu qu'on peut acheter\ndes armes au Jolly Roger. [1205][000F]Mauvais\nchoix, mais bon prix de reprise."
+    "texte_fr": "Tiens, j'ai vu qu'on peut acheter\ndes armes au Jolly Roger. [000F][1205]Mauvais\nchoix, mais bon prix de reprise."
   },
   {
     "id": 93,
@@ -1471,7 +1471,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Like[SP]just[SP]now,[SP]I[SP]saw[SP]you[SP]can[SP]buy[SP]weapons[SP]at\nJolly[SP]Roger.[1205][000F][SP]They're[SP]expensive,[SP]but[SP]they\nshelve[SP]some[SP]of[SP]the[SP]best[SP]stuff.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Tiens, j'ai vu qu'on peut acheter des armes\n[1205][000F]au Jolly Roger. Cher, mais excellent choix."
+    "texte_fr": "Tiens, j'ai vu qu'on peut acheter des armes\n[000F][1205]au Jolly Roger. Cher, mais excellent choix."
   },
   {
     "id": 95,
@@ -1486,7 +1486,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]at[SP]the[SP]Rosa[SP]Candida\nin[SP]Rengedai.[1205][000F][SP]Their[SP]prices[SP]and[SP]quality[SP]are\njust[SP]average.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Vraies armures au Rosa Candida à Rengedai.\n[1205][000F]Prix et qualité dans la moyenne."
+    "texte_fr": "Vraies armures au Rosa Candida à Rengedai.\n[000F][1205]Prix et qualité dans la moyenne."
   },
   {
     "id": 96,
@@ -1501,7 +1501,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]at[SP]the[SP]Rosa[SP]Candida\nin[SP]Rengedai.[1205][000F][SP]It's[SP]cheap,[SP]but[SP]sounds[SP]like\nit's[SP]not[SP]worth[SP]paying[SP]for.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Vraies armures au Rosa Candida à Rengedai.\n[1205][000F]Pas cher, mais ça vaut pas grand-chose."
+    "texte_fr": "Vraies armures au Rosa Candida à Rengedai.\n[000F][1205]Pas cher, mais ça vaut pas grand-chose."
   },
   {
     "id": 97,
@@ -1516,7 +1516,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]at[SP]the[SP]Rosa[SP]Candida\nin[SP]Rengedai.[1205][000F][SP]It's[SP]well-made,[SP]but[SP]expensive.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Vraies armures au Rosa Candida à\nRengedai. [1205][000F]Bien fait, mais cher."
+    "texte_fr": "Vraies armures au Rosa Candida à\nRengedai. [000F][1205]Bien fait, mais cher."
   },
   {
     "id": 98,
@@ -1531,7 +1531,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I've[SP]never[SP]heard[SP]of[SP]armor[SP]as[SP]a[SP]fashion[SP]trend...\nBut[SP]Anima[SP]Mundi[SP]sells[SP]it.[1205][000F][SP]The[SP]quality[SP]and\nprice[SP]of[SP]their[SP]stuff[SP]is[SP]normal.",
     "nom_fr": "Homme gros",
-    "texte_fr": "L'armure comme tendance mode, j'avais\njamais entendu ça... [1205][000F]Mais Anima Mundi\nen vend. Qualité et prix normaux."
+    "texte_fr": "L'armure comme tendance mode, j'avais\njamais entendu ça... [000F][1205]Mais Anima Mundi\nen vend. Qualité et prix normaux."
   },
   {
     "id": 99,
@@ -1546,7 +1546,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I've[SP]never[SP]heard[SP]of[SP]armor[SP]as[SP]a[SP]fashion[SP]trend...\nBut[SP]Anima[SP]Mundi[SP]sells[SP]it.[1205][000F][SP]The[SP]quality[SP]of\ntheir[SP]stuff[SP]is[SP]low,[SP]but[SP]at[SP]least[SP]it's[SP]cheap.",
     "nom_fr": "Homme gros",
-    "texte_fr": "L'armure comme tendance\nmode, j'avais jamais\nentendu ça... [1205][000F]Mais Anima Mundi en vend.\nQualité basse, mais au\nmoins c'est pas cher."
+    "texte_fr": "L'armure comme tendance\nmode, j'avais jamais\nentendu ça... [000F][1205]Mais Anima Mundi en vend. Qualité basse, mais au moins c'est pas cher."
   },
   {
     "id": 100,
@@ -1561,7 +1561,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I've[SP]never[SP]heard[SP]of[SP]armor[SP]as[SP]a[SP]fashion[SP]trend...\nBut[SP]Anima[SP]Mundi[SP]sells[SP]it.[1205][000F][SP]Their[SP]selection's\ngood,[SP]but[SP]they[SP]don't[SP]pay[SP]much[SP]for[SP]your[SP]stuff.",
     "nom_fr": "Homme gros",
-    "texte_fr": "L'armure comme tendance\nmode, j'avais jamais\nentendu ça... [1205][000F]Mais Anima Mundi en vend. Bon\nchoix, mais mauvais prix de reprise."
+    "texte_fr": "L'armure comme tendance\nmode, j'avais jamais\nentendu ça... [000F][1205]Mais Anima Mundi en vend. Bon choix, mais mauvais prix de reprise."
   },
   {
     "id": 101,
@@ -1606,7 +1606,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "The[SP]ones[SP]who[SP]run[SP]Rosa[SP]Candida,[SP]I[SP]mean.[1205][000F]\nThey[SP]have[SP]a[SP]branch[SP]in[SP]this[SP]ward[SP]too.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Rosa Candida, je veux dire. [1205][000F]Ils\nont une succursale ici aussi."
+    "texte_fr": "Rosa Candida, je veux dire. [000F][1205]Ils\nont une succursale ici aussi."
   },
   {
     "id": 104,
@@ -1621,7 +1621,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]there.[1205][000F][SP]They[SP]don't\nhave[SP]the[SP]widest[SP]selection,[SP]but[SP]their[SP]resale\nprices[SP]are[SP]excellent.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Vraies armures là-bas. [1205][000F]Pas le plus\ngrand choix, mais bons prix de reprise."
+    "texte_fr": "Vraies armures là-bas. [000F][1205]Pas le plus\ngrand choix, mais bons prix de reprise."
   },
   {
     "id": 105,
@@ -1651,7 +1651,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "The[SP]ones[SP]who[SP]run[SP]Rosa[SP]Candida,[SP]I[SP]mean.[1205][000F]\nThey[SP]have[SP]a[SP]branch[SP]in[SP]this[SP]ward[SP]too.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Rosa Candida, je veux dire. [1205][000F]Ils\nont une succursale ici aussi."
+    "texte_fr": "Rosa Candida, je veux dire. [000F][1205]Ils\nont une succursale ici aussi."
   },
   {
     "id": 107,
@@ -1666,7 +1666,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]there.[1205][000F][SP]Their\nquality[SP]and[SP]prices[SP]are[SP]normal.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Vraies armures là-bas.\n[1205][000F]Qualité et prix normaux."
+    "texte_fr": "Vraies armures là-bas.\n[000F][1205]Qualité et prix normaux."
   },
   {
     "id": 108,
@@ -1696,7 +1696,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "The[SP]ones[SP]who[SP]run[SP]Rosa[SP]Candida,[SP]I[SP]mean.[1205][000F]\nThey[SP]have[SP]a[SP]branch[SP]in[SP]this[SP]ward[SP]too.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Rosa Candida, je veux dire. [1205][000F]Ils\nont une succursale ici aussi."
+    "texte_fr": "Rosa Candida, je veux dire. [000F][1205]Ils\nont une succursale ici aussi."
   },
   {
     "id": 110,
@@ -1711,7 +1711,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]there.[1205][000F][SP]They[SP]have\ngood-quality[SP]stuff,[SP]but[SP]it'll[SP]cost[SP]you.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Vraies armures là-bas. [1205][000F]Bonne\nqualité, mais ça coûte."
+    "texte_fr": "Vraies armures là-bas. [000F][1205]Bonne\nqualité, mais ça coûte."
   },
   {
     "id": 111,
@@ -1741,7 +1741,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "The[SP]ones[SP]who[SP]run[SP]Rosa[SP]Candida,[SP]I[SP]mean.[1205][000F]\nThey[SP]have[SP]a[SP]branch[SP]in[SP]this[SP]ward[SP]too.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Rosa Candida, je veux dire. [1205][000F]Ils\nont une succursale ici aussi."
+    "texte_fr": "Rosa Candida, je veux dire. [000F][1205]Ils\nont une succursale ici aussi."
   },
   {
     "id": 113,
@@ -1756,7 +1756,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]there.[1205][000F][SP]You[SP]don't\ngo[SP]to[SP]them[SP]for[SP]quality,[SP]but[SP]hey,[SP]it's[SP]cheap.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Vraies armures là-bas. [1205][000F]Pas pour\nla qualité, mais c'est pas cher."
+    "texte_fr": "Vraies armures là-bas. [000F][1205]Pas pour\nla qualité, mais c'est pas cher."
   },
   {
     "id": 114,
@@ -1786,7 +1786,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "The[SP]ones[SP]who[SP]run[SP]Rosa[SP]Candida,[SP]I[SP]mean.[1205][000F]\nThey[SP]have[SP]a[SP]branch[SP]in[SP]this[SP]ward[SP]too.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Rosa Candida, je veux dire. [1205][000F]Ils\nont une succursale ici aussi."
+    "texte_fr": "Rosa Candida, je veux dire. [000F][1205]Ils\nont une succursale ici aussi."
   },
   {
     "id": 116,
@@ -1801,7 +1801,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]hear[SP]they[SP]sell[SP]real[SP]armor[SP]there.[1205][000F][SP]They[SP]have\nan[SP]excellent[SP]selection,[SP]but[SP]really[SP]low[SP]buyback\nprices.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Vraies armures là-bas. [1205][000F]Excellent choix,\nmais très mauvais prix de reprise."
+    "texte_fr": "Vraies armures là-bas. [000F][1205]Excellent choix,\nmais très mauvais prix de reprise."
   },
   {
     "id": 117,
@@ -1816,7 +1816,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]heard[SP]there[SP]was[SP]a[SP]tailor[SP]who[SP]makes[SP]armor.\nTurns[SP]out[SP]it[SP]was[SP]London[SP]Clothier.[1205][000F][SP]The[SP]selection\nthere[SP]is[SP]good,[SP]but[SP]the[SP]buyback[SP]prices[SP]aren't.",
     "nom_fr": "Homme gros",
-    "texte_fr": "J'ai entendu qu'il y avait un tailleur qui\nfait des armures. [1205][000F]C'est London Clothier.\nBon choix, mais mauvais prix de reprise."
+    "texte_fr": "J'ai entendu qu'il y avait un tailleur qui\nfait des armures. [000F][1205]C'est London Clothier.\nBon choix, mais mauvais prix de reprise."
   },
   {
     "id": 118,
@@ -1831,7 +1831,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]heard[SP]there[SP]was[SP]a[SP]tailor[SP]who[SP]makes[SP]armor.\nTurns[SP]out[SP]it[SP]was[SP]London[SP]Clothier.[1205][000F][SP]His[SP]stuff\nis[SP]cheap,[SP]but[SP]not[SP]very[SP]good.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Un tailleur fait des armures. C'est London\nClothier. [1205][000F]Pas cher, mais qualité médiocre."
+    "texte_fr": "Un tailleur fait des armures. C'est London\nClothier. [000F][1205]Pas cher, mais qualité médiocre."
   },
   {
     "id": 119,
@@ -1861,7 +1861,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]heard[SP]there[SP]was[SP]a[SP]tailor[SP]who[SP]makes[SP]armor.\nTurns[SP]out[SP]it[SP]was[SP]London[SP]Clothier.[1205][000F][SP]His[SP]prices\nand[SP]quality[SP]are[SP]both[SP]average.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Un tailleur fait des armures. C'est London\nClothier. [1205][000F]Prix et qualité dans la moyenne."
+    "texte_fr": "Un tailleur fait des armures. C'est London\nClothier. [000F][1205]Prix et qualité dans la moyenne."
   },
   {
     "id": 121,
@@ -1876,7 +1876,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]heard[SP]there[SP]was[SP]a[SP]tailor[SP]who[SP]makes[SP]armor.\nTurns[SP]out[SP]it[SP]was[SP]London[SP]Clothier.[1205][000F][SP]The[SP]selection\nthere[SP]is[SP]bad,[SP]but[SP]the[SP]buyback[SP]prices[SP]are[SP]nice.",
     "nom_fr": "Homme gros",
-    "texte_fr": "J'ai entendu qu'il y avait un tailleur qui\nfait des armures. [1205][000F]C'est London Clothier.\nMauvais choix, mais bon prix de reprise."
+    "texte_fr": "J'ai entendu qu'il y avait un tailleur qui\nfait des armures. [000F][1205]C'est London Clothier.\nMauvais choix, mais bon prix de reprise."
   },
   {
     "id": 122,
@@ -1921,7 +1921,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "They[SP]say[SP]you[SP]won't[SP]win[SP]that[SP]often,[SP]but[SP]you[SP]get\npretty[SP]good[SP]prizes[SP]when[SP]you[SP]do.[1205][000F][SP]Well,[SP]can't\nhurt[SP]to[SP]try...",
     "nom_fr": "Homme gros",
-    "texte_fr": "Paraît qu'on gagne pas souvent, mais bons\nlots. [1205][000F]Ça peut pas faire de mal d'essayer..."
+    "texte_fr": "Paraît qu'on gagne pas souvent, mais bons\nlots. [000F][1205]Ça peut pas faire de mal d'essayer..."
   },
   {
     "id": 125,
@@ -1966,7 +1966,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "They[SP]say[SP]you'll[SP]hardly[SP]ever[SP]win,[SP]but[SP]you[SP]get\nsuper[SP]rare[SP]prizes[SP]when[SP]you[SP]do.[1205][000F][SP]Well,[SP]can't\nhurt[SP]to[SP]try...",
     "nom_fr": "Homme gros",
-    "texte_fr": "On gagne quasi jamais, mais lots ultra\nrares. Ça peut pas\n[1205][000F]faire de mal d'essayer..."
+    "texte_fr": "On gagne quasi jamais, mais lots ultra\nrares. Ça peut pas\n[000F][1205]faire de mal d'essayer..."
   },
   {
     "id": 128,
@@ -2011,7 +2011,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "They[SP]say[SP]it's[SP]real[SP]easy[SP]to[SP]win,[SP]but[SP]the[SP]prizes\nare[SP]incredibly[SP]lame.[1205][000F][SP]Well,[SP]can't[SP]hurt[SP]to[SP]try...",
     "nom_fr": "Homme gros",
-    "texte_fr": "Très facile de gagner, mais lots nuls.\n[1205][000F]Ça peut pas faire de mal d'essayer..."
+    "texte_fr": "Très facile de gagner, mais lots nuls.\n[000F][1205]Ça peut pas faire de mal d'essayer..."
   },
   {
     "id": 131,
@@ -2026,7 +2026,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Hm?[1205][000A][SP]There's[SP]actual[SP]gambling[SP]at[SP]Mu?[1205][000F][SP]Who[SP]posted\nthis?[1205][000F][SP]Though[SP]I[SP]have[SP]heard[SP]that[SP]rumor[SP]before.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Hm?[1205][1205][1205][000A] Vrais jeux d'argent au Mu? [000F][000F]Qui a\nposté ça? J'avais entendu cette rumeur."
+    "texte_fr": "Hm?[1205][1205][000A][1205] Vrais jeux d'argent au Mu? [000F][000F]Qui a\nposté ça? J'avais entendu cette rumeur."
   },
   {
     "id": 132,
@@ -2056,7 +2056,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Hm?[1205][000A][SP]There's[SP]actual[SP]gambling[SP]at[SP]Mu?[1205][000F][SP]Who[SP]posted\nthis?[1205][000F][SP]Though[SP]I[SP]have[SP]heard[SP]that[SP]rumor[SP]before.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Hm?[1205][1205][1205][000A] Vrais jeux d'argent au Mu? [000F][000F]Qui a\nposté ça? J'avais entendu cette rumeur."
+    "texte_fr": "Hm?[1205][1205][000A][1205] Vrais jeux d'argent au Mu? [000F][000F]Qui a\nposté ça? J'avais entendu cette rumeur."
   },
   {
     "id": 134,
@@ -2086,7 +2086,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Hm?[1205][000A][SP]There's[SP]actual[SP]gambling[SP]at[SP]Mu?[1205][000F][SP]Who[SP]posted\nthis?[1205][000F][SP]Though[SP]I[SP]have[SP]heard[SP]that[SP]rumor[SP]before.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Hm?[1205][1205][1205][000A] Vrais jeux d'argent au Mu? [000F][000F]Qui a\nposté ça? J'avais entendu cette rumeur."
+    "texte_fr": "Hm?[1205][1205][000A][1205] Vrais jeux d'argent au Mu? [000F][000F]Qui a\nposté ça? J'avais entendu cette rumeur."
   },
   {
     "id": 136,
@@ -2116,7 +2116,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "A[SP]legendary[SP]weapon...?[1205][000F][SP]Sounds[SP]like[SP]something\nout[SP]of[SP]a[SP]video[SP]game.[SP]You[SP]really[SP]expect[SP]to\nfind[SP]something[SP]like[SP]that[SP]at[SP]a[SP]ramen[SP]shop?",
     "nom_fr": "Homme gros",
-    "texte_fr": "Une arme légendaire.[1205][000F]..? Ça fait penser à\nun jeu vidéo. Tu crois vraiment trouver\nun truc comme ça dans un resto de ramen?"
+    "texte_fr": "Une arme légendaire.[000F][1205]..? Ça fait penser à\nun jeu vidéo. Tu crois vraiment trouver\nun truc comme ça dans un resto de ramen?"
   },
   {
     "id": 138,
@@ -2131,7 +2131,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "Clair[SP]de[SP]Lune's[SP]that[SP]restaurant,[SP]right?[1205][000F]\nThere[SP]was[SP]a[SP]rumor[SP]they[SP]had[SP]a[SP]legendary[SP]weapon.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Clair de Lune, ce restaurant, non? [1205][000F]Rumeur\nqu'ils avaient une arme légendaire."
+    "texte_fr": "Clair de Lune, ce restaurant, non? [000F][1205]Rumeur\nqu'ils avaient une arme légendaire."
   },
   {
     "id": 139,
@@ -2146,7 +2146,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]get[SP]it.[1205][000F][SP]The[SP]Count[SP]at[SP]Time[SP]Castle[SP]just[SP]wants\nto[SP]sell[SP]his[SP]legendary[SP]weapon[SP]for[SP]as[SP]much[SP]as\nhe[SP]can![SP]I'm[SP]gonna[SP]post[SP]about[SP]that[SP]right[SP]now.",
     "nom_fr": "Homme gros",
-    "texte_fr": "Je vois. [1205][000F]Le Comte de Time Castle veut juste\nvendre son arme légendaire le plus cher\npossible! Je vais poster ça maintenant."
+    "texte_fr": "Je vois. [000F][1205]Le Comte de Time Castle veut juste\nvendre son arme légendaire le plus cher\npossible! Je vais poster ça maintenant."
   },
   {
     "id": 140,
@@ -2161,7 +2161,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "I[SP]did[SP]some[SP]checking,[SP]and[SP]the[SP]weapon[SP]that's\nsupposed[SP]to[SP]be[SP]at[SP]Time[SP]Castle[SP]isn't[SP]there\nyet.[1205][000F][SP]The[SP]owner[SP]hasn't[SP]gone[SP]to[SP]pick[SP]it[SP]up.",
     "nom_fr": "Homme gros",
-    "texte_fr": "J'ai vérifié, et l'arme censée être à\nTime Castle n'y est pas encore. Le\n[1205][000F]propriétaire n'est pas allé la chercher."
+    "texte_fr": "J'ai vérifié, et l'arme censée être à\nTime Castle n'y est pas encore. Le\n[000F][1205]propriétaire n'est pas allé la chercher."
   },
   {
     "id": 141,
@@ -2176,7 +2176,7 @@
     "nom_orig": "Fat[SP]man",
     "texte_orig": "What!?[1205][000A][SP]So[SP]demons[SP]actually[SP]exist?[1205][000A][SP]B-But[SP]they\nstole[SP]the[SP]legendary[SP]weapon[SP]from[SP]Time[SP]Castle!",
     "nom_fr": "Homme gros",
-    "texte_fr": "Quoi!?[1205][000A] Les démons existent?[1205][000A] Ils ont\nvolé l'arme légendaire de Time Castle!"
+    "texte_fr": "Quoi!?[000A][1205] Les démons existent?[000A][1205] Ils ont\nvolé l'arme légendaire de Time Castle!"
   },
   {
     "id": 142,

--- a/traduction/event_scripts/script_361.json
+++ b/traduction/event_scripts/script_361.json
@@ -27,7 +27,7 @@
     "nom_orig": "???",
     "texte_orig": "[1113]...[1205][000F][SP]Don't[SP]see[SP]you[SP]here[SP]often.[1205][000F][SP]But[SP]you\nprobably[SP]didn't[SP]come[SP]to[SP]visit[SP]me.[1205][000F][SP]What's[SP]up?\nDid[SP]something[SP]happen?",
     "nom_fr": "???",
-    "texte_fr": "[1113].[1205][000F][1205][000F][1205][000F].. On te voit rarement ici. Mais t'es\nsûrement pas venu me voir. Quoi de neuf?"
+    "texte_fr": "[1113].[000F][1205][000F][1205][000F][1205].. On te voit rarement ici. Mais t'es\nsûrement pas venu me voir. Quoi de neuf?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Katsuya",
     "texte_orig": "Hmph...[SP]You[SP]never[SP]change.[1205][000F][SP]How[SP]much[SP]longer[SP]are\nyou[SP]going[SP]to[SP]keep[SP]worrying[SP]our[SP]parents?",
     "nom_fr": "Katsuya",
-    "texte_fr": "Hmph... T'as pas changé. [1205][000F]Jusqu'à quand\nvas-tu continuer à inquiéter nos parents?"
+    "texte_fr": "Hmph... T'as pas changé. [000F][1205]Jusqu'à quand\nvas-tu continuer à inquiéter nos parents?"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Katsuya",
     "texte_orig": "I'm[SP]not[SP]asking[SP]you[SP]to[SP]understand[SP]me[SP]or[SP]our\nfather's[SP]position.[1205][000F][SP]But[SP]you[SP]have[SP]nothing[SP]to\ngain[SP]by[SP]running[SP]away.",
     "nom_fr": "Katsuya",
-    "texte_fr": "Je te demande pas de comprendre ma\nposition ni celle de notre père.\n[1205][000F]Mais tu n'as rien à gagner à fuir."
+    "texte_fr": "Je te demande pas de comprendre ma\nposition ni celle de notre père.\n[000F][1205]Mais tu n'as rien à gagner à fuir."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey,[SP]what's[SP]wrong[SP]with[SP]that[SP]guy?[1205][000F][SP]Did[SP]he[SP]commit\nsome[SP]crime?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, il a quoi ce\ntype? [1205][000F]Il a commis un crime?"
+    "texte_fr": "Hé, il a quoi ce\ntype? [000F][1205]Il a commis un crime?"
   },
   {
     "id": 5,
@@ -117,7 +117,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Wow,[SP]I[SP]didn't[SP]know[SP]you[SP]had[SP]a[SP]detective[SP]for\na[SP]brother,[SP][1113].[1205][000F][SP]But[SP]that's[SP]perfect!",
     "nom_fr": "Maya",
-    "texte_fr": "Waouh, je savais pas que t'avais un frère\ndétective, [1113]. [1205][000F]Mais c'est parfait!"
+    "texte_fr": "Waouh, je savais pas que t'avais un frère\ndétective, [1113]. [000F][1205]Mais c'est parfait!"
   },
   {
     "id": 8,
@@ -147,7 +147,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]don't[SP]mean[SP]to[SP]pry[SP]into[SP]your[SP]home[SP]life,[SP]but...[1205][000F]\nYou[SP]don't[SP]exactly[SP]seem[SP]to[SP]get[SP]along[SP]with[SP]your\nbrother.[SP]I'm[SP]here[SP]if[SP]you[SP]want[SP]to[SP]talk.",
     "nom_fr": "Yukino",
-    "texte_fr": "Je veux pas m'immiscer dans ta vie privée,\n[1205]mais.[000F].. Tu sembles pas vraiment t'entendre\navec ton frère. Je suis\nlà si tu veux parler."
+    "texte_fr": "Je veux pas m'immiscer dans ta vie privée,\n[1205]mais.[000F].. Tu sembles pas vraiment t'entendre\navec ton frère. Je suis là si tu veux parler."
   },
   {
     "id": 10,
@@ -357,7 +357,7 @@
     "nom_orig": "Little[SP]Chii",
     "texte_orig": "Here,[SP]you[SP]can[SP]have[SP]my[SP][E4][NULL][NULL][0004][U+1433][NULL][NULL][0004]Incense[SP]Card[SP]set[E4][NULL][NULL][0002].[1205][000F]\nIt[SP]took[SP]a[SP]long[SP]time[SP]for[SP]me[SP]to[SP]collect[SP]all\nthose![1205][000F][SP]Take[SP]good[SP]care[SP]of[SP]them.",
     "nom_fr": "Petite Chii",
-    "texte_fr": "Tiens, tu peux avoir mon [E4][NULL][NULL][0004][NULL][NULL][0004]kit de Cartes\n[1205][000F][1205][000F]Encens[E4][NULL][NULL][0002]. Ça m'a pris longtemps de tout\ncollecter! Prends-en bien soin.[U+1433]"
+    "texte_fr": "Tiens, tu peux avoir mon [E4][NULL][NULL][0004][NULL][NULL][0004]kit de Cartes\n[000F][1205][000F][1205]Encens[E4][NULL][NULL][0002]. Ça m'a pris longtemps de tout\ncollecter! Prends-en bien soin.[U+1433]"
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Little[SP]Chii",
     "texte_orig": "Look,[SP]officer![1205][000F][SP]I[SP]got[SP][1432][NULL][NULL][0014]hard[SP]evidence[1432][NULL][NULL][0014]![1205][000F][SP]Now[SP]you\nhave[SP]to[SP]believe[SP]me!",
     "nom_fr": "Petite Chii",
-    "texte_fr": "Regardez! [1205][000F][1205][000F]J'ai des [1432][NULL][NULL][0014]preuves![1432][NULL][NULL][0014]\nMaintenant vous devez me croire!"
+    "texte_fr": "Regardez! [000F][1205][000F][1205]J'ai des [1432][NULL][NULL][0014]preuves![1432][NULL][NULL][0014]\nMaintenant vous devez me croire!"
   },
   {
     "id": 25,
@@ -417,7 +417,7 @@
     "nom_orig": "Homeless[SP]lady",
     "texte_orig": "The[SP]end[SP]must[SP]be[SP]near.[SP]Huh?[SP]Haven't[SP]I[SP]seen[SP]that\nboy[SP]somewhere?",
     "nom_fr": "Clocharde",
-    "texte_fr": "La fin est proche.\nCe garçon... je l'ai déjà\nvu quelque part? \nPanneau SS: Accueil général,\nBureau étrangers RDC:\nObjets trouvés, Permis,\nConseillers 2e: Aide\nvictimes, Aide sinistrés \nPanneau 3e:\nInterrogatoire, Affaires internes\n4e: Labo, Crimes juvéniles\n5e: Personnesdisparues, Enquêtes spéciales"
+    "texte_fr": "La fin est proche.\nCe garçon... je l'ai déjà\nvu quelque part? Panneau SS: Accueil général, Bureau étrangers RDC: Objets trouvés, Permis, Conseillers 2e: Aide victimes, Aide sinistrés Panneau 3e: Interrogatoire, Affaires internes 4e: Labo, Crimes juvéniles 5e: Personnesdisparues, Enquêtes spéciales"
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Police[SP]officer",
     "texte_orig": "That's[SP]a[SP]statue[SP]of[SP]Coppy,[1205][000F][SP]the[SP]Sumaru[SP]PD[SP]mascot.\nIt's[SP]a[SP]talking[SP]doll[SP]AND[SP]a[SP]donation[SP]box!",
     "nom_fr": "Agent de police",
-    "texte_fr": "C'est Coppy, la mascotte de la police\n[1205][000F]de Sumaru. Poupée parlante ET tirelire!"
+    "texte_fr": "C'est Coppy, la mascotte de la police\n[000F][1205]de Sumaru. Poupée parlante ET tirelire!"
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Katsuya",
     "texte_orig": "The[SP]Masked[SP]Circle?[SP]What's[SP]that?[1205][000F][SP]If[SP]you[SP]try\nto[SP]distract[SP]public[SP]servants[SP]with[SP]these[SP]silly\nstories,[SP]being[SP]my[SP]brother[SP]won't[SP]help[SP]you!",
     "nom_fr": "Katsuya",
-    "texte_fr": "Le Cercle masqué? C'est quoi ça? [1205][000F]Si tu\nessaies de distraire des agents avec ces\nhistoires, être mon frère\nne te sauvera pas!"
+    "texte_fr": "Le Cercle masqué? C'est quoi ça? [000F][1205]Si tu\nessaies de distraire des agents avec ces\nhistoires, être mon frère ne te sauvera pas!"
   },
   {
     "id": 30,
@@ -507,7 +507,7 @@
     "nom_orig": "Katsuya",
     "texte_orig": "Don't[SP]go[SP]believing[SP]everything[SP]you[SP]hear.[SP]Or[SP]did\nyou[SP]help[SP]spread[SP]the[SP]rumor...?[SP]If[SP]not,[SP]drop[SP]it.",
     "nom_fr": "Katsuya",
-    "texte_fr": "Crois pas tout ce\nque t'entends. Ou t'as aidé\nà répandre la\nrumeur...? Sinon, laisse tomber."
+    "texte_fr": "Crois pas tout ce\nque t'entends. Ou t'as aidé\nà répandre la rumeur...? Sinon, laisse tomber."
   },
   {
     "id": 34,
@@ -537,7 +537,7 @@
     "nom_orig": "Police[SP]officer",
     "texte_orig": "Uhhh...[SP][1113],[SP]right?[SP]I[SP]hope[SP]you[SP]grow[SP]up[SP]to\nbe[SP]as[SP]good[SP]a[SP]cop[SP]as[SP]your[SP]brother...[1205][000F][SP]Huh?[SP]That's\nnot[SP]your[SP]plan?[SP]Well,[SP]that's[SP]disappointing.",
     "nom_fr": "Agent de police",
-    "texte_fr": "Euh... [1113], c'est ça? J'espère que tu\ngrandiras pour être aussi bon flic que ton\n[1205][000F]frère... Hein? C'est pas ton plan? Dommage."
+    "texte_fr": "Euh... [1113], c'est ça? J'espère que tu\ngrandiras pour être aussi bon flic que ton\n[000F][1205]frère... Hein? C'est pas ton plan? Dommage."
   },
   {
     "id": 36,
@@ -567,7 +567,7 @@
     "nom_orig": "Police[SP]officer",
     "texte_orig": "Katsuya[SP]is[SP]really[SP]popular[SP]with[SP]the[SP]ladies[SP]on\nthe[SP]force...[1205][000F][SP]But[SP]he[SP]doesn't[SP]have[SP]a[SP]girlfriend.\nIs[SP]he[SP]the[SP]kinda[SP]guy[SP]who's[SP]married[SP]to[SP]his[SP]job?",
     "nom_fr": "Agent de police",
-    "texte_fr": "Katsuya est très\npopulaire auprès des femmes\ndu commissariat... [1205]Mais pas de petite amie.\n[000F]Il est du genre marié\nà son boulot? Avis Si\nvous voyez cet homme, appelez le 17! Je\ncrois l'avoir vu quelque part..."
+    "texte_fr": "Katsuya est très\npopulaire auprès des femmes\ndu commissariat... [1205]Mais pas de petite amie. [000F]Il est du genre marié à son boulot? Avis Si vous voyez cet homme, appelez le 17! Je crois l'avoir vu quelque part..."
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Female[SP]officer's[SP]voice",
     "texte_orig": "*whisper*[SP]*whisper*[1205][000F]\nWhat!?[SP]Are[SP]you[SP]after[SP]Katsuya[SP]too?[1205][000F]\n*whisper*[SP]*whisper*",
     "nom_fr": "Voix d'une agente",
-    "texte_fr": "*chut* *chut* Quoi![1205][000F][1205][000F]? T'es aussi\naprès Katsuya? *chut* *chut*"
+    "texte_fr": "*chut* *chut* Quoi![000F][1205][000F][1205]? T'es aussi\naprès Katsuya? *chut* *chut*"
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Female[SP]officer's[SP]voice",
     "texte_orig": "*whisper*[SP]*whisper*[1205][000F]\nHey,[SP]not[SP]so[SP]loud![1205][000F]\n*whisper*[SP]*whisper*",
     "nom_fr": "Voix d'une agente",
-    "texte_fr": "*chut* *chut* Hé, pas\n[1205][000F][1205][000F]si fort! *chut* *chut*"
+    "texte_fr": "*chut* *chut* Hé, pas\n[000F][1205][000F][1205]si fort! *chut* *chut*"
   },
   {
     "id": 40,
@@ -612,7 +612,7 @@
     "nom_orig": "Female[SP]officer's[SP]voice",
     "texte_orig": "*whisper*[SP]*whisper*[1205][000F]\nBut[SP]there's[SP]so[SP]much[SP]competition![1205][000F]\n*whisper*[SP]*whisper*",
     "nom_fr": "Voix d'une agente",
-    "texte_fr": "*chut* *chut* Mais y'a tellement\n[1205][000F][1205][000F]de concurrence! *chut* *chut*"
+    "texte_fr": "*chut* *chut* Mais y'a tellement\n[000F][1205][000F][1205]de concurrence! *chut* *chut*"
   },
   {
     "id": 41,
@@ -627,7 +627,7 @@
     "nom_orig": "Female[SP]officer's[SP]voice",
     "texte_orig": "*whisper*[SP]*whisper*[1205][000F]\nYou[SP]think[SP]he's[SP]out[SP]of[SP]my[SP]league?[1205][000F]\n*whisper*[SP]*whisper*",
     "nom_fr": "Voix d'une agente",
-    "texte_fr": "*chut* *chut* Tu crois qu'il est\n[1205][000F][1205][000F]hors de ma portée? *chut* *chut*"
+    "texte_fr": "*chut* *chut* Tu crois qu'il est\n[000F][1205][000F][1205]hors de ma portée? *chut* *chut*"
   },
   {
     "id": 42,
@@ -642,7 +642,7 @@
     "nom_orig": "Female[SP]officer's[SP]voice",
     "texte_orig": "*whisper*[SP]*whisper*[1205][000F]\nWell,[SP]good[SP]news![SP]There's[SP]this[SP]Joker[SP]Game...[1205][000F]\n*whisper*[SP]*whisper*",
     "nom_fr": "Voix d'une agente",
-    "texte_fr": "*chut* *chut* Bonne nouvelle! [1205][000F][1205][000F]Il y\na ce Jeu de Joker... *chut* *chut*"
+    "texte_fr": "*chut* *chut* Bonne nouvelle! [000F][1205][000F][1205]Il y\na ce Jeu de Joker... *chut* *chut*"
   },
   {
     "id": 43,
@@ -712,7 +712,7 @@
     "nom_orig": "Coppy",
     "texte_orig": "Arf![1205][000F][SP]5,000[SP]yen[SP]in[SP]the[SP]fund![1205][000F][SP]Terrierific![SP]Arf!",
     "nom_fr": "Coppy",
-    "texte_fr": "Ouaf! [1205][000F][1205][000F]5 000 yens! Terrierfique! Ouaf!"
+    "texte_fr": "Ouaf! [000F][1205][000F][1205]5 000 yens! Terrierfique! Ouaf!"
   },
   {
     "id": 47,
@@ -727,7 +727,7 @@
     "nom_orig": "Coppy",
     "texte_orig": "Arf![1205][000A][SP]10,000[SP]yen[SP]in[SP]the[SP]fund![1205][000F][SP]And[SP]it's[SP]all\nthanks[SP]to[SP]citizens[SP]like[SP]you![SP]Arf!",
     "nom_fr": "Coppy",
-    "texte_fr": "Ouaf![1205][1205][000A] 10 000 yens! [000F]Merci aux\ncitoyens comme toi! Ouaf!"
+    "texte_fr": "Ouaf![1205][000A][1205] 10 000 yens! [000F]Merci aux\ncitoyens comme toi! Ouaf!"
   },
   {
     "id": 48,
@@ -742,7 +742,7 @@
     "nom_orig": "Coppy",
     "texte_orig": "Here's[SP]a[SP]gift[SP]as[SP]thanks![1205][000F][SP]It's[SP]an[SP][E4][NULL][NULL][0004]Incense[SP]Set[E4][NULL][NULL][0002]![1205][000F]\nTwo[SP]of[SP]each[SP]kind![SP]Arf!",
     "nom_fr": "Coppy",
-    "texte_fr": "Cadeau! [1205][000F][1205][000F]Un [E4][NULL][NULL][0004]Kit d'Encens[E4][NULL][NULL][0002]!\nDeux de chaque sorte! Ouaf!"
+    "texte_fr": "Cadeau! [000F][1205][000F][1205]Un [E4][NULL][NULL][0004]Kit d'Encens[E4][NULL][NULL][0002]!\nDeux de chaque sorte! Ouaf!"
   },
   {
     "id": 49,
@@ -772,6 +772,6 @@
     "nom_orig": "Coppy",
     "texte_orig": "...[1205][000F]Tightwad.",
     "nom_fr": "",
-    "texte_fr": "...[1205][000F]Radin."
+    "texte_fr": "...[000F][1205]Radin."
   }
 ]

--- a/traduction/event_scripts/script_362.json
+++ b/traduction/event_scripts/script_362.json
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Holy[SP]crap...[SP]It's[SP]a[SP]disaster[SP]area...[1205][000F][SP]Any[SP]guy\nshe[SP]took[SP]home[SP]to[SP]this[SP]would[SP]be[SP]out[SP]the[SP]door\nin[SP]seconds![1205][000F][SP]She[SP]needs[SP]a[SP]maid[SP]or[SP]something...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Bon sang... N'importe\n[1205][000F][1205][000F]quel mec partirait en\ncourant! Elle a besoin d'une femme de\nménage..."
+    "texte_fr": "Bon sang... N'importe\n[000F][1205][000F][1205]quel mec partirait en\ncourant! Elle a besoin d'une femme de ménage..."
   },
   {
     "id": 5,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah![SP]I[SP]thought[SP]looters[SP]had[SP]broken[SP]in...[1205][000F]\nIs[SP]this[SP]what[SP]it[SP]looks[SP]like[SP]all[SP]the[SP]time?",
     "nom_fr": "Ginko",
-    "texte_fr": "Aïe! J'ai cru que des pilleurs étaient\n[1205][000F]entrés... C'est comme ça tout le temps?"
+    "texte_fr": "Aïe! J'ai cru que des pilleurs étaient\n[000F][1205]entrés... C'est comme ça tout le temps?"
   },
   {
     "id": 11,
@@ -192,7 +192,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]hope[SP]everyone[SP]at[SP]the[SP]station's[SP]okay...[1205][000F]\nKing[SP]Leo's[SP]a[SP]real[SP]son[SP]of[SP]a[SP]bitch...",
     "nom_fr": "Ginko",
-    "texte_fr": "J'espère que le commissariat va\n[1205][000F]bien... Roi Lion est une ordure..."
+    "texte_fr": "J'espère que le commissariat va\n[000F][1205]bien... Roi Lion est une ordure..."
   },
   {
     "id": 13,
@@ -282,7 +282,7 @@
     "nom_orig": "Maya",
     "texte_orig": "My[SP]roommate's[SP]really[SP]well-organized.[1205][000F][SP]She's\nalways[SP]after[SP]me[SP]to[SP]clean[SP]up,[SP]but...[SP]Well...[1205][000F]\nWho[SP]has[SP]the[SP]time?[SP]Haha...[SP]ha...",
     "nom_fr": "Maya",
-    "texte_fr": "Ma coloc est très ordonnée. [1205][000F][1205][000F]Elle\nest toujours après moi pour\nranger... Qui a le temps? Haha..."
+    "texte_fr": "Ma coloc est très ordonnée. [000F][1205][000F][1205]Elle\nest toujours après moi pour\nranger... Qui a le temps? Haha..."
   },
   {
     "id": 19,
@@ -312,7 +312,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]have[SP]to[SP]do[SP]something[SP]about[SP]it.[1205][000F][SP]We[SP]can't[SP]let\nit[SP]burn[SP]freely[SP]any[SP]longer.[SP]It[SP]has[SP]to[SP]be[SP]put\nout[SP]for[SP]good[SP]this[SP]time...",
     "nom_fr": "Maya",
-    "texte_fr": "On doit agir. On ne peut plus le\n[1205][000F]laisser brûler. Il faut l'éteindre\npour de bon cette fois..."
+    "texte_fr": "On doit agir. On ne peut plus le\n[000F][1205]laisser brûler. Il faut l'éteindre\npour de bon cette fois..."
   },
   {
     "id": 21,
@@ -372,7 +372,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Ulala's[SP]been[SP]smoking[SP]in[SP]here[SP]again...[1205][000F][SP]She\nalways[SP]goes[SP]back,[SP]forgets[SP]her[SP]cigarettes,[SP]and\nthen[SP]complains[SP]endlessly[SP]about[SP]losing[SP]them.",
     "nom_fr": "Maya",
-    "texte_fr": "Ulala a encore fumé ici... [1205]Elle repart\n[000F]toujours, oublie ses\ncigarettes, et se plaint\nensuite sans arrêt de les avoir perdues."
+    "texte_fr": "Ulala a encore fumé ici... [1205]Elle repart\n[000F]toujours, oublie ses\ncigarettes, et se plaint ensuite sans arrêt de les avoir perdues."
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Maya-san[SP]lives[SP]here[SP]with[SP]her[SP]friend?[1205][000F][SP]And[SP]this\nis[SP]the[SP]result[SP]of[SP]two[SP]women[SP]living[SP]together?\nI[SP]see[SP]no[SP]boyfriends[SP]in[SP]their[SP]future...",
     "nom_fr": "Yukino",
-    "texte_fr": "Maya-san vit ici avec son amie? [1205][000F]Et voilà\nle résultat de deux femmes sous un toit?\nJe ne leur vois aucun petit ami en vue..."
+    "texte_fr": "Maya-san vit ici avec son amie? [000F][1205]Et voilà\nle résultat de deux femmes sous un toit?\nJe ne leur vois aucun petit ami en vue..."
   },
   {
     "id": 26,
@@ -417,7 +417,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "The[SP]fire[SP]department[SP]was[SP]his[SP]work[SP]too,[SP]right?\nDammit...[1205][000F][SP]If[SP]I[SP]had[SP]only[SP]known...[1205][000F][SP]I've[SP]never\nseen[SP]anyone[SP]play[SP]so[SP]dirty!",
     "nom_fr": "Yukino",
-    "texte_fr": "La caserne de pompiers, c'était lui\naussi? [1205][000F][1205][000F]Merde... Si j'avais su... Je\nn'ai jamais vu un tel manque d'honneur!"
+    "texte_fr": "La caserne de pompiers, c'était lui\naussi? [000F][1205][000F][1205]Merde... Si j'avais su... Je\nn'ai jamais vu un tel manque d'honneur!"
   },
   {
     "id": 28,
@@ -447,7 +447,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Ulala's[SP]not[SP]back[SP]yet.[1205][000F][SP]I[SP]wonder[SP]if[SP]she's[SP]out\nlooking[SP]for[SP]the[SP]culprit?",
     "nom_fr": "Yukino",
-    "texte_fr": "Ulala n'est pas rentrée.\n[1205][000F]Elle cherche le coupable?"
+    "texte_fr": "Ulala n'est pas rentrée.\n[000F][1205]Elle cherche le coupable?"
   },
   {
     "id": 30,
@@ -507,7 +507,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "Man,[SP]first[SP]that[SP]putz[SP]escaped,[SP]and[SP]now[SP]these\nweird[SP]soldiers[SP]are[SP]here...[1205][000F][SP]Why[SP]am[SP]I[SP]so[SP]unlucky?",
     "nom_fr": "Ulala",
-    "texte_fr": "Ce crétin s'est échappé, et maintenant ces\nsoldats... [1205][000F]Pourquoi j'ai si peu de chance?"
+    "texte_fr": "Ce crétin s'est échappé, et maintenant ces\nsoldats... [000F][1205]Pourquoi j'ai si peu de chance?"
   },
   {
     "id": 34,
@@ -552,7 +552,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "Man,[SP]first[SP]that[SP]putz[SP]escaped,[SP]and[SP]now[SP]these\nweird[SP]soldiers[SP]are[SP]here...[1205][000F][SP]Why[SP]am[SP]I[SP]so[SP]unlucky?",
     "nom_fr": "Ulala",
-    "texte_fr": "Ce crétin s'est échappé, et maintenant\nces soldats... Pourquoi j'ai si\npeu de chance? Une \nnouvelle chaîne. [1205][000F]La seule chose\npropre ici. Jouer un CD?\nOuiNon",
+    "texte_fr": "Ce crétin s'est échappé, et maintenant\nces soldats... Pourquoi j'ai si\npeu de chance? Une nouvelle chaîne. [000F][1205]La seule chose propre ici. Jouer un CD? OuiNon",
     "choix_fr": [
       ""
     ]

--- a/traduction/event_scripts/script_364.json
+++ b/traduction/event_scripts/script_364.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Was[SP]the[SP]shock[SP]too[SP]much[SP]for[SP]Jun?[1205][000F][SP]His[SP]image[SP]of\nBig[SP]Maya[SP]just[SP]got[SP]smashed[SP]to[SP]smithereens.[SP]The\ngap[SP]between[SP]image[SP]and[SP]reality[SP]was[SP]too[SP]big...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le choc était trop fort\npour Jun? [1205][000F]Son image de\nMaya a été réduite\nen miettes. L'écart entre\nl'image et la réalité était trop grand..."
+    "texte_fr": "Le choc était trop fort\npour Jun? [000F][1205]Son image de\nMaya a été réduite en miettes. L'écart entre l'image et la réalité était trop grand..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Ulala[SP]always[SP]seems[SP]to[SP]hang[SP]out[SP]here.[1205][000F][SP]Maybe[SP]it's\ncomfier[SP]than[SP]her[SP]room?[1205][000F][SP]Even[SP]though[SP]it's[SP]really\nmessy...",
     "nom_fr": "Ginko",
-    "texte_fr": "Ulala semble souvent être ici.\n[1205][000F][1205][000F]C'est serait plus confortable que\nsa chambre? Malgré tout ce bazar..."
+    "texte_fr": "Ulala semble souvent être ici.\n[000F][1205][000F][1205]C'est serait plus confortable que\nsa chambre? Malgré tout ce bazar..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Everyone's[SP]ganging[SP]up[SP]on[SP]me...[1205][000F][SP]Look,[SP]I'll[SP]clean\nit[SP]when[SP]this[SP]is[SP]all[SP]over.[1205][000F][SP]Cut[SP]me[SP]some[SP]slack!",
     "nom_fr": "Maya",
-    "texte_fr": "Vous me tombez tous dessus.[1205][000F][1205][000F].. Bon, je\nnettoierai quand tout\nsera fini. Ménagez-moi\nun peu!"
+    "texte_fr": "Vous me tombez tous dessus.[000F][1205][000F][1205].. Bon, je\nnettoierai quand tout\nsera fini. Ménagez-moi un peu!"
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "Hey,[SP]is[SP]that[SP]boy[SP]with[SP]the[SP]flower[SP]new?[1205][000F]\nHe's[SP]cute...[1205][000F][SP]How[SP]do[SP]you[SP]do[SP]it,[SP]Ma-ya?",
     "nom_fr": "Ulala",
-    "texte_fr": "Hé, ce gars à la fleur est nouveau? [1205][000F][1205][000F]Il\nest mignon... Comment tu fais, Ma-ya?"
+    "texte_fr": "Hé, ce gars à la fleur est nouveau? [000F][1205][000F][1205]Il\nest mignon... Comment tu fais, Ma-ya?"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Ulala",
     "texte_orig": "But[SP]you[SP]know...[SP]I[SP]think[SP]I[SP]could[SP]go[SP]for[SP]a\nyounger[SP]guy[SP]too.[1205][000F][SP]Maybe[SP]I'll[SP]find[SP]a[SP]cute[SP]one\nand[SP]keep[SP]him[SP]while[SP]I[SP]can...",
     "nom_fr": "Ulala",
-    "texte_fr": "Mais tu sais... un plus jeune me tente\naussi. Si j'en trouve un mignon, je le\n[1205]garde tant que je peux.[000F].. Un \nradiocassette neuf. La seule chose\npropre de la pièce. Lire un CD?\nOuiNon",
+    "texte_fr": "Mais tu sais... un plus jeune me tente\naussi. Si j'en trouve un mignon, je le\n[1205]garde tant que je peux.[000F].. Un radiocassette neuf. La seule chose propre de la pièce. Lire un CD? OuiNon",
     "choix_fr": [
       ""
     ]

--- a/traduction/event_scripts/script_365.json
+++ b/traduction/event_scripts/script_365.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "But[SP]why[SP]attack[SP]the[SP]Aerospace[SP]Museum?[SP]Does[SP]King\nLeo[SP]have[SP]a[SP]grudge[SP]against[SP]planes[SP]or[SP]something?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Mais pourquoi attaquer le Musée de\nl'Aéronautique? Le Roi Lion\na une dent contre\nles avions?"
+    "texte_fr": "Mais pourquoi attaquer le Musée de\nl'Aéronautique? Le Roi Lion\na une dent contre les avions?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]gotta[SP]say...[1205][000F][SP]Maya-san[SP]has[SP]basically[SP]ruined\nblimps[SP]for[SP]me[SP]forever.",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'dois dire.[1205][000F].. Maya m'a rendu\nphobique des dirigeables."
+    "texte_fr": "J'dois dire.[000F][1205].. Maya m'a rendu\nphobique des dirigeables."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "An[SP]attack[SP]from[SP]the[SP]sea[SP]and[SP]sky...[1205][000F][SP]Double\ntrouble,[SP]huh?[SP]They[SP]sure[SP]are[SP]thorough.\nThey[SP]left[SP]people[SP]with[SP]nowhere[SP]to[SP]run.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Un double assaut par la mer et le ciel.[1205][000F]..\nIls font pas les choses à moitié. Ils\nlaissent aucune issue aux gens."
+    "texte_fr": "Un double assaut par la mer et le ciel.[000F][1205]..\nIls font pas les choses à moitié. Ils\nlaissent aucune issue aux gens."
   },
   {
     "id": 4,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Oh[SP]my[SP]god![1205][000F][SP]Th-That[SP]guy's[SP]a[SP]shadowman...",
     "nom_fr": "Ginko",
-    "texte_fr": "Mon dieu! [1205][000F]C-ce type est une ombre..."
+    "texte_fr": "Mon dieu! [000F][1205]C-ce type est une ombre..."
   },
   {
     "id": 7,
@@ -147,7 +147,7 @@
     "nom_orig": "Maya",
     "texte_orig": "There's[SP]a[SP]rumor[SP]that[SP]the[SP]Master[SP]here[SP]used[SP]to[SP]be\na[SP]pirate.[SP]It[SP]isn't[SP]true,[SP]but[SP]with[SP]this[SP]decor,\nI[SP]can[SP]see[SP]why[SP]someone[SP]would[SP]think[SP]so.",
     "nom_fr": "Maya",
-    "texte_fr": "La rumeur dit que le Maître ici était\nautrefois un pirate. C'est faux, mais vu le\ndécor je n'en voudrais\nà personne d'y croire."
+    "texte_fr": "La rumeur dit que le Maître ici était\nautrefois un pirate. C'est faux, mais vu le\ndécor je n'en voudrais à personne d'y croire."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "They[SP]just[SP]built[SP]that[SP]Aerospace[SP]Museum.[SP]People\nPeople[SP]thought[SP]it[SP]didn't[SP]fit[SP]in[SP]Sumaru[SP]at[SP]first,\nbut[SP]it[SP]gets[SP]a[SP]lot[SP]of[SP]guests[SP]now.",
     "nom_fr": "Maya",
-    "texte_fr": "Quand le Musée de l'Aéronautique fut\nconstruit, les gens ont\ndit que ça jurait dans\nSumaru. Désormais y'a foule de visiteurs."
+    "texte_fr": "Quand le Musée de l'Aéronautique fut\nconstruit, les gens ont\ndit que ça jurait dans Sumaru. Désormais y'a foule de visiteurs."
   },
   {
     "id": 11,
@@ -267,7 +267,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I'm[SP]always[SP]surprised[SP]by[SP]Maya-san's[SP]courage[SP]in\nthe[SP]face[SP]of[SP]danger.[SP]She's[SP]never[SP]piloted[SP]a\nblimp[SP]before![SP]At[SP]least[SP]I[SP]don't[SP]think[SP]so...",
     "nom_fr": "Yukino",
-    "texte_fr": "Le courage de Maya face au danger\nm'impressionne toujours. Elle\na jamais piloté\nde dirigeable avant! Je\npense pas en toutcas..."
+    "texte_fr": "Le courage de Maya face au danger\nm'impressionne toujours. Elle\na jamais piloté de dirigeable avant! Je pense pas en toutcas..."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Arrrgh...[1205][000F][SP]Why[SP]did[SP]Fujii-san[SP]have[SP]to[SP]take[SP]off\nfor[SP]Mt.[SP]Katatsumuri[SP]at[SP]a[SP]time[SP]like[SP]this!?\nThat[SP]man!",
     "nom_fr": "Yukino",
-    "texte_fr": "Arrgh.[1205][000F].. Pourquoi il a\nfallu que Fujii parte\nau Mont Katatsumuri à\nun tel moment!? Ce type!"
+    "texte_fr": "Arrgh.[000F][1205].. Pourquoi il a\nfallu que Fujii parte\nau Mont Katatsumuri à un tel moment!? Ce type!"
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Reach[SP]for[SP]the[SP]stars...[1205][000F][SP]Shunsuke-san's\nlast[SP]words.[1205][000F][SP]I[SP]need[SP]to[SP]find[SP]my[SP]own[SP]star.",
     "nom_fr": "Yukino",
-    "texte_fr": "Toucher les étoiles. [1205][000F][1205][000F]Les mots finaux de\nShunsuke. Je dois saisir mon étoile."
+    "texte_fr": "Toucher les étoiles. [000F][1205][000F][1205]Les mots finaux de\nShunsuke. Je dois saisir mon étoile."
   },
   {
     "id": 20,
@@ -312,7 +312,7 @@
     "nom_orig": "Master",
     "texte_orig": "Welcome...[1205][000F][SP]What[SP]would[SP]you[SP]like?\n[1208][0007][1210][U+03BD]Buy[SP]weapons\n[1210][U+035C]Buy[SP]accessories\n[1210][U+03BD]Sell[SP]items\nDine[SP]in\nTalk[SP]to[SP]the[SP]Master\nNever[SP]mind\nLeave",
     "nom_fr": "Maître",
-    "texte_fr": "Bienvenue.[1205][000F].. Que souhaites-tu?\n[1208][0007][1210]Acheter  \n[1210]Accessoires  \n[1210]Vendre  \nManger \nDiscuter     \nRien merci\nFiler[U+03BD][U+035C][U+03BD]",
+    "texte_fr": "Bienvenue.[000F][1205].. Que souhaites-tu?\n[1208][0007][1210]Acheter  \n[1210]Accessoires  \n[1210]Vendre  \nManger \nDiscuter     \nRien merci\nFiler[U+03BD][U+035C][U+03BD]",
     "question_orig": "Welcome...[1205][000F][SP]What[SP]would[SP]you[SP]like?",
     "choix_orig": [
       "[1210]Buy[SP]weapons",
@@ -501,7 +501,7 @@
     "nom_orig": "Master",
     "texte_orig": "I've[SP]left[SP]my[SP]pirating[SP]days[SP]behind.[1205][000F][SP]Yet[SP]there\nare[SP]those[SP]who[SP]still[SP]thirst[SP]for[SP]my[SP]blood...[1205][000F]\nHar![SP]It's[SP]the[SP]prestige[SP]they're[SP]after...",
     "nom_fr": "Maître",
-    "texte_fr": "J'ai laissé la piraterie derrière moi.\n[1205][000F][1205][000F]Mais certains veulent toujours mon sang...\nHar! Ils recherchent le prestige..."
+    "texte_fr": "J'ai laissé la piraterie derrière moi.\n[000F][1205][000F][1205]Mais certains veulent toujours mon sang...\nHar! Ils recherchent le prestige..."
   },
   {
     "id": 28,
@@ -576,7 +576,7 @@
     "nom_orig": "Master",
     "texte_orig": "Children[SP]let[SP]their[SP]dreams[SP]run[SP]wild.[SP]But[SP]the\nkids[SP]of[SP]today[SP]have[SP]neither[SP]the[SP]courage[SP]to[SP]take\nto[SP]the[SP]sea[SP]nor[SP]the[SP]freedom[SP]to[SP]take[SP]to[SP]the[SP]sky.",
     "nom_fr": "Maître",
-    "texte_fr": "Les enfants ont de grands rêves, mais ceux\nd'aujourd'hui n'ont ni\nle courage de prendre\nla mer ni la liberté de voler dans le ciel."
+    "texte_fr": "Les enfants ont de grands rêves, mais ceux\nd'aujourd'hui n'ont ni\nle courage de prendre la mer ni la liberté de voler dans le ciel."
   },
   {
     "id": 33,
@@ -591,7 +591,7 @@
     "nom_orig": "Master",
     "texte_orig": "Harhar...[SP]Who[SP]knew[SP]that[SP]blimp[SP]at[SP]the[SP]Aerospace\nMuseum[SP]would[SP]really[SP]fly?[1205][000F][SP]That's[SP]certainly\nsomething[SP]you[SP]don't[SP]see[SP]every[SP]day...",
     "nom_fr": "Maître",
-    "texte_fr": "Harhar... Qui aurait imaginé que le\ndirigeable de ce musée pouvait réellement\n[1205][000F]voler? On ne voit pas ça tout les jours..."
+    "texte_fr": "Harhar... Qui aurait imaginé que le\ndirigeable de ce musée pouvait réellement\n[000F][1205]voler? On ne voit pas ça tout les jours..."
   },
   {
     "id": 34,
@@ -606,7 +606,7 @@
     "nom_orig": "Master",
     "texte_orig": "The[SP]key[SP]to[SP]survival[SP]on[SP]the[SP]sea[SP]is[SP]the[SP]courage\nto[SP]chase[SP]your[SP]dreams.[SP]Believe[SP]in[SP]your[SP]spiritual\ncompass,[SP]and[SP]you'll[SP]find[SP]your[SP]true[SP]north.",
     "nom_fr": "Maître",
-    "texte_fr": "La clé pour survivre en\nmer est le courage de\npourchasser tes rêves. Crois en ta boussole\nspirituelle et tu trouveras le vrai nord."
+    "texte_fr": "La clé pour survivre en\nmer est le courage de\npourchasser tes rêves. Crois en ta boussole spirituelle et tu trouveras le vrai nord."
   },
   {
     "id": 35,
@@ -636,7 +636,7 @@
     "nom_orig": "Master",
     "texte_orig": "They're[SP]called...[SP]the[SP]Last[SP]Battalion...[1205][000F][SP]I[SP]saw\nthem[SP]come[SP]ashore[SP]at[SP]Ebisu[SP]Beach.[1205][000F][SP]They're[SP]after\nthe[SP]hidden[SP]treasure,[SP]I[SP]see...[SP]Hellbent[SP]on[SP]it.",
     "nom_fr": "Maître",
-    "texte_fr": "Ils se nomment... le Bataillon.[1205][1205].[000F][000F]. Je les ai\nvus débarquer depuis la plage d'Ebisu. Ils\nsont déterminés à\ntrouver le tréson caché..."
+    "texte_fr": "Ils se nomment... le Bataillon.[1205][1205].[000F][000F]. Je les ai\nvus débarquer depuis la plage d'Ebisu. Ils\nsont déterminés à trouver le tréson caché..."
   },
   {
     "id": 37,
@@ -711,7 +711,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "What,[SP]you're[SP]saying[SP]they[SP]were[SP]having[SP]a[SP]costume\nparty[SP]at[SP]the[SP]concert[SP]hall?[SP]I[SP]forget[SP]what[SP]was\ngoing[SP]on[SP]there,[SP]but[SP]it[SP]wasn't[SP]that.",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Quoi, tu dis qu'il\ny avait une fête costumée\nà la salle de concert? Je me souviens pas\ntrop, mais c'était pas ça je crois."
+    "texte_fr": "Quoi, tu dis qu'il\ny avait une fête costumée\nà la salle de concert? Je me souviens pas trop, mais c'était pas ça je crois."
   },
   {
     "id": 42,

--- a/traduction/event_scripts/script_366.json
+++ b/traduction/event_scripts/script_366.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We[SP]can[SP]bring[SP]along[SP]Hanakouji-san,[SP]Tamaki,\nElly-san,[SP]Ulala-san...[1205][0008][SP]It'll[SP]be[SP]great!",
     "nom_fr": "Eikichi",
-    "texte_fr": "On pourra emmener Hanakouji, Tamaki,\nElly, Ulala...[1205][0008] Ce sera génial!"
+    "texte_fr": "On pourra emmener Hanakouji, Tamaki,\nElly, Ulala...[0008][1205] Ce sera génial!"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What[SP]is[SP]with[SP]Eikichi!?[SP]He's[SP]only[SP]planning[SP]to\ninvite[SP]girls![1205][000F][SP]I[SP]see[SP]right[SP]through[SP]his[SP]game!\nWhat[SP]a[SP]horndog!",
     "nom_fr": "Ginko",
-    "texte_fr": "Il a quoi Eikichi!? Il compte inviter\nque des filles! [1205][000F]Je vois clair dans\nson jeu! Quel gros dalleux!"
+    "texte_fr": "Il a quoi Eikichi!? Il compte inviter\nque des filles! [000F][1205]Je vois clair dans\nson jeu! Quel gros dalleux!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "That[SP]said...[1205][0008][SP]I'm[SP]totally[SP]up[SP]for[SP]the[SP]beach![1205][000F]\nEveryone[SP]can[SP]go![SP]Even[SP]Sheba[SP]and[SP]Mee-ho![1205][000F]\nRight,[SP][1113]?",
     "nom_fr": "Ginko",
-    "texte_fr": "Ceci dit.[1205][1205]..[1205][0008] La plage ça me branche!\n[000F][000F]On peut tous venir! Même Sheba et\nMee-ho! Pas vrai, [1113]?"
+    "texte_fr": "Ceci dit.[1205][1205]..[0008][1205] La plage ça me branche!\n[000F][000F]On peut tous venir! Même Sheba et\nMee-ho! Pas vrai, [1113]?"
   },
   {
     "id": 4,
@@ -102,7 +102,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Worst-case[SP]scenario...[1205][000F][SP]If[SP]that[SP]happens...[1205][000F]\nWhat[SP]will[SP]Jun-kun[SP]do?",
     "nom_fr": "Maya",
-    "texte_fr": "Dans le pire des cas.[1205][000F][1205][000F].. Si\nça arrive... Que fera Jun?"
+    "texte_fr": "Dans le pire des cas.[000F][1205][000F][1205].. Si\nça arrive... Que fera Jun?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]may[SP]have[SP]to[SP]fight[SP]my[SP]father...[1205][000F][SP]What[SP]should\nI[SP]do[SP]if[SP]we[SP]encounter[SP]him?",
     "nom_fr": "Jun",
-    "texte_fr": "Je risque d'affronter mon père.[1205][000F]..\nQue dois-je faire si on le croise?"
+    "texte_fr": "Je risque d'affronter mon père.[000F][1205]..\nQue dois-je faire si on le croise?"
   },
   {
     "id": 8,
@@ -162,7 +162,7 @@
     "nom_orig": "Jun",
     "texte_orig": "There's[SP]a[SP]lot[SP]I[SP]won't[SP]know[SP]until[SP]the[SP]time\ncomes,[SP]but[SP]I[SP]want[SP]to[SP]believe[SP]I'll[SP]do[SP]the[SP]right\nthing.[1205][000F][SP]I[SP]don't[SP]want[SP]to[SP]wear[SP]any[SP]more[SP]masks...",
     "nom_fr": "Jun",
-    "texte_fr": "Le moment venu j'ignorerai encore tant de\nchoses, mais je veux\ncroire que je ferais le\n[1205][000F]bon choix. Je ne\nveux plus porter de masque..."
+    "texte_fr": "Le moment venu j'ignorerai encore tant de\nchoses, mais je veux\ncroire que je ferais le [000F][1205]bon choix. Je ne veux plus porter de masque..."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Master",
     "texte_orig": "Welcome...[1205][000F][SP]What[SP]would[SP]you[SP]like?\n[1208][0007][1210][U+03BD]Buy[SP]weapons\n[1210][U+035C]Buy[SP]accessories\n[1210][U+03BD]Sell[SP]items\nDine[SP]in\nTalk[SP]to[SP]the[SP]Master\nNever[SP]mind\nLeave",
     "nom_fr": "Maître",
-    "texte_fr": "Bienvenue.[1205][000F].. Que souhaites-tu?\n[1208][0007][1210]Acheter  \n[1210]Accessoires  \n[1210]Vendre  \nManger \nDiscuter     \nRien merci\nFiler[U+03BD][U+035C][U+03BD]",
+    "texte_fr": "Bienvenue.[000F][1205].. Que souhaites-tu?\n[1208][0007][1210]Acheter  \n[1210]Accessoires  \n[1210]Vendre  \nManger \nDiscuter     \nRien merci\nFiler[U+03BD][U+035C][U+03BD]",
     "question_orig": "Welcome...[1205][000F][SP]What[SP]would[SP]you[SP]like?",
     "choix_orig": [
       "[1210]Buy[SP]weapons",
@@ -351,7 +351,7 @@
     "nom_orig": "Master",
     "texte_orig": "I've[SP]got[SP]no[SP]place[SP]in[SP]the[SP]sky.[1205][000F][SP]I[SP]lived[SP]on[SP]the\nsea,[SP]and[SP]I[SP]planned[SP]to[SP]return[SP]there[SP]in[SP]death.[1205][000F]\nEvolution[SP]doesn't[SP]interest[SP]me.",
     "nom_fr": "Maître",
-    "texte_fr": "Je n'ai pas ma place dans le ciel. [1205][000F][1205][000F]J'ai\nvécu en mer, et j'y retournerais\nmourir. L'évolution ne m'intéresse pas."
+    "texte_fr": "Je n'ai pas ma place dans le ciel. [000F][1205][000F][1205]J'ai\nvécu en mer, et j'y retournerais\nmourir. L'évolution ne m'intéresse pas."
   },
   {
     "id": 18,
@@ -366,7 +366,7 @@
     "nom_orig": "Master",
     "texte_orig": "Heh...[1205][0008][SP]A[SP]man[SP]needn't[SP]give[SP]any[SP]reasons[SP]for[SP]his\nstruggle.[1205][000A][SP]The[SP]light[SP]in[SP]his[SP]eyes[SP]says[SP]it[SP]all.[1205][000F]\nYou've[SP]got[SP]that[SP]light,[SP]boy.",
     "nom_fr": "Maître",
-    "texte_fr": "Hé.[1205]..[1205][0008] Un homme n'a pas besoin d'expliquer\nses tourments.[1205][000A] L'éclat dans ses yeux\n[000F]révèle tout. Tu l'as cet éclat, gamin."
+    "texte_fr": "Hé.[1205]..[0008][1205] Un homme n'a pas besoin d'expliquer\nses tourments.[000A][1205] L'éclat dans ses yeux\n[000F]révèle tout. Tu l'as cet éclat, gamin."
   },
   {
     "id": 19,
@@ -411,7 +411,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "I'm[SP]seeing[SP]things,[SP]no[SP]mistake.[1205][000F][SP]Don't[SP]know[SP]if\nthey're[SP]hallucinations[SP]or[SP]figments[SP]of[SP]my\nimagination,[SP]but[SP]I[SP]need[SP]my[SP]head[SP]examined.",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Je vois des choses, je le sais. [1205][000F]Que ce soit\nissu de mon\nimagination ou d'hallucinations,\nje dois faire examiner ma tête."
+    "texte_fr": "Je vois des choses, je le sais. [000F][1205]Que ce soit\nissu de mon\nimagination ou d'hallucinations, je dois faire examiner ma tête."
   },
   {
     "id": 22,
@@ -426,7 +426,7 @@
     "nom_orig": "Office[SP]worker",
     "texte_orig": "Oh...[SP]but[SP]that[SP]pretty[SP]nurse[SP]I've[SP]heard[SP]rumors\nabout[SP]isn't[SP]there[SP]now,[SP]I[SP]guess.[1205][000F][SP]Then[SP]what's\nthe[SP]point...?",
     "nom_fr": "Employé de bureau",
-    "texte_fr": "Oh... mais la jolie infirmière dont\nj'entendais parler ne doit pas y\n[1205][000F]être, là. Donc à quoi bon...?"
+    "texte_fr": "Oh... mais la jolie infirmière dont\nj'entendais parler ne doit pas y\n[000F][1205]être, là. Donc à quoi bon...?"
   },
   {
     "id": 23,

--- a/traduction/event_scripts/script_367.json
+++ b/traduction/event_scripts/script_367.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yeesh,[SP]it[SP]costs[SP]this[SP]much[SP]for[SP]the[SP]fabric[SP]alone?\nTailor-made[SP]stuff[SP]sure[SP]costs[SP]a[SP]lot...[1205][000F][SP]Even[SP]I\ncan[SP]only[SP]dream[SP]of[SP]buying[SP]this[SP]stuff.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Houlà, ça coûte autant rien que pour le\ntissu? Les vêtements sur mesure, c'est\n[1205][000F]cher... Même moi je peux juste en rêver."
+    "texte_fr": "Houlà, ça coûte autant rien que pour le\ntissu? Les vêtements sur mesure, c'est\n[000F][1205]cher... Même moi je peux juste en rêver."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What[SP]the[SP]hell[SP]happened[SP]to[SP]him?[1205][000F][SP]He[SP]seems[SP]like\nhe's[SP]in[SP]a[SP]rough[SP]spot...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Qu'est-ce qui lui est arrivé? [1205][000F]Il\na l'air dans une sale passe..."
+    "texte_fr": "Qu'est-ce qui lui est arrivé? [000F][1205]Il\na l'air dans une sale passe..."
   },
   {
     "id": 3,
@@ -147,7 +147,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]can't[SP]believe[SP]even[SP]a[SP]guy[SP]like[SP]him[SP]was[SP]part\nof[SP]the[SP]Masked[SP]Circle...[SP]How[SP]many[SP]of[SP]them[SP]are\nthere?[SP]And[SP]will[SP]they[SP]all[SP]turn[SP]out[SP]like[SP]him?",
     "nom_fr": "Ginko",
-    "texte_fr": "Je n'arrive pas à\ncroire qu'un type comme lui\nfaisait partie du Cercle\nMasqué... Ils sont\ncombien? Et ils vont tous finir comme lui?"
+    "texte_fr": "Je n'arrive pas à\ncroire qu'un type comme lui\nfaisait partie du Cercle Masqué... Ils sont combien? Et ils vont tous finir comme lui?"
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP]did[SP]you[SP]catch[SP]what[SP]that[SP]artist[SP]was[SP]saying?\nI[SP]wonder[SP]how[SP]they're[SP]drawing[SP]us...[SP]I'm[SP]getting\nkind[SP]of[SP]worried[SP]now.",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, tu as entendu\ncet artiste? Je me demande\ncomment ils nous\ndessinent... Ça m'inquiète."
+    "texte_fr": "Hé, tu as entendu\ncet artiste? Je me demande\ncomment ils nous dessinent... Ça m'inquiète."
   },
   {
     "id": 12,
@@ -237,7 +237,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hahaha...[SP]That[SP]Yukki...[1205][000F][SP]I[SP]don't[SP]think[SP]she's\nthe[SP]type[SP]to[SP]keep[SP]anything[SP]secret.[SP]Though[SP]I'm\nhardly[SP]one[SP]to[SP]talk...",
     "nom_fr": "Maya",
-    "texte_fr": "Hahaha... Cette Yukki.[1205][000F].. Pas du\ngenre à garder des secrets. Bien que\nje sois mal placée pour le dire..."
+    "texte_fr": "Hahaha... Cette Yukki.[000F][1205].. Pas du\ngenre à garder des secrets. Bien que\nje sois mal placée pour le dire..."
   },
   {
     "id": 16,
@@ -297,7 +297,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Come[SP]on,[SP]let's[SP]think[SP]positive![1205][000F][SP]No[SP]matter[SP]how\nbad[SP]things[SP]get,[SP]we[SP]can't[SP]be[SP]pessimistic.",
     "nom_fr": "Maya",
-    "texte_fr": "Pensons positif! [1205][000F]Peu importe comment\nça va, pas question d'être pessimiste!"
+    "texte_fr": "Pensons positif! [000F][1205]Peu importe comment\nça va, pas question d'être pessimiste!"
   },
   {
     "id": 20,
@@ -372,7 +372,7 @@
     "nom_orig": "Maya",
     "texte_orig": "It[SP]was[SP]humans,[SP]after[SP]all,[SP]who[SP]gave[SP]birth[SP]to\nthe[SP]Masked[SP]Circle...[SP]and[SP]its[SP]new[SP]executive...[1205][000F]\nHeh.",
     "nom_fr": "Maya",
-    "texte_fr": "Ce sont bien les humains qui ont créé le\nCercle Masqué... et\nson nouveau dirigeant.[1205].[000F].\nHeh."
+    "texte_fr": "Ce sont bien les humains qui ont créé le\nCercle Masqué... et\nson nouveau dirigeant.[1205].[000F]. Heh."
   },
   {
     "id": 25,
@@ -432,7 +432,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Maybe[SP]I[SP]should[SP]make[SP]him[SP]some[SP]clothes[SP]here[SP]and\ngive[SP]'em[SP]to[SP]him...[1205][000F][SP]Oh,[SP]but[SP]I[SP]don't[SP]know[SP]his\nsize.[1205][000F][SP]And[SP]if[SP]I[SP]ask,[SP]he'll[SP]know...[1205][000F][SP]Hmmm...",
     "nom_fr": "Yukino",
-    "texte_fr": "Je devrais lui faire des habits ici et les\nlui offrir.[1205][000F][1205][000F][1205][000F].. Mais je ne connais pas sa\ntaille. Et si je\ndemande, il saura... Hmmm..."
+    "texte_fr": "Je devrais lui faire des habits ici et les\nlui offrir.[000F][1205][000F][1205][000F][1205].. Mais je ne connais pas sa\ntaille. Et si je demande, il saura... Hmmm..."
   },
   {
     "id": 29,
@@ -507,7 +507,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Hmm...[1205][000F][SP]Is[SP]Maya[SP]talking[SP]about[SP]that[SP]Ixquic[SP]girl?\nHahaha...[SP]That's[SP]so[SP]like[SP]her.",
     "nom_fr": "Yukino",
-    "texte_fr": "Hmm.[1205][000F].. Maya parle de la fille Ixquic?\nHahaha... C'est tellement elle."
+    "texte_fr": "Hmm.[000F][1205].. Maya parle de la fille Ixquic?\nHahaha... C'est tellement elle."
   },
   {
     "id": 34,
@@ -522,7 +522,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "A[SP]new[SP]executive[SP]replacing[SP]King[SP]Leo,[SP]huh...?[1205][000F]\nFine![SP]They[SP]can[SP]serve[SP]up[SP]all[SP]the[SP]executives\nthey[SP]want,[SP]I'll[SP]turn[SP]'em[SP]all[SP]into[SP]hamburger.",
     "nom_fr": "Yukino",
-    "texte_fr": "Un nouveau dirigeant pour King\n[1205][000F]Leo, hein? Pas de problème! Qu'ils\nenvoient tous les dirigeants."
+    "texte_fr": "Un nouveau dirigeant pour King\n[000F][1205]Leo, hein? Pas de problème! Qu'ils\nenvoient tous les dirigeants."
   },
   {
     "id": 35,
@@ -567,7 +567,7 @@
     "nom_orig": "Man[SP]who[SP]became[SP]an[SP]English[SP]gentleman",
     "texte_orig": "I[SP]had[SP]always[SP]wanted[SP]to[SP]live[SP]as[SP]an[SP]English\ngentleman.[SP]I[SP]may[SP]be[SP]an[SP]office[SP]drone,[SP]but[SP]what\ncould[SP]a[SP]little[SP]elegant[SP]living[SP]hurt...?",
     "nom_fr": "Homme devenu gentleman anglais",
-    "texte_fr": "J'avais toujours voulu vivre comme un\ngentleman anglais. Je\nsuis un simple employé,\nmais un peu d'élégance ne nuit pas..."
+    "texte_fr": "J'avais toujours voulu vivre comme un\ngentleman anglais. Je\nsuis un simple employé, mais un peu d'élégance ne nuit pas..."
   },
   {
     "id": 38,
@@ -642,7 +642,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Just[SP]who[SP]is[SP]this[SP]Last[SP]Battalion?[1205][000F][SP]I've[SP]never\nheard[SP]them[SP]mentioned[SP]in[SP]our[SP]meetings![SP]Are[SP]they\nan[SP]enemy[SP]of[SP]the[SP]Masked[SP]Circle...?",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "C'est qui ce Bataillon? [1205][000F]Jamais\nentendus lors de nos réunions!\nSont-ils ennemis du Cercle Masqué...?"
+    "texte_fr": "C'est qui ce Bataillon? [000F][1205]Jamais\nentendus lors de nos réunions!\nSont-ils ennemis du Cercle Masqué...?"
   },
   {
     "id": 43,
@@ -702,7 +702,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Hahahahaha...[1205][000A][SP]Ha?[1205][000A][SP]I'm[SP]certain[SP]I've[SP]seen[SP]you\npeople[SP]before...",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Haha...[1205][000A] Ha?[1205][000A] J'ai vu\nces gens quelque part..."
+    "texte_fr": "Haha...[000A][1205] Ha?[000A][1205] J'ai vu\nces gens quelque part..."
   },
   {
     "id": 47,
@@ -807,7 +807,7 @@
     "nom_orig": "Middle-aged[SP]artist",
     "texte_orig": "His[SP]last[SP]work...[1205][000F][SP]It[SP]depicted[SP]a[SP]blue[SP]door\nagainst[SP]a[SP]white[SP]wall.",
     "nom_fr": "Artiste d'âge mûr",
-    "texte_fr": "Sa dernière œuvre.[1205][000F].. Une\nporte bleue sur un mur blanc."
+    "texte_fr": "Sa dernière œuvre.[000F][1205].. Une\nporte bleue sur un mur blanc."
   },
   {
     "id": 54,
@@ -822,7 +822,7 @@
     "nom_orig": "Middle-aged[SP]artist",
     "texte_orig": "It[SP]was[SP]said[SP]that[SP]the[SP]gods[SP]this[SP]demon[SP]painter\ncreated[SP]brought[SP]tears[SP]to[SP]the[SP]viewer's[SP]eye,\nand[SP]his[SP]demons[SP]chilled[SP]the[SP]viewer's[SP]blood.",
     "nom_fr": "Artiste d'âge mûr",
-    "texte_fr": "On disait que les\ndieux créés par ce peintre\ndémon faisaient pleurer le spectateur, et\nque ses démons lui glaçaient le sang."
+    "texte_fr": "On disait que les\ndieux créés par ce peintre\ndémon faisaient pleurer le spectateur, et que ses démons lui glaçaient le sang."
   },
   {
     "id": 55,
@@ -852,7 +852,7 @@
     "nom_orig": "Middle-aged[SP]artist",
     "texte_orig": "I[SP]just[SP]saw[SP]the[SP]police[SP]sketches[SP]they[SP]released...\nAwful.[SP]The[SP]artist[SP]clearly[SP]brought[SP]his[SP]prejudices\nto[SP]the[SP]work.[SP]A[SP]waste[SP]of[SP]a[SP]good[SP]canvas.",
     "nom_fr": "Artiste d'âge mûr",
-    "texte_fr": "Je viens de voir les portraits-robots\ndiffusés... Affreux. L'artiste\ny a clairement\nmis ses préjugés.\nGâchis d'une bonne toile."
+    "texte_fr": "Je viens de voir les portraits-robots\ndiffusés... Affreux. L'artiste\ny a clairement mis ses préjugés. Gâchis d'une bonne toile."
   },
   {
     "id": 57,
@@ -867,7 +867,7 @@
     "nom_orig": "Middle-aged[SP]artist",
     "texte_orig": "It's[SP]said[SP]that[SP]the[SP]demon[SP]painter[SP]sometimes\nappeared[SP]in[SP]the[SP]dreams[SP]of[SP]superior[SP]artists.\nI[SP]doubt[SP]he's[SP]part[SP]of[SP]the[SP]waking[SP]world[SP]anymore.",
     "nom_fr": "Artiste d'âge mûr",
-    "texte_fr": "On dit que le\npeintre démon apparaissait dans\nles rêves des artistes supérieurs. Je doute\nqu'il soit encore dans le monde éveillé."
+    "texte_fr": "On dit que le\npeintre démon apparaissait dans\nles rêves des artistes supérieurs. Je doute qu'il soit encore dans le monde éveillé."
   },
   {
     "id": 58,
@@ -1081,7 +1081,7 @@
     "nom_orig": "Tailor",
     "texte_orig": "But[SP]made-to-order[SP]outfits[SP]like[SP]ours[1121]are[SP]perceived\nas[SP]quite[SP]expensive.[SP]So[SP]our[SP]clientele[SP]runs[SP]older...",
     "nom_fr": "Tailleur",
-    "texte_fr": "Mais nos tenues\nsur mesure[1121]sont perçues comme\nchères. Notre clientèle est donc plutôt\nâgée..."
+    "texte_fr": "Mais nos tenues\nsur mesure[1121]sont perçues comme\nchères. Notre clientèle est donc plutôt âgée..."
   },
   {
     "id": 67,
@@ -1126,7 +1126,7 @@
     "nom_orig": "Tailor",
     "texte_orig": "I'm[SP]surprised[SP]these[SP]terrorists[SP]are[SP]targeting\nour[SP]fair[SP]city.[SP]Rumor[SP]is,[SP]it[SP]was[SP]these[SP][1432][NULL][NULL][0014]Masked\nCircle[1432][NULL][NULL][0014][SP]beasts...[1205][000F][SP]There's[SP]one[SP]in[SP]every[SP]nation.",
     "nom_fr": "Tailleur",
-    "texte_fr": "Je suis surpris que des terroristes ciblent\nnotre ville. La rumeur dit que c'était le\n[1432][NULL][NULL][0014]Cercle Masqué[1432][NULL][NULL][0014].[1205][000F].. Il y en a partout."
+    "texte_fr": "Je suis surpris que des terroristes ciblent\nnotre ville. La rumeur dit que c'était le\n[1432][NULL][NULL][0014]Cercle Masqué[1432][NULL][NULL][0014].[000F][1205].. Il y en a partout."
   },
   {
     "id": 70,
@@ -1141,7 +1141,7 @@
     "nom_orig": "Tailor",
     "texte_orig": "Are[SP]you[SP]buying[SP]armor[SP]to[SP]defend[SP]yourself[SP]from\nthe[SP]terroists[SP]as[SP]well?[SP]I[SP]hear[SP]this[SP]Masked[SP]Circle\nholds[SP]a[SP]human[SP]in[SP]no[SP]more[SP]esteem[SP]than[SP]a[SP]stone...",
     "nom_fr": "Tailleur",
-    "texte_fr": "Vous achetez des armures contre les\nterroristes? Il paraît que ce Cercle Masqué\nn'accorde pas plus de valeur\nà un homme qu'àune pierre..."
+    "texte_fr": "Vous achetez des armures contre les\nterroristes? Il paraît que ce Cercle Masqué\nn'accorde pas plus de valeur à un homme qu'àune pierre..."
   },
   {
     "id": 71,
@@ -1156,7 +1156,7 @@
     "nom_orig": "Tailor",
     "texte_orig": "I[SP]wonder[SP]where[SP]the[SP]truth[SP]lies?[1205][000F][SP]Rumors[SP]are[SP]often\nstretched[SP]and[SP]tainted[SP]with[SP]outright[SP]fabrications.\nThey[SP]must[SP]be[SP]taken[SP]with[SP]a[SP]grain[SP]of[SP]salt...",
     "nom_fr": "Tailleur",
-    "texte_fr": "Où est la vérité? [1205][000F]Les rumeurs sont souvent\namplifiées et teintées de fabrications. Il\nfaut les prendre avec précaution..."
+    "texte_fr": "Où est la vérité? [000F][1205]Les rumeurs sont souvent\namplifiées et teintées de fabrications. Il\nfaut les prendre avec précaution..."
   },
   {
     "id": 72,
@@ -1261,7 +1261,7 @@
     "nom_orig": "Tailor",
     "texte_orig": "Oh[SP]dear...[SP]These[SP]situations[SP]are[SP]the[SP]province[SP]of\nthe[SP]police,[SP]yet[SP]they[SP]were[SP]removed[SP]from[SP]the\npicture[SP]at[SP]once.[1205][000F][SP]Though[SP]I[SP]mustn't[SP]criticize.",
     "nom_fr": "Tailleur",
-    "texte_fr": "Oh mon dieu... Ces\nsituations sont du ressort\nde la police, et pourtant\nelle a été écartée\nd'emblée. [1205][000F]Mais je ne dois pas critiquer."
+    "texte_fr": "Oh mon dieu... Ces\nsituations sont du ressort\nde la police, et pourtant elle a été écartée d'emblée. [000F][1205]Mais je ne dois pas critiquer."
   },
   {
     "id": 79,
@@ -1306,7 +1306,7 @@
     "nom_orig": "Tailor",
     "texte_orig": "Well,[SP]what's[SP]done[SP]is[SP]done.[1205][000F][SP]You[SP]are[SP]the[SP]only\none[SP]who[SP]can[SP]protect[SP]yourself...[SP]Though[SP]I[SP]will\ndo[SP]what[SP]I[SP]can[SP]to[SP]assist[SP]you,[SP]of[SP]course.",
     "nom_fr": "Tailleur",
-    "texte_fr": "Ce qui est fait est fait. [1205][000F]Seul vous\npouvez vous protéger... Bien que je\nferai ce que je peux pour vous aider."
+    "texte_fr": "Ce qui est fait est fait. [000F][1205]Seul vous\npouvez vous protéger... Bien que je\nferai ce que je peux pour vous aider."
   },
   {
     "id": 82,

--- a/traduction/event_scripts/script_368.json
+++ b/traduction/event_scripts/script_368.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]bet[SP]Yukino-san[SP]is[SP]working[SP]really[SP]hard\nsomewhere[SP]in[SP]the[SP]city.[1205][000F][SP]We[SP]have[SP]to[SP]pick[SP]up\nour[SP]pace[SP]to[SP]match.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je parie que Yukino travaille dur\nquelque part en ville. [1205][000F]On doit\naccélérer pour être à la hauteur."
+    "texte_fr": "Je parie que Yukino travaille dur\nquelque part en ville. [000F][1205]On doit\naccélérer pour être à la hauteur."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Philemon[SP]said[SP]Yukino-san's[SP]soul[SP]was[SP]swallowed\ninto[SP]the[SP]abyss[SP]of[SP]the[SP]unconscious...[1205][000F][SP]But[SP]that's\nnot[SP]the[SP]same[SP]as[SP]dead,[SP]right?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Philemon a dit que l'âme de Yukino a été\nengloutie dans l'abîme de l'inconscient.[1205][000F]..\nMais c'est pas pareil que mourir?"
+    "texte_fr": "Philemon a dit que l'âme de Yukino a été\nengloutie dans l'abîme de l'inconscient.[000F][1205]..\nMais c'est pas pareil que mourir?"
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "She[SP]must[SP]be[SP]alive[SP]somewhere![1205][000F][SP]I[SP]won't[SP]let[SP]her\nbe[SP]destroyed[SP]forever!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Elle est vivante quelque part!\n[1205][000F]Je refuse qu'on la détruise!"
+    "texte_fr": "Elle est vivante quelque part!\n[000F][1205]Je refuse qu'on la détruise!"
   },
   {
     "id": 3,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "And[SP]I'm[SP]sure[SP]it[SP]wasn't[SP]just[SP]me[SP]who[SP]felt[SP]that\nway.[1205][000F][SP]She[SP]was[SP]special[SP]to[SP]everyone.",
     "nom_fr": "Maya",
-    "texte_fr": "Pas seulement moi, j'en suis sûre. Elle\n[1205][000F]était spéciale pour tout le monde."
+    "texte_fr": "Pas seulement moi, j'en suis sûre. Elle\n[000F][1205]était spéciale pour tout le monde."
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yukki's[SP]thoughts[SP]still[SP]live[SP]within[SP]Jun-kun.[1205][000F]\nShe's[SP]still[SP]fighting[SP]with[SP]us.[1205][000F][SP]Isn't[SP]that[SP]right?",
     "nom_fr": "Maya",
-    "texte_fr": "Les pensées de Yukki vivent encore en Jun.\n[1205][000F][1205][000F]Elle combat encore avec nous. N'est-ce pas?"
+    "texte_fr": "Les pensées de Yukki vivent encore en Jun.\n[000F][1205][000F][1205]Elle combat encore avec nous. N'est-ce pas?"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "So[SP]Yukki...[1205][000F][SP]Keep[SP]cheering[SP]us[SP]on...",
     "nom_fr": "Maya",
-    "texte_fr": "Alors Yukki.[1205][000F].. Encourage-nous..."
+    "texte_fr": "Alors Yukki.[000F][1205].. Encourage-nous..."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Yukino-san's[SP]Persona[SP]is[SP]still[SP]encouraging[SP]me.[1205][000F]\nIt's[SP]saying,[SP][1432][NULL][NULL][0014]Don't[SP]give[SP]up.[1432][NULL][NULL][0014][1205][000F][SP]So[SP]I[SP]won't.",
     "nom_fr": "Jun",
-    "texte_fr": "Le Persona de Yukino m'encourage encore.\n[1205][000F][1205][000F]Il dit [1432][NULL][NULL][0014]N'abandonne pas.[1432][NULL][NULL][0014] Alors je tiendrai."
+    "texte_fr": "Le Persona de Yukino m'encourage encore.\n[000F][1205][000F][1205]Il dit [1432][NULL][NULL][0014]N'abandonne pas.[1432][NULL][NULL][0014] Alors je tiendrai."
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Middle-aged[SP]artist",
     "texte_orig": "I'm[SP]not[SP]as[SP]talented[SP]as[SP]some,[SP]but[SP]I[SP]had[SP]my[SP]place\nin[SP]the[SP]art[SP]world.[1205][000F][SP]I[SP]am[SP]no[SP]longer[SP]interested[SP]in\nmaterial[SP]things.[1205][000F][SP]It's[SP]not[SP]my[SP]world[SP]anymore...",
     "nom_fr": "Artiste d'âge mûr",
-    "texte_fr": "Je n'étais pas le\nplus doué, mais j'avais ma\nplace dans l'art. [1205][000F][1205][000F]Les biens matériels ne\nm'intéressent plus. Ce\nn'est plus mon monde..."
+    "texte_fr": "Je n'étais pas le\nplus doué, mais j'avais ma\nplace dans l'art. [000F][1205][000F][1205]Les biens matériels ne m'intéressent plus. Ce n'est plus mon monde..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Middle-aged[SP]artist",
     "texte_orig": "I'm[SP]sure[SP]the[SP]demon[SP]painter[SP]felt[SP]the[SP]same[SP]way.[1205][000F]\nAnd[SP]yet[SP]it's[SP]said[SP]there[SP]was[SP]one[SP]subject[SP]even\nhe[SP]couldn't[SP]capture:[1205][000F][SP]the[SP]Fool.",
     "nom_fr": "Artiste d'âge mûr",
-    "texte_fr": "Je pense que le peintre démon ressentait\n[1205][000F][1205][000F]pareil. Pourtant, il y avait un sujet\nqu'il ne put jamais saisir: le Fou."
+    "texte_fr": "Je pense que le peintre démon ressentait\n[000F][1205][000F][1205]pareil. Pourtant, il y avait un sujet\nqu'il ne put jamais saisir: le Fou."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Middle-aged[SP]artist",
     "texte_orig": "Why[SP]did[SP]this[SP]subject[SP]elude[SP]him?[1205][000F][SP]The[SP]Fool[SP]has\nno[SP]home[SP]or[SP]job,[SP]so[SP]he[SP]wandered.[1205][000F][SP]But[SP]was[SP]that\nreally[SP]foolish?",
     "nom_fr": "Artiste d'âge mûr",
-    "texte_fr": "Pourquoi ce sujet lui échappait? [1205][000F][1205][000F]Le\nFou n'avait ni foyer ni travail, il\nerrait. Était-ce si insensé?"
+    "texte_fr": "Pourquoi ce sujet lui échappait? [000F][1205][000F][1205]Le\nFou n'avait ni foyer ni travail, il\nerrait. Était-ce si insensé?"
   },
   {
     "id": 18,
@@ -525,7 +525,7 @@
     "nom_orig": "Tailor",
     "texte_orig": "Those[SP]without[SP]worry[SP]have[SP]nothing[SP]to[SP]fight[SP]for.[1205][000F]\nThe[SP]armor[SP]here[SP]will[SP]eventually[SP]be[SP]useless.",
     "nom_fr": "Tailleur",
-    "texte_fr": "Sans souci, rien à défendre. Les armures\n[1205][000F]d'ici deviendront bientôt inutiles."
+    "texte_fr": "Sans souci, rien à défendre. Les armures\n[000F][1205]d'ici deviendront bientôt inutiles."
   },
   {
     "id": 30,
@@ -540,7 +540,7 @@
     "nom_orig": "Tailor",
     "texte_orig": "And[SP]yet,[SP]humans[SP]are[SP]curious[SP]creatures.[1205][000F][SP]When[SP]a\nthing[SP]nears[SP]its[SP]end,[SP]you[SP]become[SP]sentimental\nand[SP]involve[SP]yourself[SP]more[SP]than[SP]usual.",
     "nom_fr": "Tailleur",
-    "texte_fr": "Pourtant, les humains sont curieux. [1205][000F]À\nl'approche de la\nfin, on devient sentimental\net plus impliqué qu'à l'habitude."
+    "texte_fr": "Pourtant, les humains sont curieux. [000F][1205]À\nl'approche de la\nfin, on devient sentimental et plus impliqué qu'à l'habitude."
   },
   {
     "id": 31,
@@ -555,7 +555,7 @@
     "nom_orig": "Tailor",
     "texte_orig": "...And[SP]thus,[SP]I[SP]have[SP]prepared[SP]new[SP]armor.[1205][000F][SP]It's[SP]of\nthe[SP]highest[SP]quality,[SP]made[SP]by[SP]my[SP]own[SP]son.[1205][000F][SP]I[SP]hope\nthat[SP]you[SP]will[SP]be[SP]so[SP]good[SP]as[SP]to[SP]have[SP]a[SP]look.",
     "nom_fr": "Tailleur",
-    "texte_fr": "... Aussi ai-je\n[1205][000F][1205][000F]préparé de nouvelles armures.\nDe la meilleure qualité,\nfaites par mon fils.\nJ'espère que vous y jetterez un œil."
+    "texte_fr": "... Aussi ai-je\n[000F][1205][000F][1205]préparé de nouvelles armures.\nDe la meilleure qualité, faites par mon fils. J'espère que vous y jetterez un œil."
   },
   {
     "id": 32,

--- a/traduction/event_scripts/script_369.json
+++ b/traduction/event_scripts/script_369.json
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "He[SP]can't[SP]let[SP]go[SP]of[SP]a[SP]good[SP]scoop...[1205][000F][SP]Guess[SP]it's\nhis[SP]pride[SP]as[SP]a[SP]photographer.[1205][000F][SP]Or[SP]his[SP]pride[SP]as\na[SP]man...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Il ne peut pas lâcher un bon\n[1205][000F][1205][000F]scoop... C'est sa fierté de\nphotographe. Ou sa fierté d'homme..."
+    "texte_fr": "Il ne peut pas lâcher un bon\n[000F][1205][000F][1205]scoop... C'est sa fierté de\nphotographe. Ou sa fierté d'homme..."
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What's[SP]Eikichi[SP]doing[SP]now?[SP]What's[SP]the[SP]point[SP]of\ncoming[SP]up[SP]with[SP]songs[SP]when[SP]he[SP]doesn't[SP]even[SP]have\na[SP]band!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Qu'est-ce qu'il fait, Eikichi?\nÀ quoi ça sert\nde composer quand il n'a\nmême pas de groupe!?"
+    "texte_fr": "Qu'est-ce qu'il fait, Eikichi?\nÀ quoi ça sert\nde composer quand il n'a même pas de groupe!?"
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "One[SP]of[SP]the[SP]kids[SP]we[SP]saved[SP]said[SP]I[SP]was[SP]like\na[SP]hero.[SP]Hehe...[SP]No[SP]one's[SP]ever[SP]said[SP]that[SP]to\nme[SP]before.",
     "nom_fr": "Ginko",
-    "texte_fr": "Un enfant sauvé m'a\ndit que j'étais comme un\nhéros. Héhé... Jamais on\nm'avait dit ça avant."
+    "texte_fr": "Un enfant sauvé m'a\ndit que j'étais comme un\nhéros. Héhé... Jamais on m'avait dit ça avant."
   },
   {
     "id": 8,
@@ -267,7 +267,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Rumors[SP]becoming[SP]reality?[SP]It[SP]may[SP]look[SP]that[SP]way\nfrom[SP]a[SP]certain[SP]angle,[SP]but[SP]rumors[SP]are[SP]man's[SP]dark\nside.[SP]Isn't[SP]that[SP]what's[SP]really[SP]becoming[SP]reality?",
     "nom_fr": "Maya",
-    "texte_fr": "Les rumeurs deviennent réalité? Sous un\ncertain angle, oui. Mais les rumeurs, c'est\nle côté sombre de\nl'homme. N'est-ce pas ça?"
+    "texte_fr": "Les rumeurs deviennent réalité? Sous un\ncertain angle, oui. Mais les rumeurs, c'est\nle côté sombre de l'homme. N'est-ce pas ça?"
   },
   {
     "id": 18,
@@ -297,7 +297,7 @@
     "nom_orig": "Maya",
     "texte_orig": "My[SP]father...[SP]was[SP]just[SP]like[SP]Fujii-san...[1205][000F][SP]He[SP]had\nhis[SP]dreams[SP]and[SP]his[SP]pride[SP]as[SP]a[SP]journalist...[1205][000F]\nAnd[SP]then[SP]he...",
     "nom_fr": "",
-    "texte_fr": "Mon père... ressemblait à Fujii-san.[1205][000F][1205][000F]..\nIl avait ses rêves et sa fierté de\njournaliste... Et puis il..."
+    "texte_fr": "Mon père... ressemblait à Fujii-san.[000F][1205][000F][1205]..\nIl avait ses rêves et sa fierté de\njournaliste... Et puis il..."
   },
   {
     "id": 20,
@@ -402,7 +402,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Yeah...[SP]I[SP]can't[SP]waste[SP]what[SP]Shunsuke-san\ngave[SP]me...[1205][000F][SP]Thanks,[SP][1113].[SP]If[SP]you[SP]hadn't\nsaid[SP]that[SP]to[SP]me[SP]then,[SP]I[SP]might[SP]have...",
     "nom_fr": "Yukino",
-    "texte_fr": "Ouais... Je ne peux pas gâcher ça...\n[1205][000F]Merci, [1113]. Si tu ne m'avais pas dit\nça ce jour-là, j'aurais peut-être..."
+    "texte_fr": "Ouais... Je ne peux pas gâcher ça...\n[000F][1205]Merci, [1113]. Si tu ne m'avais pas dit\nça ce jour-là, j'aurais peut-être..."
   },
   {
     "id": 27,
@@ -582,7 +582,7 @@
     "nom_orig": "Fortunetelling[SP]fangirl",
     "texte_orig": "A-Are[SP]you[SP]the[SP]one[SP]I've[SP]been[SP]waiting[SP]for!?[1205][000F]\nWhat...?[SP]You're[SP]not?[SP]Awww,[SP]and[SP]I[SP]was[SP]getting\nmy[SP]hopes[SP]up[SP]since[SP]you're[SP]so[SP]cute...",
     "nom_fr": "Fan d'astrologie",
-    "texte_fr": "E-Est-ce que c'est vous que j'attendais![1205][000F]?\nQuoi...? Non? Dommage, j'avais de\nl'espoir vu que vous êtes si mignon..."
+    "texte_fr": "E-Est-ce que c'est vous que j'attendais![000F][1205]?\nQuoi...? Non? Dommage, j'avais de\nl'espoir vu que vous êtes si mignon..."
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Fortunetelling[SP]fangirl",
     "texte_orig": "The[SP]Sumaru[SP]Genie[SP]said[SP]if[SP]I[SP]stayed[SP]here,[SP]I'd\nmeet[SP]the[SP]one[SP]I'd[SP]been[SP]waiting[SP]for.[1205][000F][SP]Come[SP]to\nme[SP]soon...[1205][000F][SP]my[SP]love...!",
     "nom_fr": "Fan d'astrologie",
-    "texte_fr": "Le Génie de Sumaru a dit que si je\nrestais là, je rencontrerais celui que\n[1205][000F][1205][000F]j'attendais. Viens vite... mon amour...!"
+    "texte_fr": "Le Génie de Sumaru a dit que si je\nrestais là, je rencontrerais celui que\n[000F][1205][000F][1205]j'attendais. Viens vite... mon amour...!"
   },
   {
     "id": 40,
@@ -627,7 +627,7 @@
     "nom_orig": "Fortunetelling[SP]fangirl",
     "texte_orig": "Everyone[SP]in[SP]town[SP]is[SP]clamoring[SP]to[SP]get[SP]in[SP]to[SP]see\nthe[SP]Sumaru[SP]Genie.[1205][000F][SP]They[SP]want[SP]to[SP]know[SP]where[SP]the\nnext[SP]terrorist[SP]attack[SP]will[SP]be.",
     "nom_fr": "Fan d'astrologie",
-    "texte_fr": "Tout le monde en ville se bouscule pour\nvoir le Génie de Sumaru. [1205][000F]Ils veulent\nsavoir où aura lieu le prochain attentat."
+    "texte_fr": "Tout le monde en ville se bouscule pour\nvoir le Génie de Sumaru. [000F][1205]Ils veulent\nsavoir où aura lieu le prochain attentat."
   },
   {
     "id": 42,
@@ -702,7 +702,7 @@
     "nom_orig": "Fortunetelling[SP]fangirl",
     "texte_orig": "The[SP]world's[SP]going[SP]to[SP]end?[SP]Really?[SP]We'll[SP]evolve\ninto[SP]Idealians?[SP]Honestly?[SP]And[SP]the[SP]one[SP]I've[SP]been\nwaiting[SP]for[SP]still[SP]isn't[SP]here!?[SP]Seriously!?",
     "nom_fr": "Fan d'astrologie",
-    "texte_fr": "Le monde va s'éteindre? Vraiment? On va\névoluer en Idéaliens?\nSérieusement? Et celui\nque j'attends n'est\ntoujours pas là!?Vraiment!?"
+    "texte_fr": "Le monde va s'éteindre? Vraiment? On va\névoluer en Idéaliens?\nSérieusement? Et celui que j'attends n'est toujours pas là!?Vraiment!?"
   },
   {
     "id": 47,
@@ -732,7 +732,7 @@
     "nom_orig": "Fortunetelling[SP]fangirl",
     "texte_orig": "We're[SP]all[SP]in[SP]big[SP]trouble[SP]if[SP]these[SP]guys[SP]are\ninvading![1205][000F][SP]Ohhh...[SP]Isn't[SP]there[SP]any[SP]hope[SP]for\nus[SP]left!?",
     "nom_fr": "Fan d'astrologie",
-    "texte_fr": "On est dans de beaux draps si ces\ntypes nous envahissent! [1205][000F]Ohh...\nPlus aucun espoir pour nous!?"
+    "texte_fr": "On est dans de beaux draps si ces\ntypes nous envahissent! [000F][1205]Ohh...\nPlus aucun espoir pour nous!?"
   },
   {
     "id": 49,
@@ -747,7 +747,7 @@
     "nom_orig": "Sister[SP]#2",
     "texte_orig": "Hello![SP]Heeheehee![1205][000F][SP]Welcome[SP]to[SP]Satomi[SP]Tadashi's\nKounan[SP]branch.\n[1208][0006]Buy[SP]items\nSell[SP]items\nTalk[SP]to[SP]Sister[SP]#2\n[1210][B_00][U+5601][B_00]iew[SP]items\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Sœur n°2",
-    "texte_fr": "Bonjour! [1205][000F]Hihihi! Bienvenue à la\nsuccursale de Kounan.\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°2\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
+    "texte_fr": "Bonjour! [000F][1205]Hihihi! Bienvenue à la\nsuccursale de Kounan.\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°2\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
     "question_orig": "Hello![SP]Heeheehee![1205][000F][SP]Welcome[SP]to[SP]Satomi[SP]Tadashi's\nKounan[SP]branch.",
     "choix_orig": [
       "Buy[SP]items",
@@ -917,7 +917,7 @@
     "nom_orig": "Sister[SP]#2",
     "texte_orig": "I'm[SP]the[SP]second[SP]oldest[SP]of[SP]the[SP]seven[SP]sisters\nin[SP]charge[SP]of[SP]Sumaru's[SP]Satomi[SP]Tadashi[SP]stores.[1205][000F]\nAre[SP]you[SP]getting[SP]used[SP]to[SP]how[SP]similar[SP]we[SP]look?",
     "nom_fr": "Sœur n°2",
-    "texte_fr": "Je suis la deuxième des sept sœurs\ngérant les Satomi Tadashi de Sumaru.\n[1205][000F]Vous vous habituez à notre ressemblance?"
+    "texte_fr": "Je suis la deuxième des sept sœurs\ngérant les Satomi Tadashi de Sumaru.\n[000F][1205]Vous vous habituez à notre ressemblance?"
   },
   {
     "id": 56,
@@ -932,7 +932,7 @@
     "nom_orig": "Sister[SP]#2",
     "texte_orig": "Buy[SP]from[SP]any[SP]of[SP]our[SP]stores![1205][000F][SP]But[SP]mostly[SP]mine.\nWe're[SP]family,[SP]but[SP]we[SP]have[SP]annual[SP]sales[SP]contests,\nso[SP]come[SP]here[SP]as[SP]often[SP]as[SP]you[SP]can!",
     "nom_fr": "Sœur n°2",
-    "texte_fr": "Achetez dans nos magasins! [1205][000F]Surtout ici.\nOn est en famille mais on a des concours\nannuels, venez le plus souvent possible!"
+    "texte_fr": "Achetez dans nos magasins! [000F][1205]Surtout ici.\nOn est en famille mais on a des concours\nannuels, venez le plus souvent possible!"
   },
   {
     "id": 57,
@@ -962,7 +962,7 @@
     "nom_orig": "Sister[SP]#2",
     "texte_orig": "There's[SP]no[SP]point[SP]cowering[SP]in[SP]fear.[1205][000F][SP]I[SP]mean,\nwho'd[SP]waste[SP]their[SP]time[SP]bombing[SP]a[SP]drugstore?",
     "nom_fr": "Sœur n°2",
-    "texte_fr": "Ça ne sert à rien de trembler. [1205][000F]Qui perdrait\nson temps à bombarder une pharmacie?"
+    "texte_fr": "Ça ne sert à rien de trembler. [000F][1205]Qui perdrait\nson temps à bombarder une pharmacie?"
   },
   {
     "id": 59,
@@ -977,7 +977,7 @@
     "nom_orig": "Sister[SP]#2",
     "texte_orig": "People[SP]are[SP]worried[SP]about[SP]further[SP]attacks,[SP]but\nin[SP]Kounan,[SP]the[SP]police[SP]station[SP]of[SP]all[SP]places[SP]has\nalready[SP]been[SP]hit.[SP]I'm[SP]sure[SP]they're[SP]done[SP]here.",
     "nom_fr": "Sœur n°2",
-    "texte_fr": "Les gens craignent\nd'autres attaques, mais à\nKounan, c'est le commissariat\nqui a déjà été\ntouché. Je suis sûre qu'ils\nen ont fini ici."
+    "texte_fr": "Les gens craignent\nd'autres attaques, mais à\nKounan, c'est le commissariat qui a déjà été touché. Je suis sûre qu'ils en ont fini ici."
   },
   {
     "id": 60,
@@ -1007,7 +1007,7 @@
     "nom_orig": "Sister[SP]#2",
     "texte_orig": "*sob*[SP]I[SP]thought[SP]they[SP]were[SP]done[SP]with[SP]Kounan\nafter[SP]the[SP]police[SP]station...[1205][000F][SP]I[SP]can't[SP]believe\nthey[SP]bombed[SP]the[SP]Aerospace[SP]Museum[SP]too!",
     "nom_fr": "Sœur n°2",
-    "texte_fr": "*sanglot* Je croyais qu'ils en avaient\nfini avec Kounan... [1205][000F]Incroyable d'avoir\naussi bombardé le Musée de l'Aérospatiale!"
+    "texte_fr": "*sanglot* Je croyais qu'ils en avaient\nfini avec Kounan... [000F][1205]Incroyable d'avoir\naussi bombardé le Musée de l'Aérospatiale!"
   },
   {
     "id": 62,
@@ -1022,7 +1022,7 @@
     "nom_orig": "Sister[SP]#2",
     "texte_orig": "Now[SP]it's[SP]a[SP]pattern![SP]Who[SP]knows[SP]where[SP]they'll\nstrike[SP]next![SP]I'm[SP]so[SP]scared![1205][000F][SP]But[SP]I'm[SP]sure[SP]THIS\nplace[SP]will[SP]be[SP]fine.",
     "nom_fr": "Sœur n°2",
-    "texte_fr": "C'est un schéma! Tellement\npeur! Qui sait où\n[1205]ils vont frapper? [000F]Mais\nCET endroit ira bien."
+    "texte_fr": "C'est un schéma! Tellement\npeur! Qui sait où\n[1205]ils vont frapper? [000F]Mais CET endroit ira bien."
   },
   {
     "id": 63,
@@ -1067,7 +1067,7 @@
     "nom_orig": "Sister[SP]#2",
     "texte_orig": "I[SP]mean,[SP]all[SP]these[SP]strange[SP]goings-on...\nIt's[SP]just[SP]so[SP]bizarre![SP]I[SP]feel[SP]like[SP]that[SP]book\nmight[SP]actually[SP]be[SP]predicting[SP]the[SP]future!",
     "nom_fr": "Sœur n°2",
-    "texte_fr": "Je veux dire,\ntous ces événements étranges...\nTellement bizarre! J'ai l'impression que ce\nlivre prédit vraiment l'avenir!"
+    "texte_fr": "Je veux dire,\ntous ces événements étranges...\nTellement bizarre! J'ai l'impression que ce livre prédit vraiment l'avenir!"
   },
   {
     "id": 66,
@@ -1212,7 +1212,7 @@
     "nom_orig": "Sister[SP]#2",
     "texte_orig": "Our[SP]resale[SP]prices[SP]are[SP]around[SP]half[SP]the[SP]original\nprice.[SP]You[SP]can't[SP]sell[SP]anything[SP]you[SP]have[SP]equipped,\nand[SP]some[SP]special[SP]items[SP]are[SP]off-limits[SP]too.",
     "nom_fr": "Sœur n°2",
-    "texte_fr": "Nos prix de rachat\nsont environ la moitié du\nprix d'origine. Vous ne\npouvez pas vendre ce\nque vous portez,\nni certains objets spéciaux."
+    "texte_fr": "Nos prix de rachat\nsont environ la moitié du\nprix d'origine. Vous ne pouvez pas vendre ce que vous portez, ni certains objets spéciaux."
   },
   {
     "id": 75,

--- a/traduction/event_scripts/script_370.json
+++ b/traduction/event_scripts/script_370.json
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Yeah![1205][000F][SP]His[SP]son[SP]must[SP]have[SP]been[SP]one[SP]of[SP]the[SP]kids\nwe[SP]taught[SP]the[SP]Persona[SP]game[SP]to.",
     "nom_fr": "Ginko",
-    "texte_fr": "Ouais! [1205][000F]Il est parmi les gamins à\nqui on a appris le Jeu du Persona."
+    "texte_fr": "Ouais! [000F][1205]Il est parmi les gamins à\nqui on a appris le Jeu du Persona."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "You[SP]don't[SP]have[SP]to[SP]carry[SP]it[SP]alone,[SP]Jun-kun.\nWe're[SP]right[SP]here[SP]with[SP]you.[1205][000F][SP]We'll[SP]get[SP]through\nthis[SP]together.",
     "nom_fr": "May",
-    "texte_fr": "T'as pas à porter ça seul, Jun. On est\nlà avec toi. [1205][000F]On va s'en sortir ensemble."
+    "texte_fr": "T'as pas à porter ça seul, Jun. On est\nlà avec toi. [000F][1205]On va s'en sortir ensemble."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Jun",
     "texte_orig": "I[SP]took[SP]those[SP]kids'[SP]parents[SP]from[SP]them...[SP]I'm\ngoing[SP]to[SP]save[SP]them,[SP]no[SP]matter[SP]what.[1205][000F][SP]It's[SP]my\nduty[SP]as[SP]the[SP]former[SP]Joker.",
     "nom_fr": "Jun",
-    "texte_fr": "J'ai pris les parents de ces\nenfants... Je vais les sauver. C'est\n[1205][000F]mon devoir en tant qu'ancien Joker.."
+    "texte_fr": "J'ai pris les parents de ces\nenfants... Je vais les sauver. C'est\n[000F][1205]mon devoir en tant qu'ancien Joker.."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Middle-aged[SP]man",
     "texte_orig": "My[SP]kid[SP]said[SP]he[SP]saw[SP]the[SP]heroes[SP]again.[1205][000F][SP]He[SP]was\nbouncing[SP]up[SP]and[SP]down[SP]about[SP]them[SP]teaching[SP]him\nsome[SP]game.",
     "nom_fr": "Homme d'âge mûr",
-    "texte_fr": "Mon fils dit qu'il a\nrevu les héros. [1205][000F]Il était\naux anges parce qu'ils\nlui ont appris un jeu."
+    "texte_fr": "Mon fils dit qu'il a\nrevu les héros. [000F][1205]Il était\naux anges parce qu'ils lui ont appris un jeu."
   },
   {
     "id": 5,
@@ -117,7 +117,7 @@
     "nom_orig": "Middle-aged[SP]man",
     "texte_orig": "There[SP]are[SP]so[SP]many[SP]good[SP]things[SP]about[SP]what[SP]we\nhave[SP]now.[1205][000F][SP]Is[SP]it[SP]really[SP]worth[SP]throwing[SP]those\naway[SP]so[SP]we[SP]can[SP]evolve?",
     "nom_fr": "Homme d'âge mûr",
-    "texte_fr": "Il y a tant de bonnes choses dans ce\nqu'on a. [1205][000F]Ça vaut vraiment la peine\nde tout sacrifier pour évoluer?"
+    "texte_fr": "Il y a tant de bonnes choses dans ce\nqu'on a. [000F][1205]Ça vaut vraiment la peine\nde tout sacrifier pour évoluer?"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Fortunetelling[SP]fangirl",
     "texte_orig": "I[SP]heard[SP]when[SP]we[SP]evolve,[SP]we'll[SP]know[SP]our[SP]purpose\nin[SP]life,[SP]so[SP]I[SP]was[SP]thinking[SP]a[SP]lot[SP]about[SP]that.[1205][000F]\nI[SP]never[SP]thought[SP]about[SP]it[SP]before...",
     "nom_fr": "Fan de voyance",
-    "texte_fr": "J'ai entendu qu'en évoluant, on connaîtra\nnotre but dans la\nvie, alors j'y ai beaucoup\n[1205]réfléchi. [000F]Je n'y\navais jamais pensé avant..."
+    "texte_fr": "J'ai entendu qu'en évoluant, on connaîtra\nnotre but dans la\nvie, alors j'y ai beaucoup [1205]réfléchi. [000F]Je n'y avais jamais pensé avant..."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Fortunetelling[SP]fangirl",
     "texte_orig": "I[SP]didn't[SP]quite[SP]get[SP]there,[SP]but[SP]I[SP]finally[SP]found\nmyself...[1205][000F][SP]It's[SP]hard[SP]to[SP]explain,[SP]but[SP]I[SP]feel[SP]like\nI[SP]finally[SP]found[SP]the[SP]real[SP]me,[SP]with[SP]no[SP]facade.",
     "nom_fr": "Fan de voyance",
-    "texte_fr": "Je n'y suis pas tout à fait arrivée,\n[1205]mais j'ai fini par me trouver\n[000F]moi-même... C'est dur à expliquer, maisje\nsens que j'ai trouvé le vrai moi."
+    "texte_fr": "Je n'y suis pas tout à fait arrivée,\n[1205]mais j'ai fini par me trouver\n[000F]moi-même... C'est dur à expliquer, maisje sens que j'ai trouvé le vrai moi."
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Sister[SP]#2",
     "texte_orig": "Hello![SP]Heeheehee![1205][000F][SP]Welcome[SP]to[SP]Satomi[SP]Tadashi's\nKounan[SP]branch.\n[1208][0006]Buy[SP]items\nSell[SP]items\nTalk[SP]to[SP]Sister[SP]#2\n[1210][B_00][U+5601][B_00]iew[SP]items\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Sœur n°2",
-    "texte_fr": "Bonjour! [1205][000F]Hihihi! Bienvenue à la\nsuccursale de Kounan.\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°2\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
+    "texte_fr": "Bonjour! [000F][1205]Hihihi! Bienvenue à la\nsuccursale de Kounan.\n[1208][0006]Acheter objets\nVendre objets\nParler à Sœur n°2\n[1210]Voir objets\nRien\nQuitter[B_00][U+5601][B_00]",
     "question_orig": "Hello![SP]Heeheehee![1205][000F][SP]Welcome[SP]to[SP]Satomi[SP]Tadashi's\nKounan[SP]branch.",
     "choix_orig": [
       "Buy[SP]items",
@@ -347,7 +347,7 @@
     "nom_orig": "Sister[SP]#2",
     "texte_orig": "Heeheehee...[1205][000A][SP]I'm[SP]not[SP]surprised[SP]my[SP]sister[SP]has\nchanged[SP]her[SP]plans[SP]from[SP]taking[SP]over[SP]Japan[SP]to\ntaking[SP]over[SP]Xibalba.[SP]She's[SP]flexible!",
     "nom_fr": "Sœur n°2",
-    "texte_fr": "Héhéhé...[1205][000A] Ça m'étonne pas que ma sœur ait\nchangé ses plans de conquête du Japon en\nconquête de Xibalba. Elle s'adapte!"
+    "texte_fr": "Héhéhé...[000A][1205] Ça m'étonne pas que ma sœur ait\nchangé ses plans de conquête du Japon en\nconquête de Xibalba. Elle s'adapte!"
   },
   {
     "id": 18,
@@ -492,7 +492,7 @@
     "nom_orig": "Sister[SP]#2",
     "texte_orig": "Our[SP]resale[SP]prices[SP]are[SP]around[SP]half[SP]the[SP]original\nprice.[SP]You[SP]can't[SP]sell[SP]anything[SP]you[SP]have[SP]equipped,\nand[SP]some[SP]special[SP]items[SP]are[SP]off-limits[SP]too.",
     "nom_fr": "Sœur n°2",
-    "texte_fr": "Nos prix de rachat\nsont environ la moitié du\nprix d'origine. Vous ne\npouvez pas vendre ce\nque vous portez,\nni certains objets spéciaux."
+    "texte_fr": "Nos prix de rachat\nsont environ la moitié du\nprix d'origine. Vous ne pouvez pas vendre ce que vous portez, ni certains objets spéciaux."
   },
   {
     "id": 27,

--- a/traduction/event_scripts/script_371.json
+++ b/traduction/event_scripts/script_371.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]didn't[SP]know[SP]Yukino-san[SP]was[SP]friends[SP]with\nsomeone[SP]so[SP]pretty.[SP]I[SP]wonder[SP]if[SP]she[SP]was[SP]super\nstrong[SP]in[SP]battle?[1205][0014][SP]She[SP]doesn't[SP]look[SP]like[SP]it.",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'ignorais que Yukino avait de si\njolies amies. Était-elle douée au\ncombat?[1205][0014] Elle n'en a pas l'air."
+    "texte_fr": "J'ignorais que Yukino avait de si\njolies amies. Était-elle douée au\ncombat?[0014][1205] Elle n'en a pas l'air."
   },
   {
     "id": 1,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Haha...[1205][000F][SP]I'm[SP]talking[SP]about[SP]someone[SP]from[SP]my\ndreams[SP]like[SP]she[SP]was[SP]real.[SP]Maybe[SP]I'm[SP]in[SP]the\nright[SP]place[SP]here...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Haha.[1205][000F].. Je parle d'un rêve comme s'il\nétait réel. Je suis à ma place, ici..."
+    "texte_fr": "Haha.[000F][1205].. Je parle d'un rêve comme s'il\nétait réel. Je suis à ma place, ici..."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "People[SP]can[SP]only[SP]keep[SP]going[SP]because[SP]they[SP]have\ndreams[SP]and[SP]hopes.[1205][000F][SP]Without[SP]those,[SP]they'll[SP]be\nswallowed[SP]up[SP]in[SP]a[SP]dark,[SP]flapping[SP]shadow...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Les gens avancent grâce à leurs\nrêves et espoirs. [1205][000F]Sans eux, ils\nsont engloutis par les Ombres..."
+    "texte_fr": "Les gens avancent grâce à leurs\nrêves et espoirs. [000F][1205]Sans eux, ils\nsont engloutis par les Ombres..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Now[SP]that[SP]the[SP]police[SP]station's[SP]burned[SP]up,\nwe're[SP]the[SP]only[SP]ones[SP]who[SP]can[SP]save[SP]this[SP]city\nand[SP]Jun.[1205][0014][SP]Heheh,[SP]get[SP]psyched!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Le commissariat étant brûlé, seuls nous\npouvons sauver Jun et la ville.[1205][0014] Héhé,\nmotive-toi!"
+    "texte_fr": "Le commissariat étant brûlé, seuls nous\npouvons sauver Jun et la ville.[0014][1205] Héhé,\nmotive-toi!"
   },
   {
     "id": 7,
@@ -192,7 +192,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "We've[SP]finally[SP]met[SP]him.[1205][000F][SP]I'll[SP]kick[SP]his[SP]ass\nbut[SP]good[SP]this[SP]time,[SP]so[SP]he[SP]never[SP]does[SP]anything\nlike[SP]this[SP]ever[SP]again!",
     "nom_fr": "Ginko",
-    "texte_fr": "On l'a enfin trouvé. [1205][000F]Je vais lui botter les\nfesses pour qu'il\nne recommence plus jamais!"
+    "texte_fr": "On l'a enfin trouvé. [000F][1205]Je vais lui botter les\nfesses pour qu'il\nne recommence plus jamais!"
   },
   {
     "id": 13,
@@ -342,7 +342,7 @@
     "nom_orig": "Maya",
     "texte_orig": "She's[SP]so[SP]kind...[1205][0014][SP]Or[SP]maybe[SP]Yukki[SP]and[SP]her[SP]other\nfriends[SP]are[SP]supporting[SP]her...",
     "nom_fr": "Maya",
-    "texte_fr": "Elle est si gentille...[1205][0014] Ou peut-être\nque Yukki et ses amis l'aident..."
+    "texte_fr": "Elle est si gentille...[0014][1205] Ou peut-être\nque Yukki et ses amis l'aident..."
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Don't[SP]worry,[SP]this[SP]won't[SP]be[SP]happening[SP]again.\nWe'll[SP]stop[SP]them.[1205][000F][SP]So[SP]let's[SP]do[SP]it![SP]Don't[SP]let\nyour[SP]fear[SP]rule[SP]you!",
     "nom_fr": "Maya",
-    "texte_fr": "Ça n'arrivera plus. On les arrêtera.\n[1205][000F]Allons-y! Ne laisse pas la peur te dominer!"
+    "texte_fr": "Ça n'arrivera plus. On les arrêtera.\n[000F][1205]Allons-y! Ne laisse pas la peur te dominer!"
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Her[SP]Persona[SP]is[SP]also[SP]very[SP]strong...[1205][0014][SP]If[SP]I[SP]don't\ntake[SP]care[SP]of[SP]her[SP]now,[SP]she[SP]could[SP]be[SP]trouble\ndown[SP]the[SP]line...",
     "nom_fr": "Maya",
-    "texte_fr": "Sa Persona est très forte...[1205][0014] Si je ne m'en\noccupe pas, elle\nposera problème plus tard..."
+    "texte_fr": "Sa Persona est très forte...[0014][1205] Si je ne m'en\noccupe pas, elle\nposera problème plus tard..."
   },
   {
     "id": 25,
@@ -417,7 +417,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Maki-san...[1205][000F][SP]You[SP]mean[SP]Maki[SP]Sonomura?[1205][000F][SP]I'd[SP]heard\nabout[SP]her[SP]from[SP]Yukki[SP]before,[SP]but...[SP]Wow...\nSo[SP]that's[SP]her.",
     "nom_fr": "Maya",
-    "texte_fr": "Maki.[1205][000F][1205].[000F]. Tu veux dire Maki Sonomura? Yukki\nm'en avait parlé...\nWaouh... C'est donc elle."
+    "texte_fr": "Maki.[000F][1205][1205].[000F]. Tu veux dire Maki Sonomura? Yukki\nm'en avait parlé...\nWaouh... C'est donc elle."
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Maya",
     "texte_orig": "A[SP]girl[SP]swallowed[SP]by[SP]the[SP]evil[SP]in[SP]her[SP]nature,\nin[SP]this[SP]city...[1205][000F][SP]Coincidence?[1205][000F][SP]Heh.",
     "nom_fr": "Maya",
-    "texte_fr": "Une fille avalée par le mal de sa\nnature, ici.[1205][1205][000F].[000F]. Coïncidence? Hé."
+    "texte_fr": "Une fille avalée par le mal de sa\nnature, ici.[1205][000F][1205].[000F]. Coïncidence? Hé."
   },
   {
     "id": 29,
@@ -627,7 +627,7 @@
     "nom_orig": "???",
     "texte_orig": "Are[SP]you[SP][1113]?[1205][000F][SP]My[SP]name[SP]is[SP]Maki[SP]Sonomura.\nIt's[SP]nice[SP]meeting[SP]you.",
     "nom_fr": "???",
-    "texte_fr": "Es-tu [1113]? [1205][000F]Je suis Maki\nSonomura. Ravit de te rencontrer."
+    "texte_fr": "Es-tu [1113]? [000F][1205]Je suis Maki\nSonomura. Ravit de te rencontrer."
   },
   {
     "id": 42,
@@ -642,7 +642,7 @@
     "nom_orig": "Maki",
     "texte_orig": "Ahh...[SP]So[SP]you've[SP]met[SP]Philemon[SP]too.[1205][0014][SP]Well,[SP]any\nfriend[SP]of[SP]Yukino's[SP]is[SP]a[SP]friend[SP]of[SP]mine.\nCome[SP]see[SP]me[SP]if[SP]you[SP]ever[SP]need[SP]anything.",
     "nom_fr": "Maki",
-    "texte_fr": "Ahh... Tu as rencontré Philémon.[1205][0014]\nLes amis de Yukino sont mes amis.\nViens me voir si tu as besoin."
+    "texte_fr": "Ahh... Tu as rencontré Philémon.[0014][1205]\nLes amis de Yukino sont mes amis.\nViens me voir si tu as besoin."
   },
   {
     "id": 43,
@@ -732,7 +732,7 @@
     "nom_orig": "Maki",
     "texte_orig": "No,[SP]I[SP]have[SP]to[SP]step[SP]up[SP]to[SP]the[SP]plate.[1205][0014][SP]It'll[SP]be\nall[SP]right.[1205][000F][SP]Leave[SP]him[SP]to[SP]me.[SP]I'll[SP]calm[SP]him[SP]down\nsomehow...",
     "nom_fr": "Maki",
-    "texte_fr": "Non, je dois agir.[1205][0014]\n[1205]Ça ira. Laisse-le moi. [000F]Je\nvais le calmer d'une\nfaçon ou d'une autre..."
+    "texte_fr": "Non, je dois agir.[0014][1205]\n[1205]Ça ira. Laisse-le moi. [000F]Je\nvais le calmer d'une façon ou d'une autre..."
   },
   {
     "id": 49,
@@ -747,7 +747,7 @@
     "nom_orig": "Maki",
     "texte_orig": "Oh,[SP]I[SP]know[SP]that's[SP]not[SP]the[SP]real[SP]him.[1205][000F][SP]There's\nanother[SP]force[SP]causing[SP]the[SP]bad[SP]feelings[SP]inside\nhim[SP]to[SP]surface.",
     "nom_fr": "Maki",
-    "texte_fr": "Oh, je sais que ce n'est pas lui. [1205][000F]Une autre\nforce fait ressortir\nses mauvais sentiments."
+    "texte_fr": "Oh, je sais que ce n'est pas lui. [000F][1205]Une autre\nforce fait ressortir\nses mauvais sentiments."
   },
   {
     "id": 50,
@@ -762,7 +762,7 @@
     "nom_orig": "Maki",
     "texte_orig": "Everyone[SP]has[SP]feelings[SP]like[SP]that.[1205][0014][SP]You[SP]just\nleave[SP]him[SP]to[SP]me,[SP]and[SP]I'll[SP]leave[SP]it[SP]to[SP]you\nto[SP]find[SP]out[SP]why[SP]he's[SP]like[SP]this,[SP]Yukino.",
     "nom_fr": "Maki",
-    "texte_fr": "Tout le monde ressent ça.[1205][0014] Laisse-le moi,\nYukino, et découvre pourquoi\nil est comme ça."
+    "texte_fr": "Tout le monde ressent ça.[0014][1205] Laisse-le moi,\nYukino, et découvre pourquoi\nil est comme ça."
   },
   {
     "id": 51,
@@ -777,7 +777,7 @@
     "nom_orig": "Maki",
     "texte_orig": "I'm[SP]sensing[SP]something[SP]abnormal[SP]from[SP]the\nAerospace[SP]Museum.[1205][000F][SP]It's[SP]unlike[SP]anybody[SP]else's\nI[SP]know[SP]of--it's[SP]more[SP]evil,[SP]more[SP]violent..",
     "nom_fr": "Maki",
-    "texte_fr": "Je sens quelque chose d'anormal\n[1205][000F]venant du musée aérospatial. C'est\nplus maléfique, plus violent..."
+    "texte_fr": "Je sens quelque chose d'anormal\n[000F][1205]venant du musée aérospatial. C'est\nplus maléfique, plus violent..."
   },
   {
     "id": 52,
@@ -792,7 +792,7 @@
     "nom_orig": "Maki",
     "texte_orig": "A[SP]power[SP]like[SP]that[SP]could[SP]swallow[SP]up[SP]many[SP]lives\nand[SP]eventually[SP]turn[SP]on[SP]its[SP]user...[1205][001E][SP]If[SP]you're\ngoing[SP]to[SP]the[SP]museum,[SP]be[SP]careful.",
     "nom_fr": "Maki",
-    "texte_fr": "Un tel pouvoir pourrait avaler\ndes vies et se retourner contre\nson utilisateur...[1205][001E] Sois prudent."
+    "texte_fr": "Un tel pouvoir pourrait avaler\ndes vies et se retourner contre\nson utilisateur...[001E][1205] Sois prudent."
   },
   {
     "id": 53,
@@ -867,7 +867,7 @@
     "nom_orig": "Maki",
     "texte_orig": "Y-Yukino...[1205][000F][SP]Um...[1205][000A][SP]Don't[SP]push[SP]yourself[SP]too\nhard,[SP]okay?[SP]Be[SP]careful.",
     "nom_fr": "Maki",
-    "texte_fr": "Y-Yukino.[1205][000F].. Euh...[1205][000A] Ne force pas\ntrop, d'accord? Sois prudente."
+    "texte_fr": "Y-Yukino.[000F][1205].. Euh...[000A][1205] Ne force pas\ntrop, d'accord? Sois prudente."
   },
   {
     "id": 58,
@@ -882,7 +882,7 @@
     "nom_orig": "Maki",
     "texte_orig": "Hey...[SP]Where's[SP]Yukino?[1205][000F][SP]Wasn't[SP]she[SP]with[SP]you?",
     "nom_fr": "Maki",
-    "texte_fr": "Hé.. Où est Yukino? [1205][000F]Elle était avec toi?"
+    "texte_fr": "Hé.. Où est Yukino? [000F][1205]Elle était avec toi?"
   },
   {
     "id": 59,
@@ -942,7 +942,7 @@
     "nom_orig": "???",
     "texte_orig": "Are[SP]you[SP][1113]?[1205][000F][SP]My[SP]name[SP]is[SP]Maki[SP]Sonomura.\nIt's[SP]nice[SP]meeting[SP]you.",
     "nom_fr": "???",
-    "texte_fr": "Es-tu [1113]? [1205][000F]Je suis Maki\nSonomura. Ravit de te rencontrer."
+    "texte_fr": "Es-tu [1113]? [000F][1205]Je suis Maki\nSonomura. Ravit de te rencontrer."
   },
   {
     "id": 63,
@@ -957,7 +957,7 @@
     "nom_orig": "Maki",
     "texte_orig": "Ahh...[SP]So[SP]you've[SP]met[SP]Philemon[SP]too.[1205][0014][SP]Well,[SP]any\nfriend[SP]of[SP]Yukino's[SP]is[SP]a[SP]friend[SP]of[SP]mine.\nCome[SP]see[SP]me[SP]if[SP]you[SP]ever[SP]need[SP]anything.",
     "nom_fr": "Maki",
-    "texte_fr": "Ahh... Tu as rencontré Philémon.[1205][0014]\nLes amis de Yukino sont mes amis.\nViens me voir si tu as besoin."
+    "texte_fr": "Ahh... Tu as rencontré Philémon.[0014][1205]\nLes amis de Yukino sont mes amis.\nViens me voir si tu as besoin."
   },
   {
     "id": 64,
@@ -972,7 +972,7 @@
     "nom_orig": "???",
     "texte_orig": "Huh...?[SP]You[SP]have[SP]a[SP]Persona[SP]too?[1205][000F][SP]And[SP]that\nresonance...[1205][000F][SP]You[SP]must[SP]know[SP]Yukino.",
     "nom_fr": "???",
-    "texte_fr": "Tu as une Persona? [1205][000F][1205][000F]Cette résonance...\nTu dois connaître Yukino."
+    "texte_fr": "Tu as une Persona? [000F][1205][000F][1205]Cette résonance...\nTu dois connaître Yukino."
   },
   {
     "id": 65,
@@ -1032,7 +1032,7 @@
     "nom_orig": "Tired-looking[SP]man",
     "texte_orig": "*mumble*[SP]I[SP]saw...[SP]I[SP]saw...[1205][000A][SP]a[SP]monster...[SP]at[SP]the\nabandoned[SP]factory...[1205][000F][SP]*mutter*[SP]Don't[SP]you[SP]believe\nme?[SP]*mumble*",
     "nom_fr": "Homme fatigué",
-    "texte_fr": "J'ai vu... J'ai vu.[1205]..[1205][000A] un monstre...\n[000F]à l'usine... Vous ne me croyez pas?"
+    "texte_fr": "J'ai vu... J'ai vu.[1205]..[000A][1205] un monstre...\n[000F]à l'usine... Vous ne me croyez pas?"
   },
   {
     "id": 69,
@@ -1047,7 +1047,7 @@
     "nom_orig": "Tired-looking[SP]man",
     "texte_orig": "A-Another[SP]explosion...[SP]*mutter*...[1205][000F][SP]I[SP]saw[SP]it\nbefore...[SP]That[SP]was[SP]monsters[SP]too...[SP]*mumble*\nThey're[SP]all[SP]gonna[SP]die...",
     "nom_fr": "Homme fatigué",
-    "texte_fr": "U-Une autre explosion... [1205][000F]*grommelle*...\nJ'ai déjà vu ça... Des monstres aussi...\n*marmonne* Ils vont tous mourir..."
+    "texte_fr": "U-Une autre explosion... [000F][1205]*grommelle*...\nJ'ai déjà vu ça... Des monstres aussi...\n*marmonne* Ils vont tous mourir..."
   },
   {
     "id": 70,
@@ -1077,7 +1077,7 @@
     "nom_orig": "Tired-looking[SP]man",
     "texte_orig": "Th-The[SP]sketches...[1205][000A][SP]are[SP]public[SP]now?[SP]*mutter*[1205][000F]\nWill[SP]those[SP]flames[SP]go[SP]away?[SP]*mumble*",
     "nom_fr": "Homme fatigué",
-    "texte_fr": "L-Les croquis.[1205]..[1205][000A] sont publics?\n[000F]Ces flammes partiront-elles?"
+    "texte_fr": "L-Les croquis.[1205]..[000A][1205] sont publics?\n[000F]Ces flammes partiront-elles?"
   },
   {
     "id": 72,
@@ -1092,7 +1092,7 @@
     "nom_orig": "Recovering[SP]man",
     "texte_orig": "Maki-san[SP]encouraged[SP]me[SP]not[SP]to[SP]give[SP]up.[1205][000F][SP]Kind[SP]of\npathetic[SP]for[SP]the[SP]guy[SP]to[SP]be[SP]leaning[SP]on[SP]the[SP]girl\nfor[SP]support,[SP]instead[SP]of[SP]the[SP]other[SP]way[SP]around.",
     "nom_fr": "Homme en guérison",
-    "texte_fr": "Maki-san m'a encouragé à ne pas baisser\n[1205][000F]les bras. Un peu pathétique qu'un homme\ns'appuie sur une fille, et pas l'inverse."
+    "texte_fr": "Maki-san m'a encouragé à ne pas baisser\n[000F][1205]les bras. Un peu pathétique qu'un homme\ns'appuie sur une fille, et pas l'inverse."
   },
   {
     "id": 73,
@@ -1137,7 +1137,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "But[SP]all[SP]of[SP]a[SP]sudden,[SP]I[SP]don't[SP]know[SP]who[SP]I[SP]am.[1205][000F]\nAll[SP]those[SP]experiences[SP]that[SP]made[SP]me[SP]the[SP]person\nI[SP]am[SP]are[SP]gone.[1205][000F][SP]My[SP]heart[SP]is[SP]cold...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Mais je ne sais plus qui je suis.\n[1205][000F][1205][000F]Toutes les expériences qui m'ont forgé\nont disparu. Mon cœur est froid..."
+    "texte_fr": "Mais je ne sais plus qui je suis.\n[000F][1205][000F][1205]Toutes les expériences qui m'ont forgé\nont disparu. Mon cœur est froid..."
   },
   {
     "id": 76,
@@ -1197,7 +1197,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Now[SP]I[SP]understand...[SP]No[SP]matter[SP]how[SP]horrible[SP]the\npast...[SP]How[SP]sad[SP]the[SP]memory...[1205][000F][SP]They're[SP]what[SP]made\nme[SP]who[SP]I[SP]am...[1205][000F][SP]They're[SP]the[SP]reason[SP]I'm[SP]here...",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "Maintenant je comprends... Peu importe\nla tristesse des souvenirs.[1205][000F][1205][000F].. Ils m'ont\nforgé... C'est pour ça que je suis là..."
+    "texte_fr": "Maintenant je comprends... Peu importe\nla tristesse des souvenirs.[000F][1205][000F][1205].. Ils m'ont\nforgé... C'est pour ça que je suis là..."
   },
   {
     "id": 80,
@@ -1212,7 +1212,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "There's[SP]no[SP]way[SP]I[SP]can[SP]live[SP]with[SP]so[SP]great[SP]a[SP]loss.[1205][000F]\nWhat[SP]did[SP]I[SP]want[SP]so[SP]much[SP]that[SP]I[SP]joined[SP]the\nMasked[SP]Circle?[1205][000F][SP]What[SP]was[SP]my[SP]ideal!?",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "Je ne peux pas vivre avec une telle\nperte. [1205][000F][1205][000F]Que voulais-je tant pour rejoindre\nle Cercle masqué? Quel était mon idéal!?"
+    "texte_fr": "Je ne peux pas vivre avec une telle\nperte. [000F][1205][000F][1205]Que voulais-je tant pour rejoindre\nle Cercle masqué? Quel était mon idéal!?"
   },
   {
     "id": 81,
@@ -1227,7 +1227,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "I[SP]was[SP]wrong...[SP]I[SP]just[SP]wanted...[SP]to[SP]escape...[1205][000F]\nthe[SP]memory[SP]of[SP]my[SP]crimes...[1205][000F][SP]or[SP]they'd[SP]have\nsuffocated[SP]me...",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "J'avais tort... Je voulais juste...\n[1205]fuir.[1205][000F][000F].. le souvenir de mes crimes...\nou ils m'auraient étouffé..."
+    "texte_fr": "J'avais tort... Je voulais juste...\n[1205]fuir.[000F][1205][000F].. le souvenir de mes crimes...\nou ils m'auraient étouffé..."
   },
   {
     "id": 82,
@@ -1242,7 +1242,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "But[SP]who[SP]cares[SP]anymore...[SP]Not[SP]me...[1205][000F][SP]W-Watch\nclosely...[1205][000F][SP]This[SP]is[SP]what[SP]happens[SP]to[SP]someone\nwho[SP]throws[SP]his[SP]memories[SP]away...",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "Mais on s'en fout... Pas moi.[1205][000F][1205][000F]..\nR-Regarde bien... Voilà ce qui arrive\nquand on jette ses souvenirs..."
+    "texte_fr": "Mais on s'en fout... Pas moi.[000F][1205][000F][1205]..\nR-Regarde bien... Voilà ce qui arrive\nquand on jette ses souvenirs..."
   },
   {
     "id": 83,
@@ -1257,7 +1257,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Uuugghhh...[1205][000A][SP]Aaaaghhh...",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "Uuugghhh...[1205][000A] Aaaaghhh..."
+    "texte_fr": "Uuugghhh...[000A][1205] Aaaaghhh..."
   },
   {
     "id": 84,
@@ -1418,7 +1418,7 @@
     "nom_orig": "Dr.[SP]Reiko",
     "texte_orig": "All[SP]right.[1205][000F][SP]My[SP]rate[SP]for[SP]a[SP]group[SP]session[SP]is\n1,200[SP]yen.[SP]Is[SP]that[SP]okay?\n[1208][0002]Yes\nNo",
     "nom_fr": "Dr. Reiko",
-    "texte_fr": "D'accord. [1205][000F]Ma séance de groupe coûte\n1200 yens. Ça vous va?\n[1208][0002]OuiNon",
+    "texte_fr": "D'accord. [000F][1205]Ma séance de groupe coûte\n1200 yens. Ça vous va?\n[1208][0002]OuiNon",
     "question_orig": "All[SP]right.[1205][000F][SP]My[SP]rate[SP]for[SP]a[SP]group[SP]session[SP]is\n1,200[SP]yen.[SP]Is[SP]that[SP]okay?",
     "choix_orig": [
       "Yes",
@@ -1473,7 +1473,7 @@
     "nom_orig": "Dr.[SP]Reiko",
     "texte_orig": "You...[SP]seem[SP]to[SP]be[SP]carrying[SP]a[SP]very[SP]painful[SP]past\nall[SP]on[SP]your[SP]own[SP]shoulders...[1205][000F][SP]Try[SP]to[SP]forget[SP]it,\njust[SP]for[SP]this[SP]moment...",
     "nom_fr": "Dr. Reiko",
-    "texte_fr": "Vous portez un passé très douloureux\nsur vos épaules... [1205][000F]Essayez de\nl'oublier, juste un instant..."
+    "texte_fr": "Vous portez un passé très douloureux\nsur vos épaules... [000F][1205]Essayez de\nl'oublier, juste un instant..."
   },
   {
     "id": 96,
@@ -1503,7 +1503,7 @@
     "nom_orig": "Dr.[SP]Reiko",
     "texte_orig": "Maki-san[SP]has[SP]been[SP]very[SP]helpful.[1205][000F][SP]If[SP]she[SP]can[SP]give\nthat[SP]much[SP]of[SP]herself[SP]to[SP]the[SP]patients[SP]now,[SP]she'll\nmake[SP]a[SP]wonderful[SP]counselor.",
     "nom_fr": "Dr. Reiko",
-    "texte_fr": "Maki-san est d'une grande aide. [1205][000F]Si\nelle donne tant aux patients, elle\nfera une excellente conseillère."
+    "texte_fr": "Maki-san est d'une grande aide. [000F][1205]Si\nelle donne tant aux patients, elle\nfera une excellente conseillère."
   },
   {
     "id": 98,
@@ -1518,7 +1518,7 @@
     "nom_orig": "Dr.[SP]Reiko",
     "texte_orig": "I[SP]think[SP]she[SP]sees[SP]herself[SP]in[SP]the[SP]patients.[1205][0014]\nShe's[SP]just[SP]too[SP]big-hearted.",
     "nom_fr": "Dr. Reiko",
-    "texte_fr": "Elle se voit en ses patients.[1205][0014]\nElle a le cœur sur la main."
+    "texte_fr": "Elle se voit en ses patients.[0014][1205]\nElle a le cœur sur la main."
   },
   {
     "id": 99,
@@ -1578,7 +1578,7 @@
     "nom_orig": "Dr.[SP]Reiko",
     "texte_orig": "I[SP]can't[SP]abandon[SP]this[SP]clinic.[1205][0014][SP]I[SP]chose[SP]this[SP]path\nto[SP]save[SP]people[SP]like[SP]that.",
     "nom_fr": "Dr. Reiko",
-    "texte_fr": "Je n'abandonnerai pas la clinique.[1205][0014]\nJ'ai choisi de sauver ces gens."
+    "texte_fr": "Je n'abandonnerai pas la clinique.[0014][1205]\nJ'ai choisi de sauver ces gens."
   },
   {
     "id": 103,
@@ -1694,7 +1694,7 @@
     "nom_orig": "Dr.[SP]Reiko",
     "texte_orig": "Oh...[SP]You[SP]don't[SP]appear[SP]to[SP]have[SP]enough[SP]money.[1205][000F]\nI'm[SP]sorry,[SP]but[SP]I[SP]do[SP]have[SP]a[SP]clinic[SP]to[SP]maintain.",
     "nom_fr": "Dr. Reiko",
-    "texte_fr": "Oh... tu n'as pas assez d'argent. [1205][000F]Désolée,\nmais j'ai une clinique à maintenir."
+    "texte_fr": "Oh... tu n'as pas assez d'argent. [000F][1205]Désolée,\nmais j'ai une clinique à maintenir."
   },
   {
     "id": 109,

--- a/traduction/event_scripts/script_372.json
+++ b/traduction/event_scripts/script_372.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "We've[SP]been[SP]twisting[SP]our[SP]memories[SP]around[SP]without\nrealizing[SP]it,[SP]doing[SP]things[SP]the[SP]hard[SP]way...[1205][000F]\nMaybe[SP]we[SP]just[SP]don't[SP]understand[SP]ourselves.",
     "nom_fr": "Eikichi",
-    "texte_fr": "On a déformés nos\nsouvenirs sans s'en rendre\ncompte... [1205][000F]Peut-être qu'on se comprends pas."
+    "texte_fr": "On a déformés nos\nsouvenirs sans s'en rendre\ncompte... [000F][1205]Peut-être qu'on se comprends pas."
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]think[SP]Philemon[SP]knew[SP]it[SP]all[SP]from[SP]the[SP]start.[1205][000F]\nHe[SP]knew,[SP]and[SP]he[SP]was[SP]waiting[SP]for[SP]us[SP]to[SP]get[SP]to\nthe[SP]reflecting[SP]pool[SP]ourselves.",
     "nom_fr": "Maya",
-    "texte_fr": "Je pense que Philémon savait tout dès le\n[1205][000F]début... n Il attendait qu'on atteigne\nnous-mêmes le bassin de réflexion."
+    "texte_fr": "Je pense que Philémon savait tout dès le\n[000F][1205]début... n Il attendait qu'on atteigne\nnous-mêmes le bassin de réflexion."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]all[SP]feared[SP]the[SP]truth[SP]somewhere[SP]inside[SP]us.[1205][000F]\nThat[SP]curse[SP]wouldn't[SP]have[SP]been[SP]broken[SP]if[SP]we\nhadn't[SP]reunited[SP]and[SP]cleared[SP]everything[SP]up.",
     "nom_fr": "Maya",
-    "texte_fr": "On craignait tous la vérité au\n[1205][000F]fond. Sans nous retrouver, la\nmalédiction 'aurait pas été levée."
+    "texte_fr": "On craignait tous la vérité au\n[000F][1205]fond. Sans nous retrouver, la\nmalédiction 'aurait pas été levée."
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Maya",
     "texte_orig": "But[SP]now[SP]that[SP]the[SP]curse[SP]is[SP]broken,[SP]we[SP]trust\neach[SP]other[SP]even[SP]more[SP]than[SP]before.[1205][000F][SP]I[SP]think\nthat's[SP]what[SP]he[SP]wanted.",
     "nom_fr": "Maya",
-    "texte_fr": "La malédiction est brisée, donc on\nse fait plus confiance maintenant.\n[1205][000F]J'imagine qu'il voulait ca."
+    "texte_fr": "La malédiction est brisée, donc on\nse fait plus confiance maintenant.\n[000F][1205]J'imagine qu'il voulait ca."
   },
   {
     "id": 6,
@@ -132,7 +132,7 @@
     "nom_orig": "Jun",
     "texte_orig": "And[SP]so[SP]they[SP]started[SP]looking[SP]for[SP]themselves...[1205][000F]\nIronic,[SP]isn't[SP]it?[SP]Masks[SP]trick[SP]even[SP]the[SP]wearer.",
     "nom_fr": "Jun",
-    "texte_fr": "Ils se cherchent maintenant... Ironique,\n[1205][000F]n'est-ce pas? Le masque trompe son porteur."
+    "texte_fr": "Ils se cherchent maintenant... Ironique,\n[000F][1205]n'est-ce pas? Le masque trompe son porteur."
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Recovering[SP]man",
     "texte_orig": "Maki-san[SP]said[SP]she[SP]was[SP]going[SP]to[SP]go[SP]help[SP]someone.\nI[SP]don't[SP]know[SP]where[SP]she[SP]went,[SP]but[SP]I[SP]hope[SP]she's\nokay...[1205][000F][SP]Man,[SP]I[SP]should[SP]have[SP]gone[SP]with[SP]her!",
     "nom_fr": "Homme en convalescence",
-    "texte_fr": "Maki-san est partie aider\nquelqu'un... Je sais pas où elle\n[1205][000F]est, mais j'espère qu'elle va bien"
+    "texte_fr": "Maki-san est partie aider\nquelqu'un... Je sais pas où elle\n[000F][1205]est, mais j'espère qu'elle va bien"
   },
   {
     "id": 10,
@@ -308,7 +308,7 @@
     "nom_orig": "Dr.[SP]Reiko",
     "texte_orig": "Haha...[SP]You[SP]seem[SP]to[SP]be[SP]a[SP]sound[SP]mind[SP]in[SP]a[SP]sound\nbody.[SP]Come[SP]by[SP]if[SP]you[SP]ever[SP]feel[SP]unwell.[SP]I'll\nalways[SP]have[SP]time[SP]for[SP]you.",
     "nom_fr": "Dr. Reiko",
-    "texte_fr": "Ha... Tu es sain\nd'esprit et de corps. Passe\nme voir si tu te\nsens pas bien. Je serai là."
+    "texte_fr": "Ha... Tu es sain\nd'esprit et de corps. Passe\nme voir si tu te sens pas bien. Je serai là."
   },
   {
     "id": 19,
@@ -323,7 +323,7 @@
     "nom_orig": "Dr.[SP]Reiko",
     "texte_orig": "All[SP]right.[1205][000F][SP]My[SP]rate[SP]for[SP]a[SP]group[SP]session[SP]is\n1,200[SP]yen.[SP]Is[SP]that[SP]okay?\n[1208][0002]Yes\nNo",
     "nom_fr": "Dr. Reiko",
-    "texte_fr": "D'accord. [1205][000F]Ma séance de groupe coûte\n1200 yens. Ça vous va?\n[1208][0002]OuiNon",
+    "texte_fr": "D'accord. [000F][1205]Ma séance de groupe coûte\n1200 yens. Ça vous va?\n[1208][0002]OuiNon",
     "question_orig": "All[SP]right.[1205][000F][SP]My[SP]rate[SP]for[SP]a[SP]group[SP]session[SP]is\n1,200[SP]yen.[SP]Is[SP]that[SP]okay?",
     "choix_orig": [
       "Yes",
@@ -378,7 +378,7 @@
     "nom_orig": "Dr.[SP]Reiko",
     "texte_orig": "You're[SP]about[SP]to[SP]face[SP]something[SP]enormous...[1205][000F]\nAnd[SP]the[SP]pressure[SP]of[SP]it[SP]is[SP]too[SP]much[SP]to[SP]bear.[1205][000F]\nBut[SP]don't[SP]worry.[SP]You're[SP]not[SP]alone...",
     "nom_fr": "Dr. Reiko",
-    "texte_fr": "Tu vas affronter qulque chose d'immense.[1205][000F][1205][000F]..\nLa pression est trop forte... Mais ne\nt'inquiètes pas, tu n'es pas seul..."
+    "texte_fr": "Tu vas affronter qulque chose d'immense.[000F][1205][000F][1205]..\nLa pression est trop forte... Mais ne\nt'inquiètes pas, tu n'es pas seul..."
   },
   {
     "id": 23,
@@ -408,7 +408,7 @@
     "nom_orig": "Dr.[SP]Reiko",
     "texte_orig": "Maki-san[SP]just[SP]stepped[SP]out.[1205][000F][SP]She[SP]seemed[SP]like[SP]she\nhad[SP]a[SP]good[SP]reason,[SP]so[SP]I[SP]didn't[SP]stop[SP]her,[SP]but...",
     "nom_fr": "Dr. Reiko",
-    "texte_fr": "Maki-san vient de sortir. [1205][000F]Je\nne l'ai pas arrêtée, mais..."
+    "texte_fr": "Maki-san vient de sortir. [000F][1205]Je\nne l'ai pas arrêtée, mais..."
   },
   {
     "id": 25,
@@ -423,7 +423,7 @@
     "nom_orig": "Dr.[SP]Reiko",
     "texte_orig": "She'll[SP]come[SP]back,[SP]won't[SP]she?[1205][000F][SP]I'll[SP]have[SP]to[SP]wait\nfor[SP]her...",
     "nom_fr": "Dr. Reiko",
-    "texte_fr": "Elle reviendra, hein? [1205][000F]Je\nvais devoir l'attendre..."
+    "texte_fr": "Elle reviendra, hein? [000F][1205]Je\nvais devoir l'attendre..."
   },
   {
     "id": 26,
@@ -494,7 +494,7 @@
     "nom_orig": "Dr.[SP]Reiko",
     "texte_orig": "Oh...[SP]You[SP]don't[SP]appear[SP]to[SP]have[SP]enough[SP]money.[1205][000F]\nI'm[SP]sorry,[SP]but[SP]I[SP]do[SP]have[SP]a[SP]clinic[SP]to[SP]maintain.",
     "nom_fr": "Dr. Reiko",
-    "texte_fr": "Oh... on dirait que tu manques d'argent.\n[1205][000F]Désolée, j'ai une clinique à maintenir."
+    "texte_fr": "Oh... on dirait que tu manques d'argent.\n[000F][1205]Désolée, j'ai une clinique à maintenir."
   },
   {
     "id": 29,

--- a/traduction/event_scripts/script_373.json
+++ b/traduction/event_scripts/script_373.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "M-My[SP]pops[SP]is[SP]the[SP]only[SP]man[SP]I[SP]have[SP]trouble[SP]dealing\nwith...[1205][001E][SP]Ever[SP]since[SP]I[SP]was[SP]a[SP]kid,[SP]when[SP]he[SP]yells[SP]at\nme[SP]in[SP]that[SP]scratchy[SP]voice,[SP]I[SP]freeze[SP]up.",
     "nom_fr": "Eikichi",
-    "texte_fr": "M-Mon père est le seul homme avec qui j'ai\ndu mal...[1205][001E] Depuis petit, quand il me crie\ndessus de sa voix rauque, je paralyse."
+    "texte_fr": "M-Mon père est le seul homme avec qui j'ai\ndu mal...[001E][1205] Depuis petit, quand il me crie\ndessus de sa voix rauque, je paralyse."
   },
   {
     "id": 1,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]hope[SP]Hanakouji-san's[SP]okay...[1205][000F][SP]I[SP]wonder[SP]if[SP]she\nwent[SP]back[SP]to[SP]talk[SP]to[SP]her[SP]friend...[SP]Mind[SP]if[SP]we\nhit[SP]Peace[SP]Diner,[SP][1113]?",
     "nom_fr": "Eikichi",
-    "texte_fr": "J'espère qu'Hanakouji va bien.[1205][000F].. Est-elle\nretournée parler à son amie... Ça te dit\nd'aller au Peace Diner, [1113]?"
+    "texte_fr": "J'espère qu'Hanakouji va bien.[000F][1205].. Est-elle\nretournée parler à son amie... Ça te dit\nd'aller au Peace Diner, [1113]?"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]just[SP]like[SP]Yukino-san[SP]says.[SP]Everyone[SP]has\na[SP]weakness[SP]or[SP]two...[1205][000F][SP]*gag*[1205][000F][SP]D-Don't[SP]you\nthink[SP]s-s-so?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Yukino a raison. Chacun a ses\nfaiblesses.[1205].[1205][000F][000F]. *beurk* T-Tu ne trouves pas?"
+    "texte_fr": "Yukino a raison. Chacun a ses\nfaiblesses.[1205].[000F][1205][000F]. *beurk* T-Tu ne trouves pas?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "H-Hey,[SP]Maya-san's[SP]right.[SP]Let's[SP]go[SP]over[SP]to[SP]the\ndetective[SP]agency.[1205][000F][SP]I-If[SP]I[SP]stay[SP]here[SP]any[SP]longer,\nI'm...[SP]Uuurp...",
     "nom_fr": "Eikichi",
-    "texte_fr": "H-Hé, Maya a raison. Allons à l'agence\nde détectives. [1205][000F]S-Si je reste ici plus\nlongtemps, je vais... Uuurp..."
+    "texte_fr": "H-Hé, Maya a raison. Allons à l'agence\nde détectives. [000F][1205]S-Si je reste ici plus\nlongtemps, je vais... Uuurp..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I-I[SP]always[SP]wonder...[1205][000A][SP]Why[SP]do[SP]we[SP]have[SP]to[SP]come\nhere[SP]to[SP]chat...?[SP]Nngh...[1205][000F][SP]Let's[SP]just[SP]get[SP]to[SP]Mu\nand[SP]see[SP]for[SP]ourselves.[1205][000F][SP]Whaddaya[SP]say?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je me demande.[1205][1205]..[1205][000A] Pourquoi venir\ndiscuter ici.[000F][000F]..? Nngh... Allons au\nMu par nous-mêmes. T'en dis quoi?"
+    "texte_fr": "Je me demande.[1205][1205]..[000A][1205] Pourquoi venir\ndiscuter ici.[000F][000F]..? Nngh... Allons au\nMu par nous-mêmes. T'en dis quoi?"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Golly,[SP]she's[SP]going[SP]purple[SP]with[SP]rage.[1205][000F][SP]Hey,[SP]let's\nget[SP]to[SP]Giga[SP]Macho[SP]before[SP]this[SP]idol[SP]wannabe[SP]goes\non[SP]a[SP]rampage.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Waouh, elle est folle de rage. [1205][000F]Hé,\nallons au Giga Macho avant que la\nfuture idole ne pète un câble."
+    "texte_fr": "Waouh, elle est folle de rage. [000F][1205]Hé,\nallons au Giga Macho avant que la\nfuture idole ne pète un câble."
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Psh...[SP]This[SP]is[SP]why[SP]kung[SP]fu[SP]chick[SP]here[SP]is\ntrouble.[1205][000F][SP]Even[SP]a[SP]child[SP]could[SP]sit[SP]down[SP]and[SP]figure\nout[SP]the[SP]next[SP]target[SP]is[SP]the[SP]Sakanoue[SP]Building.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pfff... Cette fan de kung fu est un\n[1205][000F]boulet. Un enfant devinerait que la\ncible est le Sakanoue Building."
+    "texte_fr": "Pfff... Cette fan de kung fu est un\n[000F][1205]boulet. Un enfant devinerait que la\ncible est le Sakanoue Building."
   },
   {
     "id": 12,
@@ -207,7 +207,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "First[SP]the[SP]Masked[SP]Circle,[SP]now[SP]a[SP]group[SP]of[SP]five\nterrorists...[1205][000F][SP]What's[SP]all[SP]this[SP]BS[SP]everyone's\ntalking[SP]about[SP]all[SP]of[SP]a[SP]sudden?",
     "nom_fr": "Eikichi",
-    "texte_fr": "D'abord le Cercle masqué, et maintenant\ncinq terroristes.[1205][000F].. C'est quoi ces\nconneries que tout le monde raconte?"
+    "texte_fr": "D'abord le Cercle masqué, et maintenant\ncinq terroristes.[000F][1205].. C'est quoi ces\nconneries que tout le monde raconte?"
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ten[SP]years[SP]ago...[SP]Would[SP]my[SP]pops[SP]know[SP]something?[1205][000F]\nN-No...[SP]There's[SP]no[SP]way[SP]he'd[SP]know[SP]about[SP]my\ndreams...[1205][001E][SP]H-Hey,[SP]let's[SP]get[SP]going.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Il y a 10 ans... Mon vieux sait un\ntruc? [1205][000F]N-Non... Il n'a aucun moyen de\nconnaître mes rêves...[1205][001E] H-Hé, on y va."
+    "texte_fr": "Il y a 10 ans... Mon vieux sait un\ntruc? [000F][1205]N-Non... Il n'a aucun moyen de\nconnaître mes rêves...[001E][1205] H-Hé, on y va."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ow...[1205][000F][SP]I[SP]asked[SP]Daddy-o[SP]if[SP]he[SP]could[SP]kick[SP]those\nsoldiers'[SP]asses,[SP]and[SP]he[SP]just[SP]belted[SP]me[SP]one.\nWhat's[SP]he[SP]so[SP]mad[SP]about?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Aïe.[1205][000F].. J'ai demandé à papa s'il\npouvait battre ces soldats, et il\nm'a frappé. Pourquoi est-il furieux?"
+    "texte_fr": "Aïe.[000F][1205].. J'ai demandé à papa s'il\npouvait battre ces soldats, et il\nm'a frappé. Pourquoi est-il furieux?"
   },
   {
     "id": 17,
@@ -282,7 +282,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Snrk...[SP]Ahahahahah![1205][001E][SP]You[SP]Yisi![SP]That's[SP]hilarious![1205][001E]\nCostume[SP]practice?[SP]You[SP]always[SP]dress[SP]like[SP]that!",
     "nom_fr": "Lisa",
-    "texte_fr": "Pfft... Ahaha![1205][001E] You\nYisi! Trop drôle![1205][001E] Pratique\nde costume? Tu t'habilles déjà ainsi!"
+    "texte_fr": "Pfft... Ahaha![001E][1205] You\nYisi! Trop drôle![001E][1205] Pratique\nde costume? Tu t'habilles déjà ainsi!"
   },
   {
     "id": 19,
@@ -312,7 +312,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Snrk...[SP]Ahahahahah![1205][001E][SP]You[SP]Yisi![SP]That's[SP]hilarious![1205][001E]\nCostume[SP]practice?[SP]You[SP]always[SP]dress[SP]like[SP]that!",
     "nom_fr": "Ginko",
-    "texte_fr": "Pfft... Ahaha![1205][001E] You\nYisi! Trop drôle![1205][001E] Pratique\nde costume? Tu t'habilles déjà ainsi!"
+    "texte_fr": "Pfft... Ahaha![001E][1205] You\nYisi! Trop drôle![001E][1205] Pratique\nde costume? Tu t'habilles déjà ainsi!"
   },
   {
     "id": 21,
@@ -342,7 +342,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![1205][000F][SP]That[SP]Undie[SP]Boss[SP]up[SP]and[SP]went[SP]off[SP]on\nhis[SP]own.[SP]How[SP]reckless[SP]can[SP]he[SP]be?",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei! [1205][000F]Ce Boss Caleçon a filé seul.\nÀ quel point est-il imprudent?"
+    "texte_fr": "Kehhei! [000F][1205]Ce Boss Caleçon a filé seul.\nÀ quel point est-il imprudent?"
   },
   {
     "id": 23,
@@ -447,7 +447,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![1205][000F][SP]That[SP]dummy[SP]has[SP]no[SP]proof![1205][000F][SP]The[SP]next\ntarget[SP]HAS[SP]to[SP]be[SP]Smile[SP]Hirasaka!",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei! [1205][000F][1205][000F]Pas de preuve! La\ncible EST Smile Hirasaka!"
+    "texte_fr": "Kehhei! [000F][1205][000F][1205]Pas de preuve! La\ncible EST Smile Hirasaka!"
   },
   {
     "id": 30,
@@ -537,7 +537,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Playing[SP]Masked[SP]Circle...[1205][000F][SP]Don't[SP]you[SP]remember,\n[1113]?",
     "nom_fr": "Ginko",
-    "texte_fr": "Jouer au Cercle masqué.[1205][000F]..\nTu as oublié, [1113]?"
+    "texte_fr": "Jouer au Cercle masqué.[000F][1205]..\nTu as oublié, [1113]?"
   },
   {
     "id": 36,
@@ -567,7 +567,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]didn't[SP]expect[SP]Eikichi[SP]to[SP]react[SP]so[SP]violently\nto[SP]fish.[SP]It's[SP]like[SP]a[SP]conditioned[SP]response...\nOr[SP]is[SP]it[SP]more[SP]like[SP]animal[SP]imprinting?",
     "nom_fr": "Maya",
-    "texte_fr": "Je ne pensais\npas qu'Eikichi réagirait autant\nau poisson. On dirait un réflexe\nconditionné... Ou\nplutôt une empreinteanimale?"
+    "texte_fr": "Je ne pensais\npas qu'Eikichi réagirait autant\nau poisson. On dirait un réflexe conditionné... Ou plutôt une empreinteanimale?"
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Maya",
     "texte_orig": "...[1205][001E]Hm?[SP]Oh,[SP]it's[SP]nothing...[1205][001E][SP]I'm[SP]okay...",
     "nom_fr": "Maya",
-    "texte_fr": "...[1205][001E] Hm? Oh, rien...[1205][001E] Je vais bien..."
+    "texte_fr": "...[001E][1205] Hm? Oh, rien...[001E][1205] Je vais bien..."
   },
   {
     "id": 39,
@@ -642,7 +642,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Masquerade...[1205][000F][SP]A[SP]masked[SP]dance[SP]party...[1205][000F][SP]Could\nthis[SP]masquerade[SP]be[SP]that[SP][1432][NULL][NULL][0014]initiation[1432][NULL][NULL][0014]...?",
     "nom_fr": "Maya",
-    "texte_fr": "Mascarade.[1205][000F][1205][000F].. Un bal masqué... Ce bal\npourrait-il être cette [1432][NULL][NULL][0014]initiation[1432][NULL][NULL][0014]...?"
+    "texte_fr": "Mascarade.[000F][1205][000F][1205].. Un bal masqué... Ce bal\npourrait-il être cette [1432][NULL][NULL][0014]initiation[1432][NULL][NULL][0014]...?"
   },
   {
     "id": 43,
@@ -657,7 +657,7 @@
     "nom_orig": "Maya",
     "texte_orig": "You're[SP]right,[SP]Lisa...[1205][000F][SP]Ahaha...[1205][000F][SP]That[SP]was[SP]kind\nof[SP]embarrassing...",
     "nom_fr": "Maya",
-    "texte_fr": "Tu as raison, Lisa.[1205][000F][1205][000F].. Ahaha...\nC'était un peu gênant..."
+    "texte_fr": "Tu as raison, Lisa.[000F][1205][000F][1205].. Ahaha...\nC'était un peu gênant..."
   },
   {
     "id": 44,
@@ -702,7 +702,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]wonder[SP]what's[SP]upsetting[SP]Lisa.[1205][000F][SP]She's[SP]been\nacting[SP]like[SP]that[SP]ever[SP]since[SP]we[SP]ran[SP]into[SP]those\ntwo[SP]at[SP]Mu.",
     "nom_fr": "Maya",
-    "texte_fr": "Je me demande ce qui contrarie\n[1205][000F]Lisa. Elle agit comme ça depuis\nqu'on a croisé ces deux-là au Mu."
+    "texte_fr": "Je me demande ce qui contrarie\n[000F][1205]Lisa. Elle agit comme ça depuis\nqu'on a croisé ces deux-là au Mu."
   },
   {
     "id": 47,
@@ -717,7 +717,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmmm,[SP]Eikichi-kun's[SP]right.[1205][000F][SP]Why[SP]would[SP]they\norganize[SP]this[SP]whole[SP]song[SP]and[SP]dance?[1205][000F][SP]If[SP]we\ncan[SP]figure[SP]that[SP]out,[SP]then...",
     "nom_fr": "Maya",
-    "texte_fr": "Hmmm, Eikichi a raison. [1205][000F][1205][000F]Pourquoi\norganiseraient-ils tout ce cirque? Si\non arrive à le découvrir, alors..."
+    "texte_fr": "Hmmm, Eikichi a raison. [000F][1205][000F][1205]Pourquoi\norganiseraient-ils tout ce cirque? Si\non arrive à le découvrir, alors..."
   },
   {
     "id": 48,
@@ -732,7 +732,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Sakanoue[SP]Building[SP]or[SP]Smile[SP]Hirasaka,[SP]huh...?[1205][000F]\nThey're[SP]both[SP]in[SP]the[SP]direction[SP]Elly-san[SP]gave\nus.[SP]Guess[SP]we'll[SP]have[SP]to[SP]go[SP]check[SP]them[SP]out...",
     "nom_fr": "Maya",
-    "texte_fr": "Sakanoue Building ou Smile Hirasaka.[1205][000F]..?\nC'est la direction qu'Elly a indiquée.\nOn devrait aller y jeter un œil..."
+    "texte_fr": "Sakanoue Building ou Smile Hirasaka.[000F][1205]..?\nC'est la direction qu'Elly a indiquée.\nOn devrait aller y jeter un œil..."
   },
   {
     "id": 49,
@@ -747,7 +747,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Thanks[SP]to[SP]Elly-san,[SP]we[SP]know[SP]the[SP]next[SP]target\nis[SP]in[SP]Yumezaki.[1205][000F][SP]Question[SP]is,[SP]which[SP]building...",
     "nom_fr": "Maya",
-    "texte_fr": "Grâce à Elly, on sait que la cible est à\nYumezaki. [1205][000F]La question est: quel bâtiment..."
+    "texte_fr": "Grâce à Elly, on sait que la cible est à\nYumezaki. [000F][1205]La question est: quel bâtiment..."
   },
   {
     "id": 50,
@@ -762,7 +762,7 @@
     "nom_orig": "Maya",
     "texte_orig": "People[SP]can[SP]guess[SP]what[SP]they[SP]want,[SP]but[SP]King[SP]Leo\nis[SP]still[SP]the[SP]real[SP]culprit.[1205][000F][SP]If[SP]we[SP]defeat[SP]him,\nthe[SP]rumors[SP]should[SP]go[SP]away.",
     "nom_fr": "Maya",
-    "texte_fr": "Qu'on devine ce qu'on veut, le Roi\nLion est le vrai coupable. [1205][000F]Si on\nle bat, les rumeurs disparaîtront."
+    "texte_fr": "Qu'on devine ce qu'on veut, le Roi\nLion est le vrai coupable. [000F][1205]Si on\nle bat, les rumeurs disparaîtront."
   },
   {
     "id": 51,
@@ -777,7 +777,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Yeah...[SP]Yukki's[SP]right.[SP]We[SP]have[SP]something[SP]to\ntake[SP]care[SP]of[SP]before[SP]we[SP]can[SP]drown[SP]ourselves[SP]in\nregret.[1205][000F][SP]We[SP]need[SP]to[SP]stop[SP]the[SP]next[SP]bombing.",
     "nom_fr": "Maya",
-    "texte_fr": "Yukki a raison. Nous avons autre chose à\nfaire avant de nous noyer dans les regrets.\n[1205][000F]On doit arrêter le prochain attentat."
+    "texte_fr": "Yukki a raison. Nous avons autre chose à\nfaire avant de nous noyer dans les regrets.\n[000F][1205]On doit arrêter le prochain attentat."
   },
   {
     "id": 52,
@@ -792,7 +792,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Poor[SP]thing.[1205][000F][SP]I[SP]know.[SP]You're[SP]desperate[SP]to[SP]again\nbury[SP]the[SP]memories[SP]of[SP]the[SP]past[SP]that[SP]threaten\nto[SP]claw[SP]to[SP]the[SP]surface...",
     "nom_fr": "Maya",
-    "texte_fr": "Pauvre chou. [1205][000F]Je sais. Tu veux à tout\nprix enfouir ces vieux souvenirs qui\nmenacent de refaire surface..."
+    "texte_fr": "Pauvre chou. [000F][1205]Je sais. Tu veux à tout\nprix enfouir ces vieux souvenirs qui\nmenacent de refaire surface..."
   },
   {
     "id": 53,
@@ -807,7 +807,7 @@
     "nom_orig": "Maya",
     "texte_orig": "That's[SP]why[SP]you're[SP]anxious.[1205][000F][SP]But[SP]once[SP]those\nmemories[SP]are[SP]freed,[SP]you'll[SP]be[SP]released[SP]from\nyour[SP]suffering.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est pour ça que tu as peur. [1205][000F]Mais\nune fois ces souvenirs libérés, tu\nseras délivré de ta peine."
+    "texte_fr": "C'est pour ça que tu as peur. [000F][1205]Mais\nune fois ces souvenirs libérés, tu\nseras délivré de ta peine."
   },
   {
     "id": 54,
@@ -822,7 +822,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Now,[SP]let's[SP]go[SP]remember[SP]everything.[1205][000F][SP]Heh...",
     "nom_fr": "Maya",
-    "texte_fr": "Allons tout nous remémorer. [1205][000F]Héhé..."
+    "texte_fr": "Allons tout nous remémorer. [000F][1205]Héhé..."
   },
   {
     "id": 55,
@@ -837,7 +837,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Where[SP]in[SP]Mt.[SP]Katatsumuri[SP]would[SP]Fujii-san[SP]be...?\nI[SP]wonder[SP]if[SP]Yukki[SP]has[SP]any[SP]suggestions.",
     "nom_fr": "Maya",
-    "texte_fr": "Où Fujii pourrait-il être au Mont\nKatatsumuri...? Je me demande\nsi Yukki a une\nidée."
+    "texte_fr": "Où Fujii pourrait-il être au Mont\nKatatsumuri...? Je me demande\nsi Yukki a une idée."
   },
   {
     "id": 56,
@@ -867,7 +867,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "So[SP]where[SP]does[SP]he[SP]change[SP]and[SP]put[SP]on[SP]his[SP]makeup?[1205][001E]\n...He[SP]doesn't[SP]use[SP]the[SP]bathroom[SP]at[SP]the[SP]station,\ndoes[SP]he?",
     "nom_fr": "Yukino",
-    "texte_fr": "Alors où se change-t-il et se\nmaquille-t-il?[1205][001E]... Il n'utilise\npas les toilettes de la gare, si?"
+    "texte_fr": "Alors où se change-t-il et se\nmaquille-t-il?[001E][1205]... Il n'utilise\npas les toilettes de la gare, si?"
   },
   {
     "id": 58,
@@ -882,7 +882,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Toro[SP]recommended[SP]me[SP]some[SP]shoes[SP]that[SP]help[SP]you\nget[SP]slim[SP]just[SP]by[SP]wearing[SP]them.[1205][000F][SP]But[SP]I[SP]don't\nknow[SP]if[SP]I[SP]trust[SP]him[SP]for[SP]weight[SP]loss[SP]tips...",
     "nom_fr": "Yukino",
-    "texte_fr": "Toro m'a recommandé des chaussures pour\nmaigrir juste en les\nportant. [1205][000F]Mais puis-je lui\nfaire confiance pour ce genre de choses..."
+    "texte_fr": "Toro m'a recommandé des chaussures pour\nmaigrir juste en les\nportant. [000F][1205]Mais puis-je lui faire confiance pour ce genre de choses..."
   },
   {
     "id": 59,
@@ -897,7 +897,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Eikichi's[SP]dad[SP]asked[SP]me[SP]where[SP]he[SP]went[SP]just[SP]now.\nI[SP]had[SP]to[SP]scramble[SP]to[SP]make[SP]up[SP]a[SP]story...[1205][000F][SP]Wait,\nwhy[SP]did[SP]I[SP]go[SP]through[SP]the[SP]trouble?",
     "nom_fr": "Yukino",
-    "texte_fr": "Le père d'Eikichi m'a demandé où il était.\nJ'ai dû inventer une histoire... [1205][000F]Attends,\npourquoi je me suis donné ce mal?"
+    "texte_fr": "Le père d'Eikichi m'a demandé où il était.\nJ'ai dû inventer une histoire... [000F][1205]Attends,\npourquoi je me suis donné ce mal?"
   },
   {
     "id": 60,
@@ -912,7 +912,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Masks,[SP]masks,[SP]masks...[1205][000F][SP]They[SP]keep[SP]showing[SP]up\neverywhere[SP]we[SP]go.[SP]It's[SP]hard[SP]to[SP]believe[SP]this\nis[SP]all[SP]a[SP]coincidence.",
     "nom_fr": "Yukino",
-    "texte_fr": "Masques, masques, masques.[1205][000F].. On en\nvoit partout où on va. Difficile de\ncroire que c'est une coïncidence."
+    "texte_fr": "Masques, masques, masques.[000F][1205].. On en\nvoit partout où on va. Difficile de\ncroire que c'est une coïncidence."
   },
   {
     "id": 61,
@@ -942,7 +942,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "It's[SP]bizarre[SP]that[SP]we've[SP]asked[SP]around[SP]this[SP]much\nwith[SP]nothing[SP]to[SP]show[SP]for[SP]it.[1205][000F][SP]Do[SP]you[SP]think\npeople[SP]really[SP]know[SP]and[SP]are[SP]hiding[SP]it?",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est bizarre d'avoir autant demandé\nautour de nous sans rien trouver. [1205][000F]Tu crois\nque les gens savent et nous le cachent?"
+    "texte_fr": "C'est bizarre d'avoir autant demandé\nautour de nous sans rien trouver. [000F][1205]Tu crois\nque les gens savent et nous le cachent?"
   },
   {
     "id": 63,
@@ -1092,7 +1092,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]think[SP]Fujii-san[SP]will[SP]be[SP]at[SP]Goketsuji[SP]in[SP]the\nheart[SP]of[SP]the[SP]mountain.[1205][000F][SP]He's[SP]good[SP]friends[SP]with\nthe[SP]head[SP]monk[SP]there.",
     "nom_fr": "Yukino",
-    "texte_fr": "Je pense que Fujii sera à Goketsuji,\nau cœur de la montagne. [1205][000F]Il est très\nami avec le moine supérieur là-bas."
+    "texte_fr": "Je pense que Fujii sera à Goketsuji,\nau cœur de la montagne. [000F][1205]Il est très\nami avec le moine supérieur là-bas."
   },
   {
     "id": 73,
@@ -1213,7 +1213,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "WELCOME![1205][000F][SP]How[SP]about[SP]that?[SP]Sounded[SP]great,\ndidn't[SP]it?[SP]You[SP]gotta[SP]greet[SP]your[SP]customers\nwith[SP]your[SP]whole[SP]heart[SP]and[SP]soul[SP]like[SP]that.\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "BIENVENUE! [1205][000F]Alors, pas mal, hein?\nFaut accueillir les clients avec tout\nson cœur, comme ça.\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "BIENVENUE! [000F][1205]Alors, pas mal, hein?\nFaut accueillir les clients avec tout\nson cœur, comme ça.\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "WELCOME![1205][000F][SP]How[SP]about[SP]that?[SP]Sounded[SP]great,\ndidn't[SP]it?[SP]You[SP]gotta[SP]greet[SP]your[SP]customers\nwith[SP]your[SP]whole[SP]heart[SP]and[SP]soul[SP]like[SP]that.",
     "choix_orig": [
       "Dine[SP]in",
@@ -1266,7 +1266,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Ah![SP]Welcome,[SP]welcome![1205][000F][SP]What's[SP]this?[SP]You're\nlooking[SP]more[SP]gallant[SP]by[SP]the[SP]day![1205][000F][SP]My[SP]fool\nof[SP]a[SP]son[SP]still[SP]looks[SP]the[SP]same,[SP]though.\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Ah! [1205][000F][1205][000F]Bienvenue, bienvenue! Eh bien?\nT'es plus fringant de jour en jour!\nMon idiot de fils, lui, change pas.\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Ah! [000F][1205][000F][1205]Bienvenue, bienvenue! Eh bien?\nT'es plus fringant de jour en jour!\nMon idiot de fils, lui, change pas.\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Ah![SP]Welcome,[SP]welcome![1205][000F][SP]What's[SP]this?[SP]You're\nlooking[SP]more[SP]gallant[SP]by[SP]the[SP]day![1205][000F][SP]My[SP]fool\nof[SP]a[SP]son[SP]still[SP]looks[SP]the[SP]same,[SP]though.",
     "choix_orig": [
       "Dine[SP]in",
@@ -1319,7 +1319,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Welcome,[SP]welcome![1205][000F][SP]You[SP]kids[SP]came[SP]at[SP]a[SP]great\ntime.[SP]I[SP]just[SP]prepared[SP]a[SP]fresh[SP]catch.\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Bienvenue, bienvenue! [1205][000F]Vous tombez\nbien, les jeunes. La pêche est toute\nfraîche.\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Bienvenue, bienvenue! [000F][1205]Vous tombez\nbien, les jeunes. La pêche est toute\nfraîche.\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Welcome,[SP]welcome![1205][000F][SP]You[SP]kids[SP]came[SP]at[SP]a[SP]great\ntime.[SP]I[SP]just[SP]prepared[SP]a[SP]fresh[SP]catch.",
     "choix_orig": [
       "Dine[SP]in",
@@ -1425,7 +1425,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Welcome,[SP]welcome![1205][000F][SP]We'll[SP]be[SP]open[SP]come[SP]what\nmay![SP]If[SP]we[SP]wasted[SP]time[SP]worrying[SP]about[SP]the\nworld[SP]outside,[SP]our[SP]fish[SP]would[SP]rot!\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Bienvenue, bienvenue! [1205][000F]On reste ouverts\nquoi qu'il arrive! À s'inquiéter du monde\nextérieur, le poisson pourrirait!\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Bienvenue, bienvenue! [000F][1205]On reste ouverts\nquoi qu'il arrive! À s'inquiéter du monde\nextérieur, le poisson pourrirait!\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Welcome,[SP]welcome![1205][000F][SP]We'll[SP]be[SP]open[SP]come[SP]what\nmay![SP]If[SP]we[SP]wasted[SP]time[SP]worrying[SP]about[SP]the\nworld[SP]outside,[SP]our[SP]fish[SP]would[SP]rot!",
     "choix_orig": [
       "Dine[SP]in",
@@ -1478,7 +1478,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Yo![SP]Welcome![1205][000F][SP]You're[SP]pretty[SP]brave,[SP]going[SP]out\nat[SP]a[SP]time[SP]like[SP]this.[SP]Well,[SP]youth[SP]should[SP]be\na[SP]little[SP]reckless,[SP]I[SP]say!\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Yo! [1205][000F]Bienvenue! Z'êtes courageux de\nsortir par ces temps. Mais la jeunesse\nse doit d'être téméraire!\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Yo! [000F][1205]Bienvenue! Z'êtes courageux de\nsortir par ces temps. Mais la jeunesse\nse doit d'être téméraire!\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Yo![SP]Welcome![1205][000F][SP]You're[SP]pretty[SP]brave,[SP]going[SP]out\nat[SP]a[SP]time[SP]like[SP]this.[SP]Well,[SP]youth[SP]should[SP]be\na[SP]little[SP]reckless,[SP]I[SP]say!",
     "choix_orig": [
       "Dine[SP]in",
@@ -1531,7 +1531,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Welcome,[SP]wel...come...[1205][000F][SP]H-Hey,[SP]what's[SP]wrong?\nWhy[SP]the[SP]long[SP]faces?\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Bienv... venue.[1205][000F].. Ça va pas?\nPourquoi cette tête?\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Bienv... venue.[000F][1205].. Ça va pas?\nPourquoi cette tête?\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Welcome,[SP]wel...come...[1205][000F][SP]H-Hey,[SP]what's[SP]wrong?\nWhy[SP]the[SP]long[SP]faces?",
     "choix_orig": [
       "Dine[SP]in",
@@ -1584,7 +1584,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Welcome,[SP]welcome?[SP]Oh,[SP]just[SP]you[SP]two[SP]today?[1205][000F]\nLooks[SP]like[SP]someone's[SP]making[SP]his[SP]move!\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Bienvenue! Juste vous deux?\n[1205][000F]Quelqu'un passe à l'action!\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Bienvenue! Juste vous deux?\n[000F][1205]Quelqu'un passe à l'action!\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Welcome,[SP]welcome?[SP]Oh,[SP]just[SP]you[SP]two[SP]today?[1205][000F]\nLooks[SP]like[SP]someone's[SP]making[SP]his[SP]move!",
     "choix_orig": [
       "Dine[SP]in",
@@ -1743,7 +1743,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Today[SP]I[SP]recommend...[1205][000F][SP]Well,[SP]everything![1205][000A]\nIt's[SP]all[SP]fresh![SP]Now,[SP]what'll[SP]you[SP]have?\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Je recommande.[1205].[000F]. Tout![1205][000A]\nC'est très frais! Que prendrez-vous?\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Je recommande.[1205].[000F]. Tout![000A][1205]\nC'est très frais! Que prendrez-vous?\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Today[SP]I[SP]recommend...[1205][000F][SP]Well,[SP]everything![1205][000A]\nIt's[SP]all[SP]fresh![SP]Now,[SP]what'll[SP]you[SP]have?",
     "choix_orig": [
       "Dine[SP]in",
@@ -1811,7 +1811,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Seriously,[SP]that[SP]fool's[SP]always[SP]loafing[SP]around\nhere.[1205][001E][SP]I'm[SP]worried[SP]he[SP]might[SP]not[SP]be[SP]able[SP]to\ntake[SP]over[SP]for[SP]me[SP]someday.",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Sérieux, cet idiot traîne toujours\nici.[1205][001E] J'ai peur qu'il ne puisse pas\nreprendre l'affaire un jour."
+    "texte_fr": "Sérieux, cet idiot traîne toujours\nici.[001E][1205] J'ai peur qu'il ne puisse pas\nreprendre l'affaire un jour."
   },
   {
     "id": 101,
@@ -1856,7 +1856,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Hm?[SP]Where's[SP]my[SP]good-for-nothing[SP]boy?[1205][000F][SP]He's[SP]not\nwith[SP]you[SP]today?",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Hm? Où est mon fils? [1205][000F]Pas avec vous?"
+    "texte_fr": "Hm? Où est mon fils? [000F][1205]Pas avec vous?"
   },
   {
     "id": 104,
@@ -1871,7 +1871,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Kasugayama's[SP]school[SP]festival[SP]looks[SP]like[SP]a[SP]real\nblast[SP]this[SP]year.[SP]That[SP]student[SP]council[SP]president\nof[SP]theirs[SP]is[SP]something[SP]else,[SP]right,[SP]Eikichi!?",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Le festival du Lycée\nKasu a l'air génial cette\nannée. Leur président du\nBDE est vraiment pas\ncomme les autres, pas vrai Eikichi!?"
+    "texte_fr": "Le festival du Lycée\nKasu a l'air génial cette\nannée. Leur président du BDE est vraiment pas comme les autres, pas vrai Eikichi!?"
   },
   {
     "id": 105,
@@ -1901,7 +1901,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "What[SP]was[SP]it...[SP]Muses,[SP]right?[1205][000F][SP]I[SP]dunno,[SP]sounds\nlike[SP]some[SP]detergent[SP]to[SP]me.",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "C'était quoi... Muses? [1205][000F]Je ne sais\npas, on dirait un nom de lessive."
+    "texte_fr": "C'était quoi... Muses? [000F][1205]Je ne sais\npas, on dirait un nom de lessive."
   },
   {
     "id": 107,
@@ -1916,7 +1916,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Seems[SP]the[SP]detergent[SP]trio's[SP]gonna[SP]be[SP]playing\na[SP]concert[SP]already.[1205][000F][SP]Pretty[SP]impressive[SP]for\ngirls[SP]so[SP]young,[SP]wouldn't[SP]you[SP]say,[SP]Eikichi!?",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Paraît que le trio lessive va déjà donner\nun concert. [1205][000F]Impressionnant pour de si\njeunes filles, t'en dis quoi Eikichi!?"
+    "texte_fr": "Paraît que le trio lessive va déjà donner\nun concert. [000F][1205]Impressionnant pour de si\njeunes filles, t'en dis quoi Eikichi!?"
   },
   {
     "id": 108,
@@ -1931,7 +1931,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Sheesh,[SP]what's[SP]gotten[SP]into[SP]that[SP]CEO[SP]over[SP]there?[1205][000F]\nHe's[SP]been[SP]acting[SP]that[SP]way[SP]since[SP]the[SP]terror[SP]wave\nstarted[SP]up.[SP]Has[SP]he[SP]gone[SP]crazy[SP]with[SP]fear?",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Bordel, qu'est-ce qui prend à ce P.-D. [1205][000F]G.\nlà-bas? Il agit comme ça depuis la vague\nde terrorisme. La peur l'a rendu fou?"
+    "texte_fr": "Bordel, qu'est-ce qui prend à ce P.-D. [000F][1205]G.\nlà-bas? Il agit comme ça depuis la vague\nde terrorisme. La peur l'a rendu fou?"
   },
   {
     "id": 109,
@@ -1961,7 +1961,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Now[SP]that's[SP]an[SP]impressive[SP]bunch![SP]A[SP]real[SP]man\nwould[SP]step[SP]up[SP]to[SP]the[SP]plate[SP]like[SP]that...[1205][000F]\nRight,[SP]Eikichi!?",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Ça c'est un groupe impressionnant! Un vrai\nhomme agirait comme\nça... [1205][000F]Pas vrai, Eikichi!?"
+    "texte_fr": "Ça c'est un groupe impressionnant! Un vrai\nhomme agirait comme\nça... [000F][1205]Pas vrai, Eikichi!?"
   },
   {
     "id": 111,
@@ -1991,7 +1991,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Why's[SP]Eikichi[SP]look[SP]like[SP]he's[SP]gonna[SP]cry?[1205][000F]\nIs[SP]this[SP]about[SP]what[SP]happened[SP]about[SP]Smile\nHirasaka?[1205][000F][SP]Yeah...[SP]that[SP]was[SP]bad,[SP]all[SP]right...",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Pourquoi Eikichi va pleurer? [1205][000F][1205][000F]C'est à\ncause de ce qui s'est passé à Smile\nHirasaka? Ouais... c'était moche..."
+    "texte_fr": "Pourquoi Eikichi va pleurer? [000F][1205][000F][1205]C'est à\ncause de ce qui s'est passé à Smile\nHirasaka? Ouais... c'était moche..."
   },
   {
     "id": 113,
@@ -2066,7 +2066,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "What's[SP]wrong[SP]with[SP]Eikichi[SP]and[SP]that[SP]girl?[1205][000F]\nThey[SP]look[SP]half[SP]dead.[1205][000F][SP]Did[SP]something[SP]happen?",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Qu'ont Eikichi et la fille? [1205][000F][1205][000F]Ils ont\nl'air morts. Il s'est passé un truc?"
+    "texte_fr": "Qu'ont Eikichi et la fille? [000F][1205][000F][1205]Ils ont\nl'air morts. Il s'est passé un truc?"
   },
   {
     "id": 118,
@@ -2126,7 +2126,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "I'll[SP]have[SP]you[SP]know[SP]I'm[SP]an[SP]extremely[SP]skilled\nsalesman.[SP]A[SP]man[SP]in[SP]my[SP]line[SP]of[SP]work[SP]hears[SP]a[SP]lot\nof[SP]rumors.[SP]Some[SP]people[SP]call[SP]me[SP]a[SP]rumormonger.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Sache que je suis un vendeur extrêmement\ndoué. Dans mon métier,\non entend beaucoup de\nrumeurs. Certains\nm'appellent l'informateur."
+    "texte_fr": "Sache que je suis un vendeur extrêmement\ndoué. Dans mon métier,\non entend beaucoup de rumeurs. Certains m'appellent l'informateur."
   },
   {
     "id": 122,
@@ -2307,7 +2307,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Whoa...[1205][001E][SP]The[SP]principal[SP]at[SP]Sevens[SP]suddenly[SP]grew\nsome[SP]hair?[SP]I[SP]wonder[SP]if[SP]that[SP]was[SP]his[SP]request\nfor[SP]Joker.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Ouah...[1205][001E] Le proviseur de Seven a soudain des\ncheveux? C'était peut-être sa requête au\nJoker."
+    "texte_fr": "Ouah...[001E][1205] Le proviseur de Seven a soudain des\ncheveux? C'était peut-être sa requête au\nJoker."
   },
   {
     "id": 130,
@@ -2352,7 +2352,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Rumor[SP]is[SP]you[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002][SP]at[SP][E4][NULL][NULL][0006]Tony's\nShop[E4][NULL][NULL][0002][SP]in[SP]Yumezaki.[SP]They're[SP][E4][NULL][NULL][0006]cheap,[SP]but[SP]low\nquality[E4][NULL][NULL][0002].[1205][000F][SP]Well?[SP]Worth[SP]your[SP]while,[SP]huh?",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "On achèterait de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002] à\nla [E4][NULL][NULL][0006]Boutique de Tony[E4][NULL][NULL][0002]. [E4][NULL][NULL][0006]Peu chères\n[1205][000F]et de basse qualité[E4][NULL][NULL][0002]. Utile, non?"
+    "texte_fr": "On achèterait de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002] à\nla [E4][NULL][NULL][0006]Boutique de Tony[E4][NULL][NULL][0002]. [E4][NULL][NULL][0006]Peu chères\n[000F][1205]et de basse qualité[E4][NULL][NULL][0002]. Utile, non?"
   },
   {
     "id": 133,
@@ -2367,7 +2367,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh?[SP]Cuss[SP]High's[SP]Undie[SP]Boss[SP]isn't[SP]the[SP]Boss\nanymore?[SP]Huh...[SP]I[SP]guess[SP]that's[SP]big[SP]news[SP]for\nhis[SP]schoolmates.[SP]Okay,[SP]here's[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Quoi? Le Boss Caleçon du Lycée Kasu n'est\nplus le Boss? Ah...\nC'est une grosse nouvelle\npour eux. Bon, voici ce que je sais."
+    "texte_fr": "Quoi? Le Boss Caleçon du Lycée Kasu n'est\nplus le Boss? Ah...\nC'est une grosse nouvelle pour eux. Bon, voici ce que je sais."
   },
   {
     "id": 134,
@@ -2412,7 +2412,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "You[SP]know[SP]the[SP][E4][NULL][NULL][0006]Jolly[SP]Roger[E4][NULL][NULL][0002][SP]cafe[SP]in[SP]Kounan?[1205][000F]\nThey[SP]supposedly[SP]sell[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002].[1205][000F][SP]Their\nselection[SP]is[SP][E4][NULL][NULL][0006]cheap[SP]and[SP]low[SP]quality[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Connais-tu le [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à Kounan?\n[1205][000F][1205][000F]Ils vendent de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. C'est\n[E4][NULL][NULL][0006]pas cher et de basse qualité[E4][NULL][NULL][0002]."
+    "texte_fr": "Connais-tu le [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à Kounan?\n[000F][1205][000F][1205]Ils vendent de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. C'est\n[E4][NULL][NULL][0006]pas cher et de basse qualité[E4][NULL][NULL][0002]."
   },
   {
     "id": 137,
@@ -2427,7 +2427,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh...[1205][001E][SP]Something[SP]terrible[SP]will[SP]happen[SP]if[SP]the\nclock[SP]at[SP]Sevens[SP]starts[SP]again?[SP]That's[SP]pretty\nout-there.[SP]Well,[SP]here's[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hein...[1205][001E] Un truc terrible arrive si\nl'horloge de Seven redémarre? C'est tiré\npar les cheveux. Voici ce que je sais."
+    "texte_fr": "Hein...[001E][1205] Un truc terrible arrive si\nl'horloge de Seven redémarre? C'est tiré\npar les cheveux. Voici ce que je sais."
   },
   {
     "id": 138,
@@ -2457,7 +2457,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh?[SP]Zodiac[SP]has[SP]a[SP]secret[SP]lounge?[SP]Now[SP]that[SP]you\nmention[SP]it,[SP]I[SP]think[SP]I[SP]heard[SP]something[SP]like\nthat...[SP]So[SP]it[SP]really[SP]exists.[SP]Okay,[SP]my[SP]turn.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hein? Zodiac a un salon secret? En y\npensant, je crois\nen avoir entendu parler...\nÇa existe vraiment. Bon, à mon tour."
+    "texte_fr": "Hein? Zodiac a un salon secret? En y\npensant, je crois\nen avoir entendu parler... Ça existe vraiment. Bon, à mon tour."
   },
   {
     "id": 140,
@@ -2472,7 +2472,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "There's[SP]a[SP]rumor[SP]you[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002][SP]at\n[E4][NULL][NULL][0006]Anima[SP]Mundi[E4][NULL][NULL][0002][SP]in[SP]Yumezaki.[1205][000F][SP]Their[SP]stuff[SP]is\n[E4][NULL][NULL][0006]cheap[SP]and[SP]subpar[SP]quality[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "On trouverait de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]\nchez [E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002] à Yumezaki. [1205][000F]C'est\n[E4][NULL][NULL][0006]pas cher et de basse qualité[E4][NULL][NULL][0002]."
+    "texte_fr": "On trouverait de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]\nchez [E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002] à Yumezaki. [000F][1205]C'est\n[E4][NULL][NULL][0006]pas cher et de basse qualité[E4][NULL][NULL][0002]."
   },
   {
     "id": 141,
@@ -2532,7 +2532,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "There's[SP]a[SP]shop[SP]called[SP][E4][NULL][NULL][0006]London[SP]Clothier[E4][NULL][NULL][0002][SP]in[SP]Kounan\nthat[SP]even[SP]tailors[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]The[SP][E4][NULL][NULL][0006]quality[SP]is\nsubpar,[SP]but[SP]they're[SP]cheap[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Le magasin appelé [E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] à\nKounan fabrique de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [1205][000F]La\n[E4][NULL][NULL][0006]qualité est basse, mais c'est pas cher[E4][NULL][NULL][0002]."
+    "texte_fr": "Le magasin appelé [E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] à\nKounan fabrique de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [000F][1205]La\n[E4][NULL][NULL][0006]qualité est basse, mais c'est pas cher[E4][NULL][NULL][0002]."
   },
   {
     "id": 145,
@@ -2547,7 +2547,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Wow,[SP]that[SP]statue[SP]of[SP]the[SP]principal[SP]at[SP]Sevens\nwalks[SP]on[SP]its[SP]own?[SP]It's[SP]like[SP]the[SP]school's[SP]own\nurban[SP]legend.[SP]Well,[SP]here's[SP]a[SP]rumor[SP]in[SP]return.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Wouah, la statue du\nproviseur à Seven marche\ntoute seule? C'est la légende urbaine de\nl'école. Bon, voici une rumeur en retour."
+    "texte_fr": "Wouah, la statue du\nproviseur à Seven marche\ntoute seule? C'est la légende urbaine de l'école. Bon, voici une rumeur en retour."
   },
   {
     "id": 146,
@@ -2607,7 +2607,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Do[SP]you[SP]know[SP]the[SP]arcade[SP][E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]?[1205][000F][SP]I[SP]hear[SP]that[SP]place\nis[SP]really[SP]a[SP][E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002],[SP]and[SP]people[SP]can[SP]make[SP]a[SP][E4][NULL][NULL][0006]ton\nof[SP]money[SP]on[SP]the[SP]slots[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Tu connais l'arcade [E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]? [1205][000F]On dit que\nc'est un vrai [E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002], où on peut se\nfaire un [E4][NULL][NULL][0006]max de fric aux machines[E4][NULL][NULL][0002]."
+    "texte_fr": "Tu connais l'arcade [E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]? [000F][1205]On dit que\nc'est un vrai [E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002], où on peut se\nfaire un [E4][NULL][NULL][0006]max de fric aux machines[E4][NULL][NULL][0002]."
   },
   {
     "id": 150,
@@ -2622,7 +2622,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "This[SP]place[SP]is[SP]as[SP]good[SP]as[SP]I'd[SP]hoped[SP]for[SP]gathering\ninformation.[SP]I[SP]can[SP]listen[SP]to[SP]people[SP]talk[SP]and[SP]eat\ngreat[SP]sushi.[1205][000F][SP]Ahh...[SP]This[SP]is[SP]the[SP]life.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Cet endroit est parfait\npour avoir des infos.\nJe peux écouter les\ngens parler et manger de\nbons sushis. [1205][000F]Ahh... C'est la belle vie."
+    "texte_fr": "Cet endroit est parfait\npour avoir des infos.\nJe peux écouter les gens parler et manger de bons sushis. [000F][1205]Ahh... C'est la belle vie."
   },
   {
     "id": 151,
@@ -2637,7 +2637,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh?[SP]Masked[SP]Circle?[SP]I've[SP]never[SP]heard[SP]of[SP]it.[1205][000F]\nIs[SP]that[SP]some[SP]kind[SP]of[SP]organization?[SP]And[SP]these\npeople[SP]are[SP]here,[SP]in[SP]this[SP]city?",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Le Cercle masqué? Jamais entendu\n[1205][000F]parler. C'est une organisation? Et\nces gens sont ici, dans cette ville?"
+    "texte_fr": "Le Cercle masqué? Jamais entendu\n[000F][1205]parler. C'est une organisation? Et\nces gens sont ici, dans cette ville?"
   },
   {
     "id": 152,
@@ -2652,7 +2652,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "That's[SP]big.[SP]I[SP]should[SP]look[SP]into[SP]it[SP]immediately.[1205][000F]\nHmm,[SP]maybe[SP]the[SP]girl[SP]at[SP]Peace[SP]Diner[SP]might[SP]know\nmore.[SP]Have[SP]you[SP]tried[SP]asking[SP]her[SP]about[SP]them?",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "C'est énorme. Je\ndevrais enquêter vite. [1205][000F]Hmm,\nla fille au Peace Diner en sait peut-être\nplus. Vous avez essayé de lui demander?"
+    "texte_fr": "C'est énorme. Je\ndevrais enquêter vite. [000F][1205]Hmm,\nla fille au Peace Diner en sait peut-être plus. Vous avez essayé de lui demander?"
   },
   {
     "id": 153,
@@ -2667,7 +2667,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Heehee,[SP]I'm[SP]on[SP]fire.[SP]I've[SP]got[SP]a[SP]whole[SP]stack[SP]of\nrumors.[1205][000F][SP]How[SP]about[SP]you?[SP]Want[SP]me[SP]to[SP]tell[SP]you[SP]the\nlatest[SP]rumor[SP]in[SP]exchange[SP]for[SP]what[SP]you[SP]know?",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Héhé, je pète le feu.\nJ'ai un tas de rumeurs.\n[1205][000F]Et toi? Tu veux que je te donne la dernière\nrumeur en échange de ce que tu sais?"
+    "texte_fr": "Héhé, je pète le feu.\nJ'ai un tas de rumeurs.\n[000F][1205]Et toi? Tu veux que je te donne la dernière rumeur en échange de ce que tu sais?"
   },
   {
     "id": 154,
@@ -2757,7 +2757,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "That[SP]guy[SP]over[SP]there[SP]had[SP]a[SP]sudden[SP]stroke[SP]of[SP]luck.\nHe[SP]used[SP]to[SP]moan[SP]all[SP]the[SP]time[SP]that[SP]he'd[SP]always\nbe[SP]a[SP]wage[SP]slave[SP]with[SP]ever-spiraling[SP]debts.",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "Ce type là-bas a eu\nun coup de chance soudain.\nIl se plaignait toujours qu'il resterait un\nesclave salarié avec des dettes sans fin."
+    "texte_fr": "Ce type là-bas a eu\nun coup de chance soudain.\nIl se plaignait toujours qu'il resterait un esclave salarié avec des dettes sans fin."
   },
   {
     "id": 160,
@@ -2787,7 +2787,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "The[SP]girls[SP]in[SP]Muses[SP]are[SP]high[SP]school[SP]students?\nShouldn't[SP]they[SP]be[SP]studying...?[1205][000F][SP]Listen[SP]to[SP]me.\nI'm[SP]starting[SP]to[SP]sound[SP]like[SP]an[SP]old[SP]man.",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "Les filles de Muses sont des lycéennes?\nNe devraient-elles pas étudier.[1205][000F]..?\nÉcoutez-moi parler. On dirait un vieux."
+    "texte_fr": "Les filles de Muses sont des lycéennes?\nNe devraient-elles pas étudier.[000F][1205]..?\nÉcoutez-moi parler. On dirait un vieux."
   },
   {
     "id": 162,
@@ -2832,7 +2832,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "That[SP]president's[SP]got[SP]such[SP]a[SP]thick[SP]skull...[1205][000F]\nHe[SP]should[SP]just[SP]trust[SP]what[SP]those[SP]kids[SP]said.\nAdults[SP]are[SP]supposed[SP]to[SP]be[SP]understanding.",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "Ce président est tellement têtu... Il\n[1205][000F]devrait juste faire confiance à ces jeunes.\nLes adultes sont censés être compréhensifs."
+    "texte_fr": "Ce président est tellement têtu... Il\n[000F][1205]devrait juste faire confiance à ces jeunes.\nLes adultes sont censés être compréhensifs."
   },
   {
     "id": 165,
@@ -2847,7 +2847,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "Did[SP]you[SP]read[SP]that[SP]In[SP]Lak'ech[SP]book,[SP]too?[1205][000F]\nWhenever[SP]society's[SP]in[SP]turmoil,[SP]you[SP]see\nscrewed-up[SP]books[SP]like[SP]that[SP]pop[SP]up.",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "As-tu aussi lu In Lak'ech? Quand la\n[1205][000F]société est en crise, des livres tordus\nde ce genre font leur apparition."
+    "texte_fr": "As-tu aussi lu In Lak'ech? Quand la\n[000F][1205]société est en crise, des livres tordus\nde ce genre font leur apparition."
   },
   {
     "id": 166,
@@ -2862,7 +2862,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "Th-That[SP]president[SP]guy[SP]just[SP]up[SP]and[SP]rushed[SP]out\nall[SP]of[SP]a[SP]sudden.[1205][000F][SP]He's[SP]not[SP]gonna[SP]go[SP]pick[SP]a[SP]fight\nwith[SP]those[SP]guys,[SP]is[SP]he?",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "C-Ce président a soudainement filé\nen vitesse. [1205][000F]Il ne va pas aller\nchercher des noises à ces types, si?"
+    "texte_fr": "C-Ce président a soudainement filé\nen vitesse. [000F][1205]Il ne va pas aller\nchercher des noises à ces types, si?"
   },
   {
     "id": 167,
@@ -2877,7 +2877,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "Hwaha![SP]I've[SP]finally[SP]been[SP]promoted[SP]to[SP]president.\nEating[SP]sushi[SP]at[SP]lunch[SP]while[SP]my[SP]underlings[SP]do\nall[SP]the[SP]work[SP]proves[SP]I've[SP]gone[SP]up[SP]the[SP]ladder!",
     "nom_fr": "PDG",
-    "texte_fr": "Mwaha! Je suis\nenfin devenu président. Manger\ndes sushis le midi\npendant que mes sous-fifres\nbossent prouve que\nj'ai grimpé les échelons!"
+    "texte_fr": "Mwaha! Je suis\nenfin devenu président. Manger\ndes sushis le midi pendant que mes sous-fifres bossent prouve que j'ai grimpé les échelons!"
   },
   {
     "id": 168,
@@ -2892,7 +2892,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "Now[SP]that[SP]I'm[SP]president,[SP]I[SP]shouldn't[SP]be[SP]so\nstingy[SP]anymore.[1205][000F][SP]Hey,[SP]chef![SP]Go[SP]easy[SP]on[SP]the\nrice,[SP]okay?[SP]Hahaha!",
     "nom_fr": "PDG",
-    "texte_fr": "Je suis président, je ne dois plus\nêtre radin. [1205][000F]Hé, chef! Vas-y molo\nsur le riz, d'accord? Hahaha!"
+    "texte_fr": "Je suis président, je ne dois plus\nêtre radin. [000F][1205]Hé, chef! Vas-y molo\nsur le riz, d'accord? Hahaha!"
   },
   {
     "id": 169,
@@ -2907,7 +2907,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "I'm[SP]finally[SP]company[SP]president,[SP]so[SP]I[SP]want[SP]to\nsplurge[SP]a[SP]little[SP]and[SP]get[SP]an[SP]entire[SP]fish,[SP]but\nmy[SP]tastes[SP]haven't[SP]changed.[1205][000F][SP]One[SP]albacore,[SP]chef!",
     "nom_fr": "PDG",
-    "texte_fr": "Je suis enfin président,\nje voudrais me faire\nplaisir et prendre un poisson entier, mais\nmes goûts n'ont pas\n[1205][000F]changé. Un germon, chef!"
+    "texte_fr": "Je suis enfin président,\nje voudrais me faire\nplaisir et prendre un poisson entier, mais mes goûts n'ont pas [000F][1205]changé. Un germon, chef!"
   },
   {
     "id": 170,
@@ -2922,7 +2922,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "Hahaha.[1205][000F][SP]I[SP]hear[SP]there's[SP]going[SP]to[SP]be[SP]a[SP]masquerade\nas[SP]part[SP]of[SP]Cuss[SP]High's[SP]school[SP]festival.[1205][000F][SP]Kids\nsure[SP]come[SP]up[SP]with[SP]some[SP]interesting[SP]ideas.",
     "nom_fr": "PDG",
-    "texte_fr": "Hahaha. [1205][000F][1205][000F]J'ai entendu dire qu'il y aura un\nbal masqué au festival du Lycée Kasu. Les\njeunes ont vraiment\ndes idées intéressantes."
+    "texte_fr": "Hahaha. [000F][1205][000F][1205]J'ai entendu dire qu'il y aura un\nbal masqué au festival du Lycée Kasu. Les\njeunes ont vraiment des idées intéressantes."
   },
   {
     "id": 171,
@@ -2937,7 +2937,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "M-M-Masked[SP]Circle?[1205][000F][SP]Where[SP]did[SP]you[SP]hear--[1205][000F]\nUh,[SP]I[SP]mean...[SP]Sorry,[SP]I[SP]don't[SP]know[SP]what[SP]you're\ntalking[SP]about.",
     "nom_fr": "PDG",
-    "texte_fr": "L-Le Cercle masqué? [1205][000F][1205][000F]Où as-tu entendu--\nEuh, je veux dire... Désolé, je ne\nsais pas de quoi tu parles."
+    "texte_fr": "L-Le Cercle masqué? [000F][1205][000F][1205]Où as-tu entendu--\nEuh, je veux dire... Désolé, je ne\nsais pas de quoi tu parles."
   },
   {
     "id": 172,
@@ -2952,7 +2952,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Hahaha![1205][000F][SP]That's[SP]right,[SP]burn![1205][000F][SP]Burn![SP]Joker[SP]gave\nme[SP]my[SP]position[SP]as[SP]company[SP]president,[SP]but[SP]I\nwasn't[SP]satisfied.",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "Hahaha! [1205][000F][1205][000F]C'est ça, brûlez! Brûlez! Le\nJoker m'a donné mon poste de président,\nmais ça ne me suffisait pas."
+    "texte_fr": "Hahaha! [000F][1205][000F][1205]C'est ça, brûlez! Brûlez! Le\nJoker m'a donné mon poste de président,\nmais ça ne me suffisait pas."
   },
   {
     "id": 173,
@@ -2967,7 +2967,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "If[SP]anything,[SP]it[SP]made[SP]me[SP]feel[SP]even[SP]emptier![1205][000F]\nThat's[SP]because[SP]this[SP]society[SP]is[SP]boring!\nThis[SP]world[SP]should[SP]go[SP]up[SP]in[SP]flames!",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "Je me suis senti encore plus vide!\n[1205][000F]Car cette société est ennuyeuse! Ce\nmonde devrait être réduit en cendres!"
+    "texte_fr": "Je me suis senti encore plus vide!\n[000F][1205]Car cette société est ennuyeuse! Ce\nmonde devrait être réduit en cendres!"
   },
   {
     "id": 174,
@@ -3042,7 +3042,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Th-Those[SP]five[SP]are[SP]heroes[SP]fighting[SP]against[SP]the\nMasked[SP]Circle!?[1205][000F][SP]Then[SP]that[SP]makes[SP]them[SP]the[SP]enemy!\nWhy[SP]didn't[SP]anyone[SP]tell[SP]me!?",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "C-Ces cinq sont des héros combattant le\nCercle masqué![1205][000F]? Ça en fait des ennemis!\nPourquoi personne ne me l'a dit!?"
+    "texte_fr": "C-Ces cinq sont des héros combattant le\nCercle masqué![000F][1205]? Ça en fait des ennemis!\nPourquoi personne ne me l'a dit!?"
   },
   {
     "id": 179,
@@ -3057,7 +3057,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "The[SP]In[SP]Lak'ech...[SP]Hahaha,[SP]wonderful![SP]This[SP]dull\nworld[SP]will[SP]end[SP]and[SP]we'll[SP]start[SP]down[SP]a[SP]new[SP]path\nas[SP]transhumans--man's[SP]true[SP]ideal![SP]Hahaha!",
     "nom_fr": "Membre du Cercle",
-    "texte_fr": "In Lak'ech... Haha,\nformidable! Ce monde morne\nva tomber et on\nentamera une nouvelle voie en\ntranshumains: l'idéal de l'homme! Haha!"
+    "texte_fr": "In Lak'ech... Haha,\nformidable! Ce monde morne\nva tomber et on entamera une nouvelle voie en transhumains: l'idéal de l'homme! Haha!"
   },
   {
     "id": 180,
@@ -3147,7 +3147,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "The[SP]third[SP]member[SP]of[SP]Muses[SP]is[SP]still[SP]a[SP]mystery.\nIt's[SP]human[SP]nature[SP]to[SP]be[SP]intrigued[SP]by[SP]such\nthings.[1205][000F][SP]It's[SP]a[SP]very[SP]clever[SP]promotional[SP]trick.",
     "nom_fr": "Client Sushi VIP",
-    "texte_fr": "Le troisième membre de Muses est un\nmystère. C'est humain d'être intrigué par\nça. [1205][000F]C'est un coup promotionnel très habile."
+    "texte_fr": "Le troisième membre de Muses est un\nmystère. C'est humain d'être intrigué par\nça. [000F][1205]C'est un coup promotionnel très habile."
   },
   {
     "id": 186,
@@ -3162,7 +3162,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "The[SP]third[SP]member[SP]of[SP]Muses[SP]has[SP]finally[SP]been\nannounced![1205][000F][SP]Sadly,[SP]I[SP]only[SP]heard[SP]her[SP]voice[SP]over\nthe[SP]radio...[SP]I[SP]can't[SP]wait[SP]to[SP]see[SP]her[SP]face!",
     "nom_fr": "Client Sushi VIP",
-    "texte_fr": "Le 3e membre de Muses a enfin été annoncé!\n[1205][000F]Hélas, je n'ai entendu sa voix qu'à la\nradio... J'ai hâte de voir son visage!"
+    "texte_fr": "Le 3e membre de Muses a enfin été annoncé!\n[000F][1205]Hélas, je n'ai entendu sa voix qu'à la\nradio... J'ai hâte de voir son visage!"
   },
   {
     "id": 187,
@@ -3192,7 +3192,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Smile[SP]Hirasaka's[SP]just[SP]an[SP]ordinary[SP]train\nstation.[1205][000F][SP]What[SP]do[SP]the[SP]terrorists[SP]hope[SP]to\ngain[SP]by[SP]blowing[SP]it[SP]up?",
     "nom_fr": "Client Sushi VIP",
-    "texte_fr": "Smile Hirasaka est une gare ordinaire.\n[1205][000F]Qu'espèrent les terroristes en la faisant\nexploser?"
+    "texte_fr": "Smile Hirasaka est une gare ordinaire.\n[000F][1205]Qu'espèrent les terroristes en la faisant\nexploser?"
   },
   {
     "id": 189,
@@ -3267,7 +3267,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Rumor[SP]has[SP]it[SP]that[SP]the[SP]ghost[SP]Hanako-san[SP]is\nhaunting[SP]Sevens.[1205][000F][SP]Does[SP]she[SP]actually[SP]exist?",
     "nom_fr": "Client Sushi VIP",
-    "texte_fr": "La rumeur dit que le fantôme de Hanako\nhante Seven. [1205][000F]Existe-t-elle vraiment?"
+    "texte_fr": "La rumeur dit que le fantôme de Hanako\nhante Seven. [000F][1205]Existe-t-elle vraiment?"
   },
   {
     "id": 194,
@@ -3297,7 +3297,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "I[SP]heard[SP]the[SP]ghost[SP]of[SP]an[SP]idol[SP]who[SP]starved[SP]to\ndeath[SP]at[SP]Aoba[SP]Park[SP]is[SP]appearing[SP]there.[SP]That's\none[SP]of[SP]the[SP]saddest[SP]things[SP]I've[SP]ever[SP]heard...",
     "nom_fr": "Client Sushi VIP",
-    "texte_fr": "Le fantôme d'une idole\nmorte de faim au parc\nAoba y apparaîtrait. C'est l'une des choses\nles plus tristes que j'aie entendues..."
+    "texte_fr": "Le fantôme d'une idole\nmorte de faim au parc\nAoba y apparaîtrait. C'est l'une des choses les plus tristes que j'aie entendues..."
   },
   {
     "id": 196,
@@ -3372,7 +3372,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "There've[SP]been[SP]sightings[SP]of[SP]the[SP]Jumping[SP]Geezer\nat[SP]Mt.[SP]Katatsumuri.[SP]I[SP]thought[SP]it[SP]showed[SP]up[SP]on\nroads[SP]and[SP]tunnels...[SP]add[SP]mountains[SP]to[SP]the[SP]list.",
     "nom_fr": "Client Sushi VIP",
-    "texte_fr": "On a vu le Papé\nSauteur au Mt Katatsumuri. Je\ncroyais qu'il n'était que sur les routes et\ntunnels... Ajoutez la montagne à la liste."
+    "texte_fr": "On a vu le Papé\nSauteur au Mt Katatsumuri. Je\ncroyais qu'il n'était que sur les routes et tunnels... Ajoutez la montagne à la liste."
   },
   {
     "id": 201,
@@ -3387,7 +3387,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Gah...[1205][000F][SP]I[SP]heard[SP]something[SP]awful...[1205][000F][SP]K-Kudan's...\nKudan's[SP]at[SP]the[SP]abandoned[SP]factory...[1205][000F][SP]No,[SP]I[SP]don't\nwant[SP]to[SP]think[SP]about[SP]it!",
     "nom_fr": "Client Sushi VIP",
-    "texte_fr": "Gah.[1205][000F][1205][000F][1205][000F].. J'ai entendu un truc affreux...\nL-Le Kudan est à l'usine abandonnée...\nNon, je ne veux pas y penser!"
+    "texte_fr": "Gah.[000F][1205][000F][1205][000F][1205].. J'ai entendu un truc affreux...\nL-Le Kudan est à l'usine abandonnée...\nNon, je ne veux pas y penser!"
   },
   {
     "id": 202,
@@ -3402,7 +3402,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "You[SP]know[SP]about[SP]Giga[SP]Macho's[SP]secret[SP]CD?[1205][000F]\nI[SP]hear[SP]there[SP]is[SP]one.[SP]I'd[SP]love[SP]to[SP]know[SP]what\nkind[SP]of[SP]tracks[SP]are[SP]on[SP]it.",
     "nom_fr": "Client Sushi VIP",
-    "texte_fr": "Le CD secret du Giga Macho? [1205][000F]Il existe\nparaît-il. Je veux savoir\nce qu'il y a dessus."
+    "texte_fr": "Le CD secret du Giga Macho? [000F][1205]Il existe\nparaît-il. Je veux savoir\nce qu'il y a dessus."
   },
   {
     "id": 203,
@@ -3417,7 +3417,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "The[SP]dreaded[SP]Dresser[SP]Hag[SP]is[SP]apparently[SP]showing\nup[SP]at[SP]the[SP]abandoned[SP]factory[SP]in[SP]Kounan.[1205][000F][SP]What\nkind[SP]of[SP]monster[SP]is[SP]that,[SP]I[SP]ask[SP]you?",
     "nom_fr": "Client Sushi VIP",
-    "texte_fr": "La Furie à la Commode apparaîtrait à\nl'usine abandonnée de Kounan. [1205][000F]Mais\nc'est quoi ce monstre, à votre avis?"
+    "texte_fr": "La Furie à la Commode apparaîtrait à\nl'usine abandonnée de Kounan. [000F][1205]Mais\nc'est quoi ce monstre, à votre avis?"
   },
   {
     "id": 204,
@@ -3822,7 +3822,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Rosa[SP]Candida[SP]in[SP]Aoba[SP]seems[SP]to[SP]handle[SP]real\narmor[SP]as[SP]well.[SP]Their[SP]stuff[SP]is[SP]good[SP]quality,\nbut[SP]it's[SP]pricey.",
     "nom_fr": "Client Sushi VIP",
-    "texte_fr": "Rosa Candida à Aoba\nvendrait aussi de vraies\narmures. La qualité est bonne, mais c'est\ncher."
+    "texte_fr": "Rosa Candida à Aoba\nvendrait aussi de vraies\narmures. La qualité est bonne, mais c'est cher."
   },
   {
     "id": 231,

--- a/traduction/event_scripts/script_375.json
+++ b/traduction/event_scripts/script_375.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "So[SP]does[SP]the[SP]fortune[SP]teller[SP]here[SP]use[SP]the[SP]cards\nor[SP]a[SP]crystal[SP]ball?[1205][000F][SP]Seems[SP]like[SP]only[SP]a[SP]phony\nwould[SP]use[SP]both...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Elle utilise les cartes ou la boule de\ncristal? [1205][000F]Seule une imposteure userait les\ndeux..."
+    "texte_fr": "Elle utilise les cartes ou la boule de\ncristal? [000F][1205]Seule une imposteure userait les\ndeux..."
   },
   {
     "id": 1,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "*cough*[SP]*cough*[1205][000F][SP]H-Hey,[SP]Ginko?[1205][000F][SP]If[SP]you're[SP]that\ndead[SP]set[SP]against[SP]debuting,[SP]want[SP]me[SP]to[SP]take\nyour[SP]place?",
     "nom_fr": "Eikichi",
-    "texte_fr": "*toux* *toux* H-Hé, Ginko? [1205][000F][1205][000F]Si tu\ntiens tant à ne pas débuter, tu\nveux que je passe à ta place?"
+    "texte_fr": "*toux* *toux* H-Hé, Ginko? [000F][1205][000F][1205]Si tu\ntiens tant à ne pas débuter, tu\nveux que je passe à ta place?"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Tch![SP]That's[SP]enough[SP]already,[SP]Ginko![SP]How[SP]can[SP]you\ntalk[SP]that[SP]much[SP]shit[SP]about[SP]your[SP]friends!?[1205][000F][SP]I'm[SP]not\nlistening[SP]to[SP]any[SP]more[SP]of[SP]this!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tch! Ça suffit, Ginko! Comment tu\npeux dire autant de mal de tes\n[1205][000F]amis!? Je veux plus entendre ça!"
+    "texte_fr": "Tch! Ça suffit, Ginko! Comment tu\npeux dire autant de mal de tes\n[000F][1205]amis!? Je veux plus entendre ça!"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It[SP]ended[SP]up[SP]not[SP]mattering,[SP]but[SP]can[SP]Ginko\nactually[SP]sing?[1205][000F][SP]Maybe[SP]she[SP]didn't[SP]want[SP]to[SP]debut\nbecause[SP]she's[SP]tone[SP]deaf.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ça n'a pas compté, mais Ginko sait\nchanter? [1205][000F]P'têtre qu'elle voulait pas\ndébuter parce qu'elle est fausse."
+    "texte_fr": "Ça n'a pas compté, mais Ginko sait\nchanter? [000F][1205]P'têtre qu'elle voulait pas\ndébuter parce qu'elle est fausse."
   },
   {
     "id": 6,
@@ -147,7 +147,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "...I[SP]sure[SP]was[SP]wrong[SP]about[SP]that,[SP]huh?[1205][000F][SP]Fine,\nI'll[SP]leave[SP]it[SP]to[SP]you.[1205][000F][SP]You[SP]pick[SP]the[SP]next\ndestination,[SP][1113].",
     "nom_fr": "Eikichi",
-    "texte_fr": "... J'avais tort, hein? Bon, je\n[1205][000F][1205][000F]te laisse choisir. C'est toi qui\ndécides la destination, [1113]."
+    "texte_fr": "... J'avais tort, hein? Bon, je\n[000F][1205][000F][1205]te laisse choisir. C'est toi qui\ndécides la destination, [1113]."
   },
   {
     "id": 10,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Tch...[1205][000F][SP]Can't[SP]people[SP]figure[SP]out[SP]that[SP]things[SP]are\nonly[SP]getting[SP]worse[SP]BECAUSE[SP]they[SP]believe[SP]in\nthat[SP]damn[SP]book?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Tch.[1205][000F].. Les gens comprennent pas\nque ça empire JUSTEMENT parce\nqu'ils croient à ce fichu bouquin?"
+    "texte_fr": "Tch.[000F][1205].. Les gens comprennent pas\nque ça empire JUSTEMENT parce\nqu'ils croient à ce fichu bouquin?"
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Seriously,[SP]that[SP]guy[SP]never[SP]makes[SP]any[SP]sense[SP]to\nme.[1205][000F][SP]What's[SP]this[SP][1432][NULL][NULL][0014]crawling[SP]chaos[1432][NULL][NULL][0014][SP]about?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Sérieux, ce mec me comprend jamais.\n[1205][000F]C'est quoi ce [1432][NULL][NULL][0014]chaos rampant[1432][NULL][NULL][0014]?"
+    "texte_fr": "Sérieux, ce mec me comprend jamais.\n[000F][1205]C'est quoi ce [1432][NULL][NULL][0014]chaos rampant[1432][NULL][NULL][0014]?"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "You[SP]know[SP]about[SP]this[SP]place,[SP][1113]?[1205][000F]\nThe[SP]Genie[SP]here[SP]is[SP]popular[SP]because[SP]her[SP]readings\nare[SP]always[SP]pretty[SP]accurate.",
     "nom_fr": "Ginko",
-    "texte_fr": "Tu connais cet endroit, [1113]? [1205][000F]La\nGénie est populaire parce que ses\nprédictions sont souvent exactes."
+    "texte_fr": "Tu connais cet endroit, [1113]? [000F][1205]La\nGénie est populaire parce que ses\nprédictions sont souvent exactes."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP][1113],[SP]why[SP]don't[SP]we[SP]have[SP]her[SP]tell[SP]our\nrelationship[SP]fortune[SP]since[SP]we're[SP]here?[1205][000F][SP]Though\nI'm[SP]more[SP]than[SP]positive[SP]we're[SP]a[SP]perfect[SP]match.",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, [1113], pourquoi pas lui demander\nnos compatibilités tant qu'on est là?\n[1205][000F]Même si je suis sûre qu'on est parfaits."
+    "texte_fr": "Hé, [1113], pourquoi pas lui demander\nnos compatibilités tant qu'on est là?\n[000F][1205]Même si je suis sûre qu'on est parfaits."
   },
   {
     "id": 15,
@@ -252,7 +252,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![1205][000F][SP]If[SP]that[SP]would[SP]solve[SP]the[SP]problem,\nI'd[SP]gladly[SP]let[SP]you[SP]go[SP]up[SP]on[SP]stage!",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei! [1205][000F]Si ça résout le problème,\nje te laisse monter sur scène!"
+    "texte_fr": "Kehhei! [000F][1205]Si ça résout le problème,\nje te laisse monter sur scène!"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "This[SP]has[SP]nothing[SP]to[SP]do[SP]with[SP]you.[1205][000F][SP]And[SP]those[SP]two\nhave[SP]nothing[SP]to[SP]do[SP]with[SP]me![1205][000F][SP]Will[SP]you[SP]just[SP]mind\nyour[SP]own[SP]goddamn[SP]business!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Ça te regarde pas. [1205][000F][1205][000F]Et ces deux-là ne\nme regardent pas non plus! Mêle-toi\nde tes affaires, bon sang!?"
+    "texte_fr": "Ça te regarde pas. [000F][1205][000F][1205]Et ces deux-là ne\nme regardent pas non plus! Mêle-toi\nde tes affaires, bon sang!?"
   },
   {
     "id": 18,
@@ -297,7 +297,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey,[SP][1113].[1205][000F][SP]Can't[SP]we[SP]ask[SP]her[SP]for[SP]a[SP]reading\non[SP]the[SP]next[SP]target?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé, [1113]. [1205][000F]On peut lui demander\nune prédiction sur la cible?"
+    "texte_fr": "Hé, [1113]. [000F][1205]On peut lui demander\nune prédiction sur la cible?"
   },
   {
     "id": 20,
@@ -327,7 +327,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What's[SP]he[SP]gonna[SP]do[SP]if[SP]that[SP]makes[SP]people[SP]start\nthinking[SP]we're[SP]the[SP]culprits!?[1205][000F][SP]Ugh,[SP]he's[SP]so\nstupid[SP]sometimes!",
     "nom_fr": "Ginko",
-    "texte_fr": "Et si les gens croient qu'on est les\ncoupables!? Ugh, il\n[1205][000F]peut être stupide parfois!"
+    "texte_fr": "Et si les gens croient qu'on est les\ncoupables!? Ugh, il\n[000F][1205]peut être stupide parfois!"
   },
   {
     "id": 22,
@@ -357,7 +357,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "I[SP]guess[SP]we[SP]can't[SP]do[SP]much[SP]about[SP]it...[1205][000F][SP]No[SP]one\ncan[SP]calm[SP]them[SP]down[SP]with[SP]things[SP]getting[SP]so[SP]bad.",
     "nom_fr": "Ginko",
-    "texte_fr": "On peut rien y faire... [1205][000F]Avec la situation\nqui empire, personne peut les calmer."
+    "texte_fr": "On peut rien y faire... [000F][1205]Avec la situation\nqui empire, personne peut les calmer."
   },
   {
     "id": 24,
@@ -387,7 +387,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hey,[SP]I[SP]know![1205][000F][SP]Why[SP]don't[SP]we[SP]try[SP]asking[SP]the\nfortune[SP]teller[SP]here[SP]about[SP]the[SP]Masked[SP]Circle?",
     "nom_fr": "Maya",
-    "texte_fr": "Tiens! [1205][000F]Et si on demandait à la\ndiseuse sur le Cercle masqué?"
+    "texte_fr": "Tiens! [000F][1205]Et si on demandait à la\ndiseuse sur le Cercle masqué?"
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Oh...[1205][000F][SP]So[SP]she[SP]didn't[SP]know[SP]anything.[1205][000F][SP]Oh[SP]well![1205][000F]\nLet's[SP]go[SP]ask[SP]someone[SP]else.",
     "nom_fr": "Maya",
-    "texte_fr": "Oh.[1205][000F][1205][000F][1205][000F].. Elle ne savait rien. Tant\npis! Allons demander ailleurs."
+    "texte_fr": "Oh.[000F][1205][000F][1205][000F][1205].. Elle ne savait rien. Tant\npis! Allons demander ailleurs."
   },
   {
     "id": 27,
@@ -432,7 +432,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Right.[1205][000F][SP]Since[SP]the[SP]rumor[SP]is[SP]specifically[SP]about\nLisa,[SP]sending[SP]in[SP]a[SP]substitute[SP]won't[SP]help.[1205][000F][SP]We\nhave[SP]to[SP]get[SP]to[SP]the[SP]bottom[SP]of[SP]this.",
     "nom_fr": "Maya",
-    "texte_fr": "C'est ça. [1205][000F][1205][000F]Puisque la rumeur parle\nspécifiquement de Lisa, une remplaçante\nne marchera pas. Il faut creuser."
+    "texte_fr": "C'est ça. [000F][1205][000F][1205]Puisque la rumeur parle\nspécifiquement de Lisa, une remplaçante\nne marchera pas. Il faut creuser."
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Strange...[1205][000F][SP]It's[SP]like[SP]Lisa's[SP]desperate[SP]to[SP]hide\nsomething.[1205][000F][SP]I[SP]think[SP]that's[SP]why[SP]she[SP]flares[SP]up\nlike[SP]that...",
     "nom_fr": "Maya",
-    "texte_fr": "Étrange.[1205][000F][1205][000F].. On dirait que Lisa\ncache quelque chose. C'est pour\nça qu'elle s'emporte comme ça..."
+    "texte_fr": "Étrange.[000F][1205][000F][1205].. On dirait que Lisa\ncache quelque chose. C'est pour\nça qu'elle s'emporte comme ça..."
   },
   {
     "id": 30,
@@ -477,7 +477,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Is[SP]that[SP]riddle[SP]some[SP]kind[SP]of[SP]code?[1205][000F][SP]It[SP]makes\nsense[SP]on[SP]the[SP]surface,[SP]but[SP]I'm[SP]wondering[SP]if\nthere's[SP]some[SP]hidden[SP]meaning[SP]behind[SP]it...",
     "nom_fr": "Maya",
-    "texte_fr": "Cette énigme, c'est un code? [1205][000F]Ça a du\nsens en surface, mais je me demande\ns'il y a un sens caché derrière..."
+    "texte_fr": "Cette énigme, c'est un code? [000F][1205]Ça a du\nsens en surface, mais je me demande\ns'il y a un sens caché derrière..."
   },
   {
     "id": 32,
@@ -492,7 +492,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm...[1205][000F][SP]Guess[SP]even[SP]a[SP]fortune[SP]teller[SP]can't[SP]tell\nwhere[SP]the[SP]next[SP]bombing[SP]will[SP]be.",
     "nom_fr": "Maya",
-    "texte_fr": "Hmm.[1205][000F].. Même une diseuse ne peut\npas prévoir le prochain attentat."
+    "texte_fr": "Hmm.[000F][1205].. Même une diseuse ne peut\npas prévoir le prochain attentat."
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]think[SP]it's[SP]fine[SP]to[SP]tell[SP]him[SP]he's[SP]safe[SP]here.\nThe[SP]last[SP]target[SP]has[SP]to[SP]be[SP]the[SP]Aerospace[SP]Museum,\nand[SP]I'd[SP]hate[SP]for[SP]him[SP]to[SP]worry[SP]so[SP]much.",
     "nom_fr": "Maya",
-    "texte_fr": "Je crois qu'on peut lui dire qu'il est en\nsécurité. La dernière cible sera le Musée\naérospatial, autant qu'il\ns'inquiète pas trop."
+    "texte_fr": "Je crois qu'on peut lui dire qu'il est en\nsécurité. La dernière cible sera le Musée\naérospatial, autant qu'il s'inquiète pas trop."
   },
   {
     "id": 34,
@@ -522,7 +522,7 @@
     "nom_orig": "Maya",
     "texte_orig": "These[SP]fears[SP]and[SP]anxieties[SP]actually[SP]spring[SP]only\nfrom[SP]oneself.[1205][000F][SP]Before[SP]he[SP]knows[SP]it,[SP]man[SP]has\nunconsciously[SP]repressed[SP]these[SP]emotions.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\n...Just[SP]as[SP]you[SP]all[SP]did.[1205][000F][SP]But[SP]this[SP]selfish\nretreat[SP]from[SP]the[SP]truth[SP]cannot[SP]be[SP]forgiven\nany[SP]longer.[1205][000F][SP]Heh.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nCrawling[SP]Chaos...[1205][000F][SP]Philemon[SP]did[SP]say,[SP][1432][NULL][NULL][0014]if[SP]we[SP]want\nto[SP]save[SP]our[SP]friend[SP]from[SP]the[SP]clutches[SP]of[SP]the\nCrawling[SP]Chaos[SP]who[SP]toys[SP]with[SP]man's[SP]fate[1432][NULL][NULL][0014]...[E1][E2]\n[E3][E4][NULL][NULL]\"Yukino\nThat[SP]fortune[SP]teller's[SP]equally[SP]famous[SP]as[SP]an\ninformant.[1205][000F][SP]She[SP]talks[SP]to[SP]enough[SP]people[SP]to[SP]know\nwhat's[SP]going[SP]on[SP]in[SP]the[SP]world.",
     "nom_fr": "Maya",
-    "texte_fr": "Ces peurs et angoisses ne naissent que de\nsoi-même. [1205][000F][1205][000F][1205][000F][1205][000F][1205][000F]Sans le savoir, l'homme a refoulé\nces émotions.[E1][E2] [E3][E4][NULL][NULL]\"Maya\n ... Tout comme vous\nl'avez fait. Mais ce repli égoïste loin\ndela vérité ne peut plus être toléré. Heh.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nChaos rampant... Philémon a dit: [1432][NULL][NULL][0014]si\nnous voulons sauver notre ami des griffes\nduChaos rampant qui joue du destin[1432][NULL][NULL][0014]...[E1][E2] [E3][E4][NULL][NULL]\"Yukino\nCette diseuse est aussi connue comme\ninformatrice. Elle parle à tant de gensqu'elle\nsait ce qui se passe dans le monde."
+    "texte_fr": "Ces peurs et angoisses ne naissent que de\nsoi-même. [000F][1205][000F][1205][000F][1205][000F][1205][000F][1205]Sans le savoir, l'homme a refoulé\nces émotions.[E1][E2] [E3][E4][NULL][NULL]\"Maya\n ... Tout comme vous\nl'avez fait. Mais ce repli égoïste loin\ndela vérité ne peut plus être toléré. Heh.[E1][E2]\n[E3][E4][NULL][NULL]\"Maya\nChaos rampant... Philémon a dit: [1432][NULL][NULL][0014]si\nnous voulons sauver notre ami des griffes\nduChaos rampant qui joue du destin[1432][NULL][NULL][0014]...[E1][E2] [E3][E4][NULL][NULL]\"Yukino\nCette diseuse est aussi connue comme\ninformatrice. Elle parle à tant de gensqu'elle\nsait ce qui se passe dans le monde."
   },
   {
     "id": 35,
@@ -552,7 +552,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]had[SP]a[SP]friend[SP]back[SP]in[SP]the[SP]day[SP]who[SP]knew[SP]a[SP]lot\nabout[SP]fortune[SP]telling.[1205][000F][SP]It's[SP]not[SP]really[SP]my\nthing,[SP]though.",
     "nom_fr": "Yukino",
-    "texte_fr": "J'avais une amie\nautrefois qui s'y connaissait\nen voyance. [1205][000F]Mais c'est\npas vraiment mon truc."
+    "texte_fr": "J'avais une amie\nautrefois qui s'y connaissait\nen voyance. [000F][1205]Mais c'est pas vraiment mon truc."
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]would've[SP]thought[SP]at[SP]least[SP]someone[SP]would[SP]know\nabout[SP]the[SP]Masked[SP]Circle.[1205][000F][SP]What's[SP]your[SP]take[SP]on\nthis,[SP]Maya-san?",
     "nom_fr": "Yukino",
-    "texte_fr": "J'aurais pensé qu'au moins quelqu'un\nconnaîtrait le Cercle masqué.\n[1205][000F]Maya-san, qu'en pensez-vous?"
+    "texte_fr": "J'aurais pensé qu'au moins quelqu'un\nconnaîtrait le Cercle masqué.\n[000F][1205]Maya-san, qu'en pensez-vous?"
   },
   {
     "id": 38,
@@ -627,7 +627,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "If[SP]Eikichi's[SP]right,[SP]she[SP]should[SP]have[SP]started\npanicking[SP]when[SP]she[SP]saw[SP]that[SP]poster.[1205][000F][SP]But[SP]it\ndidn't[SP]seem[SP]to[SP]mean[SP]anything[SP]to[SP]her.",
     "nom_fr": "Yukino",
-    "texte_fr": "Si Eikichi a raison, elle aurait dû\npaniquer en voyant l'affiche. [1205][000F]Mais ça\nn'avait l'air de rien dire pour elle."
+    "texte_fr": "Si Eikichi a raison, elle aurait dû\npaniquer en voyant l'affiche. [000F][1205]Mais ça\nn'avait l'air de rien dire pour elle."
   },
   {
     "id": 42,
@@ -642,7 +642,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "The[SP]friend[SP]I[SP]called[SP]up[SP]knows[SP]a[SP]lot[SP]about[SP]fortune\ntelling...[1205][000F][SP]especially[SP]astrology.[SP]I[SP]bet[SP]she'll\nknow[SP]what[SP]the[SP]riddle[SP]means.",
     "nom_fr": "Yukino",
-    "texte_fr": "L'amie que j'ai appelée s'y connaît bien\nen voyance... [1205][000F]surtout en astro. Je parie\nqu'elle saura ce que l'énigme signifie."
+    "texte_fr": "L'amie que j'ai appelée s'y connaît bien\nen voyance... [000F][1205]surtout en astro. Je parie\nqu'elle saura ce que l'énigme signifie."
   },
   {
     "id": 43,
@@ -657,7 +657,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]don't[SP]see[SP]the[SP]point[SP]of[SP]reading[SP]the[SP]future.[1205][000F]\nIf[SP]you[SP]know[SP]what's[SP]going[SP]to[SP]happen,[SP]you[SP]won't\ncare[SP]about[SP]doing[SP]your[SP]best[SP]right[SP]now.",
     "nom_fr": "Yukino",
-    "texte_fr": "Connaître l'avenir, je n'en vois pas\n[1205][000F]l'intérêt. Si tu sais ce qui va arriver,\ntu ne feras plus d'efforts dans le moment."
+    "texte_fr": "Connaître l'avenir, je n'en vois pas\n[000F][1205]l'intérêt. Si tu sais ce qui va arriver,\ntu ne feras plus d'efforts dans le moment."
   },
   {
     "id": 44,
@@ -672,7 +672,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Well...[1205][000F][SP]It's[SP]true[SP]that[SP]we'd[SP]be[SP]more[SP]at[SP]ease\nhaving[SP]them[SP]stay[SP]here[SP]instead[SP]of[SP]wandering\naround[SP]the[SP]city.",
     "nom_fr": "Yukino",
-    "texte_fr": "Eh bien.[1205][000F].. Il est vrai qu'ils seraient plus\nen sécurité ici qu'à errer dans la ville."
+    "texte_fr": "Eh bien.[000F][1205].. Il est vrai qu'ils seraient plus\nen sécurité ici qu'à errer dans la ville."
   },
   {
     "id": 45,
@@ -687,7 +687,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]see...[1205][000F][SP]Even[SP]being[SP]afraid[SP]of[SP]the[SP]end[SP]of[SP]the\nworld[SP]means[SP]believing[SP]in[SP]the[SP]In[SP]Lak'ech.",
     "nom_fr": "Yukino",
-    "texte_fr": "Je vois.[1205][000F].. Même avoir peur de la fin du\nmonde, c'est croire en l'In Lak'ech."
+    "texte_fr": "Je vois.[000F][1205].. Même avoir peur de la fin du\nmonde, c'est croire en l'In Lak'ech."
   },
   {
     "id": 46,
@@ -702,7 +702,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "We'll[SP]never[SP]stop[SP]the[SP]rumors[SP]like[SP]this![SP]All[SP]that\nstuff[SP]the[SP]book[SP]talks[SP]about[SP]will[SP]come[SP]true...",
     "nom_fr": "Yukino",
-    "texte_fr": "On ne stoppera pas\nles rumeurs ainsi! Tout ce\ndont parle le livre\nfinira par se réaliser..."
+    "texte_fr": "On ne stoppera pas\nles rumeurs ainsi! Tout ce\ndont parle le livre finira par se réaliser..."
   },
   {
     "id": 47,
@@ -717,7 +717,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Crawling[SP]Chaos?[1205][000F][SP]Toying[SP]with[SP]man's[SP]fate...[1205][000F]\n*gasp*[SP]N-No...[1205][000F][SP]It[SP]can't[SP]be...",
     "nom_fr": "Yukino",
-    "texte_fr": "Chaos rampant? [1205][000F][1205][000F][1205][000F]Jouer avec le destin...\n*ha!* N-Non... Pas possible..."
+    "texte_fr": "Chaos rampant? [000F][1205][000F][1205][000F][1205]Jouer avec le destin...\n*ha!* N-Non... Pas possible..."
   },
   {
     "id": 48,
@@ -732,7 +732,7 @@
     "nom_orig": "???",
     "texte_orig": "Those[SP]lost[SP]in[SP]life's[SP]labyrinth[SP]drift[SP]here.[1205][000F]\nWe[SP]are[SP]a[SP]light[SP]shining[SP]upon[SP]a[SP]path[SP]into[SP]the\ndismal[SP]future.[1205][000F][SP]I[SP]am[SP]the[SP]keeper,[SP]Sumaru[SP]Genie.",
     "nom_fr": "???",
-    "texte_fr": "Ceux perdus dans le labyrinthe de la vie\n[1205][000F][1205][000F]dérivent jusqu'ici. Nous\néclairons leur chemin\nvers l'avenir. Je suis la Génie de Sumaru."
+    "texte_fr": "Ceux perdus dans le labyrinthe de la vie\n[000F][1205][000F][1205]dérivent jusqu'ici. Nous\néclairons leur chemin vers l'avenir. Je suis la Génie de Sumaru."
   },
   {
     "id": 49,
@@ -747,7 +747,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "It[SP]seems[SP]this[SP]is[SP]your[SP]first[SP]visit.[1205][000F][SP]Are[SP]you[SP]one\nwho[SP]has[SP]lost[SP]his[SP]way[SP]to[SP]the[SP]future?[SP]Or[SP]have[SP]you\ncome[SP]to[SP]hear[SP]tales[SP]of[SP]this[SP]transitory[SP]world?",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Votre première visite, on dirait.\n[1205][000F]Êtes-vous quelqu'un qui a perdu sa voie\nvers le futur? Ou venez-vous\nentendreles récits de ce monde éphémère?"
+    "texte_fr": "Votre première visite, on dirait.\n[000F][1205]Êtes-vous quelqu'un qui a perdu sa voie\nvers le futur? Ou venez-vous entendreles récits de ce monde éphémère?"
   },
   {
     "id": 50,
@@ -762,7 +762,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Masked[SP]Circle?[1205][000F][SP]This[SP]name[SP]is[SP]not[SP]known[SP]to[SP]me...[1205][000F]\nDoes[SP]it[SP]refer[SP]to[SP]some[SP]coalition?",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Cercle masqué? [1205][000F][1205][000F]Ce nom m'est\ninconnu... S'agit-il d'une coalition?"
+    "texte_fr": "Cercle masqué? [000F][1205][000F][1205]Ce nom m'est\ninconnu... S'agit-il d'une coalition?"
   },
   {
     "id": 51,
@@ -777,7 +777,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "If[SP]so,[SP]seek[SP]the[SP]counsel[SP]of[SP]the[SP]man[SP]at[SP]Honmaru\nPark.[1205][000F][SP]He[SP]knows[SP]more[SP]of[SP]this[SP]transitory[SP]world\nthan[SP]I.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Dans ce cas, consultez l'homme de Honmaru\n[1205]Park. [000F]Il connaît mieux\nce monde éphémère que\nmoi."
+    "texte_fr": "Dans ce cas, consultez l'homme de Honmaru\n[1205]Park. [000F]Il connaît mieux\nce monde éphémère que moi."
   },
   {
     "id": 52,
@@ -792,7 +792,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "But[SP]a[SP]mysterious[SP]coalition[SP]known[SP]as[SP]the[SP]Masked\nCircle,[SP]yes...?[1205][000F][SP]An[SP]intriguing[SP]story.[1205][000F][SP]I[SP]must\nadd[SP]it[SP]to[SP]my[SP]store[SP]of[SP]rumors.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Une coalition mystérieuse appelée Cercle\nmasqué, oui.[1205].[1205][000F][000F].? Une histoire fascinante.\nJe dois l'ajouter à ma réserve de rumeurs."
+    "texte_fr": "Une coalition mystérieuse appelée Cercle\nmasqué, oui.[1205].[000F][1205][000F].? Une histoire fascinante.\nJe dois l'ajouter à ma réserve de rumeurs."
   },
   {
     "id": 53,
@@ -807,7 +807,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Only[SP]the[SP]light[SP]released[SP]by[SP]this[SP]crystal[SP]ball\nof[SP]hope[SP]can[SP]dismiss[SP]the[SP]dismal[SP]feelings[SP]you\nharbor[SP]inside.[1205][000F][SP]Speak[SP]your[SP]thoughts[SP]to[SP]me.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Seule la lumière de cette boule de cristal\nde l'espoir peut\nchasser les sombres pensées\n[1205]que vous portez. [000F]Confiez-moi vos pensées."
+    "texte_fr": "Seule la lumière de cette boule de cristal\nde l'espoir peut\nchasser les sombres pensées [1205]que vous portez. [000F]Confiez-moi vos pensées."
   },
   {
     "id": 54,
@@ -822,7 +822,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Thank[SP]you[SP]for[SP]choosing[SP]me[SP]today.[SP]I'll[SP]be[SP]your\nbro--[1205][000F]*ahem*[SP]I-I[SP]said[SP]nothing.[SP]And[SP]you[SP]heard\nnothing.[E1][E2]\n[E3][E4][NULL][NULL]\"Rumormonger[SP]Sumaru[SP]Genie\nAh.[SP]You[SP]sit[SP]before[SP]me[SP]again.[SP]Have[SP]you[SP]lost\nsight[SP]of[SP]your[SP]future?[SP]Or[SP]have[SP]you[SP]come[SP]for\nstories[SP]of[SP]man's[SP]karma?",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Merci de m'avoir choisie aujourd'hui. Je\n[1205][000F]serai votre fr--*hem* J-Je\nn'ai rien dit. Et\nvous non plus.[E1][E2] [E3][E4][NULL][NULL]\"Rumormonger Sumaru Genie\n Ah.\nVous revoilà. Avez-vous perdu de vue votreavenir?\nOu pour les récits du karma humain?"
+    "texte_fr": "Merci de m'avoir choisie aujourd'hui. Je\n[000F][1205]serai votre fr--*hem* J-Je\nn'ai rien dit. Et\nvous non plus.[E1][E2] [E3][E4][NULL][NULL]\"Rumormonger Sumaru Genie\n Ah.\nVous revoilà. Avez-vous perdu de vue votreavenir?\nOu pour les récits du karma humain?"
   },
   {
     "id": 55,
@@ -965,7 +965,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "If[SP]you[SP]wish[SP]to[SP]learn[SP]more[SP]of[SP]your[SP]future,[SP]come\nto[SP]me[SP]again.[1205][000F][SP]The[SP]crystal[SP]ball[SP]and[SP]the[SP]cards\nwill[SP]be[SP]your[SP]infallible[SP]guides.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Si vous souhaitez en apprendre plus sur\nvotre avenir, revenez me voir. [1205][000F]La boule et\nles cartes seront vos guides infaillibles."
+    "texte_fr": "Si vous souhaitez en apprendre plus sur\nvotre avenir, revenez me voir. [000F][1205]La boule et\nles cartes seront vos guides infaillibles."
   },
   {
     "id": 63,
@@ -1250,7 +1250,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Very[SP]well.[1205][000F][SP]The[SP]price[SP]will[SP]be[SP]3,000[SP]yen.\nDo[SP]you[SP]still[SP]wish[SP]this?\n[1208][0002]Yes\nNo",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Très bien. [1205][000F]Le prix sera de 3 000 yens.\nSouhaitez-vous toujours cela?\n[1208][0002]OuiNon",
+    "texte_fr": "Très bien. [000F][1205]Le prix sera de 3 000 yens.\nSouhaitez-vous toujours cela?\n[1208][0002]OuiNon",
     "question_orig": "Very[SP]well.[1205][000F][SP]The[SP]price[SP]will[SP]be[SP]3,000[SP]yen.\nDo[SP]you[SP]still[SP]wish[SP]this?",
     "choix_orig": [
       "Yes",
@@ -1275,7 +1275,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Unfortunately,[SP]your[SP]coffers[SP]are[SP]drained.[1205][000F]\nA[SP]golden[SP]key[SP]opens[SP]every[SP]door,[SP]as[SP]they[SP]say.\nReturn[SP]to[SP]me[SP]in[SP]a[SP]wealthier[SP]future.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Malheureusement, votre bourse est vide.\n[1205][000F]Comme on dit, l'argent ouvre toutes les\nportes. Revenez en étant plus fortuné."
+    "texte_fr": "Malheureusement, votre bourse est vide.\n[000F][1205]Comme on dit, l'argent ouvre toutes les\nportes. Revenez en étant plus fortuné."
   },
   {
     "id": 83,
@@ -1305,7 +1305,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Yes...[SP]I[SP]see[SP]something...[1205][000F][SP]Your[SP]destiny[SP]is\nsolidifying...[SP]Hmm...[1205][000F][SP]This[SP]is...[1205][000F]\nThe[SP]Six[SP]of[SP]Wands...",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Oui... Je vois quelque chose.[1205][000F][1205][000F][1205][000F]..\nVotre destin se précise... Hm...\nC'est... Le Six de Bâtons..."
+    "texte_fr": "Oui... Je vois quelque chose.[000F][1205][000F][1205][000F][1205]..\nVotre destin se précise... Hm...\nC'est... Le Six de Bâtons..."
   },
   {
     "id": 85,
@@ -1320,7 +1320,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Victory[SP]and[SP]accomplishment...[1205][000F][SP]The[SP]card[SP]tells\nof[SP]an[SP]increase[SP]in[SP]your[SP]luck[SP]with[SP]money.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Victoire et accomplissement.[1205][000F].. La carte\nprésage une hausse de votre chance avec\nl'argent."
+    "texte_fr": "Victoire et accomplissement.[000F][1205].. La carte\nprésage une hausse de votre chance avec\nl'argent."
   },
   {
     "id": 86,
@@ -1335,7 +1335,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "For[SP]the[SP]foreseeable[SP]future,[SP]you[SP]will[SP]not[SP]be\nshort[SP]of[SP]money.[SP]You[SP]will[SP]live[SP]in[SP]comfort.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Pour les prochains temps,\nvous n'aurez pas à\nmanquer d'argent. Vous\nvivrez dans le confort."
+    "texte_fr": "Pour les prochains temps,\nvous n'aurez pas à\nmanquer d'argent. Vous vivrez dans le confort."
   },
   {
     "id": 87,
@@ -1365,7 +1365,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Heightened[SP]perception[SP]and[SP]quick[SP]thinking...[1205][000F]\nThe[SP]card[SP]tells[SP]of[SP]a[SP]significant[SP]increase[SP]in\ngained[SP]experience.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Perception accrue et pensée vive...\n[1205][000F]La carte présage une augmentation\nsignificative des gains d'expérience."
+    "texte_fr": "Perception accrue et pensée vive...\n[000F][1205]La carte présage une augmentation\nsignificative des gains d'expérience."
   },
   {
     "id": 89,
@@ -1380,7 +1380,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "For[SP]the[SP]foreseeable[SP]future,[SP]your[SP]focus[SP]will[SP]be\nintensified.[SP]You[SP]will[SP]learn[SP]more[SP]from[SP]the[SP]world\naround[SP]you[SP]than[SP]normal.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Pour les prochains\ntemps, votre concentration\nsera décuplée. Vous apprendrez bien plus du\nmonde autour de vous que d'habitude."
+    "texte_fr": "Pour les prochains\ntemps, votre concentration\nsera décuplée. Vous apprendrez bien plus du monde autour de vous que d'habitude."
   },
   {
     "id": 90,
@@ -1395,7 +1395,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Yes...[SP]I[SP]see[SP]something...[1205][000F][SP]Your[SP]destiny[SP]is\nsolidifying...[SP]Hmm...[1205][000F][SP]This[SP]is...[1205][000F]\nThe[SP]Magician...",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Oui... Je vois\n[1205][000F][1205][000F][1205][000F]quelque chose... Votre destin\nse précise... Hm... C'est... Le Mage..."
+    "texte_fr": "Oui... Je vois\n[000F][1205][000F][1205][000F][1205]quelque chose... Votre destin\nse précise... Hm... C'est... Le Mage..."
   },
   {
     "id": 91,
@@ -1410,7 +1410,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "For[SP]the[SP]foreseeable[SP]future,[SP]your[SP]positive\noutlook[SP]will[SP]give[SP]rise[SP]to[SP]new[SP]understandings,\ncausing[SP]all[SP]negotiations[SP]to[SP]proceed[SP]smoothly.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Pour les prochains\ntemps, votre optimisme fera\nnaître de nouvelles\nperspectives, permettant à\ntoutes les négociations\nde se dérouler bien."
+    "texte_fr": "Pour les prochains\ntemps, votre optimisme fera\nnaître de nouvelles perspectives, permettant à toutes les négociations de se dérouler bien."
   },
   {
     "id": 92,
@@ -1425,7 +1425,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Yes...[SP]I[SP]see[SP]something...[1205][000F][SP]Your[SP]destiny[SP]is\nsolidifying...[SP]Hmm...[1205][000F][SP]This[SP]is...[1205][000F]\nThe[SP]Wheel[SP]of[SP]Fortune...",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Oui... Je vois quelque chose.[1205][000F][1205][000F][1205][000F]..\nVotre destin se précise... Hm...\nC'est... La Roue de Fortune..."
+    "texte_fr": "Oui... Je vois quelque chose.[000F][1205][000F][1205][000F][1205]..\nVotre destin se précise... Hm...\nC'est... La Roue de Fortune..."
   },
   {
     "id": 93,
@@ -1470,7 +1470,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Yes...[SP]I[SP]see[SP]something...[1205][000F][SP]Your[SP]destiny[SP]is\nsolidifying...[SP]Hmm...[1205][000F][SP]This[SP]is...[1205][000F]\nTemperance...",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Oui... Je vois\n[1205][000F][1205][000F][1205][000F]quelque chose... Votre destin\nse précise... Hm...\nC'est... La Tempérance..."
+    "texte_fr": "Oui... Je vois\n[000F][1205][000F][1205][000F][1205]quelque chose... Votre destin\nse précise... Hm... C'est... La Tempérance..."
   },
   {
     "id": 96,
@@ -1485,7 +1485,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Silence...[1205][000F][SP]The[SP]card[SP]tells[SP]your[SP]unremarkable,\neveryday[SP]existence.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Silence.[1205][000F].. La carte reflète votre\nexistence banale et ordinaire."
+    "texte_fr": "Silence.[000F][1205].. La carte reflète votre\nexistence banale et ordinaire."
   },
   {
     "id": 97,
@@ -1515,7 +1515,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Yes...[SP]I[SP]see[SP]something...[1205][000F][SP]Your[SP]destiny[SP]is\nsolidifying...[SP]Hmm...[1205][000F][SP]This[SP]is...[1205][000F]\nThe[SP]Fool...",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Oui... Je vois\n[1205][000F][1205][000F][1205][000F]quelque chose... Votre destin\nse précise... Hm... C'est... Le Fou..."
+    "texte_fr": "Oui... Je vois\n[000F][1205][000F][1205][000F][1205]quelque chose... Votre destin\nse précise... Hm... C'est... Le Fou..."
   },
   {
     "id": 99,
@@ -1530,7 +1530,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "The[SP]cycle[SP]of[SP]life...[SP]Death[SP]and[SP]rebirth...[1205][000F]\nThe[SP]card[SP]tells[SP]of[SP]a[SP]decrease[SP]in[SP]your[SP]luck.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Le cycle de la\nvie... Mort et renaissance.[1205][000F]..\nLa carte présage une\nbaisse de votre chance."
+    "texte_fr": "Le cycle de la\nvie... Mort et renaissance.[000F][1205]..\nLa carte présage une baisse de votre chance."
   },
   {
     "id": 100,
@@ -1560,7 +1560,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Yes...[SP]I[SP]see[SP]something...[1205][000F][SP]Your[SP]destiny[SP]is\nsolidifying...[SP]Hmm...[1205][000F][SP]This[SP]is...[1205][000F]\nThe[SP]Five[SP]of[SP]Cups...[E1][E2]\n\n[E3][E4][NULL][NULL]\"Rumormonger[SP]Sumaru[SP]Genie\nLoss...[1205][000F][SP]The[SP]card[SP]tells[SP]of[SP]a[SP]sudden[SP]parting.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Oui... Je vois\n[1205][000F][1205][000F][1205][000F][1205][000F]quelque chose... Votre destin\nse précise... Hm... C'est... Le Cinq de\nCoupes...[E1][E2]\n[E3][E4][NULL][NULL]\"Génie Sumaru\nPerte...\nLa carte présage une séparation soudaine."
+    "texte_fr": "Oui... Je vois\n[000F][1205][000F][1205][000F][1205][000F][1205]quelque chose... Votre destin\nse précise... Hm... C'est... Le Cinq de\nCoupes...[E1][E2]\n[E3][E4][NULL][NULL]\"Génie Sumaru\nPerte...\nLa carte présage une séparation soudaine."
   },
   {
     "id": 102,
@@ -1590,7 +1590,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Yes...[SP]I[SP]see[SP]something...[1205][000F][SP]Your[SP]destiny[SP]is\nsolidifying...[SP]Hmm...[1205][000F][SP]This[SP]is...[1205][000F]\nThe[SP]Moon...",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Oui... Je vois\n[1205][000F][1205][000F][1205][000F]quelque chose... Votre destin\nse précise... Hm... C'est... La Lune..."
+    "texte_fr": "Oui... Je vois\n[000F][1205][000F][1205][000F][1205]quelque chose... Votre destin\nse précise... Hm... C'est... La Lune..."
   },
   {
     "id": 104,
@@ -1635,7 +1635,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Yes...[SP]I[SP]see[SP]something...[1205][000F][SP]Your[SP]destiny[SP]is\nsolidifying...[SP]Hmm...[1205][000F][SP]This[SP]is...[1205][000F]\nThe[SP]Two[SP]of[SP]Swords...",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Oui... Je vois\n[1205][000F][1205][000F][1205][000F]quelque chose... Votre destin\nse précise... Hm... C'est... Le Deux\nd'Épées..."
+    "texte_fr": "Oui... Je vois\n[000F][1205][000F][1205][000F][1205]quelque chose... Votre destin\nse précise... Hm... C'est... Le Deux d'Épées..."
   },
   {
     "id": 107,
@@ -1805,7 +1805,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "They[SP]tell[SP]of[SP][E4][NULL][NULL][0006]Tony's[SP]Shop[E4][NULL][NULL][0002][SP]in[SP]Yumezaki,[SP]which\nsells[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002].[1205][000F][SP]Their[SP][E4][NULL][NULL][0006]quality[SP]is[SP]exquisite,\nthough[SP]the[SP]prices[SP]are[SP]high[E4][NULL][NULL][0002].[SP]How[SP]dangerous...",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "On dit que [E4][NULL][NULL][0006]Tony's Shop[E4][NULL][NULL][0002] à Yumezaki vend de\n[E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. [1205][000F]Leur\n[E4][NULL][NULL][0006]qualité est exquise, mais\nles prix sont\nélevés[E4][NULL][NULL][0002]. Que c'est dangereux..."
+    "texte_fr": "On dit que [E4][NULL][NULL][0006]Tony's Shop[E4][NULL][NULL][0002] à Yumezaki vend de\n[E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. [000F][1205]Leur\n[E4][NULL][NULL][0006]qualité est exquise, mais les prix sont élevés[E4][NULL][NULL][0002]. Que c'est dangereux..."
   },
   {
     "id": 115,
@@ -1820,7 +1820,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Ah.[SP]So[SP]Eikichi[SP]of[SP]Kasugayama[SP]has[SP]abandoned[SP]his\npost[SP]as[SP]Boss...[1205][000F][SP]Knowing[SP]little[SP]about[SP]student\nlife,[SP]I[SP]am[SP]unsure[SP]as[SP]to[SP]this[SP]story's[SP]value.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Ah. Eikichi de Kasugayama\na quitté son poste\nde Boss..[1205]. [000F]Ne connaissant guère la vie\nétudiante, j'ignore la\nvaleur de cettehistoire."
+    "texte_fr": "Ah. Eikichi de Kasugayama\na quitté son poste\nde Boss..[1205]. [000F]Ne connaissant guère la vie étudiante, j'ignore la valeur de cettehistoire."
   },
   {
     "id": 116,
@@ -1835,7 +1835,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "But[SP]no[SP]matter.[SP]My[SP]tale[SP]for[SP]you[SP]concerns[SP][E4][NULL][NULL][0006]Clair\nde[SP]Lune[E4][NULL][NULL][0002][SP]in[SP]Aoba,[SP]which[SP]sells[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002].[1205][000F]\nTheir[SP][E4][NULL][NULL][0006]quality[SP]and[SP]prices[SP]are[SP]average[E4][NULL][NULL][0002].",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Peu importe. Mon histoire concerne [E4][NULL][NULL][0006]Clair\nde Lune[E4][NULL][NULL][0002] à Aoba, qui vend de [E4][NULL][NULL][0006]vraies\narmes[E4][NULL][NULL][0002]. [1205][000F]Leur [E4][NULL][NULL][0006]qualité et prix sont moyens[E4][NULL][NULL][0002]."
+    "texte_fr": "Peu importe. Mon histoire concerne [E4][NULL][NULL][0006]Clair\nde Lune[E4][NULL][NULL][0002] à Aoba, qui vend de [E4][NULL][NULL][0006]vraies\narmes[E4][NULL][NULL][0002]. [000F][1205]Leur [E4][NULL][NULL][0006]qualité et prix sont moyens[E4][NULL][NULL][0002]."
   },
   {
     "id": 117,
@@ -1850,7 +1850,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "What's[SP]this!?[SP]Ginji[SP]Sasaki[SP]counts[SP]himself[SP]among\nthe[SP]Masked[SP]Circle?[1205][000F][SP]Th-This[SP]is[SP]a[SP]heartstopping\ntale[SP]indeed...[SP]Here[SP]is[SP]one[SP]from[SP]me.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Quoi!? Ginji Sasaki fait partie du Cercle\nmasqué? [1205][000F]C'est une histoire à couper le\nsouffle... En voici une de ma part."
+    "texte_fr": "Quoi!? Ginji Sasaki fait partie du Cercle\nmasqué? [000F][1205]C'est une histoire à couper le\nsouffle... En voici une de ma part."
   },
   {
     "id": 118,
@@ -1865,7 +1865,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "It[SP]would[SP]appear[SP][E4][NULL][NULL][0006]Jolly[SP]Roger[E4][NULL][NULL][0002][SP]sells[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002].[1205][000F]\nI'm[SP]quite[SP]surprised[SP]that[SP]one[SP]so[SP]near[SP]to[SP]us[SP]would\nsell[SP][E4][NULL][NULL][0006]high-quality,[SP]high-price[SP]armaments[E4][NULL][NULL][0002].",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Il semble que [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] vende de [E4][NULL][NULL][0006]vraies\n[1205]armes[E4][NULL][NULL][0002]. [000F]Je suis surprise\nqu'un si proche voisin\nvende des [E4][NULL][NULL][0006]armements de\nqualité, au prix fort[E4][NULL][NULL][0002]."
+    "texte_fr": "Il semble que [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] vende de [E4][NULL][NULL][0006]vraies\n[1205]armes[E4][NULL][NULL][0002]. [000F]Je suis surprise\nqu'un si proche voisin vende des [E4][NULL][NULL][0006]armements de qualité, au prix fort[E4][NULL][NULL][0002]."
   },
   {
     "id": 119,
@@ -1895,7 +1895,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "I[SP]am[SP]told[SP]you[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002][SP]at[SP][E4][NULL][NULL][0006]Anima[SP]Mundi[E4][NULL][NULL][0002]\nin[SP]Yumezaki.[1205][000F][SP]It's[SP][E4][NULL][NULL][0006]high[SP]quality,[SP]but[SP]expensive[E4][NULL][NULL][0002]...\nThough[SP]I[SP]haven't[SP]confirmed[SP]the[SP]tale[SP]for[SP]myself.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "On peut acheter de\n[E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002] chez [E4][NULL][NULL][0006]Anima\n[1205]Mundi[E4][NULL][NULL][0002] à Yumezaki. [000F]C'est [E4][NULL][NULL][0006]haut de gamme, mais\ncher[E4][NULL][NULL][0002]... Je n'ai pas confirmé moi-même."
+    "texte_fr": "On peut acheter de\n[E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002] chez [E4][NULL][NULL][0006]Anima\n[1205]Mundi[E4][NULL][NULL][0002] à Yumezaki. [000F]C'est [E4][NULL][NULL][0006]haut de gamme, mais cher[E4][NULL][NULL][0002]... Je n'ai pas confirmé moi-même."
   },
   {
     "id": 121,
@@ -1925,7 +1925,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Treachery[SP]is[SP]yet[SP]another[SP]weight[SP]against[SP]man's\ninsurmountable[SP]karma.[1205][000F][SP]But[SP]as[SP]for[SP]my[SP]tale...",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "La trahison pèse encore sur le karma\nde l'homme. [1205][000F]Mais pour mon histoire..."
+    "texte_fr": "La trahison pèse encore sur le karma\nde l'homme. [000F][1205]Mais pour mon histoire..."
   },
   {
     "id": 123,
@@ -1940,7 +1940,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "The[SP][E4][NULL][NULL][0006]Aoba[SP]branch[SP]of[SP]Rosa[SP]Candida[E4][NULL][NULL][0002][SP]appears[SP]to\nsell[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]Their[SP][E4][NULL][NULL][0006]selection[SP]is[SP]impeccable,\nbut[SP]their[SP]resale[SP]prices[SP]are[SP]lacking[E4][NULL][NULL][0002].",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "La [E4][NULL][NULL][0006]branche d'Aoba de Rosa Candida[E4][NULL][NULL][0002] vend de\n[E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [1205][000F][E4][NULL][NULL][0006]Sélection irréprochable,\nmais prix de revente décevants[E4][NULL][NULL][0002]."
+    "texte_fr": "La [E4][NULL][NULL][0006]branche d'Aoba de Rosa Candida[E4][NULL][NULL][0002] vend de\n[E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [000F][1205][E4][NULL][NULL][0006]Sélection irréprochable,\nmais prix de revente décevants[E4][NULL][NULL][0002]."
   },
   {
     "id": 124,
@@ -1955,7 +1955,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "What?[SP]The[SP]lucky[SP]cat[SP]statue[SP]at[SP]the[SP]Kuzunoha\nDetective[SP]Agency[SP]talks?[SP]But[SP]isn't[SP]it[SP]a[SP]mere\nporcelain[SP]figure?[SP]Most[SP]peculiar...",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Quoi? La statue de chat porte-bonheur de\nl'Agence Kuzunoha parle?\nMais ce n'est qu'une\nfigurine en porcelaine? Très étrange..."
+    "texte_fr": "Quoi? La statue de chat porte-bonheur de\nl'Agence Kuzunoha parle?\nMais ce n'est qu'une figurine en porcelaine? Très étrange..."
   },
   {
     "id": 125,
@@ -1970,7 +1970,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "As[SP]for[SP]me,[SP]I[SP]tell[SP]the[SP]tale[SP]of[SP][E4][NULL][NULL][0006]London[SP]Clothier[E4][NULL][NULL][0002],\nwhich[SP]sells[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]Their[SP][E4][NULL][NULL][0006]selection[SP]is\npoor,[SP]but[SP]their[SP]resale[SP]prices[SP]are[SP]high[E4][NULL][NULL][0002].",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Quant à moi, je conte [E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002],\nqui vend de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [1205][000F][E4][NULL][NULL][0006]Sélection\npauvre, prix de revente élevés[E4][NULL][NULL][0002]."
+    "texte_fr": "Quant à moi, je conte [E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002],\nqui vend de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [000F][1205][E4][NULL][NULL][0006]Sélection\npauvre, prix de revente élevés[E4][NULL][NULL][0002]."
   },
   {
     "id": 126,
@@ -2000,7 +2000,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "To[SP]share[SP]stories[SP]is[SP]not[SP]my[SP]avowed[SP]vocation.[1205][000F]\nThus,[SP]I[SP]have[SP]no[SP]desire[SP]for[SP]recompense.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Partager des histoires\nn'est pas ma vocation.\n[1205][000F]Aussi n'ai-je aucun désir de contrepartie."
+    "texte_fr": "Partager des histoires\nn'est pas ma vocation.\n[000F][1205]Aussi n'ai-je aucun désir de contrepartie."
   },
   {
     "id": 128,
@@ -2030,7 +2030,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "I[SP]have[SP]a[SP]boon[SP]to[SP]request...[1205][000F][SP]Do[SP]you[SP]know[SP]of\nany[SP]skilled[SP]fortune[SP]tellers?[1205][000F][SP]Oh...[SP]Well,[SP]yes,\nI[SP]am[SP]a[SP]fortune[SP]teller[SP]myself,[SP]but...",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "J'ai une faveur à vous demander.[1205][000F][1205][000F]..\nConnaissez-vous un bon diseur de bonne\naventure? Oh... Oui,\nj'en suis une moi-même,mais..."
+    "texte_fr": "J'ai une faveur à vous demander.[000F][1205][000F][1205]..\nConnaissez-vous un bon diseur de bonne\naventure? Oh... Oui, j'en suis une moi-même,mais..."
   },
   {
     "id": 130,
@@ -2045,7 +2045,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Er...[1205][000F][SP]You[SP]see...[1205][000F][SP]N-No,[SP]never[SP]mind.[SP]I[SP]spoke[SP]too\nrashly.[1205][000F][SP]Forget[SP]this[SP]exchange[SP]took[SP]place.[1205][001E][SP]*sigh*",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Euh.[1205][000F][1205][000F][1205][000F].. Voyez-vous... N-Non, laissez\ntomber. J'ai parlé trop vite.\nOubliez cet échange.[1205][001E] *soupir*"
+    "texte_fr": "Euh.[000F][1205][000F][1205][000F][1205].. Voyez-vous... N-Non, laissez\ntomber. J'ai parlé trop vite.\nOubliez cet échange.[001E][1205] *soupir*"
   },
   {
     "id": 131,
@@ -2060,7 +2060,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "*mumble*[1205][000F][SP]just[SP]making[SP]it[SP]up...[1205][000F][SP]*mutter*[SP]are\nthey[SP]coming[SP]true...?[1205][000F][SP]*murmur*[SP]can't[SP]read[SP]my\nown...?[1205][000F][SP]*mumble*",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "*marmonne* j'invente tout.[1205][000F][1205][000F][1205][000F][1205][000F]..\n*marmonne* ça devient réalité...?\n*murmure* lire le mien...? *marmonne*"
+    "texte_fr": "*marmonne* j'invente tout.[000F][1205][000F][1205][000F][1205][000F][1205]..\n*marmonne* ça devient réalité...?\n*murmure* lire le mien...? *marmonne*"
   },
   {
     "id": 132,
@@ -2075,7 +2075,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "......[1205][000F]*gasp*[1205][000F][SP]I-I'm[SP]sorry,[SP]I[SP]was[SP]talking[SP]to\nmyself.[1205][000F][SP]D-Did[SP]you[SP]overhear[SP]what[SP]I...?[1205][000F][SP]E-Er,\nplease[SP]don't[SP]breathe[SP]a[SP]word[SP]of[SP]it.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "...[1205][000F][1205][000F][1205][000F][1205][000F]...*ha!* J-Je suis désolée, je parlais\ntoute seule. V-Vous avez entendu...? S'il\nvous plaît, n'en soufflez mot."
+    "texte_fr": "...[000F][1205][000F][1205][000F][1205][000F][1205]...*ha!* J-Je suis désolée, je parlais\ntoute seule. V-Vous avez entendu...? S'il\nvous plaît, n'en soufflez mot."
   },
   {
     "id": 133,
@@ -2090,7 +2090,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "U-Um...[1205][000F][SP]The[SP]usual[SP]way[SP]is[SP]for[SP]others[SP]to[SP]seek[SP]my\nadvice,[SP]but,[SP]w-would[SP]you...[1205][000F][SP]Look,[SP]do[SP]you[SP]mind\nif[SP]I[SP]ask[SP]you[SP]something?",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "E-Euh.[1205][000F][1205][000F].. D'habitude ce sont les autres\nqui consultent, mais, v-vous... Est-ce\nque je peux vous poser une question?"
+    "texte_fr": "E-Euh.[000F][1205][000F][1205].. D'habitude ce sont les autres\nqui consultent, mais, v-vous... Est-ce\nque je peux vous poser une question?"
   },
   {
     "id": 134,
@@ -2130,7 +2130,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Y-Yeah,[SP]I[SP]thought[SP]not.[1205][000F][SP]*cough*[SP]*ahem*[1205][000F]\nI've[SP]no[SP]idea[SP]what[SP]could[SP]have[SP]dazed[SP]me[SP]so.\nPlease,[SP]pay[SP]the[SP]episode[SP]no[SP]heed.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "O-Ouais, je m'en doutais. [1205][000F][1205][000F]*toux* *hem*\nJe ne sais pas ce qui m'a pris. S'il\nvous plaît, n'en tenez pas compte."
+    "texte_fr": "O-Ouais, je m'en doutais. [000F][1205][000F][1205]*toux* *hem*\nJe ne sais pas ce qui m'a pris. S'il\nvous plaît, n'en tenez pas compte."
   },
   {
     "id": 136,
@@ -2145,7 +2145,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Oh,[SP]thank[SP]you![1205][000F][SP]I[SP]can't[SP]live[SP]a[SP]lie[SP]anymore!\nI[SP]can't[SP]hide[SP]the[SP]truth.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Oh, merci! [1205][000F]Je ne peux plus vivre dans\nle mensonge! Faut dire la vérité."
+    "texte_fr": "Oh, merci! [000F][1205]Je ne peux plus vivre dans\nle mensonge! Faut dire la vérité."
   },
   {
     "id": 137,
@@ -2175,7 +2175,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "I'm[SP]actually[SP]an[SP]intersexed[SP]worker[SP]at[SP]a[SP]club\nwhich[SP]caters[SP]to[SP]that[SP]sort[SP]of[SP]thing...[1205][000F][SP]I'm[SP]not\na[SP]fortune[SP]teller[SP]at[SP]all!",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "En réalité, je suis employé(e) dans\nun club spécialisé... Je ne suis pas\n[1205][000F]un diseur de bonne aventure du tout!"
+    "texte_fr": "En réalité, je suis employé(e) dans\nun club spécialisé... Je ne suis pas\n[000F][1205]un diseur de bonne aventure du tout!"
   },
   {
     "id": 139,
@@ -2190,7 +2190,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "I[SP]just[SP]fooled[SP]around[SP]with[SP]it[SP]to[SP]entertain[SP]my\nclients.[SP]But[SP]then[SP]the[SP]rumor[SP]got[SP]around[SP]that\nmy[SP]fortunes[SP]came[SP]true.[SP]It[SP]got[SP]out[SP]of[SP]hand.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Je m'en servais juste pour amuser mes\nclients. Mais la rumeur s'est répandue que\nmes prédictions se\nréalisaient. Ça a dérapé."
+    "texte_fr": "Je m'en servais juste pour amuser mes\nclients. Mais la rumeur s'est répandue que\nmes prédictions se réalisaient. Ça a dérapé."
   },
   {
     "id": 140,
@@ -2205,7 +2205,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "When[SP]I[SP]came[SP]to,[SP]I[SP]was[SP]here...[1205][000F][SP]This[SP][1432][NULL][NULL][0014]crystal[1432][NULL][NULL][0014]\nball[SP]is[SP]just[SP]glass.[SP]Everything[SP]I[SP]said,[SP]I[SP]made\nup...[1205][000F][SP]The[SP]thing[SP]is,[SP]it[SP]comes[SP]true[SP]anyway!",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Quand je suis revenu(e)\n[1205][000F][1205]à moi, j'étais ici.[000F]..\nCette [1432][NULL][NULL][0014]boule de cristal[1432][NULL][NULL][0014] n'est que du verre.\nJ'inventais... Sauf que\nça se réalise quandmême!"
+    "texte_fr": "Quand je suis revenu(e)\n[000F][1205][1205]à moi, j'étais ici.[000F]..\nCette [1432][NULL][NULL][0014]boule de cristal[1432][NULL][NULL][0014] n'est que du verre. J'inventais... Sauf que ça se réalise quandmême!"
   },
   {
     "id": 141,
@@ -2220,7 +2220,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Trust[SP]me,[SP]no[SP]one[SP]was[SP]more[SP]surprised[SP]than[SP]me.[1205][000F]\nB-But[SP]the[SP]more[SP]it[SP]happened,[SP]the[SP]more[SP]I[SP]was\nconvinced...[1205][000F][SP]My[SP]readings[SP]always[SP]come[SP]true.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Croyez-moi, j'en étais le plus surpris(e).\n[1205][000F][1205][000F]Mais plus ça se produisait, plus j'étais\nconvaincu(e)... Mes\nprédictions se réalisenttoujours."
+    "texte_fr": "Croyez-moi, j'en étais le plus surpris(e).\n[000F][1205][000F][1205]Mais plus ça se produisait, plus j'étais\nconvaincu(e)... Mes prédictions se réalisenttoujours."
   },
   {
     "id": 142,
@@ -2235,7 +2235,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "So[SP]if[SP]I[SP]read[SP]my[SP]own[SP]future,[SP]and[SP]all[SP]my[SP]fortunes\ncome[SP]true...[1205][000F][SP]It[SP]ought[SP]to[SP]follow[SP]that[SP]I[SP]could\nknow[SP]my[SP]own[SP]future[SP]for[SP]certain.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Donc si je lis mon avenir, et que toutes\nmes prédictions se réalisent.[1205][000F].. Je pourrais\nconnaître mon propre avenir avec certitude."
+    "texte_fr": "Donc si je lis mon avenir, et que toutes\nmes prédictions se réalisent.[000F][1205].. Je pourrais\nconnaître mon propre avenir avec certitude."
   },
   {
     "id": 143,
@@ -2250,7 +2250,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Whether[SP]that's[SP]a[SP]good[SP]thing[SP]or[SP]a[SP]bad[SP]thing,\nI[SP]don't[SP]know.[1205][000F][SP]That's[SP]why[SP]I've[SP]been[SP]searching\nall[SP]over.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Que ce soit une\nbonne ou une mauvaise chose,\n[1205]je l'ignore. [000F]C'est pourquoi je cherche\npartout."
+    "texte_fr": "Que ce soit une\nbonne ou une mauvaise chose,\n[1205]je l'ignore. [000F]C'est pourquoi je cherche partout."
   },
   {
     "id": 144,
@@ -2280,7 +2280,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Whew...[1205][000F][SP]I[SP]feel[SP]better[SP]getting[SP]that[SP]off[SP]my\nchest.[SP]When[SP]the[SP]time[SP]comes,[SP]I'll[SP]ask[SP]you[SP]to\nread[SP]my[SP]fortune.[1205][000F][SP]*ahem*[SP]State[SP]your[SP]purpose...",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Ouf.[1205][000F][1205][000F].. Ça fait du bien d'en parler. Le\nmoment venu, je vous demanderai de me lire\nl'avenir. *hem* Votre raison d'être ici..."
+    "texte_fr": "Ouf.[000F][1205][000F][1205].. Ça fait du bien d'en parler. Le\nmoment venu, je vous demanderai de me lire\nl'avenir. *hem* Votre raison d'être ici..."
   },
   {
     "id": 146,
@@ -2295,7 +2295,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Hm.[SP]I[SP]have[SP]told[SP]you[SP]all[SP]the[SP]tales[SP]I[SP]know[SP]for\nthe[SP]nonce.[SP]Let[SP]us[SP]share[SP]stories[SP]once[SP]more[SP]when\nI[SP]have[SP]learned[SP]something[SP]worth[SP]telling.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Hm. Je vous ai dit\ntoutes les histoires que je\nconnais pour l'instant.\nPartageons à nouveau\nquand j'en aurai de nouvelles à raconter."
+    "texte_fr": "Hm. Je vous ai dit\ntoutes les histoires que je\nconnais pour l'instant. Partageons à nouveau quand j'en aurai de nouvelles à raconter."
   },
   {
     "id": 147,
@@ -2310,7 +2310,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "If[SP]you[SP]wish[SP]to[SP]peer[SP]into[SP]your[SP]future,[SP]return\nto[SP]me.[1205][000F][SP]The[SP]crystal[SP]ball[SP]and[SP]the[SP]cards[SP]will[SP]be\nyour[SP]infallible[SP]guides.",
     "nom_fr": "Génie de Sumaru",
-    "texte_fr": "Si vous souhaitez voir votre avenir,\nrevenez me voir. [1205][000F]La boule de cristal et\nles cartes seront vos guides infaillibles."
+    "texte_fr": "Si vous souhaitez voir votre avenir,\nrevenez me voir. [000F][1205]La boule de cristal et\nles cartes seront vos guides infaillibles."
   },
   {
     "id": 148,
@@ -2355,7 +2355,7 @@
     "nom_orig": "Cowardly[SP]man",
     "texte_orig": "Well,[SP]for[SP]me,[SP]it's[SP]not[SP]about[SP]striving[SP]to[SP]reach\na[SP]better[SP]tomorrow.[1205][000F][SP]I[SP]just,[SP]you[SP]know,[SP]need[SP]a\nlittle[SP]push[SP]on[SP]the[SP]way.",
     "nom_fr": "Homme craintif",
-    "texte_fr": "Pour moi, c'est pas tant d'aspirer à\nun meilleur lendemain. [1205][000F]J'ai besoin\nd'un coup de pouce de temps en temps."
+    "texte_fr": "Pour moi, c'est pas tant d'aspirer à\nun meilleur lendemain. [000F][1205]J'ai besoin\nd'un coup de pouce de temps en temps."
   },
   {
     "id": 151,
@@ -2370,7 +2370,7 @@
     "nom_orig": "Cowardly[SP]man",
     "texte_orig": "I'm[SP]no[SP]good[SP]at[SP]deciding[SP]things[SP]for[SP]myself.[1205][000F]\nI[SP]just[SP]need[SP]this[SP]place[SP]to[SP]give[SP]me[SP]a[SP]boost,\ntell[SP]me[SP]I'm[SP]on[SP]the[SP]right[SP]track.",
     "nom_fr": "Homme craintif",
-    "texte_fr": "Je suis mauvais pour décider seul.\n[1205][000F]J'ai juste besoin qu'on me dise\nque je suis sur la bonne voie."
+    "texte_fr": "Je suis mauvais pour décider seul.\n[000F][1205]J'ai juste besoin qu'on me dise\nque je suis sur la bonne voie."
   },
   {
     "id": 152,
@@ -2385,7 +2385,7 @@
     "nom_orig": "Cowardly[SP]man",
     "texte_orig": "I[SP]think[SP]the[SP]Genie[SP]is[SP]wrong[SP]just[SP]this[SP]once.[1205][000F]\nShe[SP]said[SP]Muses[SP]won't[SP]be[SP]a[SP]hit.[1205][000F][SP]They're[SP]the\ntalk[SP]of[SP]the[SP]town![SP]How[SP]could[SP]they[SP]not[SP]be[SP]huge?",
     "nom_fr": "Homme craintif",
-    "texte_fr": "Je crois que la Génie se trompe là. [1205][000F][1205][000F]Elle\na dit que les Muses ne percent pas. Elles\nfont la une! Comment ne pas cartonner?"
+    "texte_fr": "Je crois que la Génie se trompe là. [000F][1205][000F][1205]Elle\na dit que les Muses ne percent pas. Elles\nfont la une! Comment ne pas cartonner?"
   },
   {
     "id": 153,
@@ -2400,7 +2400,7 @@
     "nom_orig": "Cowardly[SP]man",
     "texte_orig": "Th-These[SP]attacks[SP]are[SP]so[SP]scary...[1205][000F][SP]I[SP]don't[SP]know\nwhere[SP]to[SP]run[SP]anymore,[SP]so[SP]I[SP]came[SP]to[SP]ask[SP]where\nnot[SP]to[SP]go.",
     "nom_fr": "Homme craintif",
-    "texte_fr": "Ces attaques sont terrifiantes.[1205][000F]..\nJe sais plus où fuir, alors je\nsuis venu demander où aller."
+    "texte_fr": "Ces attaques sont terrifiantes.[000F][1205]..\nJe sais plus où fuir, alors je\nsuis venu demander où aller."
   },
   {
     "id": 154,
@@ -2445,7 +2445,7 @@
     "nom_orig": "Cowardly[SP]man",
     "texte_orig": "Some[SP]kids[SP]were[SP]saying[SP]the[SP]gang[SP]of[SP]five[SP]from[SP]the\ncomposite[SP]sketches[SP]weren't[SP]the[SP]terrorists,[SP]but\nheroes[SP]fighting[SP]the[SP]Masked[SP]Circle.",
     "nom_fr": "Homme craintif",
-    "texte_fr": "Des gamins disaient que les cinq des\nportraits-robots n'étaient pas des\nterroristes, mais des\nhéros du Cercle masqué."
+    "texte_fr": "Des gamins disaient que les cinq des\nportraits-robots n'étaient pas des\nterroristes, mais des héros du Cercle masqué."
   },
   {
     "id": 157,
@@ -2460,7 +2460,7 @@
     "nom_orig": "Cowardly[SP]man",
     "texte_orig": "But[SP]I[SP]don't[SP]think[SP]I[SP]believe[SP]that.[1205][000F][SP]I-I[SP]mean,\nthere's[SP]no[SP]such[SP]thing[SP]as[SP]heroes,[SP]really...",
     "nom_fr": "Homme craintif",
-    "texte_fr": "Mais moi j'y crois pas. [1205][000F]J-Je veux dire,\ndes héros, ça n'existe pas vraiment..."
+    "texte_fr": "Mais moi j'y crois pas. [000F][1205]J-Je veux dire,\ndes héros, ça n'existe pas vraiment..."
   },
   {
     "id": 158,
@@ -2475,7 +2475,7 @@
     "nom_orig": "Cowardly[SP]man",
     "texte_orig": "Have[SP]you[SP]read[SP]it[SP]too?[1205][000F][SP]What[SP]am[SP]I[SP]talking[SP]about?\nThe[SP]In[SP]Lak'ech,[SP]of[SP]course!",
     "nom_fr": "Homme craintif",
-    "texte_fr": "Vous l'avez lu aussi? [1205][000F]De quoi je\nparle? L'In Lak'ech, bien sûr!"
+    "texte_fr": "Vous l'avez lu aussi? [000F][1205]De quoi je\nparle? L'In Lak'ech, bien sûr!"
   },
   {
     "id": 159,
@@ -2565,7 +2565,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "When[SP]did[SP]he[SP]become[SP]a[SP]politician?[1205][000F][SP]Never[SP]mind\nthat,[SP]when[SP]did[SP]we[SP]have[SP]an[SP]election?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Quand est-il devenu politicien?\n[1205][000F]D'ailleurs, quand a-t-on eu des élections?"
+    "texte_fr": "Quand est-il devenu politicien?\n[000F][1205]D'ailleurs, quand a-t-on eu des élections?"
   },
   {
     "id": 165,
@@ -2580,7 +2580,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "It[SP]doesn't[SP]matter[SP]much[SP]to[SP]me,[SP]but[SP]that[SP]guy's\na[SP]politician[SP]and[SP]he's[SP]leaving[SP]the[SP]decisions[SP]to\na[SP]fortune[SP]reading?[1205][000F][SP]Is[SP]that[SP]really[SP]a[SP]good[SP]idea?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ça m'importe peu, mais c'est un politicien\net il laisse ses décisions à une\nprédiction? [1205][000F]C'est vraiment une bonne idée?"
+    "texte_fr": "Ça m'importe peu, mais c'est un politicien\net il laisse ses décisions à une\nprédiction? [000F][1205]C'est vraiment une bonne idée?"
   },
   {
     "id": 166,
@@ -2595,7 +2595,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Hey,[SP]did[SP]you[SP]hear?[SP]The[SP]outdoor[SP]concert[SP]hall's\nalready[SP]packed[SP]with[SP]Muses[SP]fans.[1205][000F][SP]Man,[SP]what[SP]am\nI[SP]doing[SP]standing[SP]around[SP]here?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Hé, vous avez entendu? La salle en\nplein air est déjà bondée de fans\n[1205][000F]des Muses. Qu'est-ce que je fais là?"
+    "texte_fr": "Hé, vous avez entendu? La salle en\nplein air est déjà bondée de fans\n[000F][1205]des Muses. Qu'est-ce que je fais là?"
   },
   {
     "id": 167,
@@ -2610,7 +2610,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Hey,[SP]what's[SP]gotten[SP]into[SP]that[SP]guy[SP]now?[1205][000F][SP]Has[SP]he\ngone[SP]crazy[SP]out[SP]of[SP]fear[SP]of[SP]the[SP]attacks?[1205][000F][SP]I'm\nmore[SP]scared[SP]of[SP]him[SP]than[SP]the[SP]terrorists...",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Hé, qu'est-ce qui lui prend? [1205][000F][1205][000F]Il est\ndevenu fou de peur des attaques? Il me\nfait plus peur que les terroristes..."
+    "texte_fr": "Hé, qu'est-ce qui lui prend? [000F][1205][000F][1205]Il est\ndevenu fou de peur des attaques? Il me\nfait plus peur que les terroristes..."
   },
   {
     "id": 168,
@@ -2625,7 +2625,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Someone[SP]told[SP]me[SP]the[SP]terrorists[SP]behind[SP]the\nattacks[SP]were[SP]the[SP]Last[SP]Battalion.[SP]But[SP]who[SP]are\nthey?[1205][000F][SP]Is[SP]that[SP]some[SP]organization?",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Quelqu'un m'a dit que les terroristes\nresponsables, c'est le Bataillon.\n[1205][000F]Mais c'est qui? Une organisation?"
+    "texte_fr": "Quelqu'un m'a dit que les terroristes\nresponsables, c'est le Bataillon.\n[000F][1205]Mais c'est qui? Une organisation?"
   },
   {
     "id": 169,
@@ -2640,7 +2640,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "They[SP]released[SP]those[SP]composite[SP]sketches,[SP]right?[1205][000F]\nMan,[SP]I[SP]hope[SP]this[SP]ends[SP]soon.[SP]They[SP]need[SP]to[SP]hurry\nup[SP]and[SP]arrest[SP]those[SP]guys[SP]already.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Ils ont sorti ces portraits-robots, non?\n[1205][000F]Vivement que tout ça soit fini. Ils\ndoivent se dépêcher d'arrêter ces types."
+    "texte_fr": "Ils ont sorti ces portraits-robots, non?\n[000F][1205]Vivement que tout ça soit fini. Ils\ndoivent se dépêcher d'arrêter ces types."
   },
   {
     "id": 170,
@@ -2655,7 +2655,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Remember[SP]that[SP]stuff[SP]about[SP]the[SP]lions[SP]in[SP]that\nbook?[1205][000F][SP]Everyone[SP]thinks[SP]now[SP]that[SP]it's[SP]talking\nabout[SP]the[SP]Leonids.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "Tu te souviens des\nlions dans ce livre? [1205][000F]Tout\nle monde pense maintenant aux Léonides."
+    "texte_fr": "Tu te souviens des\nlions dans ce livre? [000F][1205]Tout\nle monde pense maintenant aux Léonides."
   },
   {
     "id": 171,
@@ -2670,7 +2670,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "I-I[SP]saw[SP]them...[1205][000F][SP]Those[SP]soldiers[SP]with[SP]long[SP]spears,\nflying[SP]overhead.[1205][000F][SP]They[SP]had[SP]numbers[SP]written[SP]on\nthem...[SP]They're[SP]definitely[SP]no[SP]ordinary[SP]army.",
     "nom_fr": "Jeune homme",
-    "texte_fr": "J-Je les ai vus.[1205][000F][1205][000F].. Ces soldats avec de\nlongues lances, volant au-dessus. Avec des\nnuméros... Ce n'est\npas une armée ordinaire."
+    "texte_fr": "J-Je les ai vus.[000F][1205][000F][1205].. Ces soldats avec de\nlongues lances, volant au-dessus. Avec des\nnuméros... Ce n'est pas une armée ordinaire."
   },
   {
     "id": 172,
@@ -2685,7 +2685,7 @@
     "nom_orig": "Politician",
     "texte_orig": "Wahaha![SP]I[SP]didn't[SP]think[SP]it[SP]would[SP]be[SP]this[SP]easy\nto[SP]become[SP]a[SP]politician.[1205][000F][SP]It[SP]pays[SP]to[SP]believe\nin[SP]crazy[SP]rumors[SP]sometimes.",
     "nom_fr": "Politicien",
-    "texte_fr": "Wahaha! Je n'aurais pas cru qu'il\nserait si facile. [1205][000F]Parfois croire\naux rumeurs ça paye vraiment."
+    "texte_fr": "Wahaha! Je n'aurais pas cru qu'il\nserait si facile. [000F][1205]Parfois croire\naux rumeurs ça paye vraiment."
   },
   {
     "id": 173,
@@ -2700,7 +2700,7 @@
     "nom_orig": "Politician",
     "texte_orig": "Never[SP]fear,[SP]citizens![1205][000F][SP]I[SP]shall[SP]fix[SP]everything,\nfrom[SP]the[SP]recession,[SP]to[SP]societal[SP]problems,\nto[SP]pollution,[SP]to[SP]your[SP]taxes!",
     "nom_fr": "Politicien",
-    "texte_fr": "N'ayez crainte, citoyens! [1205][000F]Je\nréglerai tout, récession, problèmes\nsociaux, pollution et impôts!"
+    "texte_fr": "N'ayez crainte, citoyens! [000F][1205]Je\nréglerai tout, récession, problèmes\nsociaux, pollution et impôts!"
   },
   {
     "id": 174,
@@ -2745,7 +2745,7 @@
     "nom_orig": "Politician",
     "texte_orig": "Wahahaha![1205][000F][SP]It's[SP]been[SP]so[SP]hectic[SP]lately[SP]since\nI[SP]keep[SP]getting[SP]taken[SP]for[SP]nights[SP]on[SP]the[SP]town.",
     "nom_fr": "Politicien",
-    "texte_fr": "Wahahaha! [1205][000F]C'est très agité en ce moment,\non m'invite sans cesse à des soirées."
+    "texte_fr": "Wahahaha! [000F][1205]C'est très agité en ce moment,\non m'invite sans cesse à des soirées."
   },
   {
     "id": 177,
@@ -2775,7 +2775,7 @@
     "nom_orig": "Politician",
     "texte_orig": "That[SP]reminds[SP]me...[SP]The[SP]Genie[SP]here...[SP]You[SP]can't\nsee[SP]her[SP]face,[SP]but[SP]I[SP]feel[SP]like[SP]I've[SP]heard[SP]that\nvoice[SP]somewhere.[SP]Can't[SP]put[SP]my[SP]finger[SP]on[SP]it...",
     "nom_fr": "Politicien",
-    "texte_fr": "En parlant de ça... La\nGénie ici... On ne voit\npas son visage mais cette voix... Je l'ai\nentendue quelque part\nImpossible de savoiroù..."
+    "texte_fr": "En parlant de ça... La\nGénie ici... On ne voit\npas son visage mais cette voix... Je l'ai entendue quelque part Impossible de savoiroù..."
   },
   {
     "id": 179,
@@ -2805,7 +2805,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "I[SP]didn't[SP]ask[SP]Joker[SP]to[SP]make[SP]me[SP]a[SP]politician[SP]so\nI[SP]could[SP]clean[SP]up[SP]their[SP]messes![1205][000F][SP]But[SP]they[SP]keep\non[SP]hounding[SP]me!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "J'ai pas demandé à Joker de me faire\npoliticien! Je suis pas\n[1205][000F]là pour régler leurs\ngâchis!"
+    "texte_fr": "J'ai pas demandé à Joker de me faire\npoliticien! Je suis pas\n[000F][1205]là pour régler leurs gâchis!"
   },
   {
     "id": 181,
@@ -2850,7 +2850,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Hehehe...[SP]Keep[SP]on[SP]burning...[1205][000F][SP]Burn[SP]this[SP]rotten\ncity[SP]along[SP]with[SP]its[SP]idiot[SP]people![SP]Waaahahaha!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Hihihi... Continue de brûler.[1205][000F].. Brûle cette\nville pourrie et ses idiots! Waaahahaha!"
+    "texte_fr": "Hihihi... Continue de brûler.[000F][1205].. Brûle cette\nville pourrie et ses idiots! Waaahahaha!"
   },
   {
     "id": 184,
@@ -2880,7 +2880,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Gah...[SP]This[SP]isn't[SP]funny![1205][000F][SP]If[SP]the[SP]things[SP]in[SP]that\nbook[SP]are[SP]true,[SP]the[SP]Earth[SP]will[SP]be[SP]annihilated!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Bah... C'est pas drôle! [1205][000F]Si ce que dit ce\nlivre est vrai, la Terre sera anéantie!"
+    "texte_fr": "Bah... C'est pas drôle! [000F][1205]Si ce que dit ce\nlivre est vrai, la Terre sera anéantie!"
   },
   {
     "id": 186,
@@ -2925,7 +2925,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "I[SP]won't[SP]go![1205][000F][SP]I[SP]don't[SP]care[SP]what[SP]Joker[SP]ordered,\nI[SP]refuse[SP]to[SP]obey[SP]him!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Je n'irai pas! [1205][000F]Joker peut\nm'ordonner, je refuse d'obéir!"
+    "texte_fr": "Je n'irai pas! [000F][1205]Joker peut\nm'ordonner, je refuse d'obéir!"
   },
   {
     "id": 189,
@@ -2955,7 +2955,7 @@
     "nom_orig": "Taxi[SP]driver",
     "texte_orig": "Nah,[SP]I[SP]don't[SP]drive[SP]my[SP]cab[SP]now.[1205][000F][SP]You[SP]get[SP]more\ncustomers[SP]after[SP]midnight,[SP]once[SP]the[SP]trains[SP]have\nstopped.[1205][000F][SP]I'm[SP]parked[SP]out[SP]at[SP]that[SP]old[SP]factory.",
     "nom_fr": "Chauffeur de taxi",
-    "texte_fr": "Non, je ne conduis pas maintenant.\n[1205][000F][1205][000F]Plus de clients après minuit. Je\nsuis garé à cette vieille usine."
+    "texte_fr": "Non, je ne conduis pas maintenant.\n[000F][1205][000F][1205]Plus de clients après minuit. Je\nsuis garé à cette vieille usine."
   },
   {
     "id": 191,
@@ -2970,7 +2970,7 @@
     "nom_orig": "Taxi[SP]driver",
     "texte_orig": "That[SP]reminds[SP]me,[SP]I[SP]haven't[SP]seen[SP]my[SP]buddy[SP]who\nloves[SP]yachts[SP]around.[1205][000F][SP]He[SP]always[SP]used[SP]to[SP]come\nhere.[1205][000F][SP]Well,[SP]lemme[SP]know[SP]if[SP]you[SP]need[SP]a[SP]cab.",
     "nom_fr": "Chauffeur de taxi",
-    "texte_fr": "Ça me rappelle, plus de nouvelles de mon\n[1205]pote fan de yachts. [1205][000F][000F]Il venait toujours\nici. Prévenez-moi si besoin d'un taxi."
+    "texte_fr": "Ça me rappelle, plus de nouvelles de mon\n[1205]pote fan de yachts. [000F][1205][000F]Il venait toujours\nici. Prévenez-moi si besoin d'un taxi."
   },
   {
     "id": 192,
@@ -2985,7 +2985,7 @@
     "nom_orig": "Scathing[SP]taxi[SP]driver",
     "texte_orig": "The[SP]hell[SP]are[SP]you[SP]lookin'[SP]at?[SP]And[SP]what's[SP]with\nthose[SP]clothes?[1205][000F][SP]Huh?[SP]Don't[SP]you[SP]got[SP]eyes,[SP]buddy?\nI'm[SP]a[SP]taxi[SP]driver.",
     "nom_fr": "Chauffeur hargneux",
-    "texte_fr": "C'est quoi ce regard? Et ces\nfringues? Hein? [1205][000F]T'as pas d'yeux, mon\npote? Je suis chauffeur de taxi."
+    "texte_fr": "C'est quoi ce regard? Et ces\nfringues? Hein? [000F][1205]T'as pas d'yeux, mon\npote? Je suis chauffeur de taxi."
   },
   {
     "id": 193,
@@ -3000,7 +3000,7 @@
     "nom_orig": "Scathing[SP]taxi[SP]driver",
     "texte_orig": "But[SP]my[SP]main[SP]job's[SP]a[SP]ship's[SP]captain,[SP]so[SP]I[SP]drive\nwith[SP]my[SP]yacht[SP]hat[SP]on.[1205][000F][SP]I[SP]make[SP]bank[SP]late[SP]at[SP]night,\nso[SP]I[SP]sleep[SP]in[SP]my[SP]cab[SP]at[SP]the[SP]factory[SP]by[SP]day.",
     "nom_fr": "Chauffeur hargneux",
-    "texte_fr": "Mon vrai boulot c'est capitaine de\nbateau. Je roule avec mon chapeau de\n[1205][000F]yacht. Je gagne bien la nuit,\nalorsje dors dans mon taxi à l'usine."
+    "texte_fr": "Mon vrai boulot c'est capitaine de\nbateau. Je roule avec mon chapeau de\n[000F][1205]yacht. Je gagne bien la nuit, alorsje dors dans mon taxi à l'usine."
   },
   {
     "id": 194,
@@ -3015,6 +3015,6 @@
     "nom_orig": "Scathing[SP]taxi[SP]driver",
     "texte_orig": "There's[SP]some[SP]guy[SP]who[SP]copies[SP]my[SP]style,[SP]but[SP]I\nain't[SP]seen[SP]him[SP]around[SP]lately,[SP]so[SP]I[SP]came[SP]lookin'\nfor[SP]him.[1205][000F][SP]You[SP]know[SP]anythin'[SP]about[SP]that,[SP]buddy?",
     "nom_fr": "",
-    "texte_fr": "Y'a un type qui copie mon style, mais\nj'le vois plus trop depuis un moment, alors\nj'suis venu le chercher.[1205][000F] T'aurais pas entendu parler de lui ?"
+    "texte_fr": "Y'a un type qui copie mon style, mais\nj'le vois plus trop depuis un moment, alors\nj'suis venu le chercher.[000F][1205] T'aurais pas entendu parler de lui ?"
   }
 ]

--- a/traduction/event_scripts/script_376.json
+++ b/traduction/event_scripts/script_376.json
@@ -42,7 +42,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey,[SP][1114],[SP]have[SP]you[SP]noticed?[1205][000F][SP]Everyone[SP]used\nto[SP]have[SP]a[SP]different[SP]theory[SP]about[SP]the[SP]end[SP]of[SP]the\nworld,[SP]but[SP]now[SP]they[SP]all[SP]say[SP]the[SP]same[SP]thing.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé [1114], t'as remarqué? [1205][000F]Tout le monde avait une\nthéorie différente sur la fin du monde,\nmaintenant ils disent tous la même chose."
+    "texte_fr": "Hé [1114], t'as remarqué? [000F][1205]Tout le monde avait une\nthéorie différente sur la fin du monde,\nmaintenant ils disent tous la même chose."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "If[SP]the[SP]Earth[SP]stops[SP]rotating...[1205][000F][SP]Could[SP]we[SP]save\nourselves[SP]by[SP]jumping[SP]at[SP]just[SP]the[SP]right[SP]moment?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Si la terre s'arrête de tourner.[1205][000F].. On\npeut se sauver en sautant au bon moment?"
+    "texte_fr": "Si la terre s'arrête de tourner.[000F][1205].. On\npeut se sauver en sautant au bon moment?"
   },
   {
     "id": 4,
@@ -102,7 +102,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hey...[1205][000F][SP]Don't[SP]let[SP]it[SP]bother[SP]you[SP]too[SP]much.[1205][000F]\nLet's[SP]just[SP]keep[SP]doing[SP]things[SP]the[SP]way[SP]we\nalways[SP]have.[1205][000A][SP]Sound[SP]good?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hé.[1205][000F][1205].[000F]. Ne te laisse pas tros perturber.\nContinuons à faire les choses de la\nmême manière qu'avant.[1205][000A] Okay?"
+    "texte_fr": "Hé.[000F][1205][1205].[000F]. Ne te laisse pas tros perturber.\nContinuons à faire les choses de la\nmême manière qu'avant.[000A][1205] Okay?"
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Man,[SP]that[SP]shadow[SP]of[SP][1113]-kun[SP]at[SP]the\nCaracol[SP]was[SP]scary.[1205][000F][SP]If[SP]he's[SP]walking[SP]around,[SP]you\ncan[SP]count[SP]on[SP]more[SP]bad[SP]rumors[SP]about[SP]you...",
     "nom_fr": "Maya",
-    "texte_fr": "L'ombre de [1113]-kun au Caracol était\nflippant. [1205][000F]S'il se promène dehors,\nd'autres mauvaises rumeurs surgiront..."
+    "texte_fr": "L'ombre de [1113]-kun au Caracol était\nflippant. [000F][1205]S'il se promène dehors,\nd'autres mauvaises rumeurs surgiront..."
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Maya",
     "texte_orig": "The[SP]fire[SP]crystal[SP]skull...[SP]This[SP]is[SP]the[SP]second\ntime[SP]we've[SP]had[SP]this[SP]one.[1205][000F][SP]It's[SP]the[SP]one[SP]my[SP]Shadow\ntook[SP]off[SP]with...[SP]I[SP]still[SP]feel[SP]bad[SP]about[SP]that.",
     "nom_fr": "Maya",
-    "texte_fr": "Le crâne de cristal de feu... C'est la\ndeuxième fois qu'on la eu\n [1205][000F]C'est celui que mon\nombre a emporté... Je\nm'en sens toujours mal."
+    "texte_fr": "Le crâne de cristal de feu... C'est la\ndeuxième fois qu'on la eu\n[000F][1205]C'est celui que mon ombre a emporté... Je m'en sens toujours mal."
   },
   {
     "id": 11,
@@ -192,7 +192,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Aquarius[SP]Temple...[1205][000F][SP]The[SP]wind[SP]crystal[SP]skull...[1205][000F]\nThe[SP]Order[SP]of[SP]the[SP]Holy[SP]Lance[SP]stole[SP]it[SP]and[SP]the\nheaven[SP]crystal[SP]skull.[SP]They'll[SP]be[SP]waiting...",
     "nom_fr": "Jun",
-    "texte_fr": "Le Temple du Verseau.[1205][000F][1205][000F].. Le crâne de cristal\ndu vent et du paradis... L'ordre de la\nlance bénite les a volés. Ils attendront.."
+    "texte_fr": "Le Temple du Verseau.[000F][1205][000F][1205].. Le crâne de cristal\ndu vent et du paradis... L'ordre de la\nlance bénite les a volés. Ils attendront.."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Jun",
     "texte_orig": "We[SP]already[SP]have[SP]the[SP]wind[SP]crystal[SP]skull[SP]from\nAquarius[SP]Temple.[1205][000F][SP]We[SP]need[SP]to[SP]hurry[SP]and[SP]gather\nthe[SP]remaining[SP]skulls[SP]as[SP]well...",
     "nom_fr": "Jun",
-    "texte_fr": "On a eu le crâne de cristal du vent au\n[1205][000F]Temple du Verseau  On doit se dépêcher\net récupérer les autres crânes..."
+    "texte_fr": "On a eu le crâne de cristal du vent au\n[000F][1205]Temple du Verseau  On doit se dépêcher\net récupérer les autres crânes..."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Jun",
     "texte_orig": "There's[SP]a[SP]line[SP]in[SP]the[SP]Oracle[SP]about[SP]the[SP]star\ncoming[SP]to[SP]a[SP]halt...[1205][000F][SP]I[SP]think[SP]that's[SP]why[SP]all[SP]the\ndifferent[SP]rumors[SP]were[SP]whittled[SP]down[SP]to[SP]one.",
     "nom_fr": "Jun",
-    "texte_fr": "L'oracle parle d'une\nétoile qui s'arrêtera...\n[1205][000F]Je pense que c'est pour ça que toutes les\nrumeurs se sont réduit à une seule."
+    "texte_fr": "L'oracle parle d'une\nétoile qui s'arrêtera...\n[000F][1205]Je pense que c'est pour ça que toutes les rumeurs se sont réduit à une seule."
   },
   {
     "id": 15,
@@ -252,7 +252,7 @@
     "nom_orig": "Jun",
     "texte_orig": "The[SP]closer[SP]you[SP]are[SP]to[SP]the[SP]poles,[SP]the[SP]lower[SP]the\nimpact[SP]will[SP]be...[SP]But[SP]the[SP]tsunamis[SP]and[SP]quakes\nwill[SP]still[SP]prevent[SP]anyone[SP]from[SP]surviving...",
     "nom_fr": "Jun",
-    "texte_fr": "Le plus proche tu\nes aux pôles, plus l'impact\nsera faible... Mais les tsunamis et\ntremblements de\nterre n'épargnerontpersonne..."
+    "texte_fr": "Le plus proche tu\nes aux pôles, plus l'impact\nsera faible... Mais les tsunamis et tremblements de terre n'épargnerontpersonne..."
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Welcome.[1205][000F][SP]It[SP]is[SP]my[SP]responsibility[SP]to[SP]clear[SP]the\nmurk[SP]from[SP]people's[SP]future.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Bienvenue. [1205][000F]Mon rôle de dissiper\nle brouillard du futur."
+    "texte_fr": "Bienvenue. [000F][1205]Mon rôle de dissiper\nle brouillard du futur."
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "But[SP]that[SP]responsibility[SP]will[SP]be[SP]lifted[SP]should\nour[SP]evolution[SP]erase[SP]such[SP]troubles.[1205][000F][SP]Speak[SP]your\nmind[SP]freely[SP]until[SP]the[SP]end[SP]draws[SP]nigh.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Mais cette responsabilité disparaîtra si\nnotre évolution efface ces problèmes.\n[1205][000F]Exprime-toi librement jusqu'à la fin."
+    "texte_fr": "Mais cette responsabilité disparaîtra si\nnotre évolution efface ces problèmes.\n[000F][1205]Exprime-toi librement jusqu'à la fin."
   },
   {
     "id": 19,
@@ -425,7 +425,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "If[SP]you[SP]wish[SP]to[SP]learn[SP]more[SP]of[SP]your[SP]future,[SP]come\nto[SP]me[SP]again.[1205][000F][SP]The[SP]crystal[SP]ball[SP]and[SP]the[SP]cards\nwill[SP]be[SP]your[SP]infallible[SP]guides.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Si tu désire en savoir plus sur ton\navenir, reviens bientôt. [1205][000F]La boule de\ncristal et les cartes te guideront."
+    "texte_fr": "Si tu désire en savoir plus sur ton\navenir, reviens bientôt. [000F][1205]La boule de\ncristal et les cartes te guideront."
   },
   {
     "id": 27,
@@ -710,7 +710,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Very[SP]well.[1205][000F][SP]The[SP]price[SP]will[SP]be[SP]3,000[SP]yen.\nDo[SP]you[SP]still[SP]wish[SP]this?\n[1208][0002]Yes\nNo",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Très bien. [1205][000F]3,000 yen.\nToujours d'accord?\n[1208][0002]OuiNon",
+    "texte_fr": "Très bien. [000F][1205]3,000 yen.\nToujours d'accord?\n[1208][0002]OuiNon",
     "question_orig": "Very[SP]well.[1205][000F][SP]The[SP]price[SP]will[SP]be[SP]3,000[SP]yen.\nDo[SP]you[SP]still[SP]wish[SP]this?",
     "choix_orig": [
       "Yes",
@@ -735,7 +735,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Unfortunately,[SP]your[SP]coffers[SP]are[SP]drained.[1205][000F]\nA[SP]golden[SP]key[SP]opens[SP]every[SP]door,[SP]as[SP]they[SP]say.\nReturn[SP]to[SP]me[SP]in[SP]a[SP]wealthier[SP]future.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Malheureusement, tu n'as pas assez.\n[1205][000F]Une clé dorée ouvre toutes les portes.\nReviens quand tu seras prospère"
+    "texte_fr": "Malheureusement, tu n'as pas assez.\n[000F][1205]Une clé dorée ouvre toutes les portes.\nReviens quand tu seras prospère"
   },
   {
     "id": 47,
@@ -750,7 +750,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Let[SP]us[SP]gaze[SP]into[SP]the[SP]mists...[1205][000F][SP]Am[SP]am[SP]am...\nRoice[SP]Charol[SP]Premium...[1205][000F][SP]Crystal[SP]ball...[SP]show\nme[SP]this[SP]man's[SP]destiny...",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Dans la brume...\nHm..[1205][1205]. [000F][000F]Roice Charol Premium...\nBoule de cristal...\nmontre moi son destin..."
+    "texte_fr": "Dans la brume...\nHm..[1205][1205]. [000F][000F]Roice Charol Premium...\nBoule de cristal... montre moi son destin..."
   },
   {
     "id": 48,
@@ -765,7 +765,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Yes...[SP]I[SP]see[SP]something...[1205][000F][SP]Your[SP]destiny[SP]is\nsolidifying...[SP]Hmm...[1205][000F][SP]This[SP]is...[1205][000F]\nThe[SP]Six[SP]of[SP]Wands...",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Oui... Je vois..[1205][000F][1205][000F][1205][000F].\nTon destin se cristalise...\nHmm... C'est... Le Six de Bâtons..."
+    "texte_fr": "Oui... Je vois..[000F][1205][000F][1205][000F][1205].\nTon destin se cristalise...\nHmm... C'est... Le Six de Bâtons..."
   },
   {
     "id": 49,
@@ -780,7 +780,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Victory[SP]and[SP]accomplishment...[1205][000F][SP]The[SP]card[SP]tells\nof[SP]an[SP]increase[SP]in[SP]your[SP]luck[SP]with[SP]money.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Victoire... [1205][000F]La carte montre une\naugmentation de ta chance avec l'argent"
+    "texte_fr": "Victoire... [000F][1205]La carte montre une\naugmentation de ta chance avec l'argent"
   },
   {
     "id": 50,
@@ -810,7 +810,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Yes...[SP]I[SP]see[SP]something...[1205][000F][SP]Your[SP]destiny[SP]is\nsolidifying...[SP]Hmm...[1205][000F][SP]This[SP]is...[1205][000F]\nThe[SP]Queen[SP]of[SP]Swords...",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Oui... Je vois..[1205][000F][1205][000F][1205].\n[000F]Ton destin se cristalise...\nHmm... C'est... La Reine des épées..."
+    "texte_fr": "Oui... Je vois..[000F][1205][000F][1205][1205].\n[000F]Ton destin se cristalise...\nHmm... C'est... La Reine des épées..."
   },
   {
     "id": 52,
@@ -825,7 +825,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Heightened[SP]perception[SP]and[SP]quick[SP]thinking...[1205][000F]\nThe[SP]card[SP]tells[SP]of[SP]a[SP]significant[SP]increase[SP]in\ngained[SP]experience.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Perception affiné et\npensée rapide.[1205][000F].. La carte\nmontre une\naugmentation d'éxpérience gagnée."
+    "texte_fr": "Perception affiné et\npensée rapide.[000F][1205].. La carte\nmontre une augmentation d'éxpérience gagnée."
   },
   {
     "id": 53,
@@ -900,7 +900,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Destiny...[1205][000F][SP]The[SP]card[SP]tells[SP]of[SP]an[SP]increase[SP]in\nyour[SP]luck.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Le destin.[1205][000F].. Ta chance augmentera."
+    "texte_fr": "Le destin.[000F][1205].. Ta chance augmentera."
   },
   {
     "id": 58,
@@ -915,7 +915,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "For[SP]the[SP]foreseeable[SP]future,[SP]you[SP]will[SP]be[SP]blessed\nwith[SP]good[SP]fortune[SP]and[SP]live[SP]in[SP]happiness.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Bientôt, la fortune\nt'accompgnera et tu vivras\ndans le bohnneur.\n [E4][NULL][NULL]\"Génie Sumaru, colporteuse\nde rumeurs Oui... Je vois... Ton destin se\ncristalise... Hmm...\nC'est... La Tempérance..."
+    "texte_fr": "Bientôt, la fortune\nt'accompgnera et tu vivras\ndans le bohnneur. [E4][NULL][NULL]\"Génie Sumaru, colporteuse de rumeurs Oui... Je vois... Ton destin se cristalise... Hmm... C'est... La Tempérance..."
   },
   {
     "id": 59,
@@ -945,7 +945,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Silence...[1205][000F][SP]The[SP]card[SP]tells[SP]your[SP]unremarkable,\neveryday[SP]existence.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Silence.[1205][000F].. Ton existence sera ordinaire"
+    "texte_fr": "Silence.[000F][1205].. Ton existence sera ordinaire"
   },
   {
     "id": 61,
@@ -990,7 +990,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "The[SP]cycle[SP]of[SP]life...[SP]Death[SP]and[SP]rebirth...[1205][000F]\nThe[SP]card[SP]tells[SP]of[SP]a[SP]decrease[SP]in[SP]your[SP]luck.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Le cycle de la vie.[1205][000F].. Ta chance baissera."
+    "texte_fr": "Le cycle de la vie.[000F][1205].. Ta chance baissera."
   },
   {
     "id": 64,
@@ -1020,7 +1020,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Yes...[SP]I[SP]see[SP]something...[1205][000F][SP]Your[SP]destiny[SP]is\nsolidifying...[SP]Hmm...[1205][000F][SP]This[SP]is...[1205][000F]\nThe[SP]Five[SP]of[SP]Cups...",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Oui... Je vois..[1205][000F][1205][000F][1205][000F].\nTon destin se cristalise...\nHm... C'est... Le Cinq de Coupes..."
+    "texte_fr": "Oui... Je vois..[000F][1205][000F][1205][000F][1205].\nTon destin se cristalise...\nHm... C'est... Le Cinq de Coupes..."
   },
   {
     "id": 66,
@@ -1035,7 +1035,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Loss...[1205][000F][SP]The[SP]card[SP]tells[SP]of[SP]a[SP]sudden[SP]parting.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Perte.[1205][000F].. Un départ soudain."
+    "texte_fr": "Perte.[000F][1205].. Un départ soudain."
   },
   {
     "id": 67,
@@ -1065,7 +1065,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Yes...[SP]I[SP]see[SP]something...[1205][000F][SP]Your[SP]destiny[SP]is\nsolidifying...[SP]Hmm...[1205][000F][SP]This[SP]is...[1205][000F]\nThe[SP]Moon...",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Oui... Je vois..[1205][000F][1205][000F][1205][000F]. Ton destin se\ncristalise... Hmm... C'est... La Lune..."
+    "texte_fr": "Oui... Je vois..[000F][1205][000F][1205][000F][1205]. Ton destin se\ncristalise... Hmm... C'est... La Lune..."
   },
   {
     "id": 69,
@@ -1080,7 +1080,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Insanity...[1205][000F][SP]The[SP]card[SP]tells[SP]of[SP]a[SP]decrease[SP]in\ngained[SP]experience.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Folie.[1205][000F].. Ton gain d'éxperience baissera."
+    "texte_fr": "Folie.[000F][1205].. Ton gain d'éxperience baissera."
   },
   {
     "id": 70,
@@ -1110,7 +1110,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Yes...[SP]I[SP]see[SP]something...[1205][000F][SP]Your[SP]destiny[SP]is\nsolidifying...[SP]Hmm...[1205][000F][SP]This[SP]is...[1205][000F]\nThe[SP]Two[SP]of[SP]Swords...",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Oui... Je vois..[1205][000F][1205][000F][1205][000F].\nTon destin se cristalise...\nHmm... C'est... Le Deux D'épées..."
+    "texte_fr": "Oui... Je vois..[000F][1205][000F][1205][000F][1205].\nTon destin se cristalise...\nHmm... C'est... Le Deux D'épées..."
   },
   {
     "id": 72,
@@ -1125,7 +1125,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Man's[SP]karma...[SP]Repressed[SP]emotions...[1205][000F][SP]The[SP]card\ntells[SP]of[SP]a[SP]decrease[SP]in[SP]your[SP]luck[SP]with[SP]money.[1205][000F]\n[E3][E4][NULL][NULL]\"Rumormonger[SP]Sumaru[SP]Genie\nFor[SP]the[SP]foreseeable[SP]future,[SP]you[SP]will[SP]be[SP]counted\namong[SP]the[SP]poor,[SP]forced[SP]to[SP]live[SP]in[SP]poverty[SP]and\nhunger.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Le karma... Les émotions réprimées.[1205][000F][1205][000F]..\nTa chance financière baissera. [E3][E4][NULL][NULL]\"Génie\nSumaru, colporteuse de rumeurs Bientôt,tu\nseras parmi les pauvres, contraint\nde vivre dans la faim et la misère."
+    "texte_fr": "Le karma... Les émotions réprimées.[000F][1205][000F][1205]..\nTa chance financière baissera. [E3][E4][NULL][NULL]\"Génie\nSumaru, colporteuse de rumeurs Bientôt,tu\nseras parmi les pauvres, contraint\nde vivre dans la faim et la misère."
   },
   {
     "id": 73,
@@ -1280,7 +1280,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "They[SP]tell[SP]of[SP][E4][NULL][NULL][0006]Tony's[SP]Shop[E4][NULL][NULL][0002][SP]in[SP]Yumezaki,[SP]which\nsells[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002].[1205][000F][SP]Their[SP][E4][NULL][NULL][0006]quality[SP]is[SP]exquisite,\nthough[SP]the[SP]prices[SP]are[SP]high[E4][NULL][NULL][0002].[SP]How[SP]dangerous...",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "On dit que[E4][NULL][NULL][0006]Tony[E4][NULL][NULL][0002]à Yumezaki, vend [E4][NULL][NULL][0006]des\nvrais armes[E4][NULL][NULL][0002]. [1205][000F]Leur [E4][NULL][NULL][0006]qualité est bonne,\nmais c'est cher[E4][NULL][NULL][0002]. Que c'est dangereux..."
+    "texte_fr": "On dit que[E4][NULL][NULL][0006]Tony[E4][NULL][NULL][0002]à Yumezaki, vend [E4][NULL][NULL][0006]des\nvrais armes[E4][NULL][NULL][0002]. [000F][1205]Leur [E4][NULL][NULL][0006]qualité est bonne,\nmais c'est cher[E4][NULL][NULL][0002]. Que c'est dangereux..."
   },
   {
     "id": 80,
@@ -1325,7 +1325,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "What's[SP]this!?[SP]Ginji[SP]Sasaki[SP]counts[SP]himself[SP]among\nthe[SP]Masked[SP]Circle?[1205][000F][SP]Th-This[SP]is[SP]a[SP]heartstopping\ntale[SP]indeed...[SP]Here[SP]is[SP]one[SP]from[SP]me.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Quoi!? Ginji Sasaki fait partie du\nCercle Masqué? [1205][000F]C'est un récit à\ncouper le souffle... Voici le mien."
+    "texte_fr": "Quoi!? Ginji Sasaki fait partie du\nCercle Masqué? [000F][1205]C'est un récit à\ncouper le souffle... Voici le mien."
   },
   {
     "id": 83,
@@ -1340,7 +1340,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "It[SP]would[SP]appear[SP][E4][NULL][NULL][0006]Jolly[SP]Roger[E4][NULL][NULL][0002][SP]sells[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002].[1205][000F]\nI'm[SP]quite[SP]surprised[SP]that[SP]one[SP]so[SP]near[SP]to[SP]us[SP]would\nsell[SP][E4][NULL][NULL][0006]high-quality,[SP]high-price[SP]armaments[E4][NULL][NULL][0002].",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "On dit que [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002]vend [E4][NULL][NULL][0006]des armes[E4][NULL][NULL][0002].\n[1205][000F]Je suis surprise qu'ils vendent des\narmes de [E4][NULL][NULL][0006]bonne qualité et puissance[E4][NULL][NULL][0002]."
+    "texte_fr": "On dit que [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002]vend [E4][NULL][NULL][0006]des armes[E4][NULL][NULL][0002].\n[000F][1205]Je suis surprise qu'ils vendent des\narmes de [E4][NULL][NULL][0006]bonne qualité et puissance[E4][NULL][NULL][0002]."
   },
   {
     "id": 84,
@@ -1370,7 +1370,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "I[SP]am[SP]told[SP]you[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002][SP]at[SP][E4][NULL][NULL][0006]Anima[SP]Mundi[E4][NULL][NULL][0002]\nin[SP]Yumezaki.[1205][000F][SP]It's[SP][E4][NULL][NULL][0006]high[SP]quality,[SP]but[SP]expensive[E4][NULL][NULL][0002]...\nThough[SP]I[SP]haven't[SP]confirmed[SP]the[SP]tale[SP]for[SP]myself.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "On peut, dit-on, acheter\n[E4][NULL][NULL][0006]des armures[E4][NULL][NULL][0002] à [E4][NULL][NULL][0006] Anima\n[1205]Mundi[E4][NULL][NULL][0002] à Yumezaki. [000F]Elles\nsont [E4][NULL][NULL][0006]de qualité, mais\nchères[E4][NULL][NULL][0002]... Mais je n'en suis pas sûre."
+    "texte_fr": "On peut, dit-on, acheter\n[E4][NULL][NULL][0006]des armures[E4][NULL][NULL][0002] à [E4][NULL][NULL][0006] Anima\n[1205]Mundi[E4][NULL][NULL][0002] à Yumezaki. [000F]Elles sont [E4][NULL][NULL][0006]de qualité, mais chères[E4][NULL][NULL][0002]... Mais je n'en suis pas sûre."
   },
   {
     "id": 86,
@@ -1400,7 +1400,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Treachery[SP]is[SP]yet[SP]another[SP]weight[SP]against[SP]man's\ninsurmountable[SP]karma.[1205][000F][SP]But[SP]as[SP]for[SP]my[SP]tale...",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "La trahison alourdit le karma de\nl'homme. [1205][000F]Quant à mon histoire..."
+    "texte_fr": "La trahison alourdit le karma de\nl'homme. [000F][1205]Quant à mon histoire..."
   },
   {
     "id": 88,
@@ -1415,7 +1415,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "The[SP][E4][NULL][NULL][0006]Aoba[SP]branch[SP]of[SP]Rosa[SP]Candida[E4][NULL][NULL][0002][SP]appears[SP]to\nsell[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]Their[SP][E4][NULL][NULL][0006]selection[SP]is[SP]impeccable,\nbut[SP]their[SP]resale[SP]prices[SP]are[SP]lacking[E4][NULL][NULL][0002].",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "La [E4][NULL][NULL][0006]Succursale Aoba de Rosa Candida[E4][NULL][NULL][0002] vend\n[E4][NULL][NULL][0006]des armures[E4][NULL][NULL][0002]. [1205][000F]Leur [E4][NULL][NULL][0006]sélection est bonne,\nmais le prix de revente est nul[E4][NULL][NULL][0002]."
+    "texte_fr": "La [E4][NULL][NULL][0006]Succursale Aoba de Rosa Candida[E4][NULL][NULL][0002] vend\n[E4][NULL][NULL][0006]des armures[E4][NULL][NULL][0002]. [000F][1205]Leur [E4][NULL][NULL][0006]sélection est bonne,\nmais le prix de revente est nul[E4][NULL][NULL][0002]."
   },
   {
     "id": 89,
@@ -1445,7 +1445,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "As[SP]for[SP]me,[SP]I[SP]tell[SP]the[SP]tale[SP]of[SP][E4][NULL][NULL][0006]London[SP]Clothier[E4][NULL][NULL][0002],\nwhich[SP]sells[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]Their[SP][E4][NULL][NULL][0006]selection[SP]is\npoor,[SP]but[SP]their[SP]resale[SP]prices[SP]are[SP]high[E4][NULL][NULL][0002].",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Je conte le récit du [E4][NULL][NULL][0006]Tailleur Londonien[E4][NULL][NULL][0002],\nqui vend [E4][NULL][NULL][0006]des armures[E4][NULL][NULL][0002]. [1205][000F]Leur [E4][NULL][NULL][0006]choix est\nnul, mais le prix de revente est bon[E4][NULL][NULL][0002]."
+    "texte_fr": "Je conte le récit du [E4][NULL][NULL][0006]Tailleur Londonien[E4][NULL][NULL][0002],\nqui vend [E4][NULL][NULL][0006]des armures[E4][NULL][NULL][0002]. [000F][1205]Leur [E4][NULL][NULL][0006]choix est\nnul, mais le prix de revente est bon[E4][NULL][NULL][0002]."
   },
   {
     "id": 91,
@@ -1460,7 +1460,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Come[SP]again?[1205][000F][SP]The[SP]purpose[SP]of[SP]the[SP]attacks[SP]was[SP]to\ncause[SP]those[SP]curious[SP]buildings[SP]to[SP]appear?",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Hein? [1205][000F]Les attaques visaient à faire\napparaître ces bâtiments bizarres?"
+    "texte_fr": "Hein? [000F][1205]Les attaques visaient à faire\napparaître ces bâtiments bizarres?"
   },
   {
     "id": 92,
@@ -1475,7 +1475,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Then[SP]the[SP]tale[SP]that[SP]the[SP]attacks[SP]were[SP]a[SP]part[SP]of\nthe[SP]Oracle[SP]was[SP]true...[1205][000F][SP]Very[SP]well.[SP]Here[SP]is[SP]one\nfrom[SP]me.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Alors les histoires disant que les attaques\n[1205][000F]faisaient partie de l'oracle étaient vraies"
+    "texte_fr": "Alors les histoires disant que les attaques\n[000F][1205]faisaient partie de l'oracle étaient vraies"
   },
   {
     "id": 93,
@@ -1490,7 +1490,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "They[SP]tell[SP]of[SP]a[SP][E4][NULL][NULL][0006]legendary[SP]weapon[SP]at[SP]Time[SP]Castle[E4][NULL][NULL][0002],\nwhose[SP]owner[SP]hides[SP]it[SP]away[SP]to[SP][E4][NULL][NULL][0006]charge[SP]exorbitant\nprices[E4][NULL][NULL][0002].[1205][000A][SP]What[SP]a[SP]despicable[SP]villain...",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "On dit qu'une [E4][NULL][NULL][0006]arme légendaire au Château\ndu Temps[E4][NULL][NULL][0002], est cachée pour être vendue [E4][NULL][NULL][0006] à\nprix cher [E4][NULL][NULL][0002].[1205][000A] Quel homme ignoble..."
+    "texte_fr": "On dit qu'une [E4][NULL][NULL][0006]arme légendaire au Château\ndu Temps[E4][NULL][NULL][0002], est cachée pour être vendue [E4][NULL][NULL][0006] à\nprix cher [E4][NULL][NULL][0002].[000A][1205] Quel homme ignoble..."
   },
   {
     "id": 94,
@@ -1505,7 +1505,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "*sigh*[1205][000A][SP]I'll[SP]be[SP]an[SP]Idealian[SP]soon.[1205][000F][SP]Maybe[SP]this\nis[SP]a[SP]good[SP]time.[1205][000F][SP]I[SP]want[SP]to[SP]sort[SP]out[SP]my\nfeelings[SP]while[SP]I'm[SP]still[SP]human...",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Ah.[1205][1205]..[1205][000A] Bientôt idéalienne. [000F][000F]C'est\nle moment. Je dois comprendre mes\nsentiments en tant qu'humaine..."
+    "texte_fr": "Ah.[1205][1205]..[000A][1205] Bientôt idéalienne. [000F][000F]C'est\nle moment. Je dois comprendre mes\nsentiments en tant qu'humaine..."
   },
   {
     "id": 95,
@@ -1520,7 +1520,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "My[SP]fortunes[SP]always[SP]come[SP]true,[SP]which[SP]is[SP]why[SP]I'm\nscared[SP]to[SP]read[SP]my[SP]own.[1205][000F][SP]I[SP]want[SP]to[SP]know,[SP]but[SP]it\nmakes[SP]me[SP]nervous,[SP]too.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Mes prédictions se réalisent\ntoujours, donc j'ai peur de lire la\n[1205][000F]mienne. Curieuse, mais nerveuse."
+    "texte_fr": "Mes prédictions se réalisent\ntoujours, donc j'ai peur de lire la\n[000F][1205]mienne. Curieuse, mais nerveuse."
   },
   {
     "id": 96,
@@ -1535,7 +1535,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "That's[SP]why[SP]I[SP]want[SP]you[SP]to[SP]read[SP]my[SP]fortune[SP]and\ntell[SP]me[SP]what[SP]to[SP]do.[1205][000F][SP]Neither[SP]of[SP]us[SP]are[SP]real\nfortune[SP]tellers.[1205][000A][SP]So[SP]I[SP]don't[SP]care[SP]how[SP]you[SP]do[SP]it.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "C'est pour ca que je veux que tu lises\n[1205][000F]mon avenir Nous ne sommes pas de vrais\nvoyants. [1205][000A] Peu importe comment tu le fais"
+    "texte_fr": "C'est pour ca que je veux que tu lises\n[000F][1205]mon avenir Nous ne sommes pas de vrais\nvoyants. [000A][1205] Peu importe comment tu le fais"
   },
   {
     "id": 97,
@@ -1575,7 +1575,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Wait...![1205][000F][SP]I'm[SP]sorry.[1205][000F][SP]I'm[SP]actually[SP]going[SP]to[SP]pass.[1205][000F]\nThis[SP]is[SP]no[SP]different[SP]than[SP]me[SP]leaving[SP]my[SP]life\nup[SP]to[SP]you...",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Attends.[1205][000F][1205][000F][1205][000F]..! Désolée. Je change d'avis. Ce\nserait comme laisser ma\nvie entre tes mains..."
+    "texte_fr": "Attends.[000F][1205][000F][1205][000F][1205]..! Désolée. Je change d'avis. Ce\nserait comme laisser ma\nvie entre tes mains..."
   },
   {
     "id": 99,
@@ -1590,7 +1590,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Everyone[SP]who[SP]comes[SP]here[SP]is[SP]afraid[SP]to[SP]make[SP]a\ndecision.[1205][000F][SP]I[SP]always[SP]wanted[SP]to[SP]tell[SP]them[SP]that\nonly[SP]their[SP]own[SP]decisions[SP]have[SP]any[SP]meaning.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Toutes ceux qui viennent ici ont peur\n[1205][000F]de décider. Je voulais leur dire que\nseule leur propre décision compte."
+    "texte_fr": "Toutes ceux qui viennent ici ont peur\n[000F][1205]de décider. Je voulais leur dire que\nseule leur propre décision compte."
   },
   {
     "id": 100,
@@ -1605,7 +1605,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "And[SP]as[SP]soon[SP]as[SP]you[SP]said[SP]you'd[SP]read[SP]my[SP]fortune,\nI[SP]realized[SP]I[SP]was[SP]doing[SP]the[SP]same[SP]thing.[1205][000F][SP]Yeah...[1205][000F]\nI[SP]shouldn't[SP]be[SP]getting[SP]my[SP]answer[SP]like[SP]this.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Quand tu as dit lire mon avenir, j'ai\ncompris que je faisais pareil. [1205]Oui.[1205][000F][000F].. Je\nne devrais pas recevoir ma réponse ainsi."
+    "texte_fr": "Quand tu as dit lire mon avenir, j'ai\ncompris que je faisais pareil. [1205]Oui.[000F][1205][000F].. Je\nne devrais pas recevoir ma réponse ainsi."
   },
   {
     "id": 101,
@@ -1620,7 +1620,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "I[SP]won't[SP]read[SP]my[SP]own[SP]future.[1205][000F][SP]I'll[SP]keep[SP]being\na[SP]fortune[SP]teller[SP]until[SP]the[SP]moment[SP]I[SP]evolve.[1205][000F]\nTrue,[SP]only[SP]your[SP]own[SP]decisions[SP]have[SP]meaning.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Je ne lirai pas mon destin. [1205][000F][1205][000F]Je resterai\nvoyante jusqu'à mon évolution. Seul tes\ndécisions ont de la valeur"
+    "texte_fr": "Je ne lirai pas mon destin. [000F][1205][000F][1205]Je resterai\nvoyante jusqu'à mon évolution. Seul tes\ndécisions ont de la valeur"
   },
   {
     "id": 102,
@@ -1635,7 +1635,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "But[SP]some[SP]people[SP]still[SP]need[SP]someone[SP]like[SP]me.[1205][001E]\n...Now,[SP]one[SP]who[SP]curses[SP]the[SP]wheel[SP]of[SP]fortune,[1205][000F]\ncome[SP]again[SP]if[SP]you[SP]wish[SP]to[SP]know[SP]your[SP]path.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Des personnes on encore besoin de moi.[1205][1205][001E]\n... Toi qui maudis la roue de la fortune,\n[000F]reviens pour connaître ton chemin."
+    "texte_fr": "Des personnes on encore besoin de moi.[1205][001E][1205]\n... Toi qui maudis la roue de la fortune,\n[000F]reviens pour connaître ton chemin."
   },
   {
     "id": 103,
@@ -1650,7 +1650,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "*sigh*[1205][000F][SP]You're[SP]not[SP]the[SP]first[SP]to[SP]say[SP]that[SP]to[SP]me...[1205][000F]\nThere[SP]was[SP]a[SP]young[SP]man[SP]with[SP]glasses[SP]here[SP]not\nlong[SP]ago.[SP]I[SP]asked[SP]him[SP]to[SP]read[SP]my[SP]fortune[SP]too.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Ah.[1205][000F][1205][000F].. Tu n'es pas le premier... Un jeune\nhomme à lunettes est venu récemment. Je\nlui ai aussi demandé de lire mon destin."
+    "texte_fr": "Ah.[000F][1205][000F][1205].. Tu n'es pas le premier... Un jeune\nhomme à lunettes est venu récemment. Je\nlui ai aussi demandé de lire mon destin."
   },
   {
     "id": 104,
@@ -1665,7 +1665,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "He[SP]gave[SP]me[SP]the[SP]same[SP]answer[SP]you[SP]did.[1205][000F][SP]And[SP]he[SP]went\non[SP]to[SP]ask,[SP][1432][NULL][NULL][0014]What[SP]meaning[SP]is[SP]there[SP]in[SP]an[SP]answer\ngiven[SP]to[SP]you[SP]by[SP]someone[SP]else?[1432][NULL][NULL][0014][1205][000F][SP]Would[SP]you[SP]agree?",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Il m'a donné la même réponse. [1205][000F][1205]Et m'a\n[000F]demandé, [1432][NULL][NULL][0014]Quel sens a une réponse donnée par\nquelqu'un d'autre?[1432][NULL][NULL][0014] N'es-tu pas d'accord?"
+    "texte_fr": "Il m'a donné la même réponse. [000F][1205][1205]Et m'a\n[000F]demandé, [1432][NULL][NULL][0014]Quel sens a une réponse donnée par\nquelqu'un d'autre?[1432][NULL][NULL][0014] N'es-tu pas d'accord?"
   },
   {
     "id": 105,
@@ -1680,7 +1680,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "Maybe[SP]you're[SP]right.[1205][000F][SP]If[SP]I'm[SP]too[SP]afraid[SP]to[SP]make[SP]a\ndecision[SP]and[SP]accept[SP]someone[SP]else's[SP]answer,\nI'll[SP]never[SP]find[SP]my[SP]own[SP]path.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Tu as raison. [1205][000F]Si j'ai peur de décider\net accepter la réponse des autres, Je\nne trouverais pas mon chemin."
+    "texte_fr": "Tu as raison. [000F][1205]Si j'ai peur de décider\net accepter la réponse des autres, Je\nne trouverais pas mon chemin."
   },
   {
     "id": 106,
@@ -1695,7 +1695,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "I[SP]won't[SP]read[SP]my[SP]own[SP]future.[1205][000F][SP]I'll[SP]keep[SP]being\na[SP]fortune[SP]teller[SP]until[SP]the[SP]moment[SP]I[SP]evolve.[1205][000F]\nTrue,[SP]only[SP]your[SP]own[SP]decisions[SP]have[SP]meaning.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Je ne lirai pas mon destin. [1205][000F][1205][000F]Je resterai\nvoyante jusqu'à mon évolution. Seules\ntes propres décisions ont de la valeur"
+    "texte_fr": "Je ne lirai pas mon destin. [000F][1205][000F][1205]Je resterai\nvoyante jusqu'à mon évolution. Seules\ntes propres décisions ont de la valeur"
   },
   {
     "id": 107,
@@ -1710,7 +1710,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "But[SP]some[SP]people[SP]still[SP]need[SP]someone[SP]like[SP]me.[1205][001E]\n...Now,[SP]one[SP]who[SP]curses[SP]the[SP]wheel[SP]of[SP]fortune,[1205][000F]\ncome[SP]again[SP]if[SP]you[SP]wish[SP]to[SP]know[SP]your[SP]path.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Des personnes ont encore besoin de moi.[1205][1205][001E]\n... Toi qui maudis la roue de la fortune,\n[000F]reviens pour connaître ton chemin."
+    "texte_fr": "Des personnes ont encore besoin de moi.[1205][001E][1205]\n... Toi qui maudis la roue de la fortune,\n[000F]reviens pour connaître ton chemin."
   },
   {
     "id": 108,
@@ -1725,7 +1725,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "If[SP]man[SP]evolves[SP]into[SP]Idealian,[SP]no[SP]one[SP]will[SP]ever\nbe[SP]troubled[SP]or[SP]confused[SP]again.[1205][000F][SP]Such[SP]is[SP]it[SP]to\nknow[SP]the[SP]purpose[SP]for[SP]one's[SP]existence.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Si l'homme devient Idéalien, plus\npersonne ne sera troublé. [1205][000F]Connaître\nle but de son existence fait ca."
+    "texte_fr": "Si l'homme devient Idéalien, plus\npersonne ne sera troublé. [000F][1205]Connaître\nle but de son existence fait ca."
   },
   {
     "id": 109,
@@ -1740,7 +1740,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "My[SP]gifts[SP]will[SP]no[SP]longer[SP]be[SP]needed.[1205][000F][SP]But[SP]haha,\nthat[SP]doesn't[SP]sound[SP]so[SP]bad.[SP]It[SP]doesn't[SP]mean\nI'll[SP]have[SP]nowhere[SP]to[SP]go.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Mes dons ne seront plus nécessaires.\n[1205][000F]Mais haha, c'est pas grave. Je\nn'aurais pas nul part où aller."
+    "texte_fr": "Mes dons ne seront plus nécessaires.\n[000F][1205]Mais haha, c'est pas grave. Je\nn'aurais pas nul part où aller."
   },
   {
     "id": 110,
@@ -1785,7 +1785,7 @@
     "nom_orig": "Rumormonger[SP]Sumaru[SP]Genie",
     "texte_orig": "If[SP]you[SP]wish[SP]to[SP]peer[SP]into[SP]your[SP]future,[SP]return\nto[SP]me.[1205][000F][SP]The[SP]crystal[SP]ball[SP]and[SP]the[SP]cards[SP]will[SP]be\nyour[SP]infallible[SP]guides.",
     "nom_fr": "Génie Sumaru, colporteuse de rumeurs",
-    "texte_fr": "Si tu veux voir ton\navenir, reviens. [1205][000F]La boule\nde cristal et les\ncartes seront tes guideront"
+    "texte_fr": "Si tu veux voir ton\navenir, reviens. [000F][1205]La boule\nde cristal et les cartes seront tes guideront"
   },
   {
     "id": 113,
@@ -1815,7 +1815,7 @@
     "nom_orig": "Cowardly[SP]man",
     "texte_orig": "I'll[SP]know[SP]what[SP]to[SP]do[SP]once[SP]I'm[SP]an[SP]Idealian.[1205][000F]\nI[SP]won't[SP]need[SP]to[SP]ask[SP]the[SP]fortune[SP]teller...\nI'll[SP]have[SP]my[SP]own[SP]confidence![1205][000F][SP]I[SP]can't[SP]wait!",
     "nom_fr": "Homme peureux",
-    "texte_fr": "Je saurais quoi faire quand je serai un\n[1205][000F][1205][000F]Idéalien. Pas besoin de la voyante...\nJ'aurai confiance en moi! J'ai trop hâte!"
+    "texte_fr": "Je saurais quoi faire quand je serai un\n[000F][1205][000F][1205]Idéalien. Pas besoin de la voyante...\nJ'aurai confiance en moi! J'ai trop hâte!"
   },
   {
     "id": 115,
@@ -1830,7 +1830,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Hey,[SP]what's[SP]going[SP]to[SP]happen[SP]to[SP]the[SP]Earth[SP]below?[1205][000F]\nIf[SP]it's[SP]gonna[SP]get[SP]destroyed,[SP]will[SP]there[SP]be[SP]some\nhuge[SP]explosion?[1205][000F][SP]That's[SP]kind[SP]of[SP]exciting.",
     "nom_fr": "Jeune Homme",
-    "texte_fr": "Hé, qu'est-ce qui va arriver à la terre?\n[1205][000F][1205][000F]Si il y'a destruction, y'aura-t-il une\nexplosion? C'est asset excitant."
+    "texte_fr": "Hé, qu'est-ce qui va arriver à la terre?\n[000F][1205][000F][1205]Si il y'a destruction, y'aura-t-il une\nexplosion? C'est asset excitant."
   },
   {
     "id": 116,
@@ -1860,7 +1860,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Some[SP]guys[SP]were[SP]saying[SP]that[SP]when[SP]the[SP]Grand\nCross[SP]happens,[SP]the[SP]gravitational[SP]forces[SP]will\ntwist[SP]the[SP]Earth[SP]up[SP]like[SP]a[SP]pretzel.[1205][000F][SP]Neat.",
     "nom_fr": "Jeune Homme",
-    "texte_fr": "Certains disent que quand la Croix\nCosmique aura lieu, la gravité déformera\nla Terre comme un bretzel. [1205][000F]Cool."
+    "texte_fr": "Certains disent que quand la Croix\nCosmique aura lieu, la gravité déformera\nla Terre comme un bretzel. [000F][1205]Cool."
   },
   {
     "id": 118,
@@ -1890,7 +1890,7 @@
     "nom_orig": "Young[SP]man",
     "texte_orig": "Inertia[SP]will[SP]blast[SP]everything[SP]away.[1205][000F][SP]The[SP]oceans,\nthe[SP]mountains,[SP]even[SP]the[SP]air.[1205][000F][SP]Yeah,[SP]that'd\ndefinitely[SP]qualify[SP]as[SP][1432][NULL][NULL][0014]annihilation.[1432][NULL][NULL][0014]",
     "nom_fr": "Jeune Homme",
-    "texte_fr": "LInertie projettera tout au loin. [1205][000F][1205][000F]Les\nocéans, les montagnes,\net même l'air. Ouais,\nce serait clairement un [1432][NULL][NULL][0014]anéantissement[1432][NULL][NULL][0014]"
+    "texte_fr": "LInertie projettera tout au loin. [000F][1205][000F][1205]Les\nocéans, les montagnes,\net même l'air. Ouais, ce serait clairement un [1432][NULL][NULL][0014]anéantissement[1432][NULL][NULL][0014]"
   },
   {
     "id": 120,
@@ -1905,7 +1905,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Wahahaha![1205][000A][SP]God[SP]is[SP]on[SP]my[SP]side![1205][000F][SP]Soon,[SP]the[SP]Earth\nwill[SP]be[SP]destroyed[SP]and[SP]only[SP]we[SP]in[SP]Sumaru[SP]will\nsurvive.[1205][000F][SP]We'll[SP]be[SP]the[SP]only[SP]humans[SP]left[SP]living!",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Mwahaha![1205][1205][1205][000A] Dieu est avec moi! [000F][000F]Bientôt, la\nTerre sera détruite et seul nous à Sumaru\nsurvivrons. Nous serons\nles seuls sur Terre!"
+    "texte_fr": "Mwahaha![1205][1205][000A][1205] Dieu est avec moi! [000F][000F]Bientôt, la\nTerre sera détruite et seul nous à Sumaru\nsurvivrons. Nous serons les seuls sur Terre!"
   },
   {
     "id": 121,
@@ -1920,7 +1920,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "You[SP]know[SP]what[SP]that[SP]means?[1205][000F][SP]As[SP]a[SP]politician,\nI'll[SP]be[SP]the[SP]most[SP]powerful[SP]man[SP]alive![1205][000F][SP]Wahahahaha!",
     "nom_fr": "Membre du Cercle Masqué",
-    "texte_fr": "Tu sais ce que ça veut dire? En tant que\n[1205][000F][1205][000F]politicien, je serai\nl'homme le plus puissant\ndu monde! Mwahahaha! Message de debug. Vous\nne devriez pas me\nvoir. Reset du BIT voyance."
+    "texte_fr": "Tu sais ce que ça veut dire? En tant que\n[000F][1205][000F][1205]politicien, je serai\nl'homme le plus puissant du monde! Mwahahaha! Message de debug. Vous ne devriez pas me voir. Reset du BIT voyance."
   },
   {
     "id": 122,
@@ -1935,7 +1935,7 @@
     "nom_orig": "Spiteful[SP]man",
     "texte_orig": "I[SP]work[SP]at[SP]Sumaru[SP]TV,[SP]and[SP]one[SP]of[SP]my[SP]coworkers\nis[SP]the[SP]biggest[SP]scaredy[SP]cat.[1205][000F][SP]We[SP]were[SP]at[SP]the[SP]old\nabandoned[SP]factory[SP]and[SP]I[SP]told[SP]him[SP]a[SP]scary[SP]story.",
     "nom_fr": "Homme malveillant",
-    "texte_fr": "Je bosse à Sumaru TV, et un collègue est un\nvrai trouillard. à\n[1205][000F]la vieille usine abandonnée\nje lui ai raconté une histoire flippante."
+    "texte_fr": "Je bosse à Sumaru TV, et un collègue est un\nvrai trouillard. à\n[000F][1205]la vieille usine abandonnée je lui ai raconté une histoire flippante."
   },
   {
     "id": 123,
@@ -1950,7 +1950,7 @@
     "nom_orig": "Spiteful[SP]man",
     "texte_orig": "I[SP]told[SP]him[SP]no[SP]one[SP]knows[SP]what[SP]it's[SP]actually\nabout,[SP]it's[SP]just[SP]really[SP]creepy.[1205][000F][SP]It's[SP]scarier\nif[SP]you[SP]put[SP]it[SP]that[SP]way,[SP]right?",
     "nom_fr": "Homme malveillant",
-    "texte_fr": "Je lui ai dit que\npersonne sait ce que c'est.\n[1205][000F]Dit comme ca, Ca fait encore plus peur non?"
+    "texte_fr": "Je lui ai dit que\npersonne sait ce que c'est.\n[000F][1205]Dit comme ca, Ca fait encore plus peur non?"
   },
   {
     "id": 124,
@@ -1965,6 +1965,6 @@
     "nom_orig": "Spiteful[SP]man",
     "texte_orig": "And[SP]just[SP]like[SP]I[SP]thought,[SP]whatever[SP]he[SP]imagined\nfreaked[SP]him[SP]out.[SP]He[SP]went[SP]white[SP]as[SP]a[SP]sheet![1205][000F]\nHeeheehee...[SP]Ahahaha![SP]It[SP]still[SP]cracks[SP]me[SP]up!",
     "nom_fr": "",
-    "texte_fr": "Et comme je le pensais, ce qu'il a imaginé\nl'a terrorisé. Il est devenu blanc comme un linge ![1205][000F]\nHihi... Ahaha ! Ça me fait encore rire !"
+    "texte_fr": "Et comme je le pensais, ce qu'il a imaginé\nl'a terrorisé. Il est devenu blanc comme un linge ![000F][1205]\nHihi... Ahaha ! Ça me fait encore rire !"
   }
 ]

--- a/traduction/event_scripts/script_377.json
+++ b/traduction/event_scripts/script_377.json
@@ -12,7 +12,7 @@
     "nom_orig": "Trish",
     "texte_orig": "You[SP]came[SP]for[SP]no[SP]reason?[1205][000A][SP]No[SP]browsing[SP]allowed!\nGet[SP]out!",
     "nom_fr": "Trish",
-    "texte_fr": "T'es venu sans raison?[1205][000A]\nArrête de fouiner! Dehors!"
+    "texte_fr": "T'es venu sans raison?[000A][1205]\nArrête de fouiner! Dehors!"
   },
   {
     "id": 1,
@@ -72,7 +72,7 @@
     "nom_orig": "Trish",
     "texte_orig": "Well,[SP]come[SP]again.[SP]I'll[SP]be[SP]waiting![1205][000F]\nBye-bye!",
     "nom_fr": "Trish",
-    "texte_fr": "Bon, à plus. Je t'attendrais! [1205][000F]Bye-bye!"
+    "texte_fr": "Bon, à plus. Je t'attendrais! [000F][1205]Bye-bye!"
   },
   {
     "id": 5,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey...[1205][000A][SP]What[SP]is[SP]this[SP]place...?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé...[1205][000A] C'est quoi ca...?"
+    "texte_fr": "Hé...[000A][1205] C'est quoi ca...?"
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Wow.[1205][000A][SP]Sure[SP]is[SP]convenient,[SP]being[SP]able[SP]to[SP]get\nourselves[SP]healed[SP]like[SP]that...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Wow.[1205][000A] C'est vraiment pratique de\npouvoir se soigner comme ca..."
+    "texte_fr": "Wow.[000A][1205] C'est vraiment pratique de\npouvoir se soigner comme ca..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah![SP]Who[SP]is[SP]that!?[1205][000A][SP]She's[SP]too[SP]cute!",
     "nom_fr": "Ginko",
-    "texte_fr": "Ah! C'est qui!?[1205][000A] Elle est mignonne!"
+    "texte_fr": "Ah! C'est qui!?[000A][1205] Elle est mignonne!"
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Don't[SP]the[SP]rates[SP]here[SP]seem[SP]higher[SP]than[SP]other\nstores?[SP]She's[SP]awful[SP]greedy[SP]for[SP]someone[SP]so[SP]cute.",
     "nom_fr": "Ginko",
-    "texte_fr": "Ses prix sont chers\ncomparé aux autres, non?\nElle est super cupide\npour une fée mignonne"
+    "texte_fr": "Ses prix sont chers\ncomparé aux autres, non?\nElle est super cupide pour une fée mignonne"
   },
   {
     "id": 9,
@@ -192,7 +192,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "This[SP]is[SP]a[SP]healing[SP]spring.[1205][000A][SP]For[SP]a[SP]price,\nTrish[SP]here[SP]will[SP]cure[SP]your[SP]wounds.[1205][000F][SP]But[SP]her\nfees[SP]are[SP]out[SP]of[SP]this[SP]world...",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est une source de guérison.[1205][1205][000A]\nTrish soignera vos blessures et le\n[000F]reste. Mais pas gratuitement..."
+    "texte_fr": "C'est une source de guérison.[1205][000A][1205]\nTrish soignera vos blessures et le\n[000F]reste. Mais pas gratuitement..."
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Is[SP]she[SP]really[SP]a[SP]fairy?[1205][000F][SP]She's[SP]more[SP]devious\nthan[SP]your[SP]average[SP]demon.",
     "nom_fr": "Yukino",
-    "texte_fr": "Est-elle vraiment un fée? [1205][000F]Elle\nest malicieuse comme un démon."
+    "texte_fr": "Est-elle vraiment un fée? [000F][1205]Elle\nest malicieuse comme un démon."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Don't[SP]let[SP]her[SP]looks[SP]fool[SP]you.[1205][000F][SP]She's[SP]got[SP]the\nheart[SP]of[SP]a[SP]tax[SP]collector.[1205][000F][SP]I've[SP]paid[SP]her[SP]ripoff\nprices[SP]many[SP]times[SP]before...",
     "nom_fr": "Yukino",
-    "texte_fr": "Ne te fie pas par son look. [1205][000F][1205][000F]Elle\na le coeur d'un percepteur. J'ai\ndéja payé ses prix exorbitants..."
+    "texte_fr": "Ne te fie pas par son look. [000F][1205][000F][1205]Elle\na le coeur d'un percepteur. J'ai\ndéja payé ses prix exorbitants..."
   },
   {
     "id": 15,
@@ -252,7 +252,7 @@
     "nom_orig": "???",
     "texte_orig": "This[SP]world[SP]runs[SP]on[SP]give-and-take![1205][000F][SP]Hey,[SP]wait!\nIs[SP]this[SP]your[SP]first[SP]time[SP]here?",
     "nom_fr": "???",
-    "texte_fr": "Ici c'est donnant-donnat! [1205][000F]Hé,\nattends! C'est ta première fois ici?"
+    "texte_fr": "Ici c'est donnant-donnat! [000F][1205]Hé,\nattends! C'est ta première fois ici?"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "???",
     "texte_orig": "Then[SP]I[SP]better[SP]introduce[SP]myself.[1205][000A][SP]Name's[SP]Trish.[1205][000F]\nThis[SP]is[SP]my[SP]fountain[SP]of[SP]healing.[1205][000A][SP]I'll[SP]treat\nyour[SP]wounds!",
     "nom_fr": "???",
-    "texte_fr": "Je me présente.[1205][1205][000A] Mon nom est Trish.\n[000F]Ca c'est ma fontaine de guérison.[1205][000A]\nJe m'occupe de tes blessures!"
+    "texte_fr": "Je me présente.[1205][000A][1205] Mon nom est Trish.\n[000F]Ca c'est ma fontaine de guérison.[000A][1205]\nJe m'occupe de tes blessures!"
   },
   {
     "id": 18,
@@ -282,7 +282,7 @@
     "nom_orig": "Trish",
     "texte_orig": "Not[SP]for[SP]free,[SP]of[SP]course.[1205][000F][SP]This[SP]world[SP]runs[SP]on\ngive-and-take![1205][000F][SP]Give[SP]me[SP]money[SP]and[SP]I'll[SP]take\naway[SP]your[SP]pain!",
     "nom_fr": "Trish",
-    "texte_fr": "C'est pas gratuit bien sûr. [1205][000F][1205][000F]Ici\nc'est donnant-donnant! Donne moi\nde l'argent et je m'occupe de toi!"
+    "texte_fr": "C'est pas gratuit bien sûr. [000F][1205][000F][1205]Ici\nc'est donnant-donnant! Donne moi\nde l'argent et je m'occupe de toi!"
   },
   {
     "id": 19,
@@ -297,7 +297,7 @@
     "nom_orig": "Trish",
     "texte_orig": "This[SP]world[SP]runs[SP]on[SP]give-and-take![1205][000F][SP]Give[SP]me[SP]money\nand[SP]I'll[SP]take[SP]away[SP]your[SP]pain![1205][000F][SP]What'll[SP]it[SP]be?",
     "nom_fr": "Trish",
-    "texte_fr": "Ici c'est donnant-donnant! [1205][000F][1205][000F]Donne moi de\nl'argent et je m'occupe de toi! Donc?"
+    "texte_fr": "Ici c'est donnant-donnant! [000F][1205][000F][1205]Donne moi de\nl'argent et je m'occupe de toi! Donc?"
   },
   {
     "id": 20,
@@ -394,7 +394,7 @@
     "nom_orig": "Trish",
     "texte_orig": "My[SP]fees[SP]depend[SP]on[SP]the[SP]current[SP]market[SP]value[SP]for\nhealing,[SP]but[SP]I[SP]do[SP]cure[SP]everyone,[SP]so[SP]you[SP]might\nsave[SP]a[SP]little[SP]in[SP]the[SP]long[SP]run.",
     "nom_fr": "Trish",
-    "texte_fr": "Mes tarifs dépendent de la valeur du\nmarché pour les soins, mais je soigne tout\nle monde, donc tu pourras économiser\nunpeu au final. Erreur Aucun BIT de saut.\nContactez Kanada, ou plutôt votre chef QA."
+    "texte_fr": "Mes tarifs dépendent de la valeur du\nmarché pour les soins, mais je soigne tout\nle monde, donc tu pourras économiser unpeu au final. Erreur Aucun BIT de saut. Contactez Kanada, ou plutôt votre chef QA."
   },
   {
     "id": 25,
@@ -424,7 +424,7 @@
     "nom_orig": "Trish",
     "texte_orig": "Okay![1205][000A][SP]Now[SP]let's[SP]see...[1205][000A][SP]With[SP]the[SP]going[SP]rate\nfor[SP]healing...[1205][000A][SP]That's...",
     "nom_fr": "Trish",
-    "texte_fr": "D'accord![1205][000A] Donc...[1205][000A] Selon les\nprix actuels... [1205][000A]Ca fait..."
+    "texte_fr": "D'accord![000A][1205] Donc...[000A][1205] Selon les\nprix actuels... [000A][1205]Ca fait..."
   },
   {
     "id": 27,
@@ -464,7 +464,7 @@
     "nom_orig": "Trish",
     "texte_orig": "Don't[SP]be[SP]a[SP]skinflint![SP]And[SP]don't[SP]blame[SP]me[SP]if\nyou[SP]wind[SP]up[SP]dead![1205][000F][SP]In[SP]fact,[SP]I[SP]hope[SP]you[SP]die,\nyou[SP]mangy,[SP]dirty[SP]bum!",
     "nom_fr": "Trish",
-    "texte_fr": "Sois pas radin! M'accuse pas si tu meurs!\n[1205][000F]J'espère que tu\ncrèves sale clodo pouilleux!"
+    "texte_fr": "Sois pas radin! M'accuse pas si tu meurs!\n[000F][1205]J'espère que tu\ncrèves sale clodo pouilleux!"
   },
   {
     "id": 29,
@@ -479,7 +479,7 @@
     "nom_orig": "Trish",
     "texte_orig": "Alright![SP]Then[SP]here[SP]goes![1205][000F]\nPain,[SP]pain,[SP]go[SP]away![1205][0008]\nTralalalala!",
     "nom_fr": "Trish",
-    "texte_fr": "D'accord! On y va! [1205]Douleur,\n[000F]douleur, va-t'en![1205][0008] Tralala!"
+    "texte_fr": "D'accord! On y va! [1205]Douleur,\n[000F]douleur, va-t'en![0008][1205] Tralala!"
   },
   {
     "id": 30,
@@ -509,7 +509,7 @@
     "nom_orig": "Trish",
     "texte_orig": "It's[SP]dangerous[SP]outside[SP]these[SP]doors.[1205][000F][SP]Let[SP]your\nguard[SP]down[SP]for[SP]a[SP]second,[SP]you'll[SP]have[SP]scars[SP]for\nlife.[1205][000F][SP]That's[SP]why[SP]I'm[SP]here![SP]Don't[SP]be[SP]cheap!",
     "nom_fr": "Trish",
-    "texte_fr": "C'est dangereux dehors. [1205][000F][1205][000F]Baisse ta guarde\nune seconde et tu te feras défoncer. C'est\npour ca que je suis là! Ne soit pas radin!"
+    "texte_fr": "C'est dangereux dehors. [000F][1205][000F][1205]Baisse ta guarde\nune seconde et tu te feras défoncer. C'est\npour ca que je suis là! Ne soit pas radin!"
   },
   {
     "id": 32,
@@ -576,7 +576,7 @@
     "nom_orig": "Trish",
     "texte_orig": "Alright![SP]Pain,[SP]pain,[SP]go[SP]a...[SP]Hey![SP]You[SP]don't\nhave[SP]enough[SP]money![SP]Come[SP]back[SP]when[SP]your\nwallet's[SP]fuller!",
     "nom_fr": "Trish",
-    "texte_fr": "D'accord! Douleur, douleur,\nva-t'... Hé! T'as\npas assez d'argent!\nReviens quand tes poches\nseront pleines! Erreur Aucun BIT de saut.\nContactez Kanada, ou plutôt votre chef QA."
+    "texte_fr": "D'accord! Douleur, douleur,\nva-t'... Hé! T'as\npas assez d'argent! Reviens quand tes poches seront pleines! Erreur Aucun BIT de saut. Contactez Kanada, ou plutôt votre chef QA."
   },
   {
     "id": 35,
@@ -591,7 +591,7 @@
     "nom_orig": "Jun",
     "texte_orig": "A[SP]healing[SP]spring...[1205][000F][SP]That[SP]fairy's[SP]going[SP]to\ncure[SP]our[SP]wounds![1205][000F][SP]Isn't[SP]that[SP]great,[SP][1113]?",
     "nom_fr": "Jun",
-    "texte_fr": "Une source de\n[1205][000F][1205][000F]guérison... Cette fée soignera\nnos blessures! C'est pas top? [1113]?"
+    "texte_fr": "Une source de\n[000F][1205][000F][1205]guérison... Cette fée soignera\nnos blessures! C'est pas top? [1113]?"
   },
   {
     "id": 36,
@@ -606,6 +606,6 @@
     "nom_orig": "Jun",
     "texte_orig": "O-Oh,[SP]she[SP]charges[SP]for[SP]it...[1205][000F][SP]Of[SP]course...\nUnderstandable...[1205][000F][SP]What's[SP]a[SP]little[SP]money[SP]in\nexchange[SP]for[SP]your[SP]health?",
     "nom_fr": "",
-    "texte_fr": "O-Oh, elle fait payer...[1205][000F] Bien sûr...\nCompréhensible...[1205][000F] Un peu d'argent\nen échange de la santé, c'est raisonnable."
+    "texte_fr": "O-Oh, elle fait payer...[000F][1205] Bien sûr...\nCompréhensible...[000F][1205] Un peu d'argent\nen échange de la santé, c'est raisonnable."
   }
 ]

--- a/traduction/event_scripts/script_378.json
+++ b/traduction/event_scripts/script_378.json
@@ -42,7 +42,7 @@
     "nom_orig": "???",
     "texte_orig": "Oh?[1205][001E][SP]You're[SP]home,[SP]Lisa?[1205][001E][SP]I[SP]told[SP]you,[SP]in[SP]this\nhouse,[SP]when[SP]you[SP]come[SP]home[SP]you[SP]must[SP]report\nto[SP]your[SP]father.",
     "nom_fr": "???",
-    "texte_fr": "Oh?[1205][001E] Tu es là, Lisa?[1205][001E] Je t'ai dit\nque dans cette maison, au retour\ntu dois te présenter à ton père."
+    "texte_fr": "Oh?[001E][1205] Tu es là, Lisa?[001E][1205] Je t'ai dit\nque dans cette maison, au retour\ntu dois te présenter à ton père."
   },
   {
     "id": 3,
@@ -72,7 +72,7 @@
     "nom_orig": "???",
     "texte_orig": "Oh?[1205][001E][SP]You're[SP]home,[SP]Lisa?[1205][001E][SP]I[SP]told[SP]you,[SP]in[SP]this\nhouse,[SP]when[SP]you[SP]come[SP]home[SP]you[SP]must[SP]report\nto[SP]your[SP]father.",
     "nom_fr": "???",
-    "texte_fr": "Oh?[1205][001E] Tu es là, Lisa?[1205][001E] Je t'ai dit\nque dans cette maison, au retour\ntu dois te présenter à ton père."
+    "texte_fr": "Oh?[001E][1205] Tu es là, Lisa?[001E][1205] Je t'ai dit\nque dans cette maison, au retour\ntu dois te présenter à ton père."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Kehhei![SP]Shut[SP]up![1205][001E][SP]Ngo[SP]Faan[SP]Lai[SP]Laa,\nI'm[SP]ho[1205][000A]oo[1205][000A]oo[1205][000A]oo[1205][000A]ome![1205][001E][SP]There,[SP]happy[SP]now!?",
     "nom_fr": "Lisa",
-    "texte_fr": "Kehhei! La ferme![1205][001E] Ngo Faan Lai Laa,\nje su[1205][000A]uis[1205][000A] re[1205][000A]ntrée[1205][000A]e![1205][001E] Satisfait!?"
+    "texte_fr": "Kehhei! La ferme![001E][1205] Ngo Faan Lai Laa,\nje su[000A][1205]uis[000A][1205] re[000A][1205]ntrée[000A][1205]e![001E][1205] Satisfait!?"
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Kehhei![SP]Shut[SP]up![1205][001E][SP]Ngo[SP]Faan[SP]Lai[SP]Laa,\nI'm[SP]ho[1205][000A]oo[1205][000A]oo[1205][000A]oo[1205][000A]ome![1205][001E][SP]There,[SP]happy[SP]now!?",
     "nom_fr": "Ginko",
-    "texte_fr": "Kehhei! La ferme![1205][001E] Ngo Faan Lai Laa,\nje su[1205][000A]uis[1205][000A] re[1205][000A]ntrée[1205][000A]e![1205][001E] Satisfaite!?"
+    "texte_fr": "Kehhei! La ferme![001E][1205] Ngo Faan Lai Laa,\nje su[000A][1205]uis[000A][1205] re[000A][1205]ntrée[000A][1205]e![001E][1205] Satisfaite!?"
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "P-Proper[SP]Japanese[SP]lady!?[1205][001E][SP]I[SP]wondered[SP]what[SP]kind\nof[SP]classy[SP]family[SP]lived[SP]here,[SP]but[SP]it[SP]was[SP]HER\nhouse!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "V-vraie dame japonaise!?[1205][001E] Je me\ndemandais quelle famille noble\nvivait ici, mais c'est SA maison!?"
+    "texte_fr": "V-vraie dame japonaise!?[001E][1205] Je me\ndemandais quelle famille noble\nvivait ici, mais c'est SA maison!?"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "So[SP]that's[SP]her[SP]dad,[SP]and[SP]this[SP]is[SP]her[SP]house...[1205][001E]\nShe's[SP]a[SP]white[SP]girl[SP]who[SP]uses[SP]Cantonese...[1205][001E]\nWhat[SP]country[SP]IS[SP]she[SP]from!?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Donc c'est son père, et c'est sa\nmaison...[1205][001E] Une fille blonde qui parle\ncantonais...[1205][001E] Elle vient de QUEL pays!?"
+    "texte_fr": "Donc c'est son père, et c'est sa\nmaison...[001E][1205] Une fille blonde qui parle\ncantonais...[001E][1205] Elle vient de QUEL pays!?"
   },
   {
     "id": 12,
@@ -222,7 +222,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Guess[SP]Lisa[SP]doesn't[SP]get[SP]along[SP]with[SP]her[SP]dad...[1205][001E]\nShe's[SP]lucky[SP]to[SP]even[SP]have[SP]one...",
     "nom_fr": "Maya",
-    "texte_fr": "Lisa ne s'entend pas avec son père...[1205][001E]\nElle a de la chance d'en avoir un..."
+    "texte_fr": "Lisa ne s'entend pas avec son père...[001E][1205]\nElle a de la chance d'en avoir un..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Lisa's[SP]relationship[SP]with[SP]her[SP]father[SP]seems\nstrained.[SP]What[SP]a[SP]burden[SP]for[SP]her[SP]parents[SP]to\nhave[SP]such[SP]a[SP]rebellious[SP]child.[SP]The[SP]poor[SP]man.[E1][E2]\n[E3][E4][NULL][NULL]\"Yukino\nMy[SP]dad[SP]ran[SP]off[SP]one[SP]day[SP]with[SP]another[SP]woman...[1205][001E]\nI'd[SP]only[SP]kick[SP]his[SP]ass[SP]if[SP]I[SP]ever[SP]saw[SP]him[SP]again.",
     "nom_fr": "Maya",
-    "texte_fr": "La relation de Lisa avec son père est\ntendue. Quelle charge d'avoir un enfant si\nrebelle. Le pauvre homme.[E1][E2]\n[E3][E4][NULL][NULL]\"Yukino Mon père\nest parti avec une autre femme...[1205][001E] Je lui\ncasserais la gueule si je le revoyais."
+    "texte_fr": "La relation de Lisa avec son père est\ntendue. Quelle charge d'avoir un enfant si\nrebelle. Le pauvre homme.[E1][E2]\n[E3][E4][NULL][NULL]\"Yukino Mon père\nest parti avec une autre femme...[001E][1205] Je lui\ncasserais la gueule si je le revoyais."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Her[SP]father...[1205][000F][SP]Yes.[SP]I've[SP]always[SP]wanted[SP]to\nhave[SP]something[SP]like[SP]this[SP]to[SP]defend.[SP]I[SP]was\nso[SP]jealous[SP]of[SP]Lisa...",
     "nom_fr": "Jun",
-    "texte_fr": "Son père.[1205][000F].. Oui.\nJ'ai toujours voulu quelque\nchose à défendre. J'enviais Lisa pour ça..."
+    "texte_fr": "Son père.[000F][1205].. Oui.\nJ'ai toujours voulu quelque\nchose à défendre. J'enviais Lisa pour ça..."
   },
   {
     "id": 17,
@@ -383,7 +383,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "The[SP]sweepstakes,[SP]you[SP]say?[SP]Ah,[SP]yes,[SP]of[SP]course.\nThis[SP]was[SP]delivered[SP]here.[SP]Go[SP]on,[SP]take[SP]it.",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Le tirage au sort? Ah oui, bien sûr. Ceci\na été livré ici. Tenez, prenez-le. Lettre\n[NULL][NULL]Merci d'avoir participé à notre tirage.\nMalheureusement, vous n'êtes pas gagnantcette\nfois. Tentez à nouveau votre chance![NULL][NULL]"
+    "texte_fr": "Le tirage au sort? Ah oui, bien sûr. Ceci\na été livré ici. Tenez, prenez-le. Lettre\n[NULL][NULL]Merci d'avoir participé à notre tirage. Malheureusement, vous n'êtes pas gagnantcette fois. Tentez à nouveau votre chance![NULL][NULL]"
   },
   {
     "id": 25,
@@ -398,7 +398,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "The[SP]sweepstakes,[SP]you[SP]say?[SP]Ah,[SP]yes,[SP]of[SP]course.\nThis[SP]was[SP]delivered[SP]here.[SP]Go[SP]on,[SP]take[SP]it.",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Le tirage au sort? Ah oui, bien sûr. Ceci a\nété livré ici. Tenez, prenez-le. Lettre\n[NULL][NULL]Merci d'avoir participé à notre tirage.\nFélicitations! Vous avez été sélectionnégagnant! \n[NULL][NULL]Veuillez accepter ceci [E4][NULL][NULL][NULL][E4][NULL][NULL] en guise\nde prix. Tentez à nouveau votre chance![NULL][NULL] \nVous n'avez plus de place pour un autre [E4][NULL][NULL][NULL][E4][NULL][NULL]..."
+    "texte_fr": "Le tirage au sort? Ah oui, bien sûr. Ceci a\nété livré ici. Tenez, prenez-le. Lettre\n[NULL][NULL]Merci d'avoir participé à notre tirage. Félicitations! Vous avez été sélectionnégagnant! [NULL][NULL]Veuillez accepter ceci [E4][NULL][NULL][NULL][E4][NULL][NULL] en guise de prix. Tentez à nouveau votre chance![NULL][NULL] Vous n'avez plus de place pour un autre [E4][NULL][NULL][NULL][E4][NULL][NULL]..."
   },
   {
     "id": 26,
@@ -413,7 +413,7 @@
     "nom_orig": "Lisa's[SP]father",
     "texte_orig": "What[SP]a[SP]tragedy...[1205][001E][SP]She's[SP]still[SP]bent[SP]on[SP]using\nCantonese[SP]rather[SP]than[SP]her[SP]beautiful[SP]native\ntongue.",
     "nom_fr": "Père de Lisa",
-    "texte_fr": "Quelle tragédie...[1205][001E] Elle s'obstine à parler\ncantonnais plutôt que sa belle langue\nmaternelle."
+    "texte_fr": "Quelle tragédie...[001E][1205] Elle s'obstine à parler\ncantonnais plutôt que sa belle langue\nmaternelle."
   },
   {
     "id": 27,
@@ -428,7 +428,7 @@
     "nom_orig": "Lisa's[SP]father",
     "texte_orig": "We[SP]used[SP]to[SP]spend[SP]so[SP]much[SP]time[SP]together...[1205][001E]\nWhy[SP]has[SP]she[SP]become[SP]so[SP]rebellious...?",
     "nom_fr": "Père de Lisa",
-    "texte_fr": "On passait tant de temps ensemble...[1205][001E]\nPourquoi est-elle si rebelle...?"
+    "texte_fr": "On passait tant de temps ensemble...[001E][1205]\nPourquoi est-elle si rebelle...?"
   },
   {
     "id": 28,
@@ -443,7 +443,7 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "What[SP]a[SP]tragedy...[1205][001E][SP]She's[SP]still[SP]bent[SP]on[SP]using\nCantonese[SP]rather[SP]than[SP]her[SP]beautiful[SP]native\ntongue.",
     "nom_fr": "Père de Ginko",
-    "texte_fr": "Quelle tragédie...[1205][001E] Elle s'obstine à parler\ncantonnais plutôt que sa belle langue\nmaternelle."
+    "texte_fr": "Quelle tragédie...[001E][1205] Elle s'obstine à parler\ncantonnais plutôt que sa belle langue\nmaternelle."
   },
   {
     "id": 29,
@@ -458,6 +458,6 @@
     "nom_orig": "Ginko's[SP]father",
     "texte_orig": "We[SP]used[SP]to[SP]spend[SP]so[SP]much[SP]time[SP]together...[1205][001E]\nWhy[SP]has[SP]she[SP]become[SP]so[SP]rebellious...?",
     "nom_fr": "Père de Lisa",
-    "texte_fr": "On passait tant de temps ensemble...[1205][001E]\nPourquoi est-elle si rebelle...?"
+    "texte_fr": "On passait tant de temps ensemble...[001E][1205]\nPourquoi est-elle si rebelle...?"
   }
 ]

--- a/traduction/event_scripts/script_379.json
+++ b/traduction/event_scripts/script_379.json
@@ -12,7 +12,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Welcome[SP]to[SP]the[SP]Velvet[SP]Room.[1205][001E][SP]Here,[SP]various\naspects[SP]of[SP]man's[SP]soul[SP]are[SP]awakened...",
     "nom_fr": "Igor",
-    "texte_fr": "Bienvenue dans la Velvet Room.[1205][001E] Ici,\ndivers aspects de l'âme s'éveillent..."
+    "texte_fr": "Bienvenue dans la Velvet Room.[001E][1205] Ici,\ndivers aspects de l'âme s'éveillent..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Igor",
     "texte_orig": "We[SP]have[SP]been[SP]waiting[SP]for[SP]you[SP]at[SP]the[SP]command\nof[SP]our[SP]master,[SP]Philemon.[1205][001E][SP]My[SP]name[SP]is[SP]Igor.",
     "nom_fr": "Igor",
-    "texte_fr": "Nous vous attendions sur ordre de\nnotre maître, Philémon.[1205][001E] Je suis Igor"
+    "texte_fr": "Nous vous attendions sur ordre de\nnotre maître, Philémon.[001E][1205] Je suis Igor"
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Nameless",
     "texte_orig": "I[SP]am[SP]Nameless...[1205][001E][SP]A[SP]pianist[SP]who[SP]opens[SP]the\nshuttered[SP]doors[SP]of[SP]one's[SP]soul...",
     "nom_fr": "Nameless",
-    "texte_fr": "Je suis Nameless...[1205][001E] Un pianiste qui\nouvre les portes closes de l'âme..."
+    "texte_fr": "Je suis Nameless...[001E][1205] Un pianiste qui\nouvre les portes closes de l'âme..."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Demon[SP]Painter",
     "texte_orig": "I'm[SP]a[SP]demon[SP]painter.[1205][001E][SP]My[SP]art[SP]depicts[SP]the[SP]gods\nand[SP]demons[SP]that[SP]dwell[SP]within[SP]man.",
     "nom_fr": "Demon Painter",
-    "texte_fr": "Je suis un peintre démon.[1205][001E] Mon art\ndépeint dieux et démons en l'homme."
+    "texte_fr": "Je suis un peintre démon.[001E][1205] Mon art\ndépeint dieux et démons en l'homme."
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Hey,[SP][1113]...[1205][001E][SP]Doesn't[SP]being[SP]here[SP]feel[SP]like...[1205][001E]\nWell,[SP]kinda[SP]like[SP]how[SP]it[SP]does[SP]when[SP]you[SP]summon\na[SP]Persona?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Hé, [1113]...[1205][001E] Être ici ça ressemble\npas un peu...[1205][001E] À ce qu'on ressent\nquand on invoque un Persona?"
+    "texte_fr": "Hé, [1113]...[001E][1205] Être ici ça ressemble\npas un peu...[001E][1205] À ce qu'on ressent\nquand on invoque un Persona?"
   },
   {
     "id": 7,
@@ -132,7 +132,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Philemon's[SP]their[SP]master?[1205][001E][SP]New[SP]Personas...?[1205][001E]\nThat[SP]means[SP]there[SP]are[SP]tons[SP]of[SP]Personas!",
     "nom_fr": "Lisa",
-    "texte_fr": "Philemon leur maître?[1205][001E] Nouveaux Personae?[1205][001E]\nÇa veut dire qu'il y en a des tas!"
+    "texte_fr": "Philemon leur maître?[001E][1205] Nouveaux Personae?[001E][1205]\nÇa veut dire qu'il y en a des tas!"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "And[SP]these[SP]people[SP]are[SP]going[SP]to[SP]help[SP]us[SP]get[SP]them![1205][001E]\nWe[SP]should[SP]pay[SP]close[SP]attention,[SP][1113].",
     "nom_fr": "Lisa",
-    "texte_fr": "Et ces gens vont nous aider à les obtenir\n![1205][001E] On devrait bien écouter, [1113]."
+    "texte_fr": "Et ces gens vont nous aider à les obtenir\n![001E][1205] On devrait bien écouter, [1113]."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Philemon's[SP]their[SP]master?[1205][001E][SP]New[SP]Personas...?[1205][001E]\nThat[SP]means[SP]there[SP]are[SP]tons[SP]of[SP]Personas!",
     "nom_fr": "Ginko",
-    "texte_fr": "Philemon leur maître?[1205][001E] Nouveaux Personae?[1205][001E]\nÇa veut dire qu'il y en a des tas!"
+    "texte_fr": "Philemon leur maître?[001E][1205] Nouveaux Personae?[001E][1205]\nÇa veut dire qu'il y en a des tas!"
   },
   {
     "id": 11,
@@ -177,7 +177,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "And[SP]these[SP]people[SP]are[SP]going[SP]to[SP]help[SP]us[SP]get[SP]them![1205][001E]\nWe[SP]should[SP]pay[SP]close[SP]attention,[SP][1113].",
     "nom_fr": "Ginko",
-    "texte_fr": "Et ces gens vont nous aider à les obtenir\n![1205][001E] On devrait bien écouter, [1113]."
+    "texte_fr": "Et ces gens vont nous aider à les obtenir\n![001E][1205] On devrait bien écouter, [1113]."
   },
   {
     "id": 12,
@@ -192,7 +192,7 @@
     "nom_orig": "Maya",
     "texte_orig": "What[SP]a[SP]wonderful[SP]song...[1205][001E][SP]It[SP]feels[SP]like[SP]it\ntouches[SP]my[SP]soul.[1205][001E][SP]Doesn't[SP]it[SP]make[SP]you[SP]incredibly\nat[SP]ease?",
     "nom_fr": "Maya",
-    "texte_fr": "Quelle belle musique...[1205][001E] On dirait qu'elle\ntouche mon âme.[1205][001E] Ça ne\nvous met pas à l'aise?"
+    "texte_fr": "Quelle belle musique...[001E][1205] On dirait qu'elle\ntouche mon âme.[001E][1205] Ça ne\nvous met pas à l'aise?"
   },
   {
     "id": 13,
@@ -207,7 +207,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]song...[1205][000F][SP]It's[SP]intolerable![1205][000F][SP]Let's[SP]leave\nthis[SP]place[SP]at[SP]once,[SP][1113]-kun![E1][E2]\n[E3][E4][NULL][NULL]\"Yukino\nThis[SP]brings[SP]back[SP]memories...[1205][001E][SP]This[SP]place[SP]was[SP]a\nhuge[SP]help[SP]for[SP]me[SP]and[SP]my[SP]friends[SP]when[SP]we[SP]were\nyounger.[1205][001E][SP]It[SP]was[SP]fun,[SP]despite[SP]everything.",
     "nom_fr": "Maya",
-    "texte_fr": "Cette chanson.[1205][000F][1205][000F].. Insupportable! Partons\nd'ici tout de suite, [1113]![E1][E2] [E3][E4][NULL][NULL]\"Yukino\nCela\nme rappelle des souvenirs...[1205][001E] Cet endroit a\nbeaucoup aidé mes amis et moi\ndans notrejeunesse.[1205][001E] C'était bien, malgré tout."
+    "texte_fr": "Cette chanson.[000F][1205][000F][1205].. Insupportable! Partons\nd'ici tout de suite, [1113]![E1][E2] [E3][E4][NULL][NULL]\"Yukino\nCela\nme rappelle des souvenirs...[001E][1205] Cet endroit a\nbeaucoup aidé mes amis et moi\ndans notrejeunesse.[001E][1205] C'était bien, malgré tout."
   },
   {
     "id": 14,
@@ -222,7 +222,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Listen[SP]to[SP]me,[SP][1113].[SP]Don't[SP]waste[SP]your[SP]youth\non[SP]things[SP]you'll[SP]regret.[1205][001E][SP]You're[SP]only[SP]young\nonce,[SP]after[SP]all...",
     "nom_fr": "Yukino",
-    "texte_fr": "Écoute-moi, [1113]. Ne gaspille\npas ta jeunesse à des regrets.[1205][001E]\nOn n'est jeune qu'une fois..."
+    "texte_fr": "Écoute-moi, [1113]. Ne gaspille\npas ta jeunesse à des regrets.[001E][1205]\nOn n'est jeune qu'une fois..."
   },
   {
     "id": 15,
@@ -237,7 +237,7 @@
     "nom_orig": "Jun",
     "texte_orig": "S-So[SP]this[SP]is[SP]the[SP]Velvet[SP]Room...[1205][000F][SP]My[SP]father\ntold[SP]me[SP]about[SP]it[SP]once.[1205][000F][SP]But[SP]to[SP]see[SP]it[SP]with\nmy[SP]own[SP]eyes...",
     "nom_fr": "Jun",
-    "texte_fr": "A-Alors c'est ça la Velvet Room.[1205][000F][1205][000F]..\nMon père m'en avait parlé. Mais la\nvoir de mes propres yeux..."
+    "texte_fr": "A-Alors c'est ça la Velvet Room.[000F][1205][000F][1205]..\nMon père m'en avait parlé. Mais la\nvoir de mes propres yeux..."
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Jun",
     "texte_orig": "Such[SP]a[SP]strange[SP]feeling.[1205][000F][SP]It's[SP]the[SP]exact\nopposite[SP]of[SP]my[SP]father...[SP]So[SP]peaceful...",
     "nom_fr": "Jun",
-    "texte_fr": "Quelle étrange sensation. [1205][000F]C'est tout\nl'opposé de mon père... Si paisible..."
+    "texte_fr": "Quelle étrange sensation. [000F][1205]C'est tout\nl'opposé de mon père... Si paisible..."
   },
   {
     "id": 17,
@@ -488,7 +488,7 @@
     "nom_orig": "Igor",
     "texte_orig": "To[SP][1432][NULL][NULL][0014]take[SP]on[1432][NULL][NULL][0014][SP]a[SP]Persona[SP]means[SP]for[SP]a[SP]Persona-\nuser[SP]such[SP]as[SP]yourself[SP]to[SP]accept[SP]it[SP]into[SP]you.\nJust[SP]having[SP]its[SP]card[SP]will[SP]do[SP]you[SP]no[SP]good.",
     "nom_fr": "Igor",
-    "texte_fr": "[1432][NULL][NULL][0014]Porter[1432][NULL][NULL][0014] un Persona signifie, pour un\nutilisateur comme vous, l'accepter en soi.\nPosséder sa carte seule\nne vous servira àrien."
+    "texte_fr": "[1432][NULL][NULL][0014]Porter[1432][NULL][NULL][0014] un Persona signifie, pour un\nutilisateur comme vous, l'accepter en soi.\nPosséder sa carte seule ne vous servira àrien."
   },
   {
     "id": 28,
@@ -578,7 +578,7 @@
     "nom_orig": "Igor",
     "texte_orig": "A[SP]Persona's[SP]abilities[SP]differ[SP]depending[SP]on\nits[SP]type.[SP]Each[SP]has[SP]its[SP]own[SP]strengths[SP]and\nweaknesses.",
     "nom_fr": "Igor",
-    "texte_fr": "Les capacités d'un\nPersona varient selon son\ntype. Chacun a ses\nforces et ses faiblesses."
+    "texte_fr": "Les capacités d'un\nPersona varient selon son\ntype. Chacun a ses forces et ses faiblesses."
   },
   {
     "id": 34,
@@ -1058,7 +1058,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Ah,[SP]yes,[SP]one[SP]final[SP]caveat:[SP]Even[SP]with[SP]the\nrequisite[SP]number[SP]of[SP]cards,[SP]you[SP]cannot[SP]summon\nPersonas[SP]that[SP]are[SP]five[SP]levels[SP]higher[SP]than[SP]you.",
     "nom_fr": "Igor",
-    "texte_fr": "Dernier avertissement: même avec assez de\ncartes, vous ne\npouvez invoquer des Personae\nde cinq niveaux supérieurs au vôtre."
+    "texte_fr": "Dernier avertissement: même avec assez de\ncartes, vous ne\npouvez invoquer des Personae de cinq niveaux supérieurs au vôtre."
   },
   {
     "id": 66,
@@ -1403,7 +1403,7 @@
     "nom_orig": "Igor",
     "texte_orig": "My[SP]duty[SP]is[SP]to[SP]summon[SP]new[SP]Personas.[SP]I[SP]use[SP]the\nTarot[SP]Cards[SP]you[SP]carry[SP]as[SP]a[SP]medium[SP]to[SP]summon\nthe[SP]Personas[SP]slumbering[SP]deep[SP]within[SP]your[SP]soul.",
     "nom_fr": "Igor",
-    "texte_fr": "Mon devoir est d'invoquer de nouvelles\nPersonae. J'utilise vos\nCartes de Tarot pour\ninvoquer celles qui sommeillent en vous."
+    "texte_fr": "Mon devoir est d'invoquer de nouvelles\nPersonae. J'utilise vos\nCartes de Tarot pour invoquer celles qui sommeillent en vous."
   },
   {
     "id": 89,
@@ -1448,7 +1448,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Some[SP]require[SP]special[SP]conditions[SP]to[SP]be[SP]summoned.\nThey[SP]slumber[SP]at[SP]the[SP]depths[SP]of[SP]the[SP]unconscious\nmind...[SP]You[SP]will[SP]need[SP]a[SP]way[SP]to[SP]awaken[SP]them.",
     "nom_fr": "Igor",
-    "texte_fr": "Certains nécessitent\ndes conditions spéciales.\nIls sommeillent dans l'inconscient... Il\nfaudra un moyen de les éveiller."
+    "texte_fr": "Certains nécessitent\ndes conditions spéciales.\nIls sommeillent dans l'inconscient... Il faudra un moyen de les éveiller."
   },
   {
     "id": 92,
@@ -2018,7 +2018,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Their[SP]personalities[SP]can[SP]be[SP]divided[SP]into[SP]eight\nclassifications:[SP]wise,[SP]foolish,[SP]joyful,[SP]timid,\nforceful,[SP]gloomy,[SP]snappish,[SP]and[SP]haughty...",
     "nom_fr": "Igor",
-    "texte_fr": "Leurs personnalités peuvent se diviser en\nhuit catégories: sage,\nsot, joyeux, craintif,\nforcené, sombre, brusque et hautain..."
+    "texte_fr": "Leurs personnalités peuvent se diviser en\nhuit catégories: sage,\nsot, joyeux, craintif, forcené, sombre, brusque et hautain..."
   },
   {
     "id": 130,
@@ -2108,7 +2108,7 @@
     "nom_orig": "Belladonna",
     "texte_orig": "My[SP]duty[SP]is[U+070F]\nTo[SP]calm[SP]the[SP]hearts[SP]of[SP]visitors[U+070F][1205][001E]\nFor[SP]this,[SP]I[SP]must[SP]hear[SP]my[SP]heart's[SP]music[U+070F]",
     "nom_fr": "Belladonna",
-    "texte_fr": "Mon devoir est D'apaiser les cœurs[1205][001E]\nJ'entends la musique de mon cœur[U+070F][U+070F][U+070F]"
+    "texte_fr": "Mon devoir est D'apaiser les cœurs[001E][1205]\nJ'entends la musique de mon cœur[U+070F][U+070F][U+070F]"
   },
   {
     "id": 136,
@@ -2153,7 +2153,7 @@
     "nom_orig": "Nameless",
     "texte_orig": "To[SP]create[SP]it,[SP]I[SP]must[SP]confront[SP]what[SP]is[SP]in[SP]my\nheart.[1205][001E][SP]That[SP]is[SP]why[SP]90,000[SP]and[SP]155[SP]nights[SP]have\npassed[SP]since[SP]I[SP]closed[SP]my[SP]own[SP]eyes.",
     "nom_fr": "Nameless",
-    "texte_fr": "Pour la créer, j'affronte mon cœur.[1205][001E] C'est\npourquoi 90 000 et 155 nuits se sont\nécoulées depuis que j'ai fermé les yeux."
+    "texte_fr": "Pour la créer, j'affronte mon cœur.[001E][1205] C'est\npourquoi 90 000 et 155 nuits se sont\nécoulées depuis que j'ai fermé les yeux."
   },
   {
     "id": 139,
@@ -2442,7 +2442,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Hm?[1205][000F][SP]It[SP]seems[SP]one[SP]of[SP]your[SP]Personas[SP]is[SP]trying[SP]to\nbe[SP]reborn[SP]into[SP]a[SP]new[SP]form.",
     "nom_fr": "Igor",
-    "texte_fr": "Hm? [1205][000F]L'un de vos Personae cherche à\nrenaître sous une nouvelle forme."
+    "texte_fr": "Hm? [000F][1205]L'un de vos Personae cherche à\nrenaître sous une nouvelle forme."
   },
   {
     "id": 156,
@@ -2472,7 +2472,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Do[SP]you[SP]know[SP]about[SP]Fusion[SP]Spells?[1205][000F][SP]When[SP]you[SP]use\nthem,[SP]sometimes[SP]your[SP]Personas[SP]will[SP]undergo\nmutations.",
     "nom_fr": "",
-    "texte_fr": "Connaissez-vous les Sorts de Fusion? [1205][000F]Quand\nvous les utilisez,\nles Persona peuvent muter."
+    "texte_fr": "Connaissez-vous les Sorts de Fusion? [000F][1205]Quand\nvous les utilisez,\nles Persona peuvent muter."
   },
   {
     "id": 158,
@@ -2547,7 +2547,7 @@
     "nom_orig": "Igor",
     "texte_orig": "Oh...[1205][000F][SP]And[SP]if[SP]you[SP]already[SP]have[SP]the[SP]Persona[SP]that\nyour[SP]Persona[SP]will[SP]mutate[SP]into,[SP]you[SP]will[SP]not[SP]be\nable[SP]to[SP]perform[SP]the[SP]mutation.",
     "nom_fr": "Igor",
-    "texte_fr": "Oh.[1205][000F].. Et si vous possédez déjà le Persona\nen lequel votre Persona va muter, vous ne\npourrez pas effectuer la mutation."
+    "texte_fr": "Oh.[000F][1205].. Et si vous possédez déjà le Persona\nen lequel votre Persona va muter, vous ne\npourrez pas effectuer la mutation."
   },
   {
     "id": 163,
@@ -2622,7 +2622,7 @@
     "nom_orig": "Demon[SP]Painter",
     "texte_orig": "The[SP]Tarot[SP]is[SP]a[SP]model[SP]of[SP]the[SP]heart.[SP]One's[SP]heart\naffects[SP]one's[SP]destiny.[1205][001E][SP]Now,[SP]would[SP]you[SP]like[SP]me\nto[SP]paint[SP]you[SP]something?\n[1208][0004]Request[SP]card\nTalk\nCancel\nLeave",
     "nom_fr": "Demon Painter",
-    "texte_fr": "Le Tarot est un modèle du cœur.\nLe cœur influence le destin.[1205][001E]\nVoulez-vous que je peigne\nquelque chose ?\n[1208][0004]Demander une carte\nParler\nAnnuler\nQuitter",
+    "texte_fr": "Le Tarot est un modèle du cœur.\nLe cœur influence le destin.[001E][1205]\nVoulez-vous que je peigne\nquelque chose ?\n[1208][0004]Demander une carte\nParler\nAnnuler\nQuitter",
     "question_orig": "The[SP]Tarot[SP]is[SP]a[SP]model[SP]of[SP]the[SP]heart.[SP]One's[SP]heart\naffects[SP]one's[SP]destiny.[1205][001E][SP]Now,[SP]would[SP]you[SP]like[SP]me\nto[SP]paint[SP]you[SP]something?",
     "choix_orig": [
       "Request[SP]card",

--- a/traduction/event_scripts/script_380.json
+++ b/traduction/event_scripts/script_380.json
@@ -12,7 +12,7 @@
     "nom_orig": "???",
     "texte_orig": "Blauch...[1205][001E][SP]O-Okay,[SP]I[SP]ate[SP]the[SP]strawberry[SP]tanmen...[1205][001E]\nN-Now[SP]let's[SP]get[SP]down[SP]to[SP]business...",
     "nom_fr": "???",
-    "texte_fr": "Blauch...[1205][001E] B-Bon, j'ai mangé le tanmen\nfraise...[1205][001E] Bon, aux choses sérieuses..."
+    "texte_fr": "Blauch...[001E][1205] B-Bon, j'ai mangé le tanmen\nfraise...[001E][1205] Bon, aux choses sérieuses..."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "Ah-ah-ah...[1205][001E][SP]I[SP]heard[SP]from[SP]the[SP]Chief[SP]and[SP]Tamaki\nthat[SP]the[SP][1432][NULL][NULL][0014]secret[SP]dish[1432][NULL][NULL][0014][SP]is[SP]the[SP]password[SP]to\ngetting[SP]an[SP]under-the-table[SP]deal.",
     "nom_fr": "Tadashi",
-    "texte_fr": "Ah-ah-ah...[1205][001E] Le Chef et Tamaki m'ont dit\nque le [1432][NULL][NULL][0014]plat secret[1432][NULL][NULL][0014] est le mot de passe\npour conclure une affaire discrète."
+    "texte_fr": "Ah-ah-ah...[001E][1205] Le Chef et Tamaki m'ont dit\nque le [1432][NULL][NULL][0014]plat secret[1432][NULL][NULL][0014] est le mot de passe\npour conclure une affaire discrète."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "I[SP]must've[SP]just[SP]ordered[SP]the[SP]wrong[SP]thing...\nI[SP]heard[SP]it[SP]was[SP]something[SP]disgusting.[1205][001E][SP]What[SP]about\nthe[SP]sweet[SP]red[SP]bean[SP]gyoza?",
     "nom_fr": "Tadashi",
-    "texte_fr": "J'ai dû commander le mauvais truc...\nJ'ai entendu que c'était dégoûtant.[1205][001E] Et\nles gyoza aux haricots rouges sucrés?"
+    "texte_fr": "J'ai dû commander le mauvais truc...\nJ'ai entendu que c'était dégoûtant.[001E][1205] Et\nles gyoza aux haricots rouges sucrés?"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Why[SP]me...?[1205][001E][SP]One[SP]banana[SP]char[SP]siu[SP]ramen,[SP]Ma'am!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Pourquoi moi...?[1205][001E] Un ramen char siu banane!"
+    "texte_fr": "Pourquoi moi...?[001E][1205] Un ramen char siu banane!"
   },
   {
     "id": 6,
@@ -117,7 +117,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "I[SP]knew[SP]this[SP]day[SP]would[SP]come,[SP]Eikichi...[1205][001E][SP]These\nweapons[SP]are[SP]on[SP]the[SP]house,[SP]as[SP]a[SP]farewell[SP]gift.[1205][001E]\nHmmm...[SP]Let's[SP]see...",
     "nom_fr": "Patronne",
-    "texte_fr": "Je savais que ce jour viendrait,\nEikichi...[1205][001E] Ces armes sont offertes,\nadieu.[1205][001E] Hmmm... Voyons voir..."
+    "texte_fr": "Je savais que ce jour viendrait,\nEikichi...[001E][1205] Ces armes sont offertes,\nadieu.[001E][1205] Hmmm... Voyons voir..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "Eikichi,[SP]you[SP]get[SP]a[SP][E4][NULL][NULL][0004][U+1433][NULL][NULL][0007]Standard[SP]Case[E4][NULL][NULL][0002].[1205][000F][SP]Mr.[SP]Cool\nhere[SP]gets[SP]a[SP][E4][NULL][NULL][0004][U+1433][NULL][NULL][0006]Misericorde[E4][NULL][NULL][0002]...[1205][000F][SP]And[SP]I'll[SP]throw[SP]in\nsome[SP][E4][NULL][NULL][0004][U+1433][NULL][NULL][0008]Leather[SP]Gloves[E4][NULL][NULL][0002][SP]for[SP]the[SP]girl.",
     "nom_fr": "Patronne",
-    "texte_fr": "Eikichi: [E4][NULL][NULL][0004][NULL][NULL][0007]Mallette standard[E4][NULL][NULL][0002]. [1205][000F][1205][000F]M. le cool:\n[E4][NULL][NULL][0004][NULL][NULL][0006]Miséricorde[E4][NULL][NULL][0002]... Et des [E4][NULL][NULL][0004][NULL][NULL][0008]Gants en cuir[E4][NULL][NULL][0002] pour la\nfille.[U+1433][U+1433][U+1433]"
+    "texte_fr": "Eikichi: [E4][NULL][NULL][0004][NULL][NULL][0007]Mallette standard[E4][NULL][NULL][0002]. [000F][1205][000F][1205]M. le cool:\n[E4][NULL][NULL][0004][NULL][NULL][0006]Miséricorde[E4][NULL][NULL][0002]... Et des [E4][NULL][NULL][0004][NULL][NULL][0008]Gants en cuir[E4][NULL][NULL][0002] pour la\nfille.[U+1433][U+1433][U+1433]"
   },
   {
     "id": 9,
@@ -147,7 +147,7 @@
     "nom_orig": "Ma'am",
     "texte_orig": "But[SP]rules[SP]are[SP]rules.[1205][000F][SP]You[SP]have[SP]to[SP]eat[SP]what[SP]you\nordered,[SP]or[SP]I'll[SP]pretend[SP]this[SP]never[SP]happened.",
     "nom_fr": "Patronne",
-    "texte_fr": "Règles sont règles. [1205][000F]Tu dois manger ce que\ntu as commandé, sinon ça n'a pas eu lieu."
+    "texte_fr": "Règles sont règles. [000F][1205]Tu dois manger ce que\ntu as commandé, sinon ça n'a pas eu lieu."
   },
   {
     "id": 10,
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "There![SP]I[SP]choked[SP]it[SP]down![SP]Take[SP]that![1205][001E]\nBluuuuuurrghhhh...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Voilà! J'ai avalé ça! Dans\nta face![1205][001E] Bluuuurghhhh..."
+    "texte_fr": "Voilà! J'ai avalé ça! Dans\nta face![001E][1205] Bluuuurghhhh..."
   },
   {
     "id": 11,
@@ -252,7 +252,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I've[SP]known[SP]her[SP]since[SP]I[SP]was[SP]a[SP]kid,[SP]so[SP]I'm[SP]pretty\nfamiliar[SP]with[SP]this[SP]place.[SP]And[SP]I[SP]know[SP]there's[SP]no\nway[SP]you[SP]can[SP]buy[SP]weapons[SP]here.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je la connais depuis\nque je suis gamin, donc\nje connais bien cet endroit. Et je sais\nqu'on ne peut pas acheter d'armes ici."
+    "texte_fr": "Je la connais depuis\nque je suis gamin, donc\nje connais bien cet endroit. Et je sais qu'on ne peut pas acheter d'armes ici."
   },
   {
     "id": 17,
@@ -282,7 +282,7 @@
     "nom_orig": "Tadashi",
     "texte_orig": "Heh...[1205][000F][SP]I'm[SP]a[SP]detective[SP]whose[SP]beat[SP]is[SP]the\ndarkness[SP]of[SP]the[SP]city.[1205][000F][SP]Come[SP]to[SP]the[SP]Kuzunoha\nDetective[SP]Agency[SP]for[SP]your[SP]investigative[SP]needs.",
     "nom_fr": "Tadashi",
-    "texte_fr": "Heh.[1205][000F][1205][000F].. Je suis un détective dont le terrain\nest l'ombre de la ville. Venez à l'agence\nde détectives Kuzunoha pour vos enquêtes."
+    "texte_fr": "Heh.[000F][1205][000F][1205].. Je suis un détective dont le terrain\nest l'ombre de la ville. Venez à l'agence\nde détectives Kuzunoha pour vos enquêtes."
   },
   {
     "id": 19,
@@ -342,7 +342,7 @@
     "nom_orig": "Washout[SP]student",
     "texte_orig": "Maaaan,[SP]what[SP]a[SP]surprise.[1205][000F][SP]I[SP]can't[SP]believe[SP]you\ncan[SP]eat[SP]stuff[SP]like[SP]that.[1205][000F][SP]The[SP]city[SP]sure[SP]is\na[SP]scary[SP]place.",
     "nom_fr": "Lycéen raté",
-    "texte_fr": "Maaaan, quelle surprise. [1205][000F][1205][000F]J'arrive\npas à croire que tu manges des trucs\ncomme ça. La ville est flippante."
+    "texte_fr": "Maaaan, quelle surprise. [000F][1205][000F][1205]J'arrive\npas à croire que tu manges des trucs\ncomme ça. La ville est flippante."
   },
   {
     "id": 23,

--- a/traduction/event_scripts/script_381.json
+++ b/traduction/event_scripts/script_381.json
@@ -72,7 +72,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Oh,[SP]no,[SP]we[SP]just[SP]had[SP]a[SP]question...[1205][001E][SP]Can[SP]we[SP]see\nthe[SP]chief[SP]detective?",
     "nom_fr": "Lisa",
-    "texte_fr": "Non, juste une question...[1205][001E] On\npeut voir le chef enquêteur?"
+    "texte_fr": "Non, juste une question...[001E][1205] On\npeut voir le chef enquêteur?"
   },
   {
     "id": 5,
@@ -132,7 +132,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "I[SP]knew[SP]it[SP]was[SP]something[SP]like[SP]that...[1205][001E][SP]Anyway,\nit's[SP]not[SP]like[SP]rumors[SP]can[SP]magically[SP]come[SP]true.\nLike[SP]Joker.[SP]He[SP]must[SP]have[SP]always[SP]existed.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Je m'en doutais...[1205][001E] De toute façon, les\nrumeurs ne deviennent pas réalité comme par\nmagie. Comme Joker. Il\na toujours dû exister"
+    "texte_fr": "Je m'en doutais...[001E][1205] De toute façon, les\nrumeurs ne deviennent pas réalité comme par\nmagie. Comme Joker. Il a toujours dû exister"
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "???",
     "texte_orig": "I[SP]see...[1205][001E][SP]The[SP]unusual[SP]incidents[SP]lately[SP]would\nmake[SP]more[SP]sense[SP]if[SP]rumors[SP]were[SP]indeed[SP]becoming\nreality...",
     "nom_fr": "???",
-    "texte_fr": "Je vois...[1205][001E] Tout\nles incidents s'expliqueraient\nsi les rumeurs étaient réelles"
+    "texte_fr": "Je vois...[001E][1205] Tout\nles incidents s'expliqueraient\nsi les rumeurs étaient réelles"
   },
   {
     "id": 11,
@@ -222,7 +222,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Is[SP]this[SP]really[SP]necessary...?[1205][001E][SP]Shouldn't[SP]we[SP]go\nafter[SP]the[SP]guy[SP]instead[SP]of[SP]hanging[SP]out[SP]here?",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est nécessaire...?[1205][001E] On ferait mieux\nd'aller le chercher au lieu de traîner."
+    "texte_fr": "C'est nécessaire...?[001E][1205] On ferait mieux\nd'aller le chercher au lieu de traîner."
   },
   {
     "id": 15,
@@ -418,7 +418,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "There's[SP]only[SP]one[SP]of[SP]you[SP]in[SP]the[SP]world...[1205][001E][SP]That's\njust[SP]plain[SP]common[SP]sense.[SP]But[SP]who[SP]can[SP]prove[SP]it?",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Vous êtes unique dans ce monde...[1205][001E] C'est du\nsimple bon sens. Mais qui peut le prouver?"
+    "texte_fr": "Vous êtes unique dans ce monde...[001E][1205] C'est du\nsimple bon sens. Mais qui peut le prouver?"
   },
   {
     "id": 25,
@@ -433,7 +433,7 @@
     "nom_orig": "Chief[SP]Todoroki",
     "texte_orig": "It's[SP]the[SP]same[SP]way[SP]with[SP]rumors.[SP]They[SP]can't[SP]be\nproved,[SP]and[SP]yet...[1205][001E][SP]Would[SP]it[SP]be[SP]so[SP]strange[SP]if\nthey[SP]started[SP]coming[SP]true?",
     "nom_fr": "Chef Todoroki",
-    "texte_fr": "Les rumeurs, c'est pareil. On ne\npeut pas les prouver, et pourtant...[1205][001E]\nElles pourraient devenir réelles."
+    "texte_fr": "Les rumeurs, c'est pareil. On ne\npeut pas les prouver, et pourtant...[001E][1205]\nElles pourraient devenir réelles."
   },
   {
     "id": 26,
@@ -548,7 +548,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "Meowvelous![1432][NULL][NULL][0007][1205][000F]\nI[SP]can't[SP]believe[SP]you[SP]fed[SP]me[SP]50[SP]times,[SP]purrrr[1432][NULL][NULL][0007][1205][000F]\nYou're[SP]so[SP]generous,[SP]Misterrr[1432][NULL][NULL][0007]",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Miaougnifique![1205][000F][1205][000F][1432][NULL][NULL][0007] Tu m'as nourri 50\nfois, rrron[1432][NULL][NULL][0007] Tu es si généreux[1432][NULL][NULL][0007]"
+    "texte_fr": "Miaougnifique![000F][1205][000F][1205][1432][NULL][NULL][0007] Tu m'as nourri 50\nfois, rrron[1432][NULL][NULL][0007] Tu es si généreux[1432][NULL][NULL][0007]"
   },
   {
     "id": 33,
@@ -563,7 +563,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "Amazing,[SP]meow![1205][000F]\nYou've[SP]fed[SP]me[SP]80[SP]times[SP]now,[SP]meow[1432][NULL][NULL][0007][1205][000F]\nDo[SP]you[SP]have[SP]a[SP]kitten[SP]agenda,[SP]meow?",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Incroyable, miaou! [1205][000F][1205][000F]80 repas déja,\nmiaou[1432][NULL][NULL][0007] T'as pas un agenda félin, miaou?"
+    "texte_fr": "Incroyable, miaou! [000F][1205][000F][1205]80 repas déja,\nmiaou[1432][NULL][NULL][0007] T'as pas un agenda félin, miaou?"
   },
   {
     "id": 34,
@@ -593,7 +593,7 @@
     "nom_orig": "Lucky[SP]cat[SP]statue",
     "texte_orig": "I[SP]feel[SP]bad[SP]at[SP]being[SP]given[SP]so[SP]much,[SP]meow![1205][000F]\nSo[SP]I[SP]have[SP]a[SP]purresent[SP]for[SP]you!",
     "nom_fr": "Statue de chat",
-    "texte_fr": "Je me sens mal d'avoir tant\n[1205][000F]reçu, miaou! J'ai un cadeau!"
+    "texte_fr": "Je me sens mal d'avoir tant\n[000F][1205]reçu, miaou! J'ai un cadeau!"
   },
   {
     "id": 36,
@@ -668,7 +668,7 @@
     "nom_orig": "Tamaki",
     "texte_orig": "Stoooop![1205][000F][SP]Where[SP]are[SP]you[SP]going?[SP]You[SP]have[SP]to[SP]file\nyour[SP]request[SP]for[SP]the[SP]rumor![SP]Talk[SP]to[SP]the[SP]Chief!",
     "nom_fr": "Tamaki",
-    "texte_fr": "Stoooop! [1205][000F]Où allez-vous? Vous devez déposer\nvotre demande de rumeur! Parlez au Chef!"
+    "texte_fr": "Stoooop! [000F][1205]Où allez-vous? Vous devez déposer\nvotre demande de rumeur! Parlez au Chef!"
   },
   {
     "id": 41,

--- a/traduction/event_scripts/script_382.json
+++ b/traduction/event_scripts/script_382.json
@@ -72,7 +72,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Y-Yes,[SP]Sir!?[1205][001E][SP]D-Daddy-o...[SP]I-I[SP]mean,[SP]Dad...\nHear[SP]me[SP]out![SP]Th-There's[SP]a[SP]good[SP]explanation\nfor[SP]this!",
     "nom_fr": "Eikichi",
-    "texte_fr": "O-Oui, chef!?[1205][001E] P-P'pa... e-enfin, Papa...\nÉcoute-moi! Y a une bonne explication!"
+    "texte_fr": "O-Oui, chef!?[001E][1205] P-P'pa... e-enfin, Papa...\nÉcoute-moi! Y a une bonne explication!"
   },
   {
     "id": 5,
@@ -132,7 +132,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Ha![SP]Hahaha...![1205][001E][SP]C-Come[SP]on,[SP]Dad...[1205][001E][SP]D-Don't[SP]be\nridiculous...!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ha! Hahaha...![1205][001E] A-Allons,\nPapa...[1205][001E] S-Sois pas ridicule...!"
+    "texte_fr": "Ha! Hahaha...![001E][1205] A-Allons,\nPapa...[001E][1205] S-Sois pas ridicule...!"
   },
   {
     "id": 9,
@@ -162,7 +162,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "M-My[SP]pops[SP]is[SP]the[SP]only[SP]man[SP]I[SP]have[SP]trouble[SP]dealing\nwith...[1205][001E][SP]Ever[SP]since[SP]I[SP]was[SP]a[SP]kid,[SP]when[SP]he[SP]yells[SP]at\nme[SP]in[SP]that[SP]scratchy[SP]voice,[SP]I[SP]freeze[SP]up.",
     "nom_fr": "Eikichi",
-    "texte_fr": "M-Mon vieux est le seul homme avec qui j'ai\ndu mal...[1205][001E] Depuis mon enfance, quand il me\ncrie dessus avec sa voix éraillée, je gèle."
+    "texte_fr": "M-Mon vieux est le seul homme avec qui j'ai\ndu mal...[001E][1205] Depuis mon enfance, quand il me\ncrie dessus avec sa voix éraillée, je gèle."
   },
   {
     "id": 11,
@@ -207,7 +207,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Snrk...[SP]Ahahahahah![1205][001E][SP]You[SP]Yisi![SP]That's[SP]hilarious![1205][001E]\nCostume[SP]practice?[SP]You[SP]always[SP]dress[SP]like[SP]that!",
     "nom_fr": "Lisa",
-    "texte_fr": "Pfft... Ahahaha![1205][001E] You\nYisi! C'est tordant![1205][001E] Quel\ncostume? Tu t'habilles toujours comme ça!"
+    "texte_fr": "Pfft... Ahahaha![001E][1205] You\nYisi! C'est tordant![001E][1205] Quel\ncostume? Tu t'habilles toujours comme ça!"
   },
   {
     "id": 14,
@@ -237,7 +237,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Snrk...[SP]Ahahahahah![1205][001E][SP]You[SP]Yisi![SP]That's[SP]hilarious![1205][001E]\nCostume[SP]practice?[SP]You[SP]always[SP]dress[SP]like[SP]that!",
     "nom_fr": "Ginko",
-    "texte_fr": "Pfft... Ahahaha![1205][001E] You\nYisi! C'est tordant![1205][001E] Quel\ncostume? Tu t'habilles toujours comme ça!"
+    "texte_fr": "Pfft... Ahahaha![001E][1205] You\nYisi! C'est tordant![001E][1205] Quel\ncostume? Tu t'habilles toujours comme ça!"
   },
   {
     "id": 16,
@@ -252,7 +252,7 @@
     "nom_orig": "Maya",
     "texte_orig": "I[SP]didn't[SP]expect[SP]Eikichi[SP]to[SP]react[SP]so[SP]violently\nto[SP]fish.[SP]It's[SP]like[SP]a[SP]conditioned[SP]response...\nOr[SP]is[SP]it[SP]more[SP]like[SP]animal[SP]imprinting?",
     "nom_fr": "Maya",
-    "texte_fr": "Je ne pensais\npas qu'Eikichi réagirait autant\nau poisson. On dirait un réflexe\nconditionné... Ou\nplutôt une empreinteanimale?"
+    "texte_fr": "Je ne pensais\npas qu'Eikichi réagirait autant\nau poisson. On dirait un réflexe conditionné... Ou plutôt une empreinteanimale?"
   },
   {
     "id": 17,
@@ -267,7 +267,7 @@
     "nom_orig": "Maya",
     "texte_orig": "...[1205][001E]Hm?[SP]Oh,[SP]it's[SP]nothing...[1205][001E][SP]I'm[SP]okay...",
     "nom_fr": "Maya",
-    "texte_fr": "...[1205][001E] Hm? Oh, rien...[1205][001E] Tout va bien..."
+    "texte_fr": "...[001E][1205] Hm? Oh, rien...[001E][1205] Tout va bien..."
   },
   {
     "id": 18,
@@ -297,7 +297,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "So[SP]where[SP]does[SP]he[SP]change[SP]and[SP]put[SP]on[SP]his[SP]makeup?[1205][001E]\n...He[SP]doesn't[SP]use[SP]the[SP]bathroom[SP]at[SP]the[SP]station,\ndoes[SP]he?",
     "nom_fr": "Yukino",
-    "texte_fr": "Où se change-t-il et se maquille-t-il\nalors?[1205][001E].. Il ne le fait pas dans les\ntoilettes de la gare, si?"
+    "texte_fr": "Où se change-t-il et se maquille-t-il\nalors?[001E][1205].. Il ne le fait pas dans les\ntoilettes de la gare, si?"
   },
   {
     "id": 20,
@@ -380,7 +380,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Today[SP]I[SP]recommend...[1205][000F][SP]Well,[SP]everything![1205][000A]\nIt's[SP]all[SP]fresh![SP]Now,[SP]what'll[SP]you[SP]have?\n[1208][0004]Dine[SP]in\nTalk[SP]to[SP]Eikichi's[SP]dad\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Aujourd'hui je recommande.[1205][000F].. Eh bien,\ntout![1205][000A] C'est tout frais! Que\nvoulez-vous?\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
+    "texte_fr": "Aujourd'hui je recommande.[000F][1205].. Eh bien,\ntout![000A][1205] C'est tout frais! Que\nvoulez-vous?\n[1208][0004]Manger ici\nParler au père\nRien\nPartir",
     "question_orig": "Today[SP]I[SP]recommend...[1205][000F][SP]Well,[SP]everything![1205][000A]\nIt's[SP]all[SP]fresh![SP]Now,[SP]what'll[SP]you[SP]have?",
     "choix_orig": [
       "Dine[SP]in",
@@ -448,7 +448,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Seriously,[SP]that[SP]fool's[SP]always[SP]loafing[SP]around\nhere.[1205][001E][SP]I'm[SP]worried[SP]he[SP]might[SP]not[SP]be[SP]able[SP]to\ntake[SP]over[SP]for[SP]me[SP]someday.",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Sérieux, cet idiot traîne toujours\nici.[1205][001E] J'ai peur qu'il ne soit pas\ncapable de prendre la relève un jour."
+    "texte_fr": "Sérieux, cet idiot traîne toujours\nici.[001E][1205] J'ai peur qu'il ne soit pas\ncapable de prendre la relève un jour."
   },
   {
     "id": 27,
@@ -463,7 +463,7 @@
     "nom_orig": "Eikichi's[SP]dad",
     "texte_orig": "Huh?[SP]What[SP]about[SP]what[SP]Eikichi[SP]wants?[SP]Don't[SP]be\nridiculous,[SP]kid![SP]A[SP]son[SP]follows[SP]in[SP]his[SP]father's\nfootsteps![SP]That's[SP]how[SP]it's[SP]always[SP]been.",
     "nom_fr": "Père d'Eikichi",
-    "texte_fr": "Hein? Et ce que veut Eikichi? Sois pas\nridicule, mon grand! Un\nfils suit les traces\nde son père! Ça a toujours été comme ça."
+    "texte_fr": "Hein? Et ce que veut Eikichi? Sois pas\nridicule, mon grand! Un\nfils suit les traces de son père! Ça a toujours été comme ça."
   },
   {
     "id": 28,
@@ -689,7 +689,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Whoa...[1205][001E][SP]The[SP]principal[SP]at[SP]Sevens[SP]suddenly[SP]grew\nsome[SP]hair?[SP]I[SP]wonder[SP]if[SP]that[SP]was[SP]his[SP]request\nfor[SP]Joker.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Ouah...[1205][001E] Le directeur de Seven a poussé des\ncheveux? Sa requête pour Joker, peut-être?"
+    "texte_fr": "Ouah...[001E][1205] Le directeur de Seven a poussé des\ncheveux? Sa requête pour Joker, peut-être?"
   },
   {
     "id": 39,
@@ -719,7 +719,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh...[SP]You[SP]were[SP]at[SP]Sevens'[SP]clock[SP]tower...[1205][000F][SP]and\nyou[SP]saw[SP]a[SP]real[SP]ghost?[SP]Yikes,[SP]I'm[SP]not[SP]much[SP]for\nspooky[SP]stuff.[1205][000F][SP]I'll[SP]tell[SP]you[SP]a[SP]story[SP]instead.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hm... À la tour de Seven, un vrai fantôme?\n[1205][000F][1205][000F]Oh là là, les trucs effrayants, c'est pas\nmon truc. Voici une histoire à la place."
+    "texte_fr": "Hm... À la tour de Seven, un vrai fantôme?\n[000F][1205][000F][1205]Oh là là, les trucs effrayants, c'est pas\nmon truc. Voici une histoire à la place."
   },
   {
     "id": 41,
@@ -794,7 +794,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "You[SP]know[SP]the[SP][E4][NULL][NULL][0006]Jolly[SP]Roger[E4][NULL][NULL][0002][SP]cafe[SP]in[SP]Kounan?[1205][000F]\nThey[SP]supposedly[SP]sell[SP][E4][NULL][NULL][0006]real[SP]weapons[E4][NULL][NULL][0002].[1205][000F][SP]Their\nselection[SP]is[SP][E4][NULL][NULL][0006]cheap[SP]and[SP]low[SP]quality[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Vous connaissez [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à Kounan?\n[1205][000F][1205][000F]Ils ont de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. Leur sélection\nest [E4][NULL][NULL][0006]bon marché, mauvaise qualité[E4][NULL][NULL][0002] ."
+    "texte_fr": "Vous connaissez [E4][NULL][NULL][0006]Jolly Roger[E4][NULL][NULL][0002] à Kounan?\n[000F][1205][000F][1205]Ils ont de [E4][NULL][NULL][0006]vraies armes[E4][NULL][NULL][0002]. Leur sélection\nest [E4][NULL][NULL][0006]bon marché, mauvaise qualité[E4][NULL][NULL][0002] ."
   },
   {
     "id": 46,
@@ -809,7 +809,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh...[1205][001E][SP]Something[SP]terrible[SP]will[SP]happen[SP]if[SP]the\nclock[SP]at[SP]Sevens[SP]starts[SP]again?[SP]That's[SP]pretty\nout-there.[SP]Well,[SP]here's[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hm...[1205][001E] Quelque chose de terrible si\nl'horloge de Seven repart? C'est\nbizarre. Voilà ce que je sais."
+    "texte_fr": "Hm...[001E][1205] Quelque chose de terrible si\nl'horloge de Seven repart? C'est\nbizarre. Voilà ce que je sais."
   },
   {
     "id": 47,
@@ -824,7 +824,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "The[SP]rumor[SP]is[SP]that[SP][E4][NULL][NULL][0006]Rosa[SP]Candida[E4][NULL][NULL][0002][SP]sells\n[E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]They[SP]have[SP][E4][NULL][NULL][0006]reasonable[SP]prices,\nbut[SP]low-quality[SP]stuff[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "[E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002] vend de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [1205][000F][E4][NULL][NULL][0006]Prix\nraisonnables, mais qualité médiocre[E4][NULL][NULL][0002]."
+    "texte_fr": "[E4][NULL][NULL][0006]Rosa Candida[E4][NULL][NULL][0002] vend de [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [000F][1205][E4][NULL][NULL][0006]Prix\nraisonnables, mais qualité médiocre[E4][NULL][NULL][0002]."
   },
   {
     "id": 48,
@@ -854,7 +854,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "There's[SP]a[SP]rumor[SP]you[SP]can[SP]buy[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002][SP]at\n[E4][NULL][NULL][0006]Anima[SP]Mundi[E4][NULL][NULL][0002][SP]in[SP]Yumezaki.[1205][000F][SP]Their[SP]stuff[SP]is\n[E4][NULL][NULL][0006]cheap[SP]and[SP]subpar[SP]quality[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "De [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002] chez\n[E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002] à Yumezaki.\n[1205][000F]Leur sélection: [E4][NULL][NULL][0006]bon marché, piètre qualité[E4][NULL][NULL][0002]."
+    "texte_fr": "De [E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002] chez\n[E4][NULL][NULL][0006]Anima Mundi[E4][NULL][NULL][0002] à Yumezaki.\n[000F][1205]Leur sélection: [E4][NULL][NULL][0006]bon marché, piètre qualité[E4][NULL][NULL][0002]."
   },
   {
     "id": 50,
@@ -914,7 +914,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "There's[SP]a[SP]shop[SP]called[SP][E4][NULL][NULL][0006]London[SP]Clothier[E4][NULL][NULL][0002][SP]in[SP]Kounan\nthat[SP]even[SP]tailors[SP][E4][NULL][NULL][0006]real[SP]armor[E4][NULL][NULL][0002].[1205][000F][SP]The[SP][E4][NULL][NULL][0006]quality[SP]is\nsubpar,[SP]but[SP]they're[SP]cheap[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "[E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] à Kounan confectionne de\n[E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [1205][000F][E4][NULL][NULL][0006]Qualité médiocre, mais pas\ncher[E4][NULL][NULL][0002]."
+    "texte_fr": "[E4][NULL][NULL][0006]London Clothier[E4][NULL][NULL][0002] à Kounan confectionne de\n[E4][NULL][NULL][0006]vraies armures[E4][NULL][NULL][0002]. [000F][1205][E4][NULL][NULL][0006]Qualité médiocre, mais pas\ncher[E4][NULL][NULL][0002]."
   },
   {
     "id": 54,
@@ -944,7 +944,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "What[SP]is[SP]that[SP]exactly?[1205][000F][SP]Some[SP]kind[SP]of[SP]special\njob...?[1205][000F][SP]Well,[SP]anyways.[SP]Here's[SP]what[SP]I[SP]know.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "C'est quoi exactement? [1205][000F][1205][000F]Un genre de métier\nspécial...? Bref. Voilà ce que je sais."
+    "texte_fr": "C'est quoi exactement? [000F][1205][000F][1205]Un genre de métier\nspécial...? Bref. Voilà ce que je sais."
   },
   {
     "id": 56,
@@ -959,7 +959,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "You[SP]know[SP]those[SP][E4][NULL][NULL][0006]magazine[SP]sweepstakes[E4][NULL][NULL][0002]?[SP]I[SP]hear[SP]you\ncan[SP]win[SP][E4][NULL][NULL][0006]real[SP]weapons[SP]and[SP]rare[SP]items[E4][NULL][NULL][0002].[SP]They're\n[E4][NULL][NULL][0006]seldom[SP]won,[SP]but[SP]the[SP]prizes[SP]are[SP]very[SP]rare[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Vous connaissez les\n[E4][NULL][NULL][0006]tirages de magazines[E4][NULL][NULL][0002]? On\npeut gagner de [E4][NULL][NULL][0006]vraies\narmes et objets rares[E4][NULL][NULL][0002].\n[E4][NULL][NULL][0006]Peu gagnés, mais les lots sont rares[E4][NULL][NULL][0002]."
+    "texte_fr": "Vous connaissez les\n[E4][NULL][NULL][0006]tirages de magazines[E4][NULL][NULL][0002]? On\npeut gagner de [E4][NULL][NULL][0006]vraies armes et objets rares[E4][NULL][NULL][0002]. [E4][NULL][NULL][0006]Peu gagnés, mais les lots sont rares[E4][NULL][NULL][0002]."
   },
   {
     "id": 57,
@@ -1004,7 +1004,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Do[SP]you[SP]know[SP]the[SP]arcade[SP][E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]?[1205][000F][SP]I[SP]hear[SP]that[SP]place\nis[SP]really[SP]a[SP][E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002],[SP]and[SP]people[SP]can[SP]make[SP]a[SP][E4][NULL][NULL][0006]ton\nof[SP]money[SP]on[SP]the[SP]slots[E4][NULL][NULL][0002].",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Vous connaissez [E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]? [1205][000F]C'est en réalité\nun [E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002], et on peut se faire une\n[E4][NULL][NULL][0006]belle somme aux machines à sous[E4][NULL][NULL][0002]."
+    "texte_fr": "Vous connaissez [E4][NULL][NULL][0006]Mu[E4][NULL][NULL][0002]? [000F][1205]C'est en réalité\nun [E4][NULL][NULL][0006]casino[E4][NULL][NULL][0002], et on peut se faire une\n[E4][NULL][NULL][0006]belle somme aux machines à sous[E4][NULL][NULL][0002]."
   },
   {
     "id": 60,
@@ -1034,7 +1034,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Huh?[SP]Masked[SP]Circle?[SP]I've[SP]never[SP]heard[SP]of[SP]it.[1205][000F]\nIs[SP]that[SP]some[SP]kind[SP]of[SP]organization?[SP]And[SP]these\npeople[SP]are[SP]here,[SP]in[SP]this[SP]city?",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "Hm? Cercle masqué? Jamais entendu\n[1205][000F]parler. C'est une organisation? Et\nils sont ici, dans cette ville?"
+    "texte_fr": "Hm? Cercle masqué? Jamais entendu\n[000F][1205]parler. C'est une organisation? Et\nils sont ici, dans cette ville?"
   },
   {
     "id": 62,
@@ -1049,7 +1049,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "That's[SP]big.[SP]I[SP]should[SP]look[SP]into[SP]it[SP]immediately.[1205][000F]\nHmm,[SP]maybe[SP]the[SP]girl[SP]at[SP]Peace[SP]Diner[SP]might[SP]know\nmore.[SP]Have[SP]you[SP]tried[SP]asking[SP]her[SP]about[SP]them?",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "C'est sérieux. Je dois me renseigner.\n[1205][000F]Hmm, la fille de Peace Diner en sait\npeut-être plus. Lui avez-vous demandé?"
+    "texte_fr": "C'est sérieux. Je dois me renseigner.\n[000F][1205]Hmm, la fille de Peace Diner en sait\npeut-être plus. Lui avez-vous demandé?"
   },
   {
     "id": 63,
@@ -1064,7 +1064,7 @@
     "nom_orig": "Rumormonger[SP]Toro",
     "texte_orig": "Looks[SP]like[SP]you've[SP]got[SP]a[SP]lot[SP]of[SP]rumors[SP]ready\nto[SP]unload.[1205][000F][SP]I'll[SP]gather[SP]some[SP]new[SP]ones[SP]too,\nso[SP]let's[SP]swap[SP]stories[SP]then.",
     "nom_fr": "Toro l'informateur",
-    "texte_fr": "On dirait que vous avez des rumeurs\nà partager. [1205][000F]Je vais en collecter\naussi, alors échangeons bientôt."
+    "texte_fr": "On dirait que vous avez des rumeurs\nà partager. [000F][1205]Je vais en collecter\naussi, alors échangeons bientôt."
   },
   {
     "id": 64,
@@ -1199,7 +1199,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "The[SP]girls[SP]in[SP]Muses[SP]are[SP]high[SP]school[SP]students?\nShouldn't[SP]they[SP]be[SP]studying...?[1205][000F][SP]Listen[SP]to[SP]me.\nI'm[SP]starting[SP]to[SP]sound[SP]like[SP]an[SP]old[SP]man.",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "Les filles des Muses sont lycéennes? Elles\nne devraient pas étudier.[1205][000F]..? Écoutez-moi.\nJe commence à parler comme un vieux."
+    "texte_fr": "Les filles des Muses sont lycéennes? Elles\nne devraient pas étudier.[000F][1205]..? Écoutez-moi.\nJe commence à parler comme un vieux."
   },
   {
     "id": 73,
@@ -1214,7 +1214,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "What[SP]the[SP]hell[SP]is[SP]this[SP]old[SP]man[SP]saying!?[SP]It[SP]was\nplaying[SP]with[SP]fire[SP]that[SP]killed[SP]tons[SP]of[SP]people!\nI'll[SP]sew[SP]up[SP]that[SP]mouth[SP]and[SP]see[SP]how[SP]you[SP]like[SP]it!",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "Qu'est-ce qu'il raconte\nce vieux!? Jouer avec\nle feu a tué des\ntonnes de gens! Je vais lui\ncoudre la bouche pour voir s'il aime ça!"
+    "texte_fr": "Qu'est-ce qu'il raconte\nce vieux!? Jouer avec\nle feu a tué des tonnes de gens! Je vais lui coudre la bouche pour voir s'il aime ça!"
   },
   {
     "id": 74,
@@ -1259,7 +1259,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "Did[SP]you[SP]read[SP]that[SP]In[SP]Lak'ech[SP]book,[SP]too?[1205][000F]\nWhenever[SP]society's[SP]in[SP]turmoil,[SP]you[SP]see\nscrewed-up[SP]books[SP]like[SP]that[SP]pop[SP]up.",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "As-tu lu le livre In Lak'ech? Dès que\n[1205][000F]la société est en crise, on voit de\ndrôles de livres comme ça apparaître."
+    "texte_fr": "As-tu lu le livre In Lak'ech? Dès que\n[000F][1205]la société est en crise, on voit de\ndrôles de livres comme ça apparaître."
   },
   {
     "id": 77,
@@ -1274,7 +1274,7 @@
     "nom_orig": "Count[SP]Sushi",
     "texte_orig": "Th-That[SP]president[SP]guy[SP]just[SP]up[SP]and[SP]rushed[SP]out\nall[SP]of[SP]a[SP]sudden.[1205][000F][SP]He's[SP]not[SP]gonna[SP]go[SP]pick[SP]a[SP]fight\nwith[SP]those[SP]guys,[SP]is[SP]he?",
     "nom_fr": "Comte Sushi",
-    "texte_fr": "Ce président est parti d'un coup. Il ne va\n[1205][000F]pas chercher des noises à ces gars, si?"
+    "texte_fr": "Ce président est parti d'un coup. Il ne va\n[000F][1205]pas chercher des noises à ces gars, si?"
   },
   {
     "id": 78,
@@ -1289,7 +1289,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "Hwaha![SP]I've[SP]finally[SP]been[SP]promoted[SP]to[SP]president.\nEating[SP]sushi[SP]at[SP]lunch[SP]while[SP]my[SP]underlings[SP]do\nall[SP]the[SP]work[SP]proves[SP]I've[SP]gone[SP]up[SP]the[SP]ladder!",
     "nom_fr": "PDG",
-    "texte_fr": "Hahaha! J'ai enfin été promu président.\nManger des sushis le midi pendant que mes\nsubordonnés bossent prouve\nque j'ai réussi!"
+    "texte_fr": "Hahaha! J'ai enfin été promu président.\nManger des sushis le midi pendant que mes\nsubordonnés bossent prouve que j'ai réussi!"
   },
   {
     "id": 79,
@@ -1304,7 +1304,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "Now[SP]that[SP]I'm[SP]president,[SP]I[SP]shouldn't[SP]be[SP]so\nstingy[SP]anymore.[1205][000F][SP]Hey,[SP]chef![SP]Go[SP]easy[SP]on[SP]the\nrice,[SP]okay?[SP]Hahaha!",
     "nom_fr": "PDG",
-    "texte_fr": "Puisque je suis président, je ne\ndevrais plus être radin. [1205][000F]Hé, chef!\nAllez-y mollo sur le riz, okay? Hahaha!"
+    "texte_fr": "Puisque je suis président, je ne\ndevrais plus être radin. [000F][1205]Hé, chef!\nAllez-y mollo sur le riz, okay? Hahaha!"
   },
   {
     "id": 80,
@@ -1319,7 +1319,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "I'm[SP]finally[SP]company[SP]president,[SP]so[SP]I[SP]want[SP]to\nsplurge[SP]a[SP]little[SP]and[SP]get[SP]an[SP]entire[SP]fish,[SP]but\nmy[SP]tastes[SP]haven't[SP]changed.[1205][000F][SP]One[SP]albacore,[SP]chef!",
     "nom_fr": "PDG",
-    "texte_fr": "Je suis enfin président de l'entreprise, je\nveux dépenser un peu et m'offrir un poisson\nentier, mais mes goûts\n[1205][000F]restent. Un thon, chef!"
+    "texte_fr": "Je suis enfin président de l'entreprise, je\nveux dépenser un peu et m'offrir un poisson\nentier, mais mes goûts [000F][1205]restent. Un thon, chef!"
   },
   {
     "id": 81,
@@ -1334,7 +1334,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "Hahaha.[1205][000F][SP]I[SP]hear[SP]there's[SP]going[SP]to[SP]be[SP]a[SP]masquerade\nas[SP]part[SP]of[SP]Cuss[SP]High's[SP]school[SP]festival.[1205][000F][SP]Kids\nsure[SP]come[SP]up[SP]with[SP]some[SP]interesting[SP]ideas.",
     "nom_fr": "PDG",
-    "texte_fr": "Hahaha. [1205][000F][1205][000F]J'ai entendu dire qu'il y aura une\nmascarade pour le festival de Lycée Kakasu.\nCes enfants ont\ndes idées vraimentintéressantes."
+    "texte_fr": "Hahaha. [000F][1205][000F][1205]J'ai entendu dire qu'il y aura une\nmascarade pour le festival de Lycée Kakasu.\nCes enfants ont des idées vraimentintéressantes."
   },
   {
     "id": 82,
@@ -1349,7 +1349,7 @@
     "nom_orig": "Company[SP]president",
     "texte_orig": "M-M-Masked[SP]Circle?[1205][000F][SP]Where[SP]did[SP]you[SP]hear--[1205][000F]\nUh,[SP]I[SP]mean...[SP]Sorry,[SP]I[SP]don't[SP]know[SP]what[SP]you're\ntalking[SP]about.",
     "nom_fr": "PDG",
-    "texte_fr": "L-Le Cercle masqué? [1205][000F][1205][000F]Où avez- vous\nentendu-- Euh, je veux dire... Désolé,\nje ne vois pas de quoi vous parlez."
+    "texte_fr": "L-Le Cercle masqué? [000F][1205][000F][1205]Où avez- vous\nentendu-- Euh, je veux dire... Désolé,\nje ne vois pas de quoi vous parlez."
   },
   {
     "id": 83,
@@ -1364,7 +1364,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Hahaha![1205][000F][SP]That's[SP]right,[SP]burn![1205][000F][SP]Burn![SP]Joker[SP]gave\nme[SP]my[SP]position[SP]as[SP]company[SP]president,[SP]but[SP]I\nwasn't[SP]satisfied.",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Haha! [1205][000F][1205][000F]C'est ça, brûlez! Brûlez!\nJoker m'a donné mon poste de\nprésident, mais ça ne suffisait pas."
+    "texte_fr": "Haha! [000F][1205][000F][1205]C'est ça, brûlez! Brûlez!\nJoker m'a donné mon poste de\nprésident, mais ça ne suffisait pas."
   },
   {
     "id": 84,
@@ -1379,7 +1379,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "If[SP]anything,[SP]it[SP]made[SP]me[SP]feel[SP]even[SP]emptier![1205][000F]\nThat's[SP]because[SP]this[SP]society[SP]is[SP]boring!\nThis[SP]world[SP]should[SP]go[SP]up[SP]in[SP]flames!",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "Faux, je me sentais encore plus vide!\n[1205][000F]Cette société est ennuyeuse! Ce monde\ndevrait périr dans les flammes!"
+    "texte_fr": "Faux, je me sentais encore plus vide!\n[000F][1205]Cette société est ennuyeuse! Ce monde\ndevrait périr dans les flammes!"
   },
   {
     "id": 85,
@@ -1454,7 +1454,7 @@
     "nom_orig": "Masked[SP]Circle[SP]member",
     "texte_orig": "Th-Those[SP]five[SP]are[SP]heroes[SP]fighting[SP]against[SP]the\nMasked[SP]Circle!?[1205][000F][SP]Then[SP]that[SP]makes[SP]them[SP]the[SP]enemy!\nWhy[SP]didn't[SP]anyone[SP]tell[SP]me!?",
     "nom_fr": "Membre du Cercle masqué",
-    "texte_fr": "C-Ces cinq sont des héros luttant contre\nle Cercle masqué![1205][000F]? Ce sont des ennemis!\nPourquoi personne m'a rien dit!?"
+    "texte_fr": "C-Ces cinq sont des héros luttant contre\nle Cercle masqué![000F][1205]? Ce sont des ennemis!\nPourquoi personne m'a rien dit!?"
   },
   {
     "id": 90,
@@ -1574,7 +1574,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "The[SP]third[SP]member[SP]of[SP]Muses[SP]has[SP]finally[SP]been\nannounced![1205][000F][SP]Sadly,[SP]I[SP]only[SP]heard[SP]her[SP]voice[SP]over\nthe[SP]radio...[SP]I[SP]can't[SP]wait[SP]to[SP]see[SP]her[SP]face!",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Le troisième membre des Muses enfin\n[1205][000F]annoncé! Hélas, que sa voix à la\nradio... J'ai hâte de voir son visage!"
+    "texte_fr": "Le troisième membre des Muses enfin\n[000F][1205]annoncé! Hélas, que sa voix à la\nradio... J'ai hâte de voir son visage!"
   },
   {
     "id": 98,
@@ -1604,7 +1604,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Smile[SP]Hirasaka's[SP]just[SP]an[SP]ordinary[SP]train\nstation.[1205][000F][SP]What[SP]do[SP]the[SP]terrorists[SP]hope[SP]to\ngain[SP]by[SP]blowing[SP]it[SP]up?",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Smile Hirasaka n'est qu'une gare ordinaire.\n[1205][000F]Qu'espèrent les terroristes\nà la faire sauter?"
+    "texte_fr": "Smile Hirasaka n'est qu'une gare ordinaire.\n[000F][1205]Qu'espèrent les terroristes\nà la faire sauter?"
   },
   {
     "id": 100,
@@ -1634,7 +1634,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "But[SP]if[SP]there[SP]is[SP]a[SP]group[SP]fighting[SP]the[SP]Masked\nCircle...[SP]That's[SP]pretty[SP]interesting[SP]in[SP]its\nown[SP]right.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Mais s'il existe un groupe qui combat le\nCercle masqué... C'est\nplutôt intéressant en\nsoi."
+    "texte_fr": "Mais s'il existe un groupe qui combat le\nCercle masqué... C'est\nplutôt intéressant en soi."
   },
   {
     "id": 102,
@@ -1679,7 +1679,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Rumor[SP]has[SP]it[SP]that[SP]the[SP]ghost[SP]Hanako-san[SP]is\nhaunting[SP]Sevens.[1205][000F][SP]Does[SP]she[SP]actually[SP]exist?",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "On dit que le fantôme Hanako-san\nhante Seven. [1205][000F]Existe-t-elle vraiment?"
+    "texte_fr": "On dit que le fantôme Hanako-san\nhante Seven. [000F][1205]Existe-t-elle vraiment?"
   },
   {
     "id": 105,
@@ -1709,7 +1709,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "I[SP]heard[SP]the[SP]ghost[SP]of[SP]an[SP]idol[SP]who[SP]starved[SP]to\ndeath[SP]at[SP]Aoba[SP]Park[SP]is[SP]appearing[SP]there.[SP]That's\none[SP]of[SP]the[SP]saddest[SP]things[SP]I've[SP]ever[SP]heard...",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Le fantôme d'une idole\nmorte de faim au parc\nAoba y apparaît. C'est l'une des choses les\nplus tristes que j'aie entendues..."
+    "texte_fr": "Le fantôme d'une idole\nmorte de faim au parc\nAoba y apparaît. C'est l'une des choses les plus tristes que j'aie entendues..."
   },
   {
     "id": 107,
@@ -1784,7 +1784,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "There've[SP]been[SP]sightings[SP]of[SP]the[SP]Jumping[SP]Geezer\nat[SP]Mt.[SP]Katatsumuri.[SP]I[SP]thought[SP]it[SP]showed[SP]up[SP]on\nroads[SP]and[SP]tunnels...[SP]add[SP]mountains[SP]to[SP]the[SP]list.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "On a aperçu le Vieux Sauteur au Mont\nKatatsumuri. Je croyais\nqu'il apparaissait sur\nles routes et\ntunnels... Ajoutons les montagnes."
+    "texte_fr": "On a aperçu le Vieux Sauteur au Mont\nKatatsumuri. Je croyais\nqu'il apparaissait sur les routes et tunnels... Ajoutons les montagnes."
   },
   {
     "id": 112,
@@ -1799,7 +1799,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Gah...[1205][000F][SP]I[SP]heard[SP]something[SP]awful...[1205][000F][SP]K-Kudan's...\nKudan's[SP]at[SP]the[SP]abandoned[SP]factory...[1205][000F][SP]No,[SP]I[SP]don't\nwant[SP]to[SP]think[SP]about[SP]it!",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Argh.[1205][000F][1205][000F][1205][000F].. J'ai entendu un truc horrible...\nK-Kudan... Kudan est à l'usine\nabandonnée... Non, je ne veux pas y penser!"
+    "texte_fr": "Argh.[000F][1205][000F][1205][000F][1205].. J'ai entendu un truc horrible...\nK-Kudan... Kudan est à l'usine\nabandonnée... Non, je ne veux pas y penser!"
   },
   {
     "id": 113,
@@ -1814,7 +1814,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "You[SP]know[SP]about[SP]Giga[SP]Macho's[SP]secret[SP]CD?[1205][000F]\nI[SP]hear[SP]there[SP]is[SP]one.[SP]I'd[SP]love[SP]to[SP]know[SP]what\nkind[SP]of[SP]tracks[SP]are[SP]on[SP]it.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Vous savez pour le CD de Giga\n[1205][000F]Macho? On dit qu'il existe. Je veux\nsavoir quels morceaux sont dessus."
+    "texte_fr": "Vous savez pour le CD de Giga\n[000F][1205]Macho? On dit qu'il existe. Je veux\nsavoir quels morceaux sont dessus."
   },
   {
     "id": 114,
@@ -1829,7 +1829,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "The[SP]dreaded[SP]Dresser[SP]Hag[SP]is[SP]apparently[SP]showing\nup[SP]at[SP]the[SP]abandoned[SP]factory[SP]in[SP]Kounan.[1205][000F][SP]What\nkind[SP]of[SP]monster[SP]is[SP]that,[SP]I[SP]ask[SP]you?",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "La Sorcière du Placard semble\napparaître à l'usine abandonnée de\n[1205][000F]Kounan. C'est quoi comme monstre, ça?"
+    "texte_fr": "La Sorcière du Placard semble\napparaître à l'usine abandonnée de\n[000F][1205]Kounan. C'est quoi comme monstre, ça?"
   },
   {
     "id": 115,
@@ -1859,7 +1859,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "I[SP]hear[SP]Time[SP]Castle[SP]in[SP]Rengedai[SP]sells[SP]real\nweapons.[SP]Sounds[SP]dangerous...[SP]It's[SP]good[SP]quality\nstuff,[SP]but[SP]it's[SP]pricey.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Time Castle à Rengedai\nvend de vraies armes.\nDangereux... Bonne qualité,\nmais c'est cher."
+    "texte_fr": "Time Castle à Rengedai\nvend de vraies armes.\nDangereux... Bonne qualité, mais c'est cher."
   },
   {
     "id": 117,
@@ -1874,7 +1874,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "I[SP]hear[SP]Time[SP]Castle[SP]in[SP]Rengedai[SP]sells[SP]real\nweapons.[SP]Sounds[SP]dangerous...[SP]It's[SP]cheap,\nsubpar[SP]stuff.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Time Castle à Rengedai\nvend de vraies armes.\nDangereux... Bon marché,\nmais piètre qualité."
+    "texte_fr": "Time Castle à Rengedai\nvend de vraies armes.\nDangereux... Bon marché, mais piètre qualité."
   },
   {
     "id": 118,
@@ -2069,7 +2069,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "Jolly[SP]Roger[SP]in[SP]Kounan[SP]sells[SP]real[SP]weapons,\nI[SP]hear.[SP]They[SP]pay[SP]a[SP]lot[SP]on[SP]resale,[SP]but[SP]their\nselection[SP]is[SP]pretty[SP]bad.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Jolly Roger à Kounan\nvendrait de vraies armes.\nBon prix de\nrachat, mais sélection mauvaise."
+    "texte_fr": "Jolly Roger à Kounan\nvendrait de vraies armes.\nBon prix de rachat, mais sélection mauvaise."
   },
   {
     "id": 131,
@@ -2354,7 +2354,7 @@
     "nom_orig": "Sushi[SP]Royalty",
     "texte_orig": "I[SP]hear[SP]that[SP]the[SP]prizes[SP]for[SP]the[SP]magazine\nsweepstakes[SP]are[SP]real[SP]weapons[SP]and[SP]items.\nYou[SP]rarely[SP]win,[SP]but[SP]the[SP]prizes[SP]are[SP]good.",
     "nom_fr": "Sushi Royalty",
-    "texte_fr": "Les lots des tirages de magazines sont de\nvraies armes et objets.\nRares à gagner, mais\nbons."
+    "texte_fr": "Les lots des tirages de magazines sont de\nvraies armes et objets.\nRares à gagner, mais bons."
   },
   {
     "id": 150,

--- a/traduction/event_scripts/script_387.json
+++ b/traduction/event_scripts/script_387.json
@@ -12,7 +12,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Dude,[SP]what[SP]is[SP]this...?[1205][000F][SP]Some[SP]kinda[SP]stage?\nThere's[SP]even[SP]lighting...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Qu'es que c'est que ça? [1205][000F]Une\nscène? C'est même éclairé..."
+    "texte_fr": "Qu'es que c'est que ça? [000F][1205]Une\nscène? C'est même éclairé..."
   },
   {
     "id": 1,
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Oh,[SP]are[SP]we[SP]heading[SP]back[SP]for[SP]a[SP]bit?[1205][000F][SP]Guess[SP]we\ncan't[SP]stock[SP]up[SP]on[SP]weapons[SP]and[SP]stuff[SP]otherwise.\nOkay,[SP]let's[SP]go.",
     "nom_fr": "Eikichi",
-    "texte_fr": "On fait demi-tour? C'est vrai qu'on\n[1205][000F]pourra pas faire le plein\nd'équipement sinon. Aller, on y va."
+    "texte_fr": "On fait demi-tour? C'est vrai qu'on\n[000F][1205]pourra pas faire le plein\nd'équipement sinon. Aller, on y va."
   },
   {
     "id": 2,
@@ -57,7 +57,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Looks[SP]like[SP]the[SP]Last[SP]Battalion[SP]makes[SP]something\nuseful[SP]every[SP]now[SP]and[SP]then.[1205][000F][SP]Well,[SP]might[SP]as[SP]well\ntake[SP]advantage[SP]of[SP]it!",
     "nom_fr": "Ginko",
-    "texte_fr": "On dirait que le Bataillon peut être utile\n[1205][000F]de temps à autre. Autant en profiter!"
+    "texte_fr": "On dirait que le Bataillon peut être utile\n[000F][1205]de temps à autre. Autant en profiter!"
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "This[SP]mark...[1205][000F][SP]Did[SP]the[SP]Last[SP]Battalion[SP]leave\nthis[SP]here...?",
     "nom_fr": "Maya",
-    "texte_fr": "Cette marque.[1205][000F].. C'est le\nbataillon qui à laissé ça?"
+    "texte_fr": "Cette marque.[000F][1205].. C'est le\nbataillon qui à laissé ça?"
   },
   {
     "id": 5,
@@ -102,7 +102,7 @@
     "nom_orig": "Jun",
     "texte_orig": "It[SP]looks[SP]like...[SP]a[SP]teleporter...[1205][000F][SP]I[SP]think[SP]we\ncan[SP]activate[SP]it[SP]just[SP]by[SP]getting[SP]on[SP]and[SP]pushing\na[SP]button.[SP]But[SP]where[SP]does[SP]it[SP]lead...?",
     "nom_fr": "Jun",
-    "texte_fr": "On dirait un téléporteur. [1205][000F]On devrait\npouvoir l'activer en appuyant sur le bouton\nà l'intérieur. Mais où il pourrait ammener?"
+    "texte_fr": "On dirait un téléporteur. [000F][1205]On devrait\npouvoir l'activer en appuyant sur le bouton\nà l'intérieur. Mais où il pourrait ammener?"
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Jun",
     "texte_orig": "It's[SP]strange...[1205][000F][SP]It[SP]doesn't[SP]look[SP]as[SP]though[SP]the\nLast[SP]Battalion[SP]even[SP]used[SP]this.[1205][000F][SP]It's[SP]like[SP]they\nleft[SP]it[SP]just[SP]for[SP]us...",
     "nom_fr": "Jun",
-    "texte_fr": "On dirait que le Bataillon\n[1205][000F][1205][000F]ne s'en est même pas\nservi. C'est comme s'il était conçu\nspécialement pour nous... \nSe téléporter à Seven?[SP][SP]\nOuiNon",
+    "texte_fr": "On dirait que le Bataillon\n[000F][1205][000F][1205]ne s'en est même pas\nservi. C'est comme s'il était conçu spécialement pour nous... Se téléporter à Seven?[SP][SP] OuiNon",
     "choix_fr": [
       "Oui",
       "Non"
@@ -137,7 +137,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah!?[1205][000F][SP]What's[SP]this?",
     "nom_fr": "Ginko",
-    "texte_fr": "Ahh![1205][000F]? C'est quoi?"
+    "texte_fr": "Ahh![000F][1205]? C'est quoi?"
   },
   {
     "id": 9,
@@ -152,7 +152,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Heh,[SP]can't[SP]you[SP]tell?[1205][000F][SP]It's[SP]a[SP]stage,[SP]duh!\nIt[SP]even[SP]has[SP]its[SP]own[SP]lighting[SP]setup!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Bah, je sais pas moi.[1205][000F].. Une scène\npeut être? Tu vois pas l'éclairage?"
+    "texte_fr": "Bah, je sais pas moi.[000F][1205].. Une scène\npeut être? Tu vois pas l'éclairage?"
   },
   {
     "id": 10,
@@ -182,7 +182,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]showtime![1205][000F][SP]Are[SP]you[SP]ready,[SP]Xibalba!?[1205][000F][SP]Because\nMichel's[SP]about[SP]to[SP]rock[SP]your[SP]socks[SP]off!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Est-ce que tout le monde est prêt?\n[1205][000F][1205][000F]Parce que le spectacle commence!"
+    "texte_fr": "Est-ce que tout le monde est prêt?\n[000F][1205][000F][1205]Parce que le spectacle commence!"
   },
   {
     "id": 12,

--- a/traduction/event_scripts/script_388.json
+++ b/traduction/event_scripts/script_388.json
@@ -27,7 +27,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Yeah...[SP]Yasuo's[SP]in[SP]charge[SP]of[SP]it[SP]all.[1205][001E][SP]And[SP]here\nI[SP]thought[SP]he[SP]was[SP]just[SP]putting[SP]in[SP]extra[SP]effort\nfor[SP]the[SP]school...[SP]That[SP]bastard...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ouais... Yasuo est responsable de tout ça.[1205][001E]\nEt moi qui croyais qu'il faisait juste des\nefforts pour l'école... Ce salaud..."
+    "texte_fr": "Ouais... Yasuo est responsable de tout ça.[001E][1205]\nEt moi qui croyais qu'il faisait juste des\nefforts pour l'école... Ce salaud..."
   },
   {
     "id": 2,

--- a/traduction/event_scripts/script_389.json
+++ b/traduction/event_scripts/script_389.json
@@ -12,7 +12,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Hellooooo![1205][000F][SP]Welcome[SP]to[SP]the[SP]record[SP]store\nGIGA[SP]MACHOOOO![SP]State[SP]your[SP]business!\n[1208][0004]Buy[SP]CDs\nTalk[SP]to[SP]employee\nNever[SP]mind\nLeave[SP]the[SP]store",
     "nom_fr": "Employé",
-    "texte_fr": "Bonjooouuuur! [1205][000F]Bienvenue au\nmagasin de disques\nGIGA MACHO! Que vous faut-il?\n[1208][0004]Acheter des CDs\nParler\nAnnuler\nQuitter",
+    "texte_fr": "Bonjooouuuur! [000F][1205]Bienvenue au\nmagasin de disques\nGIGA MACHO! Que vous faut-il?\n[1208][0004]Acheter des CDs\nParler\nAnnuler\nQuitter",
     "question_orig": "Hellooooo![1205][000F][SP]Welcome[SP]to[SP]the[SP]record[SP]store\nGIGA[SP]MACHOOOO![SP]State[SP]your[SP]business!",
     "choix_orig": [
       "Buy[SP]CDs",
@@ -107,7 +107,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Heeeey...[SP]Does[SP]that[SP]blonde[SP]girl[SP]with[SP]you[SP]happen\nto[SP]be[SP]Lisa-san[SP]from[SP]Muses?[1205][000F][SP]Whoa![SP]She's[SP]the[SP]real\ndeal!",
     "nom_fr": "Employé",
-    "texte_fr": "Heeey... La fille blonde avec\nvous, c'est pas Lisa des Muses par\n[1205][000F]hasard? Waouh! C'est bien elle!"
+    "texte_fr": "Heeey... La fille blonde avec\nvous, c'est pas Lisa des Muses par\n[000F][1205]hasard? Waouh! C'est bien elle!"
   },
   {
     "id": 5,
@@ -137,7 +137,7 @@
     "nom_orig": "Employee",
     "texte_orig": "*sigh*[1205][000F][SP]We've[SP]lost[SP]so[SP]many[SP]customers[SP]to[SP]this\nawful[SP]terror[SP]wave...[1205][000F][SP]I[SP]should[SP]sue[SP]for\nobstruction[SP]of[SP]business.",
     "nom_fr": "Employé",
-    "texte_fr": "*soupir* Avec cette vague de terreur,\n[1205][000F][1205][000F]on a perdu tant de clients... Je\ndevrais porter plainte!"
+    "texte_fr": "*soupir* Avec cette vague de terreur,\n[000F][1205][000F][1205]on a perdu tant de clients... Je\ndevrais porter plainte!"
   },
   {
     "id": 7,
@@ -182,7 +182,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Man,[SP]you[SP]always[SP]have[SP]the[SP]best[SP]timing.[SP]We[SP]juuust\ngot[SP]in[SP]some[SP]new[SP]singles[SP]in[SP]the[SP]Terzo[SP]corner.[1205][000F]\nHere,[SP]come[SP]take[SP]a[SP]look.",
     "nom_fr": "Employé",
-    "texte_fr": "Wah, vous tombez bien. On vient juuuste\nde recevoir des nouveaux singles dans\n[1205][000F]le rayon Terzo. Venez voir!"
+    "texte_fr": "Wah, vous tombez bien. On vient juuuste\nde recevoir des nouveaux singles dans\n[000F][1205]le rayon Terzo. Venez voir!"
   },
   {
     "id": 10,
@@ -197,7 +197,7 @@
     "nom_orig": "Employee",
     "texte_orig": "The[SP]city's[SP]a[SP]mess[SP]right[SP]now,[SP]but[SP]we[SP]did[SP]get\nour[SP]scheduled[SP]delivery[SP]of[SP]new[SP]material.[1205][000F][SP]I've\nfinally[SP]put[SP]together[SP]a[SP]Quarto[SP]corner.",
     "nom_fr": "Employé",
-    "texte_fr": "La ville est sens dessus dessous, mais on a\nquand même reçu\nnotre livraison de nouvelles\n[1205][000F]sorties. J'ai monté un rayon Quarto."
+    "texte_fr": "La ville est sens dessus dessous, mais on a\nquand même reçu\nnotre livraison de nouvelles [000F][1205]sorties. J'ai monté un rayon Quarto."
   },
   {
     "id": 11,
@@ -212,7 +212,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Geez,[SP]we're[SP]getting[SP]in[SP]so[SP]much[SP]new[SP]music[SP]these\ndays,[SP]I'm[SP]running[SP]out[SP]of[SP]rack[SP]space[SP]for[SP]it[SP]all.[1205][000F]\nAaaanyways,[SP]we[SP]have[SP]a[SP]Quinto[SP]corner[SP]at[SP]last.",
     "nom_fr": "Employé",
-    "texte_fr": "Pfff, on reçoit tellement de nouvelles\nmusiques en ce moment que je manque de\n[1205]rayonnage. [000F]Boooon, on a\nenfin un rayon Quinto."
+    "texte_fr": "Pfff, on reçoit tellement de nouvelles\nmusiques en ce moment que je manque de\n[1205]rayonnage. [000F]Boooon, on a enfin un rayon Quinto."
   },
   {
     "id": 12,
@@ -227,7 +227,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Now[SP]that's[SP]weird...[1205][000F][SP]Did[SP]we[SP]used[SP]to[SP]carry[SP]this\n[1432][NULL][NULL][0014]secret[SP]CD[1432][NULL][NULL][0014]?[1205][000F][SP]Huh,[SP]well,[SP]I[SP]see[SP]we[SP]have[SP]it[SP]in\nstock...[SP]so[SP]I[SP]guess[SP]we[SP]carry[SP]it[SP]now!",
     "nom_fr": "Employé",
-    "texte_fr": "C'est bizarre..[1205][000F][1205][000F]. On avait ce [1432][NULL][NULL][0014]CD secret[1432][NULL][NULL][0014]\nen stock? Bah, je vois qu'on l'a en\nrayon... donc je suppose qu'on le vend !"
+    "texte_fr": "C'est bizarre..[000F][1205][000F][1205]. On avait ce [1432][NULL][NULL][0014]CD secret[1432][NULL][NULL][0014]\nen stock? Bah, je vois qu'on l'a en\nrayon... donc je suppose qu'on le vend !"
   },
   {
     "id": 13,
@@ -272,7 +272,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Wow,[SP]you're[SP]something[SP]else.[1205][000F][SP]You've[SP]bought[SP]up\nevery[SP]CD[SP]in[SP]the[SP]shop![SP]Thanks,[SP]thanks,[SP]and[SP]in\ncase[SP]I[SP]forget,[SP]thanks!",
     "nom_fr": "Employé",
-    "texte_fr": "Waouh, vous êtes incroyable. [1205][000F]Vous\navez acheté tous les CDs! Merci,\nmerci, et au cas où j'oublie, merci!"
+    "texte_fr": "Waouh, vous êtes incroyable. [000F][1205]Vous\navez acheté tous les CDs! Merci,\nmerci, et au cas où j'oublie, merci!"
   },
   {
     "id": 16,
@@ -417,7 +417,7 @@
     "nom_orig": "Employee",
     "texte_orig": "Hmm?[1205][000F][SP]The[SP]Quarto[SP]corner's[SP]sold[SP]out?[1205][000F][SP]That[SP]was...\ndisappointingly[SP]quick...[1205][000F][SP]But[SP]I[SP]won't[SP]complain!",
     "nom_fr": "Employé",
-    "texte_fr": "Hm? [1205][000F][1205][000F][1205][000F]Le rayon Quarto est épuisé? C'était...\nsacrément rapide... Mais je me plains pas!"
+    "texte_fr": "Hm? [000F][1205][000F][1205][000F][1205]Le rayon Quarto est épuisé? C'était...\nsacrément rapide... Mais je me plains pas!"
   },
   {
     "id": 25,
@@ -477,6 +477,6 @@
     "nom_orig": "Employee",
     "texte_orig": "Thanks![1205][000F][SP]Come[SP]again!",
     "nom_fr": "",
-    "texte_fr": "Merci ![1205][000F] Revenez nous voir !"
+    "texte_fr": "Merci ![000F][1205] Revenez nous voir !"
   }
 ]

--- a/traduction/event_scripts/script_390.json
+++ b/traduction/event_scripts/script_390.json
@@ -732,7 +732,7 @@
     "nom_orig": "Mitsugi,[SP]the[SP]Theater[SP]Guide",
     "texte_orig": "[1432][NULL][NULL][0014]Another[SP]day[SP]at[SP]the[SP]movies.[SP]The[SP]WOMAN[SP]at[SP]the\ncounter[SP]glances[SP]out[SP]the[SP]window.[SP]She[SP]seems[SP]to[SP]be\nwaiting[SP]for[SP]someone.[SP]And[SP]then,[SP]as[SP]always...[1432][NULL][NULL][0014]",
     "nom_fr": "Mitsugi, la guide du théâtre",
-    "texte_fr": "[1432][NULL][NULL][0014]Encore une journée. La FEMME au guichet\nregarde par la\nfenêtre. Elle semble attendre\nquelqu'un. Et puis, comme toujours...[1432][NULL][NULL][0014]"
+    "texte_fr": "[1432][NULL][NULL][0014]Encore une journée. La FEMME au guichet\nregarde par la\nfenêtre. Elle semble attendre quelqu'un. Et puis, comme toujours...[1432][NULL][NULL][0014]"
   },
   {
     "id": 49,
@@ -807,7 +807,7 @@
     "nom_orig": "Mitsugi,[SP]the[SP]Theater[SP]Guide",
     "texte_orig": "[1432][NULL][NULL][0014]CLOSE-UP[SP]on[SP]the[SP]WOMAN's[SP]face.[SP]She[SP]stares\npensively[SP]out[SP]the[SP]window.[SP]She[SP]realizes[SP]that[SP]she's\nbeen[SP]thinking[SP]about[SP]the[SP]MAN[SP]more[SP]and[SP]more...[1432][NULL][NULL][0014]",
     "nom_fr": "Mitsugi, la guide du théâtre",
-    "texte_fr": "[1432][NULL][NULL][0014]GROS PLAN sur le visage de la FEMME. Elle\nregarde, pensive, par\nla fenêtre. Elle réalise\nqu'elle pense de plus en plus à l'HOMME...[1432][NULL][NULL][0014]"
+    "texte_fr": "[1432][NULL][NULL][0014]GROS PLAN sur le visage de la FEMME. Elle\nregarde, pensive, par\nla fenêtre. Elle réalise qu'elle pense de plus en plus à l'HOMME...[1432][NULL][NULL][0014]"
   },
   {
     "id": 54,

--- a/traduction/event_scripts/script_391.json
+++ b/traduction/event_scripts/script_391.json
@@ -147,7 +147,7 @@
     "nom_orig": "Mitsugi,[SP]the[SP]Theater[SP]Guide",
     "texte_orig": "Thanks[SP]for[SP]your[SP]hard[SP]work![SP]I've[SP]been[SP]watching,\nand[SP]I[SP]gotta[SP]say,[SP]I'm[SP]impressed![SP]Let[SP]me[SP]unlock\na[SP]new[SP]mode[SP]for[SP]you.",
     "nom_fr": "Mitsugi, la guide du cinéma",
-    "texte_fr": "Merci pour votre travail!\nJe vous ai observé.\nImpressionnant! Laissez-moi débloquer un\nnouveau mode. [NULL][NULL]BGM[NULL][NULL]ajouté à la Galerie."
+    "texte_fr": "Merci pour votre travail!\nJe vous ai observé.\nImpressionnant! Laissez-moi débloquer un nouveau mode. [NULL][NULL]BGM[NULL][NULL]ajouté à la Galerie."
   },
   {
     "id": 10,

--- a/traduction/event_scripts/script_392.json
+++ b/traduction/event_scripts/script_392.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Whew...[1205][0014][SP]Is[SP]everyone[SP]okay?",
     "nom_fr": "Maya",
-    "texte_fr": "Ouf...[1205][0014] Rien de cassé?"
+    "texte_fr": "Ouf...[0014][1205] Rien de cassé?"
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh...?[1205][0014][SP]Why[SP]am[SP]I[SP]crying?[SP]The[SP]tears...[1205][0014]\nThey[SP]*sniff*[SP]won't[SP]stop...",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein...?[1205][0014] Pourquoi je pleure?[1205][0014]\n*sniff* Ça ne s'arrête pas..."
+    "texte_fr": "Hein...?[0014][1205] Pourquoi je pleure?[0014][1205]\n*sniff* Ça ne s'arrête pas..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]like...[1205][0014][SP]some[SP]cherished[SP]memory...[SP]Warmer\nthan[SP]what[SP]I[SP]felt[SP]with[SP][1113][SP]or[SP]Ginko...[1205][0014]\nLike[SP]being[SP]hugged[SP]by[SP]my[SP]mom...",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est...[1205][0014] si précieux... Plus doux qu'avec\n[1113]ou Ginko...[1205][0014] Comme un câlin de ma\nmère..."
+    "texte_fr": "C'est...[0014][1205] si précieux... Plus doux qu'avec\n[1113]ou Ginko...[0014][1205] Comme un câlin de ma\nmère..."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "How[SP]strange...[1205][0014][SP]I[SP]felt[SP]it[SP]too.[SP]What[SP]was[SP]that\nodd[SP]wave[SP]of[SP]nostalgia[SP]about...?",
     "nom_fr": "Maya",
-    "texte_fr": "Étrange...[1205][0014] Je le sens aussi. Qu'était\ndonc ce sentiment de nostalgie..."
+    "texte_fr": "Étrange...[0014][1205] Je le sens aussi. Qu'était\ndonc ce sentiment de nostalgie..."
   },
   {
     "id": 5,

--- a/traduction/event_scripts/script_393.json
+++ b/traduction/event_scripts/script_393.json
@@ -27,7 +27,7 @@
     "nom_orig": "Male[SP]student",
     "texte_orig": "By[SP]the[SP]way,[SP]have[SP]you[SP]heard[SP]of[SP]the[SP]Joker[SP]Game?[1205][000F]\nI[SP]heard[SP]it[SP]can[SP]grant[SP]any[SP]wish.[SP]I[SP]wonder[SP]if\nit'd[SP]help[SP]me[SP]be[SP]more[SP]like[SP]you,[SP]Senpai.",
     "nom_fr": "Lycéen",
-    "texte_fr": "Au fait, t'as entendu parler du jeu\n[1205][000F]du Joker? Apparemment, il permet\nd'exaucer n'importe quel vœu."
+    "texte_fr": "Au fait, t'as entendu parler du jeu\n[000F][1205]du Joker? Apparemment, il permet\nd'exaucer n'importe quel vœu."
   },
   {
     "id": 2,
@@ -72,7 +72,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "After[SP]all,[SP]my[SP]face[SP]is[SP]all[SP]jacked[SP]up.[1205][000F][SP]I[SP]just\nwanted[SP]a[SP]piece[SP]of[SP]the[SP]action...[1205][000F][SP]I[SP]specifically\nchose[SP]a[SP]school[SP]with[SP]a[SP]festival,[SP]too...",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "Je suis complètement défiguré. [1205][000F][1205][000F]Je voulais\nma part moi... J'ai choisi un lycée avec\nun festival pour une raison..."
+    "texte_fr": "Je suis complètement défiguré. [000F][1205][000F][1205]Je voulais\nma part moi... J'ai choisi un lycée avec\nun festival pour une raison..."
   },
   {
     "id": 5,

--- a/traduction/event_scripts/script_394.json
+++ b/traduction/event_scripts/script_394.json
@@ -12,7 +12,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Whew...[1205][0014][SP]Is[SP]everyone[SP]okay?",
     "nom_fr": "Maya",
-    "texte_fr": "Ouf...[1205][0014] Tout va bien?"
+    "texte_fr": "Ouf...[0014][1205] Tout va bien?"
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh...?[1205][0014][SP]Why[SP]am[SP]I[SP]crying?[SP]The[SP]tears...[1205][0014]\nThey[SP]*sniff*[SP]won't[SP]stop...",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein...?[1205][0014] Pourquoi je pleure?[1205][0014]\n*snif* Ça s'arrête pas..."
+    "texte_fr": "Hein...?[0014][1205] Pourquoi je pleure?[0014][1205]\n*snif* Ça s'arrête pas..."
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "It's[SP]like...[1205][0014][SP]some[SP]cherished[SP]memory...[SP]Warmer\nthan[SP]what[SP]I[SP]felt[SP]with[SP][1113][SP]or[SP]Ginko...[1205][0014]\nLike[SP]being[SP]hugged[SP]by[SP]my[SP]mom...",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est comme...[1205][0014] un souvenir précieux...\nPlus chaleureux qu'avec [1113] ou\nGinko...[1205][0014] Comme un câlin de ma mère..."
+    "texte_fr": "C'est comme...[0014][1205] un souvenir précieux...\nPlus chaleureux qu'avec [1113] ou\nGinko...[0014][1205] Comme un câlin de ma mère..."
   },
   {
     "id": 4,
@@ -72,7 +72,7 @@
     "nom_orig": "Maya",
     "texte_orig": "How[SP]strange...[1205][0014][SP]I[SP]felt[SP]it[SP]too.[SP]What[SP]was[SP]that\nodd[SP]wave[SP]of[SP]nostalgia[SP]about...?",
     "nom_fr": "Maya",
-    "texte_fr": "C'est bizarre...[1205][0014] Moi aussi. C'était\nquoi cette vague de nostalgie?"
+    "texte_fr": "C'est bizarre...[0014][1205] Moi aussi. C'était\nquoi cette vague de nostalgie?"
   },
   {
     "id": 5,
@@ -132,7 +132,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I've[SP]been[SP]a[SP]Persona-user[SP]since[SP]I[SP]played\nthe[SP][1432][NULL][NULL][0014]Persona[SP]Game[1432][NULL][NULL][0014][SP]back[SP]in[SP]high[SP]school...[1205][0014]\nThat[SP]was[SP]three[SP]years[SP]ago.",
     "nom_fr": "Yukino",
-    "texte_fr": "J'utilise un Persona depuis que\nj'ai joué au [1432][NULL][NULL][0014]Jeu du Persona[1432][NULL][NULL][0014] au\nlycée...[1205][0014] C'était il y a trois ans."
+    "texte_fr": "J'utilise un Persona depuis que\nj'ai joué au [1432][NULL][NULL][0014]Jeu du Persona[1432][NULL][NULL][0014] au\nlycée...[0014][1205] C'était il y a trois ans."
   },
   {
     "id": 9,
@@ -237,7 +237,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Well,[SP]we[SP]can[SP]save[SP]your[SP]origin[SP]stories\nfor[SP]later.[SP]Let's[SP]focus[SP]on[SP]where[SP]we\nshould[SP]go[SP]from[SP]here!",
     "nom_fr": "Maya",
-    "texte_fr": "Bon, on gardera vos\norigines pour plus tard.\nConcentrons-nous sur ce\nqu'on fait maintenant!"
+    "texte_fr": "Bon, on gardera vos\norigines pour plus tard.\nConcentrons-nous sur ce qu'on fait maintenant!"
   },
   {
     "id": 16,
@@ -447,7 +447,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Like...[1205][001E][SP]the[SP]clocks[SP]in[SP]the[SP]classrooms?\nTheir[SP]faces[SP]have[SP]the[SP]same[SP]design[SP]as\nour[SP]emblem.",
     "nom_fr": "Ginko",
-    "texte_fr": "Comme...[1205][001E] les horloges des salles? Leurs\ncadrans ont le même motif que l'emblème."
+    "texte_fr": "Comme...[001E][1205] les horloges des salles? Leurs\ncadrans ont le même motif que l'emblème."
   },
   {
     "id": 30,
@@ -492,7 +492,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "The[SP]memories[SP]evoked[SP]by[SP]the[SP]lady[SP]Maya-san...[1205][001E]\nThey[SP]were[SP]warm,[SP]sad,[SP]and[SP]painful,[SP]all[SP]at\nonce...[1205][001E][SP]Like[SP]the[SP]wringing[SP]of[SP]my[SP]heart...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Les souvenirs qu'a éveillés Maya...[1205][001E] Ils\nétaient chauds, tristes et douloureux à la\nfois...[1205][001E] Comme si mon cœur se serrait..."
+    "texte_fr": "Les souvenirs qu'a éveillés Maya...[001E][1205] Ils\nétaient chauds, tristes et douloureux à la\nfois...[001E][1205] Comme si mon cœur se serrait..."
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "You[SP]felt[SP]it[SP]too,[SP]right,[SP][1113]?[SP]And[SP]yet,\nthis[SP]is[SP]our[SP]first[SP]meeting...[1205][001E][SP]Is[SP]this[SP]a\nlove[SP]that's[SP]destined[SP]to[SP]be?",
     "nom_fr": "Eikichi",
-    "texte_fr": "T'as ressenti ça aussi, [1113]? Et\npourtant, c'est notre première\nrencontre...[1205][001E] Est-ce un amour destiné?"
+    "texte_fr": "T'as ressenti ça aussi, [1113]? Et\npourtant, c'est notre première\nrencontre...[001E][1205] Est-ce un amour destiné?"
   },
   {
     "id": 34,
@@ -537,7 +537,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Nah,[SP]that's[SP]impossible![1205][001E][SP]We've[SP]never\neven[SP]met[SP]before.",
     "nom_fr": "Ginko",
-    "texte_fr": "Impossible![1205][001E] On ne s'est\njamais rencontrées avant."
+    "texte_fr": "Impossible![001E][1205] On ne s'est\njamais rencontrées avant."
   },
   {
     "id": 36,
@@ -552,7 +552,7 @@
     "nom_orig": "Maya",
     "texte_orig": "We[SP]were[SP]actually[SP]looking[SP]for[SP]you[SP]earlier.[1205][001E]\nI[SP]mean,[SP]there's[SP]no[SP]way[SP]we'd[SP]leave[SP]without\ninterviewing[SP]the[SP]famous[SP][1113]-kun!",
     "nom_fr": "Maya",
-    "texte_fr": "On vous cherchait tout à l'heure, en\nfait.[1205][001E] Hors de question qu'on parte\nsans interviewer le célèbre [1113]!"
+    "texte_fr": "On vous cherchait tout à l'heure, en\nfait.[001E][1205] Hors de question qu'on parte\nsans interviewer le célèbre [1113]!"
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Maya",
     "texte_orig": "*staaa[1205][000F]a[1205][000F]a[1205][000F]a[1205][000F]a[1205][000F]re*[1205][001E]\nBut[SP]that[SP]aside,[SP][1113]-kun...[1205][001E]\nHave[SP]we[SP]met[SP]somewhere[SP]before?",
     "nom_fr": "Maya",
-    "texte_fr": "*regaaaaaarde*[1205][001E] Mais bon, à part ça,\n[1205][000F][1205][000F][1205][000F][1205][000F][1205][000F][1113]-kun...[1205][001E] On s'est déjà vus quelque part?"
+    "texte_fr": "*regaaaaaarde*[001E][1205] Mais bon, à part ça,\n[000F][1205][000F][1205][000F][1205][000F][1205][000F][1205][1113]-kun...[001E][1205] On s'est déjà vus quelque part?"
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Nah,[SP]just[SP]kidding![1205][001E][SP]Like[SP]that'd[SP]even[SP]be\npossible![1205][001E][SP]You're[SP]just[SP]such[SP]a[SP]fine-lookin'\nguy[SP]that[SP]I[SP]had[SP]to[SP]get[SP]a[SP]good[SP]ogle[SP]in!",
     "nom_fr": "Maya",
-    "texte_fr": "Nan, je rigole![1205][001E] Comme si c'était possible\n![1205][001E] T'es juste tellement beau gosse que\nj'ai pas pu m'empêcher de mater!"
+    "texte_fr": "Nan, je rigole![001E][1205] Comme si c'était possible\n![001E][1205] T'es juste tellement beau gosse que\nj'ai pas pu m'empêcher de mater!"
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "This[SP]is[SP]a[SP]surprise.[1205][001E][SP]I[SP]never[SP]knew[SP]there\nwere[SP]other[SP]Persona-users[SP]besides[SP]us...[1205][001E]\nBy[SP]which[SP]I[SP]mean[SP]my[SP]old[SP]pals.",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est une surprise.[1205][001E] Je savais pas qu'il\ny avait d'autres Manieur de Persona...[1205][001E] En\ndehors de mes anciens amis."
+    "texte_fr": "C'est une surprise.[001E][1205] Je savais pas qu'il\ny avait d'autres Manieur de Persona...[001E][1205] En\ndehors de mes anciens amis."
   },
   {
     "id": 40,
@@ -612,7 +612,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "You've[SP]heard[SP]of[SP]it,[SP]right?[1205][001E][SP]The[SP]SEBEC\nScandal[SP]three[SP]years[SP]ago.[SP]Mikage-cho[SP]got\ncompletely[SP]walled[SP]off...",
     "nom_fr": "Yukino",
-    "texte_fr": "T'en as entendu parler,\nnon?[1205][001E] Le scandale SEBEC\nil y a trois\nans. Mikage-cho a été bouclée..."
+    "texte_fr": "T'en as entendu parler,\nnon?[001E][1205] Le scandale SEBEC\nil y a trois\nans. Mikage-cho a été bouclée..."
   },
   {
     "id": 41,
@@ -627,7 +627,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "It's[SP]a[SP]long[SP]story,[SP]but...[1205][001E][SP]That's[SP]when[SP]I\nawoke[SP]to[SP]my[SP]Persona.[1205][001E][SP]There[SP]was[SP]me[SP]and\neight[SP]other[SP]guys...",
     "nom_fr": "Yukino",
-    "texte_fr": "C'est long à raconter...[1205][001E] C'est\nlà que j'ai éveillé mon Persona.[1205][001E]\nIl y avait moi et huit autres..."
+    "texte_fr": "C'est long à raconter...[001E][1205] C'est\nlà que j'ai éveillé mon Persona.[001E][1205]\nIl y avait moi et huit autres..."
   },
   {
     "id": 42,
@@ -657,7 +657,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "The[SP]news[SP]called[SP]it[SP]an[SP]accident,[SP]but[SP]that\nwasn't[SP]it[SP]at[SP]all.[1205][001E][SP]SEBEC's[SP]Kandori...[1205][001E]\nHaha,[SP]never[SP]mind.[SP]Water[SP]under[SP]the[SP]bridge.",
     "nom_fr": "Yukino",
-    "texte_fr": "Les médias ont appelé ça un accident,\nmais c'était loin d'être ça.[1205][001E] Kandori de\nSEBEC...[1205][001E] Laisse tomber. C'est du passé.[NULL]"
+    "texte_fr": "Les médias ont appelé ça un accident,\nmais c'était loin d'être ça.[001E][1205] Kandori de\nSEBEC...[001E][1205] Laisse tomber. C'est du passé.[NULL]"
   },
   {
     "id": 44,
@@ -672,7 +672,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Oh[SP]yeah![1205][0014][SP]Wait[SP]a[SP]second,[SP][1113]!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ah ouais![1205][0014] Attendez, [1113]!"
+    "texte_fr": "Ah ouais![0014][1205] Attendez, [1113]!"
   },
   {
     "id": 45,
@@ -732,7 +732,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Sorry...[1205][001E][SP]But[SP]I'm[SP]already[SP]carrying[SP]my\nfavorite[SP]weapon!",
     "nom_fr": "Yukino",
-    "texte_fr": "Désolée...[1205][001E] Mais j'ai\ndéjà mon arme favorite!"
+    "texte_fr": "Désolée...[001E][1205] Mais j'ai\ndéjà mon arme favorite!"
   },
   {
     "id": 49,

--- a/traduction/event_scripts/script_395.json
+++ b/traduction/event_scripts/script_395.json
@@ -27,7 +27,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Aiyah!?[1205][000F][SP]This[SP]is[SP]Class[SP]1-C[SP]at[SP]Sevens![1205][000F][SP]I[SP]can't\nbelieve[SP]Xibalba[SP]was[SP]hooked[SP]up[SP]to[SP]here...",
     "nom_fr": "Ginko",
-    "texte_fr": "Aiyah![1205][000F][1205][000F]? La 1-C de Seven! Dire que\nXibalba était relié à cet endroit..."
+    "texte_fr": "Aiyah![000F][1205][000F][1205]? La 1-C de Seven! Dire que\nXibalba était relié à cet endroit..."
   },
   {
     "id": 2,
@@ -42,7 +42,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Hmm....[1205][000F][SP]I[SP]personally[SP]don't[SP]mind[SP]shooting[SP]the\nrapids[SP]every[SP]time...[1205][000F][SP]But[SP]I[SP]guess[SP]you[SP]don't\nagree,[SP]huh?",
     "nom_fr": "Maya",
-    "texte_fr": "Hmm.[1205][000F][1205][000F].. Descendre les rapides m'allait...\nMais vous n'êtes pas d'accord, hein?"
+    "texte_fr": "Hmm.[000F][1205][000F][1205].. Descendre les rapides m'allait...\nMais vous n'êtes pas d'accord, hein?"
   },
   {
     "id": 3,
@@ -107,7 +107,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Uh...[1205][000F][SP]Ginko?",
     "nom_fr": "Eikichi",
-    "texte_fr": "Euh.[1205][000F]. Ginko?"
+    "texte_fr": "Euh.[000F][1205]. Ginko?"
   },
   {
     "id": 7,
@@ -137,6 +137,6 @@
     "nom_orig": "Ginko",
     "texte_orig": "Wait...[SP]Huh?[1205][000F][SP]Is[SP]this...?",
     "nom_fr": "",
-    "texte_fr": "Attends... Hein ?[1205][000F] C'est...?"
+    "texte_fr": "Attends... Hein ?[000F][1205] C'est...?"
   }
 ]

--- a/traduction/event_scripts/script_396.json
+++ b/traduction/event_scripts/script_396.json
@@ -12,7 +12,7 @@
     "nom_orig": "School[SP]paper[SP]writer",
     "texte_orig": "Our[SP]editor,[SP]who[SP]went[SP]to[SP]go[SP]investigate[SP]the\nlinks[SP]between[SP]the[SP]emblem[SP]curse[SP]and[SP]Cuss[SP]High,\nisn't[SP]back[SP]yet...",
     "nom_fr": "Rédacteur du journal scolaire",
-    "texte_fr": "Notre rédactrice enquête\nsur l'emblème et le\nlycée Kakasu, elle\nn'est pas encore revenue..."
+    "texte_fr": "Notre rédactrice enquête\nsur l'emblème et le\nlycée Kakasu, elle n'est pas encore revenue..."
   },
   {
     "id": 1,
@@ -42,7 +42,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "Don't[SP]worry.[SP]I'm[SP]sure[SP]she's[SP]somewhere[SP]dozing\noff[SP]again.[E1][E2]\n[E3][E4][NULL][NULL]\"Eikichi\nH-Hey...![1205][001E][SP]Did[SP]you[SP]just[SP]say[SP][1432][NULL][NULL][0014]Miyabi[SP]Hanakouji[1432][NULL][NULL][0014]?\nYou[SP]know[SP]Hanakouji-san!?[1205][001E][SP]Tell[SP]me!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Pas d'inquiétude. Elle doit dormir quelque\npart.[E1][E2] [E3][E4][NULL][NULL]\"Eikichi\n [1205]H-Hé.[001E]..![1205][001E] Tu as dit [1432][NULL][NULL][0014]Miyabi\nHanakouji[1432][NULL][NULL][0014]? Tu la connais!? Dis-moi!"
+    "texte_fr": "Pas d'inquiétude. Elle doit dormir quelque\npart.[E1][E2] [E3][E4][NULL][NULL]\"Eikichi\n [1205]H-Hé.[001E]..![001E][1205] Tu as dit [1432][NULL][NULL][0014]Miyabi\nHanakouji[1432][NULL][NULL][0014]? Tu la connais!? Dis-moi!"
   },
   {
     "id": 3,
@@ -57,7 +57,7 @@
     "nom_orig": "School[SP]paper[SP]writer",
     "texte_orig": "M-Miyabi[SP]Hanakouji[SP]is[SP]a[SP]student[SP]here...[1205][001E]\nShe[SP]said[SP]she[SP]was[SP]heading[SP]to[SP]Cuss[SP]High.\nDid[SP]you[SP]see[SP]her[SP]there?",
     "nom_fr": "Rédacteur du journal scolaire",
-    "texte_fr": "M-Miyabi Hanakouji est élève ici...[1205][001E] Elle\nallait au lycée Kakasu. Tu l'as vue là-bas?"
+    "texte_fr": "M-Miyabi Hanakouji est élève ici...[001E][1205] Elle\nallait au lycée Kakasu. Tu l'as vue là-bas?"
   },
   {
     "id": 4,
@@ -87,7 +87,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Wow...[1205][001E][SP]So[SP]Hanakouji-san[SP]goes[SP]to[SP]Sevens...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Wow...[1205][001E] Donc va au Seven..."
+    "texte_fr": "Wow...[001E][1205] Donc va au Seven..."
   },
   {
     "id": 6,
@@ -102,7 +102,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Haha...[1205][001E][SP]Wow...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Ah...[1205][001E] Wow..."
+    "texte_fr": "Ah...[001E][1205] Wow..."
   },
   {
     "id": 7,
@@ -117,7 +117,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "What?[SP]You[SP]saw[SP]Kozy...?[1205][001E][SP]Don't[SP]you[SP]know?[1205][001E]\nKozy[SP]is...",
     "nom_fr": "Lycéenne",
-    "texte_fr": "Quoi? Tu as vu Kozy...?[1205][001E]\nTu sais pas?[1205][001E] Kozy est..."
+    "texte_fr": "Quoi? Tu as vu Kozy...?[001E][1205]\nTu sais pas?[001E][1205] Kozy est..."
   },
   {
     "id": 8,
@@ -132,7 +132,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "What!?[1205][001E][SP]Ohhh...[SP]So[SP]you[SP]know[SP]her[SP]too!",
     "nom_fr": "Eikichi",
-    "texte_fr": "Quoi!?[1205][001E] Ohhh... Tu la connais!"
+    "texte_fr": "Quoi!?[001E][1205] Ohhh... Tu la connais!"
   },
   {
     "id": 9,
@@ -207,7 +207,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "She's[SP]my[SP]ex-girlfriend![1205][001E][SP]We[SP]were[SP]dating[SP]in\ngrade[SP]school!",
     "nom_fr": "Eikichi",
-    "texte_fr": "C'est mon ex![1205][001E] On\nsortait ensemble en primaire!"
+    "texte_fr": "C'est mon ex![001E][1205] On\nsortait ensemble en primaire!"
   },
   {
     "id": 14,
@@ -252,7 +252,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "H-Hey,[SP]Undie[SP]Boss![1205][001E][SP]I[SP]know[SP]Miyabi[SP]really[SP]well...[1205][001E]\nWhat[SP]was[SP]your[SP]relationship[SP]with[SP]her?",
     "nom_fr": "Lisa",
-    "texte_fr": "H-Hey, Boss des calbutes![1205][001E]\nJe connais bien Miyabi...[1205][001E]\nC'était quoi ta relation avec elle?"
+    "texte_fr": "H-Hey, Boss des calbutes![001E][1205]\nJe connais bien Miyabi...[001E][1205]\nC'était quoi ta relation avec elle?"
   },
   {
     "id": 17,
@@ -282,7 +282,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "H-Hey,[SP]Undie[SP]Boss![1205][001E][SP]I[SP]know[SP]Miyabi[SP]really[SP]well...[1205][001E]\nWhat[SP]was[SP]your[SP]relationship[SP]with[SP]her?",
     "nom_fr": "Ginko",
-    "texte_fr": "H-Hey, Boss des calbutes![1205][001E]\nJe connais bien Miyabi...[1205][001E]\nC'était quoi ta relation avec elle?"
+    "texte_fr": "H-Hey, Boss des calbutes![001E][1205]\nJe connais bien Miyabi...[001E][1205]\nC'était quoi ta relation avec elle?"
   },
   {
     "id": 19,
@@ -312,7 +312,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "Sooo...[SP]Uh...[1205][001E][SP]How[SP]do[SP]you[SP]know[SP]her?",
     "nom_fr": "Lisa",
-    "texte_fr": "Alors... [1205][001E] Comment tu la connais?"
+    "texte_fr": "Alors... [001E][1205] Comment tu la connais?"
   },
   {
     "id": 21,
@@ -342,7 +342,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Sooo...[SP]Uh...[1205][001E][SP]How[SP]do[SP]you[SP]know[SP]her?",
     "nom_fr": "Ginko",
-    "texte_fr": "Alors... [1205][001E] Comment tu la connais?"
+    "texte_fr": "Alors... [001E][1205] Comment tu la connais?"
   },
   {
     "id": 23,
@@ -357,7 +357,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Wow...[1205][001E][SP]So[SP]Hanakouji-san[SP]is[SP]at[SP]Sevens...[1205][001E]\nJust[SP]wow...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Wow...[1205][001E] Donc est à Seven...[1205][001E] Juste wow..."
+    "texte_fr": "Wow...[001E][1205] Donc est à Seven...[001E][1205] Juste wow..."
   },
   {
     "id": 24,
@@ -372,7 +372,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "Oh...[1205][001E][SP]She's[SP]not[SP]gonna[SP]pop[SP]in[SP]here[SP]all[SP]of[SP]a\nsudden,[SP]is[SP]she!?[1205][001E][SP]M-My[SP]heart[SP]couldn't[SP]take[SP]it...",
     "nom_fr": "Eikichi",
-    "texte_fr": "Oh...[1205][001E] Elle ne va\npas débarquer ici comme ça,\nhein!?[1205][001E] M-mon cœur ne supporterait pas..."
+    "texte_fr": "Oh...[001E][1205] Elle ne va\npas débarquer ici comme ça,\nhein!?[001E][1205] M-mon cœur ne supporterait pas..."
   },
   {
     "id": 25,
@@ -387,7 +387,7 @@
     "nom_orig": "Eikichi",
     "texte_orig": "So[SP]how's[SP]Hanakouji-san[SP]been?[1205][001E][SP]Her[SP]personality?[1205][000F]\nStill[SP]awesome,[SP]I'm[SP]sure.[1205][000F][SP]Her[SP]popularity?[1205][000F]\nStill[SP]up[SP]there,[SP]no[SP]doubt.",
     "nom_fr": "Eikichi",
-    "texte_fr": "Alors, comment va?\n[1205][1205][1205][001E][1205]Sa personnalité? [000F][000F][000F]Toujours\ngéniale. Sa popularité? Toujours au top."
+    "texte_fr": "Alors, comment va?\n[1205][1205][001E][1205][1205]Sa personnalité? [000F][000F][000F]Toujours\ngéniale. Sa popularité? Toujours au top."
   },
   {
     "id": 26,
@@ -402,7 +402,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "His[SP]grade[SP]school[SP]crush,[SP]huh...?[1205][001E][SP]Putting[SP]aside\nwhether[SP]I[SP]believe[SP]that[SP]at[SP]all,[SP]he[SP]hasn't[SP]figured\nout[SP]yet[SP]that[SP]Kozy[SP]IS[SP]Hanakouji-san.",
     "nom_fr": "Lisa",
-    "texte_fr": "Son amour de l'école primaire, hein...?[1205][001E]\nPeu importe si j'y crois, il n'a pas\nréalisé que Kozy EST Hanakouji."
+    "texte_fr": "Son amour de l'école primaire, hein...?[001E][1205]\nPeu importe si j'y crois, il n'a pas\nréalisé que Kozy EST Hanakouji."
   },
   {
     "id": 27,
@@ -417,7 +417,7 @@
     "nom_orig": "Lisa",
     "texte_orig": "No[SP]wonder[SP]Miyabi[SP]told[SP]me[SP]to[SP]keep[SP]quiet.[1205][001E]\nHeheheh...[1205][001E][SP]This[SP]should[SP]be[SP]interesting.\nLet's[SP]not[SP]say[SP]anything,[SP][1113]!",
     "nom_fr": "Lisa",
-    "texte_fr": "Pas étonnant que Miyabi m'ait dit de\nme taire.[1205][001E] Héhéhé...[1205][001E] Ça va être\nintéressant. Ne disons rien, [1113]!"
+    "texte_fr": "Pas étonnant que Miyabi m'ait dit de\nme taire.[001E][1205] Héhéhé...[001E][1205] Ça va être\nintéressant. Ne disons rien, [1113]!"
   },
   {
     "id": 28,
@@ -432,7 +432,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "His[SP]grade[SP]school[SP]crush,[SP]huh...?[1205][001E][SP]Putting[SP]aside\nwhether[SP]I[SP]believe[SP]that[SP]at[SP]all,[SP]he[SP]hasn't[SP]figured\nout[SP]yet[SP]that[SP]Kozy[SP]IS[SP]Hanakouji-san.",
     "nom_fr": "Ginko",
-    "texte_fr": "Son amour de l'école primaire...?[1205][001E]\nPeu importe si j'y crois, il n'a\npas réalisé que Kozy EST Hanakouji."
+    "texte_fr": "Son amour de l'école primaire...?[001E][1205]\nPeu importe si j'y crois, il n'a\npas réalisé que Kozy EST Hanakouji."
   },
   {
     "id": 29,
@@ -447,7 +447,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "No[SP]wonder[SP]Miyabi[SP]told[SP]me[SP]to[SP]keep[SP]quiet.[1205][001E]\nHeheheh...[1205][001E][SP]This[SP]should[SP]be[SP]interesting.\nLet's[SP]not[SP]say[SP]anything,[SP][1113]!",
     "nom_fr": "Ginko",
-    "texte_fr": "Pas étonnant que Miyabi m'ait dit de\nme taire.[1205][001E] Héhéhé...[1205][001E] Ça va être\nintéressant. Ne disons rien, [1113]!"
+    "texte_fr": "Pas étonnant que Miyabi m'ait dit de\nme taire.[001E][1205] Héhéhé...[001E][1205] Ça va être\nintéressant. Ne disons rien, [1113]!"
   },
   {
     "id": 30,
@@ -462,7 +462,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Huh?[1205][001E][SP]Sheba[SP]and[SP]Mee-ho[SP]were[SP]looking[SP]for[SP]me?",
     "nom_fr": "Ginko",
-    "texte_fr": "Hein?[1205][001E] Sheba et Mee-ho me cherchaient?"
+    "texte_fr": "Hein?[001E][1205] Sheba et Mee-ho me cherchaient?"
   },
   {
     "id": 31,
@@ -477,7 +477,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "Hmm...[1205][001E][SP]I[SP]don't[SP]have[SP]time[SP]for[SP]this,[SP]so[SP]I'll\nleave[SP]them[SP]alone[SP]for[SP]now.",
     "nom_fr": "",
-    "texte_fr": "Hmm...[1205][001E] Je n'ai pas le temps pour ça,\nje les laisserai pour l'instant."
+    "texte_fr": "Hmm...[001E][1205] Je n'ai pas le temps pour ça,\nje les laisserai pour l'instant."
   },
   {
     "id": 32,
@@ -492,7 +492,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "What's[SP]up,[SP]Chinyan?[1205][001E][SP]Huh?[SP]You[SP]want[SP]to[SP]go[SP]find\nSheba[SP]and[SP]Mee-ho?",
     "nom_fr": "Ginko",
-    "texte_fr": "Quoi de neuf, Chinyan?[1205][001E] Tu veux\nretrouver Sheba et Mee-ho?"
+    "texte_fr": "Quoi de neuf, Chinyan?[001E][1205] Tu veux\nretrouver Sheba et Mee-ho?"
   },
   {
     "id": 33,
@@ -507,7 +507,7 @@
     "nom_orig": "Ginko",
     "texte_orig": "...That's[SP]okay.[1205][001E][SP]I'm[SP]sure[SP]they[SP]just[SP]want[SP]to[SP]ask\nme[SP]to[SP]go[SP]for[SP]karaoke[SP]or[SP]something[SP]stupid[SP]like\nthat...",
     "nom_fr": "Ginko",
-    "texte_fr": "... Ça ira.[1205][001E] Je suis sûr qu'elles\nveulent juste m'inviter au karaoké\nou un truc idiot du genre..."
+    "texte_fr": "... Ça ira.[001E][1205] Je suis sûr qu'elles\nveulent juste m'inviter au karaoké\nou un truc idiot du genre..."
   },
   {
     "id": 34,
@@ -522,7 +522,7 @@
     "nom_orig": "Maya",
     "texte_orig": "Whaaat!?[1205][001E][SP]Eikichi's[SP]ex-girlfriend[SP]goes\nto[SP]Sevens!?",
     "nom_fr": "Maya",
-    "texte_fr": "Quoi!?[1205][001E] L'ex d'Eikichi va au Seven!?"
+    "texte_fr": "Quoi!?[001E][1205] L'ex d'Eikichi va au Seven!?"
   },
   {
     "id": 35,
@@ -552,7 +552,7 @@
     "nom_orig": "Maya",
     "texte_orig": "...[1205][001E]Lisa[SP]has[SP]a[SP]lot[SP]of[SP]friends,[SP]right?[1205][001E]\nIt[SP]doesn't[SP]seem[SP]like...[SP]well...",
     "nom_fr": "Maya",
-    "texte_fr": "...[1205][001E] Lisa a beaucoup d'amis, non?[1205][001E]\nÇa n'a pas l'air de... enfin..."
+    "texte_fr": "...[001E][1205] Lisa a beaucoup d'amis, non?[001E][1205]\nÇa n'a pas l'air de... enfin..."
   },
   {
     "id": 37,
@@ -567,7 +567,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Wow,[SP]so[SP]Eikichi's[SP]ex[SP]goes[SP]here...[1205][001E][SP]Wait,[SP]this\nis[SP]no[SP]time[SP]to[SP]tease[SP]him[SP]about[SP]it.[1205][001E][SP]We[SP]have[SP]to\nbreak[SP]the[SP]emblems,[SP]remember?",
     "nom_fr": "Yukino",
-    "texte_fr": "Wow, l'ex d'Eikichi est ici...[1205][001E] Mais\nc'est pas le moment.[1205][001E] On doit détruire\nles emblèmes, tu te souviens?"
+    "texte_fr": "Wow, l'ex d'Eikichi est ici...[001E][1205] Mais\nc'est pas le moment.[001E][1205] On doit détruire\nles emblèmes, tu te souviens?"
   },
   {
     "id": 38,
@@ -582,7 +582,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]think[SP]that[SP]was[SP]the[SP]last[SP]emblem[SP]in[SP]this[SP]room.[1205][001E]\nLet's[SP]move[SP]on.",
     "nom_fr": "Yukino",
-    "texte_fr": "C'était le dernier emblème\nde cette salle.[1205][001E] On y va."
+    "texte_fr": "C'était le dernier emblème\nde cette salle.[001E][1205] On y va."
   },
   {
     "id": 39,
@@ -597,7 +597,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Come[SP]to[SP]think[SP]of[SP]it,[SP]didn't[SP]someone[SP]say[SP]there\nwere[SP]emblems[SP]in[SP]the[SP]teachers'[SP]lounge?[1205][000F][SP]I[SP]think\nthose'll[SP]be[SP]the[SP]last[SP]ones[SP]left.",
     "nom_fr": "Yukino",
-    "texte_fr": "En y pensant, quelqu'un n'a pas dit qu'il\ny avait des emblèmes dans la salle des\n[1205][000F]profs? Ce seront sûrement les derniers."
+    "texte_fr": "En y pensant, quelqu'un n'a pas dit qu'il\ny avait des emblèmes dans la salle des\n[000F][1205]profs? Ce seront sûrement les derniers."
   },
   {
     "id": 40,
@@ -612,7 +612,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]hope[SP]Lisa's[SP]making[SP]the[SP]right[SP]choice.[1205][001E][SP]I[SP]know\nit[SP]sounds[SP]hokey,[SP]but[SP]friendship[SP]is[SP]magic.[1205][001E]\nI[SP]know[SP]you[SP]must[SP]have[SP]friends[SP]you[SP]care[SP]about.",
     "nom_fr": "Yukino",
-    "texte_fr": "J'espère que Lisa fait\nle bon choix.[1205][001E] Ça peut\nparaître idiot, mais\nl'amitié c'est magique.[1205][001E]\nTu as des amis qui comptent pour toi."
+    "texte_fr": "J'espère que Lisa fait\nle bon choix.[001E][1205] Ça peut\nparaître idiot, mais\nl'amitié c'est magique.[001E][1205]\nTu as des amis qui comptent pour toi."
   },
   {
     "id": 41,
@@ -627,7 +627,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "What's[SP]Eikichi[SP]doing[SP]alone,[SP]anyway?[1205][001E][SP]I'm[SP]starting\nto[SP]wonder[SP]if[SP]it[SP]was[SP]him[SP]who[SP]dumped[SP]his[SP]ex...\nWouldn't[SP]it[SP]have[SP]been[SP]the[SP]other[SP]way[SP]around?",
     "nom_fr": "Yukino",
-    "texte_fr": "Qu'est-ce qu'Eikichi fait tout seul?[1205][001E] Je me\ndemande si ce n'est pas lui qui s'est fait \nlarguer... Ça serait pas plutôt l'inverse?"
+    "texte_fr": "Qu'est-ce qu'Eikichi fait tout seul?[001E][1205] Je me\ndemande si ce n'est pas lui qui s'est fait \nlarguer... Ça serait pas plutôt l'inverse?"
   },
   {
     "id": 42,
@@ -687,7 +687,7 @@
     "nom_orig": "Bandaged[SP]male[SP]student",
     "texte_orig": "I[SP]know[SP]you[SP]t-t-took[SP]a[SP]bad[SP]g-g-grade[SP]on[SP]your\nEnglish[SP]t-test[SP]so[SP]the[SP]others[SP]wouldn't[SP]f-feel\nbad...[SP]I[SP]know[SP]you[SP]l-l-like[SP]to[SP]be[SP]alone...",
     "nom_fr": "Lycéen blessé",
-    "texte_fr": "Je sais que t-tu as\neu une m-mauvaise note au\nc-contrôle d'anglais pour épargner les\nautres... Je sais\nque t-tu aimes êtreseule..."
+    "texte_fr": "Je sais que t-tu as\neu une m-mauvaise note au\nc-contrôle d'anglais pour épargner les autres... Je sais que t-tu aimes êtreseule..."
   },
   {
     "id": 46,
@@ -867,7 +867,7 @@
     "nom_orig": "Female[SP]student",
     "texte_orig": "H-How[SP]interesting...[1205][001E][SP]But[SP]why[SP]exactly[SP]did[SP]they\nbreak[SP]up[SP]in[SP]the[SP]first[SP]place?[SP]I'm[SP]dying[SP]to[SP]know!",
     "nom_fr": "Lycéenne",
-    "texte_fr": "I-Intéressant... [1205][001E] Mais pourquoi exactement\nont-ils rompu? Je meurs\nd'envie de le savoir!"
+    "texte_fr": "I-Intéressant... [001E][1205] Mais pourquoi exactement\nont-ils rompu? Je meurs\nd'envie de le savoir!"
   },
   {
     "id": 58,
@@ -927,7 +927,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "I[SP]think[SP]that[SP]was[SP]the[SP]last[SP]emblem[SP]in[SP]this[SP]room.[1205][001E]\nLet's[SP]move[SP]on.",
     "nom_fr": "Yukino",
-    "texte_fr": "C'était le dernier emblème de\nla salle.[1205][001E] Passons à la suite."
+    "texte_fr": "C'était le dernier emblème de\nla salle.[001E][1205] Passons à la suite."
   },
   {
     "id": 62,
@@ -942,7 +942,7 @@
     "nom_orig": "Yukino",
     "texte_orig": "Come[SP]to[SP]think[SP]of[SP]it,[SP]didn't[SP]someone[SP]say[SP]there\nwere[SP]emblems[SP]in[SP]the[SP]teachers'[SP]lounge?[1205][000F][SP]I[SP]think\nthose'll[SP]be[SP]the[SP]last[SP]ones[SP]left.",
     "nom_fr": "Yukino",
-    "texte_fr": "En repensant, quelqu'un n'a pas dit qu'il\ny avait des emblèmes dans la salle des\n[1205][000F]profs? Ce seront sûrement les derniers."
+    "texte_fr": "En repensant, quelqu'un n'a pas dit qu'il\ny avait des emblèmes dans la salle des\n[000F][1205]profs? Ce seront sûrement les derniers."
   },
   {
     "id": 63,


### PR DESCRIPTION
…d EBOOT

- Fix remaining 4313 [1205][00XX] swapped tags across 290 files causing kanji, @ and E corruption
- Reformat 1008 entries with 4+ overflow lines into 3 lines max to fix pagination
- Replace 'Cuss High' with 'Lycee Kasu' in all scripts
- Replace 'Drunk young man' with 'Jeune homme ivre'
- Replace 'Employee' (nom) with 'Employée' in nom_fr
- Fix manual text errors: devraiment, rejointSugimoto, se moquerera, Allons les aider
- Fix EBOOT: remove double dots around TM tag in save data messages